### PR TITLE
Add support for Ollama

### DIFF
--- a/app/core/config_provider.py
+++ b/app/core/config_provider.py
@@ -13,12 +13,20 @@ class ConfigProvider:
             "password": os.getenv("NEO4J_PASSWORD"),
         }
         self.github_key = os.getenv("GITHUB_PRIVATE_KEY")
+        self.ollama_endpoint = os.getenv("OLLAMA_ENDPOINT", "http://localhost:11434")
+        self.ollama_model = os.getenv("OLLAMA_MODEL", "llama2")
 
     def get_neo4j_config(self):
         return self.neo4j_config
 
     def get_github_key(self):
         return self.github_key
+
+    def get_ollama_config(self):
+        return {
+            "endpoint": self.ollama_endpoint,
+            "model": self.ollama_model,
+        }
 
     def get_demo_repo_list(self):
         return [

--- a/app/modules/intelligence/agents/agent_factory.py
+++ b/app/modules/intelligence/agents/agent_factory.py
@@ -24,6 +24,7 @@ from app.modules.intelligence.provider.provider_service import (
     AgentType,
     ProviderService,
 )
+from langchain_ollama import Ollama
 
 
 class AgentFactory:
@@ -69,6 +70,10 @@ class AgentFactory:
             "LLD_agent": lambda: LLDChatAgent(mini_llm, reasoning_llm, self.db),
             "code_generation_agent": lambda: CodeGenerationChatAgent(
                 mini_llm, reasoning_llm, self.db
+            ),
+            "ollama_agent": lambda: Ollama(
+                base_url=self.provider_service.get_ollama_endpoint(),
+                model=self.provider_service.get_ollama_model(),
             ),
         }
 

--- a/app/modules/intelligence/agents/agent_injector_service.py
+++ b/app/modules/intelligence/agents/agent_injector_service.py
@@ -28,6 +28,7 @@ from app.modules.intelligence.provider.provider_service import (
     AgentType,
     ProviderService,
 )
+from langchain_ollama import Ollama
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +59,10 @@ class AgentInjectorService:
             "LLD_agent": LLDChatAgent(mini_llm, reasoning_llm, self.sql_db),
             "code_generation_agent": CodeGenerationChatAgent(
                 mini_llm, reasoning_llm, self.sql_db
+            ),
+            "ollama_agent": Ollama(
+                base_url=self.provider_service.get_ollama_endpoint(),
+                model=self.provider_service.get_ollama_model(),
             ),
         }
 

--- a/app/modules/intelligence/provider/provider_service.py
+++ b/app/modules/intelligence/provider/provider_service.py
@@ -7,6 +7,7 @@ from crewai import LLM
 from langchain_anthropic import ChatAnthropic
 from langchain_openai.chat_models import ChatOpenAI
 from portkey_ai import PORTKEY_GATEWAY_URL, createHeaders
+from langchain_ollama import Ollama
 
 from app.modules.key_management.secret_manager import SecretManager
 from app.modules.users.user_preferences_model import UserPreferences
@@ -43,6 +44,11 @@ class ProviderService:
                 id="anthropic",
                 name="Anthropic",
                 description="An AI safety-focused company known for models like Claude.",
+            ),
+            ProviderInfo(
+                id="ollama",
+                name="Ollama",
+                description="A provider for running open source models locally.",
             ),
         ]
 
@@ -195,6 +201,12 @@ class ProviderService:
                         default_headers=portkey_headers,
                     )
 
+        elif preferred_provider == "ollama":
+            logging.info("Initializing Ollama LLM")
+            ollama_endpoint = os.getenv("OLLAMA_ENDPOINT", "http://localhost:11434")
+            ollama_model = os.getenv("OLLAMA_MODEL", "llama2")
+            self.llm = Ollama(base_url=ollama_endpoint, model=ollama_model)
+
         else:
             raise ValueError("Invalid LLM provider selected.")
 
@@ -323,6 +335,12 @@ class ProviderService:
                         default_headers=portkey_headers,
                     )
 
+        elif preferred_provider == "ollama":
+            logging.info("Initializing Ollama LLM")
+            ollama_endpoint = os.getenv("OLLAMA_ENDPOINT", "http://localhost:11434")
+            ollama_model = os.getenv("OLLAMA_MODEL", "llama2")
+            self.llm = Ollama(base_url=ollama_endpoint, model=ollama_model)
+
         else:
             raise ValueError("Invalid LLM provider selected.")
 
@@ -337,6 +355,8 @@ class ProviderService:
             return "OpenAI"
         elif isinstance(llm, ChatAnthropic):
             return "Anthropic"
+        elif isinstance(llm, Ollama):
+            return "Ollama"
         elif isinstance(llm, LLM):
             return "OpenAI" if llm.model.split("/")[0] == "openai" else "Anthropic"
         else:

--- a/app/modules/intelligence/tools/tool_service.py
+++ b/app/modules/intelligence/tools/tool_service.py
@@ -37,6 +37,7 @@ from app.modules.intelligence.tools.kg_based_tools.get_nodes_from_tags_tool impo
 )
 from app.modules.intelligence.tools.tool_schema import ToolInfo
 from langchain_ollama import Ollama
+from app.core.config_provider import config_provider
 
 
 class ToolService:
@@ -73,10 +74,10 @@ class ToolService:
         }
 
     def _get_ollama_endpoint(self) -> str:
-        return self.db.query(ConfigProvider).first().get_ollama_config()["endpoint"]
+        return config_provider.get_ollama_config()["endpoint"]
 
     def _get_ollama_model(self) -> str:
-        return self.db.query(ConfigProvider).first().get_ollama_config()["model"]
+        return config_provider.get_ollama_config()["model"]
 
     async def run_tool(self, tool_id: str, params: Dict[str, Any]) -> Dict[str, Any]:
         tool = self.tools.get(tool_id)

--- a/app/modules/intelligence/tools/tool_service.py
+++ b/app/modules/intelligence/tools/tool_service.py
@@ -36,6 +36,7 @@ from app.modules.intelligence.tools.kg_based_tools.get_nodes_from_tags_tool impo
     GetNodesFromTags,
 )
 from app.modules.intelligence.tools.tool_schema import ToolInfo
+from langchain_ollama import Ollama
 
 
 class ToolService:
@@ -65,7 +66,17 @@ class ToolService:
             "get_node_neighbours_from_node_id": GetNodeNeighboursFromNodeIdTool(
                 self.db
             ),
+            "ollama_tool": Ollama(
+                base_url=self._get_ollama_endpoint(),
+                model=self._get_ollama_model(),
+            ),
         }
+
+    def _get_ollama_endpoint(self) -> str:
+        return self.db.query(ConfigProvider).first().get_ollama_config()["endpoint"]
+
+    def _get_ollama_model(self) -> str:
+        return self.db.query(ConfigProvider).first().get_ollama_config()["model"]
 
     async def run_tool(self, tool_id: str, params: Dict[str, Any]) -> Dict[str, Any]:
         tool = self.tools.get(tool_id)


### PR DESCRIPTION
Related to #188

Add support for Ollama to enable users to run open source models locally.

* **Provider Service Integration**
  - Add Ollama API integration in `app/modules/intelligence/provider/provider_service.py`
  - Implement method to get Ollama LLM
  - Update `list_available_llms` method to include Ollama

* **Configuration Options**
  - Add configuration options for Ollama endpoint and model selection in `app/core/config_provider.py`
  - Update `ConfigProvider` class to include Ollama settings

* **Agent Factory and Injector Service**
  - Add support for Ollama models in `app/modules/intelligence/agents/agent_factory.py`
  - Implement method to create Ollama agent
  - Add support for Ollama models in `app/modules/intelligence/agents/agent_injector_service.py`
  - Implement method to get Ollama agent

* **Tool Service**
  - Add tools for Ollama model support in `app/modules/intelligence/tools/tool_service.py`
  - Implement methods to interact with Ollama models



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added support for Ollama as a new Language Model (LLM) provider.
  - Introduced configuration options for Ollama endpoint and model.
  - Expanded agent and tool capabilities to include Ollama-based services.

- **Improvements**
  - Enhanced configuration management for LLM providers.
  - Extended agent and tool initialization to support new Ollama integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->