### PR TITLE
Add "node_ids" in conversation API of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,8 @@ Potpie provides a set of tools that agents can use to interact with the knowledg
    curl -X POST 'http://localhost:8001/api/v1/conversations/your-conversation-id/message/' \
      -H 'Content-Type: application/json' \
      -d '{
-       "content": "Your question or request here"
+       "content": "Your question or request here",
+       "node_ids":[]
      }'
    ```
 


### PR DESCRIPTION
a recent change in API structure of conversation api lead to following issue, #311

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced conversation API requests to accept additional contextual data, improving the flexibility of interactions without affecting current functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->