### PR TITLE
Resolve logger deprecation warnings

### DIFF
--- a/app/modules/intelligence/tools/kg_based_tools/get_code_from_probable_node_name_tool.py
+++ b/app/modules/intelligence/tools/kg_based_tools/get_code_from_probable_node_name_tool.py
@@ -142,7 +142,7 @@ class GetCodeFromProbableNodeNameTool:
 
             return self._process_result(node_data, project, node_id)
         except Exception as e:
-            logger.warn(
+            logger.warning(
                 f"Unexpected error in GetCodeFromProbableNodeNameTool: {str(e)}"
             )
             return {"error": f"An unexpected error occurred: {str(e)}"}


### PR DESCRIPTION
## Summary
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated logging to use the recommended warning method for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->