### PR TITLE
fix: https for redirect uri scheme bcz of loadbalancer forwarding

### DIFF
--- a/app/modules/integrations/integrations_router.py
+++ b/app/modules/integrations/integrations_router.py
@@ -218,7 +218,7 @@ async def linear_oauth_redirect(
         # Get redirect URI from query params or construct from current request
         redirect_uri = request.query_params.get(
             "redirect_uri",
-            f"{request.url.scheme}://{request.url.hostname}/api/v1/integrations/linear/callback",
+            f"https://{request.url.hostname}/api/v1/integrations/linear/callback",
         )
 
         # Get state parameter if provided
@@ -279,9 +279,10 @@ async def linear_oauth_callback(
                 from .integrations_schema import LinearSaveRequest
                 from datetime import datetime
 
+                # Always use HTTPS in production
                 save_request = LinearSaveRequest(
                     code=code,
-                    redirect_uri=f"{request.url.scheme}://{request.url.hostname}/api/v1/integrations/linear/callback",
+                    redirect_uri=f"https://{request.url.hostname}/api/v1/integrations/linear/callback",
                     instance_name="Linear Integration",  # Will be updated with org name in service
                     integration_type="linear",
                     timestamp=datetime.utcnow().isoformat() + "Z",


### PR DESCRIPTION
Fix url scheme, scheme is being changed when being forwarded through nginx. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security and reliability of the Linear integration’s OAuth flow by enforcing HTTPS for redirect and callback URLs. This prevents authentication failures in environments with mixed schemes or behind proxies and reduces setup misconfigurations. No user action is required; existing connections continue to work, and new authorizations will consistently use secure HTTPS callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->