### PR TITLE
fix: Add wait time for database initialization and reorder FastAPI app

### DIFF
--- a/start.ps1
+++ b/start.ps1
@@ -51,6 +51,9 @@ do {
 
 Write-Host "Postgres is up - applying database migrations"
 
+# Additional wait to ensure database is fully initialized
+Start-Sleep -Seconds 5
+
 # Ensure uv is available
 if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
     Write-Host "Error: uv command not found. Install uv from https://docs.astral.sh/uv/getting-started/ before running this script."
@@ -72,12 +75,12 @@ if ($LASTEXITCODE -ne 0) {
     exit 1
 }
 
-# Start FastAPI application (using uvicorn instead of gunicorn for Windows compatibility)
-Write-Host "Starting momentum application..."
-Start-Process -NoNewWindow powershell -ArgumentList "uv run uvicorn app.main:app --host 0.0.0.0 --port 8001 --reload --log-level debug"
-
 # Start Celery worker
 Write-Host "Starting Celery worker"
 Start-Process -NoNewWindow powershell -ArgumentList "uv run celery -A app.celery.celery_app worker --loglevel=debug -Q ${Env:CELERY_QUEUE_NAME}_process_repository,${Env:CELERY_QUEUE_NAME}_agent_tasks -E --pool=solo"
+
+# Start FastAPI application (using uvicorn instead of gunicorn for Windows compatibility)
+Write-Host "Starting momentum application..."
+uv run uvicorn app.main:app --host 0.0.0.0 --port 8001 --reload --log-level debug
 
 Write-Host "All services started successfully!"


### PR DESCRIPTION
## What does this PR do?
This PR fixes Windows-specific startup issues in the Potpie development environment, addressing PostgreSQL connection failures, service timing problems, and process management issues on Windows PowerShell.

Fixes #513 

## Changes Made
Windows Startup Script **start.ps1**
1. **Added database initialization buffer:** Added 5-second wait after PostgreSQL reports ready to prevent connection rejections
2. **Reordered service startup:** Start Celery worker before FastAPI application to ensure proper dependency handling
3. **Fixed process management:** Changed FastAPI startup from background process to foreground execution for better Windows compatibility

## Key Technical Details
**Issue:** PostgreSQL reported "ready" but still rejected connections for 15-20 seconds
**Root Cause:** Race condition between Docker container readiness and actual database initialization
**Solution:** Added Start-Sleep -Seconds 5 after pg_isready check
**Impact:** Reduces startup time from ~45+ seconds (with failures) to ~45 seconds (reliable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows compatibility for application startup process.

* **Chores**
  * Modified startup sequence to optimize initialization timing.
  * Enhanced Postgres readiness confirmation with additional delay.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->