### PR TITLE
fix: Unclear error when accessing private repository branches

### DIFF
--- a/app/modules/code_provider/github/github_service.py
+++ b/app/modules/code_provider/github/github_service.py
@@ -522,16 +522,16 @@ class GithubService:
                             raise HTTPException(
                                 status_code=403,
                                 detail=f"Access denied to repository {repo_name}. You don't have sufficient permissions to access this repository."
-                            )
+                            ) from e
                         elif e.status == 404:
                             raise HTTPException(
                                 status_code=404,
                                 detail=f"Repository {repo_name} not found on GitHub."
-                            )
+                            ) from e
                         else:
                             raise HTTPException(
                                 status_code=e.status, detail=f"GitHub API error: {str(e)}"
-                            )
+                            ) from e
                     # Fallback for non-status errors
                     elif (
                         "permission" in error_message
@@ -540,8 +540,8 @@ class GithubService:
                     ):
                             raise HTTPException(
                                   status_code=403,
-                                  detail=f"Access denied to repository {repo_name}. You don't have sufficient permissions."
-                            )
+                                  detail=f"Access denied to repository {repo_name}. You don't have sufficient permissions to access this repository"
+                            ) from e
                     else:
                         logger.error(
                             f"Error fetching branches for repo {repo_name}: {str(e)}", 
@@ -561,7 +561,7 @@ class GithubService:
             raise HTTPException(
                 status_code=500,
                 detail=f"Unexpected error: {str(e)}"
-            )
+            ) from e
 
     @classmethod
     def get_public_github_instance(cls):


### PR DESCRIPTION
## Description

- this PR address the issue #348 
- Added better error handling for when github repository are private
- Added error handling for user doesnt have enough permissions for the repository

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages and handling when fetching branch lists from GitHub repositories, providing clearer feedback for permission issues, missing repositories, and unexpected errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->