### PR TITLE
fix: anthropic prompts (issue #211)

### DIFF
--- a/app/modules/intelligence/prompts/classification_prompts.py
+++ b/app/modules/intelligence/prompts/classification_prompts.py
@@ -487,6 +487,8 @@ class ClassificationPrompts:
         """,
     }
 
+    REDUNDANT_INHIBITION_TAIL : str = "\n\nReturn ONLY JSON content, and nothing else. Don't provide reason or any other text in the response."
+
     @classmethod
     def get_classification_prompt(cls, agent_type: AgentType) -> str:
-        return cls.CLASSIFICATION_PROMPTS.get(agent_type, "")
+        return cls.CLASSIFICATION_PROMPTS.get(agent_type, "") + cls.REDUNDANT_INHIBITION_TAIL


### PR DESCRIPTION
- without the prompt at the end limiting Anthropic's reply format it will always give reason for classification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced classification prompt generation with a new constant that ensures JSON-only response format
	- Improved response control for AI-generated classification prompts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->