### PR TITLE
LocalRepoService fixes

### DIFF
--- a/app/modules/code_provider/local_repo/local_repo_service.py
+++ b/app/modules/code_provider/local_repo/local_repo_service.py
@@ -15,14 +15,13 @@ logger = logging.getLogger(__name__)
 
 
 class LocalRepoService:
-    def __init__(self, db: Session,base_path: str = "."):
+    def __init__(self, db: Session):
         self.db = db
         self.project_manager = ProjectService(db)
         self.projects_dir = os.path.join(os.getcwd(), "projects")
         self.max_workers = 10
         self.max_depth = 4
         self.executor = ThreadPoolExecutor(max_workers=self.max_workers)
-        self.base_path = os.path.abspath(base_path)
 
     def get_repo(self, repo_path: str) -> git.Repo:
         if not os.path.exists(repo_path):

--- a/app/modules/code_provider/local_repo/local_repo_service.py
+++ b/app/modules/code_provider/local_repo/local_repo_service.py
@@ -138,12 +138,12 @@ class LocalRepoService:
             current_depth = len(path.split("/")) if path else 0
 
         # If we've reached max depth, return truncated indicator
-        # if current_depth >= self.max_depth:
-        #     return {
-        #         "type": "directory",
-        #         "name": path.split("/")[-1] or repo.name,
-        #         "children": [{"type": "file", "name": "...", "path": "truncated"}],
-        #     }
+        if current_depth >= self.max_depth:
+            return {
+                "type": "directory",
+                "name": path.split("/")[-1] or repo.name,
+                "children": [{"type": "file", "name": "...", "path": "truncated"}],
+            }
 
         structure = {
             "type": "directory",


### PR DESCRIPTION
Fixes #261 

added method _get_content(), to fix the local repo parsing issue.

![Screenshot from 2025-02-17 10-16-55](https://github.com/user-attachments/assets/6e633339-9819-468b-bf35-406b61749bda)
![Screenshot from 2025-02-17 10-25-20](https://github.com/user-attachments/assets/b3bd8619-7def-4a3f-9aa7-9808ad124cce)
![Screenshot from 2025-02-17 10-32-16](https://github.com/user-attachments/assets/f7838daf-ad5f-4264-aece-431b96b98ecb)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a method for retrieving structured content from specified paths within the local repository, improving content accessibility.
  
- **Refactor**
  - Enhanced the retrieval and organization of repository content with a more robust approach to handling both directories and files.
  - Improved error handling to ensure reliable responses for invalid paths and unexpected conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->