### PR TITLE
Docs: Update README with Windows setup commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,14 @@ git pull origin main
 
 Create a `.env` file in the `potpie-ui` directory and copy the required configuration from `.env.template`.
 
+**Mac/Linux:**
 ```bash
 cp .env.template .env
 ```
-
+**Windows:**
+```bash
+copy .env.template .env
+```
 ### 4. Build the Frontend
 
 ```bash


### PR DESCRIPTION
I noticed the setup commands use cp, which fails on Windows. I added the copy command to help Windows users set up the environment faster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Windows-specific environment setup instructions for .env configuration to complement existing Mac and Linux guidelines, ensuring all users have clear platform-specific setup documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->