### PR TITLE
fix(api): Standardize HTTP status codes for new resource creation

### DIFF
--- a/app/modules/integrations/integrations_router.py
+++ b/app/modules/integrations/integrations_router.py
@@ -1943,7 +1943,7 @@ async def update_integration_status(
 
 
 # New endpoints using schema models
-@router.post("/create", response_model=IntegrationResponse)
+@router.post("/create", response_model=IntegrationResponse,status_code=201)
 async def create_integration(
     request: IntegrationCreateRequest,
     integrations_service: IntegrationsService = Depends(get_integrations_service),

--- a/app/modules/intelligence/prompts/prompt_router.py
+++ b/app/modules/intelligence/prompts/prompt_router.py
@@ -22,7 +22,7 @@ router = APIRouter()
 
 class PromptAPI:
     @staticmethod
-    @router.post("/prompts/", response_model=PromptResponse)
+    @router.post("/prompts/", response_model=PromptResponse,status_code=201)
     async def create_prompt(
         prompt: PromptCreate,
         db: Session = Depends(get_db),

--- a/app/modules/media/media_router.py
+++ b/app/modules/media/media_router.py
@@ -19,7 +19,7 @@ router = APIRouter()
 
 class MediaAPI:
     @staticmethod
-    @router.post("/media/upload", response_model=AttachmentUploadResponse)
+    @router.post("/media/upload", response_model=AttachmentUploadResponse,status_code=201)
     async def upload_image(
         file: UploadFile = File(..., description="Image file to upload"),
         message_id: Optional[str] = Query(


### PR DESCRIPTION

This PR standardizes **HTTP status codes** for resource creation across multiple modules.  
All relevant endpoints now return **`201 Created`** instead of inconsistent codes (`200`, `204`, or custom responses`).
Fixes #254
---

##  Changes Made  
Updated status codes to follow REST conventions in:

- `app/modules/integrations/integrations_router.py`
- `app/modules/intelligence/prompts/prompt_router.py`
- `app/modules/media/media_router.py`

**What was changed:**
- Adjusted `POST` endpoints to return `201 Created` on successful resource creation.
- Ensured returned payload structure remains unchanged.
- Improved consistency across modules for client-side handling.

---

## Why This Is Needed  
- The project had inconsistent status codes for resource creation.  
- REST best practices recommend using **201** for successful POST requests that create resources.  
- Standardization improves API clarity, reduces ambiguity, and aligns with expected client behavior.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Corrected HTTP response status codes across multiple API creation endpoints. Integration creation, prompt generation, and media upload operations now consistently return the proper 201 Created status code upon successful completion, ensuring compliance with REST standards and enabling client applications to more accurately identify and process newly created resources in their responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->