### PR TITLE
Fix file fetching with missing line numbers

### DIFF
--- a/app/modules/code_provider/github/github_service.py
+++ b/app/modules/code_provider/github/github_service.py
@@ -119,8 +119,8 @@ class GithubService:
         self,
         repo_name: str,
         file_path: str,
-        start_line: int,
-        end_line: int,
+        start_line: Optional[int],
+        end_line: Optional[int],
         branch_name: str,
         project_id: str,
     ) -> str:
@@ -163,11 +163,15 @@ class GithubService:
                     decoded_content = content_bytes.decode("latin1", errors="replace")
             lines = decoded_content.splitlines()
 
-            if (start_line == end_line == 0) or (start_line == end_line == None):
+            if (
+                (start_line == 0 and end_line == 0)
+                or (start_line is None and end_line is None)
+            ):
                 return decoded_content
             # added -2 to start and end line to include the function definition/ decorator line
-            start = start_line - 2 if start_line - 2 > 0 else 0
-            selected_lines = lines[start:end_line]
+            start = start_line - 2 if start_line is not None and start_line - 2 > 0 else 0
+            end = end_line if end_line is not None else None
+            selected_lines = lines[start:end]
             return "\n".join(selected_lines)
         except Exception as e:
             logger.error(
@@ -345,7 +349,7 @@ class GithubService:
                 for installation in user_installations:
                     app_auth = auth.get_installation_auth(installation["id"])
                     repos_url = installation["repositories_url"]
-                    github = Github(auth=app_auth)  # do not remove this line
+                    github = Github(auth=app_auth)  # noqa: F841 - required to initialize GitHub client
                     auth_headers = {"Authorization": f"Bearer {app_auth.token}"}
 
                     async with session.get(

--- a/app/modules/code_provider/github/github_service.py
+++ b/app/modules/code_provider/github/github_service.py
@@ -163,13 +163,14 @@ class GithubService:
                     decoded_content = content_bytes.decode("latin1", errors="replace")
             lines = decoded_content.splitlines()
 
-            if (
-                (start_line == 0 and end_line == 0)
-                or (start_line is None and end_line is None)
+            if (start_line == 0 and end_line == 0) or (
+                start_line is None and end_line is None
             ):
                 return decoded_content
             # added -2 to start and end line to include the function definition/ decorator line
-            start = start_line - 2 if start_line is not None and start_line - 2 > 0 else 0
+            start = (
+                start_line - 2 if start_line is not None and start_line - 2 > 0 else 0
+            )
             end = end_line if end_line is not None else None
             selected_lines = lines[start:end]
             return "\n".join(selected_lines)
@@ -349,7 +350,9 @@ class GithubService:
                 for installation in user_installations:
                     app_auth = auth.get_installation_auth(installation["id"])
                     repos_url = installation["repositories_url"]
-                    github = Github(auth=app_auth)  # noqa: F841 - required to initialize GitHub client
+                    github = Github(
+                        auth=app_auth
+                    )  # noqa: F841 - required to initialize GitHub client
                     auth_headers = {"Authorization": f"Bearer {app_auth.token}"}
 
                     async with session.get(

--- a/app/modules/code_provider/local_repo/local_repo_service.py
+++ b/app/modules/code_provider/local_repo/local_repo_service.py
@@ -35,8 +35,8 @@ class LocalRepoService:
         self,
         repo_name: str,
         file_path: str,
-        start_line: int,
-        end_line: int,
+        start_line: Optional[int],
+        end_line: Optional[int],
         branch_name: str,
         project_id: str,
     ) -> str:
@@ -58,10 +58,14 @@ class LocalRepoService:
             file_full_path = os.path.join(repo_path, file_path)
             with open(file_full_path, "r", encoding="utf-8") as file:
                 lines = file.readlines()
-                if (start_line == end_line == 0) or (start_line == end_line == None):
+                if (
+                    (start_line == 0 and end_line == 0)
+                    or (start_line is None and end_line is None)
+                ):
                     return "".join(lines)
-                start = start_line - 2 if start_line - 2 > 0 else 0
-                selected_lines = lines[start:end_line]
+                start = start_line - 2 if start_line is not None and start_line - 2 > 0 else 0
+                end = end_line if end_line is not None else None
+                selected_lines = lines[start:end]
                 return "".join(selected_lines)
         except Exception as e:
             logger.error(

--- a/app/modules/code_provider/local_repo/local_repo_service.py
+++ b/app/modules/code_provider/local_repo/local_repo_service.py
@@ -58,12 +58,15 @@ class LocalRepoService:
             file_full_path = os.path.join(repo_path, file_path)
             with open(file_full_path, "r", encoding="utf-8") as file:
                 lines = file.readlines()
-                if (
-                    (start_line == 0 and end_line == 0)
-                    or (start_line is None and end_line is None)
+                if (start_line == 0 and end_line == 0) or (
+                    start_line is None and end_line is None
                 ):
                     return "".join(lines)
-                start = start_line - 2 if start_line is not None and start_line - 2 > 0 else 0
+                start = (
+                    start_line - 2
+                    if start_line is not None and start_line - 2 > 0
+                    else 0
+                )
                 end = end_line if end_line is not None else None
                 selected_lines = lines[start:end]
                 return "".join(selected_lines)


### PR DESCRIPTION
## Summary
- allow optional `start_line` and `end_line` when fetching file content
- handle `None` values safely in GitHub and local repo services

## Testing
- `ruff check app/modules/code_provider/github/github_service.py app/modules/code_provider/local_repo/local_repo_service.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*