### PR TITLE
fix: requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -69,4 +69,4 @@ pathspec==0.12.1
 pytest
 pytest-asyncio
 Pillow==10.0.1
-python-multipart==0.0.6
+python-multipart>=0.0.7


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Relaxed dependency constraint for python-multipart from an exact pin to a minimum version (now requires python-multipart >= 0.0.7). This allows installation of newer releases, improving compatibility with upstream updates and enabling receipt of ongoing fixes and improvements without manual intervention. All other dependencies remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->