### PR TITLE
Replaces MD5 to SHA-256 Algo which is more secure in code_graph_service.py

### DIFF
--- a/app/modules/parsing/graph_construction/code_graph_service.py
+++ b/app/modules/parsing/graph_construction/code_graph_service.py
@@ -20,8 +20,8 @@ class CodeGraphService:
         # Concatenate path and signature
         combined_string = f"{user_id}:{path}"
 
-        # Create a SHA-1 hash of the combined string
-        hash_object = hashlib.md5()
+        # Create a SHA-256 hash of the combined string
+        hash_object = hashlib.sha256()
         hash_object.update(combined_string.encode("utf-8"))
 
         # Get the hexadecimal representation of the hash


### PR DESCRIPTION
Using a broken or weak cryptographic hash function can leave data vulnerable, and should not be used code.

To fix this here Replace the MD5 hashing algorithm with SHA-256 in the generate_node_id method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the security of node ID generation by updating the hashing algorithm used internally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->