### PR TITLE
Fix Neo4j Driver Resource Leak in KG-based Tools

### DIFF
--- a/app/modules/intelligence/tools/kg_based_tools/get_code_from_node_id_tool.py
+++ b/app/modules/intelligence/tools/kg_based_tools/get_code_from_node_id_tool.py
@@ -2,14 +2,15 @@ import asyncio
 from typing import Any, Dict
 
 from langchain_core.tools import StructuredTool
-from neo4j import GraphDatabase
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
-from app.core.config_provider import config_provider
 from app.modules.code_provider.code_provider_service import CodeProviderService
 from app.modules.projects.projects_model import Project
 from app.modules.intelligence.tools.tool_utils import truncate_dict_response
+from app.modules.intelligence.tools.kg_based_tools.neo4j_driver_manager import (
+    get_neo4j_driver,
+)
 from app.modules.utils.logger import setup_logger
 
 logger = setup_logger(__name__)
@@ -38,19 +39,8 @@ class GetCodeFromNodeIdTool:
     def __init__(self, sql_db: Session, user_id: str):
         self.sql_db = sql_db
         self.user_id = user_id
-        self.neo4j_driver = self._create_neo4j_driver()
-
-    def _create_neo4j_driver(self) -> GraphDatabase.driver:
-        neo4j_config = config_provider.get_neo4j_config()
-        uri = neo4j_config.get("uri")
-        username = neo4j_config.get("username")
-        password = neo4j_config.get("password")
-        if not uri or not username or not password:
-            raise ValueError("Neo4j configuration is incomplete")
-        return GraphDatabase.driver(
-            uri,
-            auth=(username, password),
-        )
+        # Use shared driver from singleton manager - prevents resource leaks
+        self.neo4j_driver = get_neo4j_driver()
 
     async def arun(self, project_id: str, node_id: str) -> Dict[str, Any]:
         return await asyncio.to_thread(self.run, project_id, node_id)
@@ -162,10 +152,6 @@ class GetCodeFromNodeIdTool:
             return "/".join(parts[projects_index + 2 :])
         except ValueError:
             return file_path
-
-    def __del__(self):
-        if hasattr(self, "neo4j_driver"):
-            self.neo4j_driver.close()
 
 
 def get_code_from_node_id_tool(sql_db: Session, user_id: str) -> StructuredTool:

--- a/app/modules/intelligence/tools/kg_based_tools/neo4j_driver_manager.py
+++ b/app/modules/intelligence/tools/kg_based_tools/neo4j_driver_manager.py
@@ -1,0 +1,187 @@
+import atexit
+import logging
+import threading
+from typing import Optional
+
+from neo4j import GraphDatabase, Driver
+
+from app.core.config_provider import config_provider
+
+logger = logging.getLogger(__name__)
+
+
+class Neo4jDriverManager:
+    """
+    Thread-safe singleton manager for Neo4j driver connections.
+    
+    Uses lazy initialization and configures connection pooling
+    for optimal resource usage.
+    
+    Usage:
+        driver = Neo4jDriverManager.get_driver()
+        with driver.session() as session:
+            result = session.run(query, params)
+    """
+    
+    _instance: Optional["Neo4jDriverManager"] = None
+    _lock: threading.Lock = threading.Lock()
+    _driver: Optional[Driver] = None
+    
+    MAX_CONNECTION_LIFETIME = 3600
+    MAX_CONNECTION_POOL_SIZE = 50
+    CONNECTION_ACQUISITION_TIMEOUT = 60
+    
+    def __new__(cls) -> "Neo4jDriverManager":
+        """Ensure only one instance exists (singleton pattern)."""
+        if cls._instance is None:
+            with cls._lock:
+                # Double-check locking pattern
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
+        return cls._instance
+    
+    @classmethod
+    def get_driver(cls) -> Driver:
+        """
+        Get the shared Neo4j driver instance.
+        
+        Creates the driver on first call (lazy initialization).
+        Thread-safe for concurrent access.
+        
+        Returns:
+            Configured Neo4j driver with connection pooling
+            
+        Raises:
+            ValueError: If Neo4j configuration is incomplete
+            Exception: If connection to Neo4j fails
+        """
+        if cls._driver is None:
+            with cls._lock:
+                # Double-check after acquiring lock
+                if cls._driver is None:
+                    cls._driver = cls._create_driver()
+        return cls._driver
+    
+    @classmethod
+    def _create_driver(cls) -> Driver:
+        """
+        Create and configure the Neo4j driver.
+        
+        Configures connection pooling to prevent resource exhaustion
+        under high load.
+        """
+        neo4j_config = config_provider.get_neo4j_config()
+        
+        uri = neo4j_config.get("uri")
+        username = neo4j_config.get("username")
+        password = neo4j_config.get("password")
+        
+        if not uri or not username or not password:
+            raise ValueError(
+                "Neo4j configuration is incomplete. "
+                "Required: NEO4J_URI, NEO4J_USERNAME, NEO4J_PASSWORD"
+            )
+        
+        logger.info(
+            f"Creating shared Neo4j driver with pool size {cls.MAX_CONNECTION_POOL_SIZE}"
+        )
+        
+        driver = GraphDatabase.driver(
+            uri,
+            auth=(username, password),
+            max_connection_lifetime=cls.MAX_CONNECTION_LIFETIME,
+            max_connection_pool_size=cls.MAX_CONNECTION_POOL_SIZE,
+            connection_acquisition_timeout=cls.CONNECTION_ACQUISITION_TIMEOUT,
+        )
+        
+        try:
+            driver.verify_connectivity()
+            logger.info("Neo4j driver connected and verified successfully")
+        except Exception as e:
+            logger.error(f"Failed to verify Neo4j connectivity: {e}")
+            driver.close()
+            raise
+        
+        return driver
+    
+    @classmethod
+    def close(cls) -> None:
+        """
+        Close the shared driver and release all connections.
+        
+        Should be called during application shutdown.
+        Thread-safe - can be called from any thread.
+        """
+        with cls._lock:
+            if cls._driver is not None:
+                logger.info("Closing shared Neo4j driver")
+                try:
+                    cls._driver.close()
+                except Exception as e:
+                    logger.warning(f"Error closing Neo4j driver: {e}")
+                finally:
+                    cls._driver = None
+    
+    @classmethod
+    def is_connected(cls) -> bool:
+        """
+        Check if the driver is connected and healthy.
+        
+        Returns:
+            True if driver exists and can connect to Neo4j
+        """
+        if cls._driver is None:
+            return False
+        
+        try:
+            cls._driver.verify_connectivity()
+            return True
+        except Exception:
+            return False
+    
+    @classmethod
+    def get_pool_status(cls) -> dict:
+        """
+        Get current connection pool status for monitoring.
+        
+        Useful for debugging connection issues and monitoring.
+        
+        Returns:
+            Dict with pool metrics (varies by Neo4j driver version)
+        """
+        if cls._driver is None:
+            return {"initialized": False}
+        
+        return {
+            "initialized": True,
+            "max_pool_size": cls.MAX_CONNECTION_POOL_SIZE,
+            "max_connection_lifetime": cls.MAX_CONNECTION_LIFETIME,
+            "connected": cls.is_connected(),
+        }
+
+
+def get_neo4j_driver() -> Driver:
+    """
+    Convenience function to get the shared Neo4j driver.
+    
+    This is the primary interface for tools to obtain a driver.
+    
+    Example:
+        from .neo4j_driver_manager import get_neo4j_driver
+        
+        driver = get_neo4j_driver()
+        with driver.session() as session:
+            result = session.run("MATCH (n) RETURN n LIMIT 1")
+    """
+    return Neo4jDriverManager.get_driver()
+
+
+def close_neo4j_driver() -> None:
+    """
+    Close the shared Neo4j driver.
+    
+    Should be called during application shutdown.
+    """
+    Neo4jDriverManager.close()
+
+atexit.register(close_neo4j_driver)


### PR DESCRIPTION
Problem : 
Each knowledge graph tool (`GetCodeFromNodeIdTool`, `GetCodeFromMultipleNodeIdsTool`, etc.) was creating a new Neo4j driver instance in init and relying on del for cleanup. Since Python's garbage collector is non-deterministic, this caused:

- Connection pool exhaustion under load
- Memory leaks
- "Too many open connections" errors on Neo4j server

Solution : 
Introduced `Neo4jDriverManager` - a thread-safe singleton that provides a shared, connection-pooled Neo4j driver. All KG-based tools now use `get_neo4j_driver()` instead of creating individual drivers.

Changes : 

- New:  neo4j_driver_manager.py - Singleton manager with connection pooling
- Modified: 4 tool files to use the shared driver
- Added: Comprehensive test suite for the driver manager

Impact : 

- Reduces driver instances from O(n) per n requests to O(1)
- Connections managed via pooling (max 50 concurrent)
- Automatic cleanup on application shutdown via atexit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved Neo4j database connection management with centralized driver handling, thread-safe initialization, and optimized connection pooling for enhanced system stability and resource efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->