### PR TITLE
Add Email Validation for Share Chat Recipients

### DIFF
--- a/app/modules/utils/email_helper.py
+++ b/app/modules/utils/email_helper.py
@@ -2,6 +2,8 @@ import os
 
 import resend
 
+import re
+
 
 class EmailHelper:
     def __init__(self):
@@ -47,3 +49,9 @@ Co-Founder, Potpie 🥧</p>
 
         email = resend.Emails.send(params)
         return email
+
+
+def is_valid_email(email: str) -> bool:
+    """Simple regex-based email validation."""
+    pattern = r"^[\w\.-]+@[\w\.-]+\.\w+$"
+    return re.match(pattern, email) is not None

--- a/app/modules/utils/email_helper.py
+++ b/app/modules/utils/email_helper.py
@@ -53,5 +53,5 @@ Co-Founder, Potpie 🥧</p>
 
 def is_valid_email(email: str) -> bool:
     """Simple regex-based email validation."""
-    pattern = r"^[\w\.-]+@[\w\.-]+\.\w+$"
+    pattern = r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
     return re.match(pattern, email) is not None


### PR DESCRIPTION
This PR fixes the issue https://github.com/potpie-ai/potpie/issues/347

**Overview:**
This PR introduces email format validation in the ShareChatService's share_chat method. Before adding recipient emails to the conversation, the system now checks if each email address is valid using a regex-based validator. If any invalid emails are detected, a 400 Bad Request error is raised with a clear message listing the invalid addresses.

**Changes Implemented:**

- Added a new is_valid_email utility function inside email_helper.py.
- Integrated email validation in the share_chat method in access_service.py.
- Improved error handling to show all invalid emails at once.
- Added unit tests for valid and invalid email cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added validation to ensure all recipient email addresses are correctly formatted before allowing them to be added to a chat's shared access list.
- **Bug Fixes**
	- Prevented invalid email addresses from being accepted when sharing private chats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->