### PR TITLE
Fix deduplication logic in get_user_repos to preserve repo order

### DIFF
--- a/app/modules/code_provider/github/github_router.py
+++ b/app/modules/code_provider/github/github_router.py
@@ -21,10 +21,9 @@ async def get_user_repos(
     # Remove duplicates while preserving order
     seen = set()
     deduped_repos = []
-    for repo in reversed(user_repo_list["repositories"]):
-        # Create tuple of values to use as hash key
+    for repo in user_repo_list["repositories"]:
         repo_key = repo["full_name"]
-
+        
         if repo_key not in seen:
             seen.add(repo_key)
             deduped_repos.append(repo)


### PR DESCRIPTION
## Fixes #355 
## Description:
This PR updates the deduplication logic in the get_user_repos() function to preserve the original order of repositories. The previous implementation iterated in reverse, causing the order to be flipped and potentially confusing users.

Changes Made:

- Replaced reverse iteration with a forward loop

- Used repo["full_name"] as the unique identifier

- Ensured the first occurrence of each repo is kept