### PR TITLE
feat: add sorting options to conversations API

### DIFF
--- a/app/modules/users/user_controller.py
+++ b/app/modules/users/user_controller.py
@@ -19,10 +19,10 @@ class UserController:
         return await self.service.get_user_profile_pic(uid)
 
     async def get_conversations_for_user(
-        self, user_id: str, start: int, limit: int
+        self, user_id: str, start: int, limit: int, sort: str = "updated_at", order: str = "desc"
     ) -> List[UserConversationListResponse]:
         conversations = self.service.get_conversations_with_projects_for_user(
-            user_id, start, limit
+            user_id, start, limit, sort, order
         )
         response = []
         agent_ids = [

--- a/app/modules/users/user_router.py
+++ b/app/modules/users/user_router.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Literal
 
 from fastapi import Depends, Query
 from sqlalchemy.orm import Session
@@ -20,16 +20,19 @@ class UserAPI:
     @router.get(
         "/user/conversations/",
         response_model=List[UserConversationListResponse],
+        description="Get a list of conversations for the current user with sorting options."
     )
     async def get_conversations_for_user(
         user=Depends(AuthService.check_auth),
         start: int = Query(0, ge=0),
         limit: int = Query(10, ge=1),
+        sort: Literal["updated_at", "created_at"] = Query("updated_at", description="Field to sort by"),
+        order: Literal["asc", "desc"] = Query("desc", description="Direction of sort"),
         db: Session = Depends(get_db),
     ):
         user_id = user["user_id"]
         controller = UserController(db)
-        return await controller.get_conversations_for_user(user_id, start, limit)
+        return await controller.get_conversations_for_user(user_id, start, limit, sort, order)
 
     @router.get("/user/{user_id}/public-profile", response_model=UserProfileResponse)
     async def fetch_user_profile_pic(

--- a/app/modules/users/user_service.py
+++ b/app/modules/users/user_service.py
@@ -114,17 +114,30 @@ class UserService:
             return None
 
     def get_conversations_with_projects_for_user(
-        self, user_id: str, start: int, limit: int
+        self, user_id: str, start: int, limit: int, sort: str = "updated_at", order: str = "desc"
     ) -> List[Conversation]:
         try:
-            conversations = (
-                self.db.query(Conversation)
-                .filter(Conversation.user_id == user_id)
-                .order_by(desc(Conversation.updated_at))
-                .offset(start)
-                .limit(limit)
-                .all()
-            )
+            # Build the query
+            query = self.db.query(Conversation).filter(Conversation.user_id == user_id)
+
+            # Validate sort field
+            if sort not in ["updated_at", "created_at"]:
+                sort = "updated_at"  # Default to updated_at if invalid
+
+            # Apply sorting
+            sort_column = getattr(Conversation, sort)
+
+            # Validate order
+            if order.lower() not in ["asc", "desc"]:
+                order = "desc"  # Default to desc if invalid
+
+            if order.lower() == "asc":
+                query = query.order_by(sort_column)
+            else:  # Default to desc
+                query = query.order_by(desc(sort_column))
+
+            # Apply pagination
+            conversations = query.offset(start).limit(limit).all()
 
             logger.info(
                 f"Retrieved {len(conversations)} conversations with projects for user {user_id}"


### PR DESCRIPTION
## 🚀 Add Sorting Options to Conversations API

### 📄 Description
This PR adds **sorting capabilities** to the Conversations List API endpoint. Users can now **customize the sorting order** of their conversations based on two fields:

- `created_at`
- `updated_at`

Users can also specify whether the sorting should be in **ascending** (`asc`) or **descending** (`desc`) order.

---

### 🔍 Current Behavior
Currently, the `/user/conversations/` API always returns the list of conversations sorted by `updated_at` in **descending order**, and there is **no support for dynamic sorting** via query parameters.

---

### ✨ New Behavior
With this PR, users can now control the sorting using the following **optional query parameters**:

#### ✅ Supported Query Parameters
- `sort`: Field to sort by  
  - Allowed values: `updated_at`, `created_at`
- `order`: Direction of sort  
  - Allowed values: `asc`, `desc`

#### 🔧 Example Usage
```http
GET /user/conversations/?sort=created_at&order=asc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for sorting and ordering when retrieving user conversations. Users can now specify sorting by "updated_at" or "created_at" and choose ascending or descending order using new query parameters.
- **Documentation**
  - Updated endpoint descriptions to reflect new sorting options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->