### PR TITLE
feat: Add work email validation for SSO authentication

### DIFF
--- a/app/modules/auth/auth_router.py
+++ b/app/modules/auth/auth_router.py
@@ -36,6 +36,14 @@ from app.modules.users.user_service import UserService
 from app.modules.utils.APIRouter import APIRouter
 from app.modules.utils.posthog_helper import PostHogClient
 
+# Import publicsuffix2 for proper domain extraction (handles multi-part TLDs)
+try:
+    from publicsuffix2 import get_sld
+    HAS_PUBLICSUFFIX2 = True
+except ImportError:
+    HAS_PUBLICSUFFIX2 = False
+    get_sld = None
+
 SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL", None)
 
 auth_router = APIRouter()
@@ -105,6 +113,10 @@ def extract_domain(email: str) -> str:
     Extracts the registrable domain from an email address using public suffix list.
     Handles multi-part TLDs correctly (e.g., .co.uk, .com.au).
     
+    Validates and normalizes the email (strip and lower), parses the domain with
+    publicsuffix2 to get the registrable domain, and returns that lowercase string
+    or empty string on invalid input.
+    
     Args:
         email: User's email address
         
@@ -116,34 +128,46 @@ def extract_domain(email: str) -> str:
         extract_domain('user@eng.company.com') -> 'company.com'
         extract_domain('user@gmail.co.uk') -> 'gmail.co.uk' (not 'co.uk')
     """
+    # Validate and normalize email input
     if not email or not isinstance(email, str):
         return ""
-
-    parts = email.lower().strip().split("@")
+    
+    # Strip whitespace and convert to lowercase
+    email = email.strip().lower()
+    if not email:
+        return ""
+    
+    # Split email to extract domain part
+    parts = email.split("@")
     if len(parts) != 2:
         return ""
-
+    
     domain = parts[1]
+    if not domain:
+        return ""
     
     # Use publicsuffix2 library to get the registrable domain (second-level domain)
     # This properly handles multi-part TLDs like .co.uk, .com.au, etc.
-    try:
-        from publicsuffix2 import get_sld
-        registrable_domain = get_sld(domain)
-        # If get_sld returns None or empty, fall back to the domain itself
-        return registrable_domain if registrable_domain else domain
-    except ImportError:
-        # Fallback to simple logic if publicsuffix2 is not available
-        # This is less accurate but won't break if the library isn't installed
-        domain_parts = domain.split('.')
-        if len(domain_parts) >= 2:
-            # Take the last two parts (e.g., 'company.com')
-            # Note: This will fail for multi-part TLDs like .co.uk
-            return '.'.join(domain_parts[-2:])
-        return domain
-    except Exception:
-        # If get_sld fails for any reason, fall back to the domain
-        return domain
+    if HAS_PUBLICSUFFIX2 and get_sld:
+        try:
+            registrable_domain = get_sld(domain)
+            # If get_sld returns None or empty, fall back to the domain itself
+            # This can happen for invalid domains or edge cases
+            return registrable_domain if registrable_domain else domain
+        except Exception:
+            # If get_sld fails for any reason (invalid domain, etc.), fall back
+            # This ensures the function always returns something reasonable
+            pass
+    
+    # Fallback to simple logic if publicsuffix2 is not available
+    # This is less accurate but won't break if the library isn't installed
+    # Note: This will fail for multi-part TLDs like .co.uk, .com.au
+    domain_parts = domain.split('.')
+    if len(domain_parts) >= 2:
+        # Take the last two parts (e.g., 'company.com')
+        return '.'.join(domain_parts[-2:])
+    
+    return domain
 
 
 def is_generic_email(email: str) -> bool:

--- a/app/modules/auth/auth_router.py
+++ b/app/modules/auth/auth_router.py
@@ -39,6 +39,7 @@ from app.modules.utils.posthog_helper import PostHogClient
 # Import publicsuffix2 for proper domain extraction (handles multi-part TLDs)
 try:
     from publicsuffix2 import get_sld
+
     HAS_PUBLICSUFFIX2 = True
 except ImportError:
     HAS_PUBLICSUFFIX2 = False
@@ -112,17 +113,17 @@ def extract_domain(email: str) -> str:
     """
     Extracts the registrable domain from an email address using public suffix list.
     Handles multi-part TLDs correctly (e.g., .co.uk, .com.au).
-    
+
     Validates and normalizes the email (strip and lower), parses the domain with
     publicsuffix2 to get the registrable domain, and returns that lowercase string
     or empty string on invalid input.
-    
+
     Args:
         email: User's email address
-        
+
     Returns:
         The registrable domain in lowercase, or empty string if invalid
-        
+
     Example:
         extract_domain('user@GmAiL.CoM') -> 'gmail.com'
         extract_domain('user@eng.company.com') -> 'company.com'
@@ -131,21 +132,21 @@ def extract_domain(email: str) -> str:
     # Validate and normalize email input
     if not email or not isinstance(email, str):
         return ""
-    
+
     # Strip whitespace and convert to lowercase
     email = email.strip().lower()
     if not email:
         return ""
-    
+
     # Split email to extract domain part
     parts = email.split("@")
     if len(parts) != 2:
         return ""
-    
+
     domain = parts[1]
     if not domain:
         return ""
-    
+
     # Use publicsuffix2 library to get the registrable domain (second-level domain)
     # This properly handles multi-part TLDs like .co.uk, .com.au, etc.
     if HAS_PUBLICSUFFIX2 and get_sld:
@@ -158,15 +159,15 @@ def extract_domain(email: str) -> str:
             # If get_sld fails for any reason (invalid domain, etc.), fall back
             # This ensures the function always returns something reasonable
             pass
-    
+
     # Fallback to simple logic if publicsuffix2 is not available
     # This is less accurate but won't break if the library isn't installed
     # Note: This will fail for multi-part TLDs like .co.uk, .com.au
-    domain_parts = domain.split('.')
+    domain_parts = domain.split(".")
     if len(domain_parts) >= 2:
         # Take the last two parts (e.g., 'company.com')
-        return '.'.join(domain_parts[-2:])
-    
+        return ".".join(domain_parts[-2:])
+
     return domain
 
 

--- a/app/modules/auth/auth_router.py
+++ b/app/modules/auth/auth_router.py
@@ -44,52 +44,52 @@ load_dotenv(override=True)
 # Blocked email domains (generic/personal email providers)
 BLOCKED_DOMAINS = {
     # Google
-    'gmail.com',
-    'googlemail.com',
+    "gmail.com",
+    "googlemail.com",
     # Microsoft
-    'outlook.com',
-    'hotmail.com',
-    'live.com',
-    'msn.com',
+    "outlook.com",
+    "hotmail.com",
+    "live.com",
+    "msn.com",
     # Yahoo
-    'yahoo.com',
-    'yahoo.co.uk',
-    'yahoo.co.in',
-    'yahoo.fr',
-    'yahoo.de',
-    'ymail.com',
-    'rocketmail.com',
+    "yahoo.com",
+    "yahoo.co.uk",
+    "yahoo.co.in",
+    "yahoo.fr",
+    "yahoo.de",
+    "ymail.com",
+    "rocketmail.com",
     # Apple
-    'icloud.com',
-    'me.com',
-    'mac.com',
+    "icloud.com",
+    "me.com",
+    "mac.com",
     # Other Popular Providers
-    'aol.com',
-    'protonmail.com',
-    'proton.me',
-    'mail.com',
-    'zoho.com',
-    'yandex.com',
-    'yandex.ru',
-    'gmx.com',
-    'gmx.de',
-    'mail.ru',
-    'fastmail.com',
-    'hushmail.com',
-    'tutanota.com',
-    'tutanota.de',
-    'rediffmail.com',
-    'inbox.com',
+    "aol.com",
+    "protonmail.com",
+    "proton.me",
+    "mail.com",
+    "zoho.com",
+    "yandex.com",
+    "yandex.ru",
+    "gmx.com",
+    "gmx.de",
+    "mail.ru",
+    "fastmail.com",
+    "hushmail.com",
+    "tutanota.com",
+    "tutanota.de",
+    "rediffmail.com",
+    "inbox.com",
     # Temporary/Disposable Email Services
-    'tempmail.com',
-    '10minutemail.com',
-    'guerrillamail.com',
-    'mailinator.com',
-    'maildrop.cc',
-    'throwaway.email',
-    'temp-mail.org',
-    'getnada.com',
-    'minuteinbox.com',
+    "tempmail.com",
+    "10minutemail.com",
+    "guerrillamail.com",
+    "mailinator.com",
+    "maildrop.cc",
+    "throwaway.email",
+    "temp-mail.org",
+    "getnada.com",
+    "minuteinbox.com",
 }
 
 
@@ -97,54 +97,54 @@ def extract_domain(email: str) -> str:
     """
     Extracts the domain from an email address (case-insensitive).
     Handles subdomains correctly - only checks root domain.
-    
+
     Args:
         email: User's email address
-        
+
     Returns:
         The domain in lowercase, or empty string if invalid
-        
+
     Example:
         extract_domain('user@GmAiL.CoM') -> 'gmail.com'
         extract_domain('user@eng.company.com') -> 'company.com'
     """
     if not email or not isinstance(email, str):
-        return ''
-    
-    parts = email.lower().strip().split('@')
+        return ""
+
+    parts = email.lower().strip().split("@")
     if len(parts) != 2:
-        return ''
-    
+        return ""
+
     domain = parts[1]
-    
+
     # For subdomains, we only check the root domain
     # e.g., eng.company.com -> company.com
     # This allows work email subdomains
-    domain_parts = domain.split('.')
+    domain_parts = domain.split(".")
     if len(domain_parts) >= 2:
         # Take the last two parts (e.g., 'company.com')
-        return '.'.join(domain_parts[-2:])
-    
+        return ".".join(domain_parts[-2:])
+
     return domain
 
 
 def is_generic_email(email: str) -> bool:
     """
     Checks if an email domain is from a generic/personal email provider.
-    
+
     Args:
         email: User's email address
-        
+
     Returns:
         True if generic email, False if work email
     """
     if not email:
         return False
-    
+
     domain = extract_domain(email)
     if not domain:
         return False
-    
+
     return domain in BLOCKED_DOMAINS
 
 
@@ -599,7 +599,7 @@ class AuthAPI:
             # Check if user already exists by email (legacy user check)
             user_service = UserService(db)
             existing_user = user_service.get_user_by_email(verified_email)
-            
+
             if is_generic_email(verified_email):
                 if not existing_user:
                     # New user with generic email - block them

--- a/app/modules/auth/auth_router.py
+++ b/app/modules/auth/auth_router.py
@@ -43,7 +43,6 @@ auth_router = APIRouter()
 load_dotenv(override=True)
 
 
-
 async def send_slack_message(message: str):
     payload = {"text": message}
     if SLACK_WEBHOOK_URL:

--- a/app/modules/auth/auth_router.py
+++ b/app/modules/auth/auth_router.py
@@ -673,22 +673,6 @@ class AuthAPI:
                 user_agent=user_agent,
             )
 
-            # Additional validation: If user was just created and has generic email, block them
-            # This is a double-check in case the above check didn't catch it
-            if response.status == "new_user" and is_generic_email(verified_email):
-                logger.warning(
-                    f"Blocked new user creation with generic email: {verified_email} via {sso_request.sso_provider}"
-                )
-                # Note: User might already be created in DB, but we'll return error
-                # In production, you might want to delete the user here
-                return JSONResponse(
-                    content={
-                        "error": "Personal email addresses are not allowed. Please use your work/corporate email to sign in.",
-                        "details": "Generic email providers (Gmail, Yahoo, Outlook, etc.) cannot be used for new signups.",
-                    },
-                    status_code=403,  # Forbidden
-                )
-
             # Send Slack notification for new users
             if response.status == "new_user":
                 await send_slack_message(

--- a/app/modules/auth/auth_router.py
+++ b/app/modules/auth/auth_router.py
@@ -104,13 +104,13 @@ def extract_domain(email: str) -> str:
     """
     Extracts the registrable domain from an email address using public suffix list.
     Handles multi-part TLDs correctly (e.g., .co.uk, .com.au).
-    
+
     Args:
         email: User's email address
-        
+
     Returns:
         The registrable domain in lowercase, or empty string if invalid
-        
+
     Example:
         extract_domain('user@GmAiL.CoM') -> 'gmail.com'
         extract_domain('user@eng.company.com') -> 'company.com'
@@ -124,22 +124,23 @@ def extract_domain(email: str) -> str:
         return ""
 
     domain = parts[1]
-    
+
     # Use publicsuffix2 library to get the registrable domain (second-level domain)
     # This properly handles multi-part TLDs like .co.uk, .com.au, etc.
     try:
         from publicsuffix2 import get_sld
+
         registrable_domain = get_sld(domain)
         # If get_sld returns None or empty, fall back to the domain itself
         return registrable_domain if registrable_domain else domain
     except ImportError:
         # Fallback to simple logic if publicsuffix2 is not available
         # This is less accurate but won't break if the library isn't installed
-        domain_parts = domain.split('.')
+        domain_parts = domain.split(".")
         if len(domain_parts) >= 2:
             # Take the last two parts (e.g., 'company.com')
             # Note: This will fail for multi-part TLDs like .co.uk
-            return '.'.join(domain_parts[-2:])
+            return ".".join(domain_parts[-2:])
         return domain
     except Exception:
         # If get_sld fails for any reason, fall back to the domain

--- a/requirements.txt
+++ b/requirements.txt
@@ -184,7 +184,7 @@ psutil==7.0.0
 psycopg-binary==3.3.2
 psycopg2-binary==2.9.11
 psycopg2-pool==1.2
-publicsuffix2==3.0.1
+publicsuffix2==2.20191221
 py-key-value-aio==0.3.0
 py-key-value-shared==0.3.0
 pyarrow==22.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -184,7 +184,7 @@ psutil==7.0.0
 psycopg-binary==3.3.2
 psycopg2-binary==2.9.11
 psycopg2-pool==1.2
-publicsuffix2==2.20191221
+tldextract==5.3.0
 py-key-value-aio==0.3.0
 py-key-value-shared==0.3.0
 pyarrow==22.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -184,6 +184,7 @@ psutil==7.0.0
 psycopg-binary==3.3.2
 psycopg2-binary==2.9.11
 psycopg2-pool==1.2
+publicsuffix2==3.0.1
 py-key-value-aio==0.3.0
 py-key-value-shared==0.3.0
 pyarrow==22.0.0


### PR DESCRIPTION
- Block new users with generic email providers (Gmail, Yahoo, Outlook, etc.)
- Block all new GitHub signups (existing users can still sign in)
- Allow legacy users with generic emails to continue using the service
- Add server-side validation in /sso/login and /signup endpoints
- Add email domain validation utilities (extract_domain, is_generic_email)
- Return 403 Forbidden with clear error messages for blocked attempts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signups via Google SSO using common personal/generic email domains are now blocked for new accounts (existing legacy accounts with such emails remain allowed).
  * New GitHub-based signups are blocked unless the GitHub provider is already linked to an existing account.
  * Blocked registration attempts return clear 403 error responses with explanatory payloads.

* **Chores**
  * Improved registrable-domain parsing for more reliable generic-email detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->