### PR TITLE
Include agent_tasks queue when starting Celery worker in start scripts

### DIFF
--- a/start.ps1
+++ b/start.ps1
@@ -78,6 +78,6 @@ Start-Process -NoNewWindow powershell -ArgumentList "uvicorn app.main:app --host
 
 # Start Celery worker
 Write-Host "Starting Celery worker"
-Start-Process -NoNewWindow powershell -ArgumentList "celery -A app.celery.celery_app worker --loglevel=debug -Q ${Env:CELERY_QUEUE_NAME}_process_repository -E --pool=solo"
+Start-Process -NoNewWindow powershell -ArgumentList "celery -A app.celery.celery_app worker --loglevel=debug -Q ${Env:CELERY_QUEUE_NAME}_process_repository,${Env:CELERY_QUEUE_NAME}_agent_tasks -E --pool=solo"
 
 Write-Host "All services started successfully!"

--- a/start.sh
+++ b/start.sh
@@ -47,4 +47,4 @@ gunicorn --worker-class uvicorn.workers.UvicornWorker --workers 1 --timeout 1800
 
 echo "Starting Celery worker"
 # Start Celery worker with the new setup
-celery -A app.celery.celery_app worker --loglevel=debug -Q "${CELERY_QUEUE_NAME}_process_repository" -E --concurrency=1 --pool=solo &
+celery -A app.celery.celery_app worker --loglevel=debug -Q "${CELERY_QUEUE_NAME}_process_repository,${CELERY_QUEUE_NAME}_agent_tasks" -E --concurrency=1 --pool=solo &


### PR DESCRIPTION
* Updated the Celery worker startup command in `start.ps1` to listen to both `${Env:CELERY_QUEUE_NAME}_process_repository` and `${Env:CELERY_QUEUE_NAME}_agent_tasks` queues.
* Updated the Celery worker startup command in `start.sh` to listen to both `${CELERY_QUEUE_NAME}_process_repository` and `${CELERY_QUEUE_NAME}_agent_tasks` queues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated background task worker configuration to process multiple task types, improving system resource allocation and task handling efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->