### PR TITLE
Revert prod deployment config changes from 4c05277b

### DIFF
--- a/deployment/prod/celery/Jenkinsfile_CELERY_Prod
+++ b/deployment/prod/celery/Jenkinsfile_CELERY_Prod
@@ -20,15 +20,14 @@ pipeline {
                     // Determine environment based on branch
                     def branch = env.GIT_BRANCH
 
-                    /*if (branch == "origin/dir-restruct") {
+                    if (branch == "origin/dir-restruct") {
                         env.ENVIRONMENT = 'dir-restruct'
                     } else if (branch == "origin/main"){
                         env.ENVIORNMENT = 'main'
                     } else {
                         error("Unknown branch: ${branch}. This pipeline only supports main and staging branches.")
-                    }*/
+                    }
 
-                    env.ENVIORNMENT = branch;
                     checkout scm
                     // Capture the short Git commit hash to use as the image tag
                     env.GIT_COMMIT_HASH = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
@@ -124,7 +123,7 @@ pipeline {
 
                     if (!imageDeploySucceeded) {
                         echo 'Rolling back to previous revision...'
-                        sh "kubectl rollout undo deployment/celery-api-deployment -n ${params.namespace}"
+                        sh 'kubectl rollout undo deployment/celery-api-deployment -n ${params.namespace}'
                     }
                 }
             }

--- a/deployment/prod/celery/celery-api-supervisord.conf
+++ b/deployment/prod/celery/celery-api-supervisord.conf
@@ -3,10 +3,7 @@ nodaemon=true
 loglevel=debug
 
 [program:celery]
-# Do not source /app/.env in shell: keys with hyphens (e.g. META-LLAMA_API_KEY) break bash.
-# The app and alembic load .env via load_dotenv().
-# CELERY_QUEUE_NAME should be set as Kubernetes environment variable.
-command=/bin/bash -c 'alembic upgrade heads && echo "Starting Celery Worker with New Relic..." && newrelic-admin run-program celery -A app.celery.celery_app worker --loglevel=debug -Q "${CELERY_QUEUE_NAME}_process_repository,${CELERY_QUEUE_NAME}_agent_tasks" -E --concurrency=3 --max-memory-per-child=2000000 --max-tasks-per-child=200 --optimization=fair'
+command=/bin/bash -c 'source /app/.env && alembic upgrade heads && echo "Starting Celery Worker with New Relic..." && newrelic-admin run-program celery -A app.celery.celery_app worker --loglevel=debug -Q "${CELERY_QUEUE_NAME}_process_repository,${CELERY_QUEUE_NAME}_agent_tasks" -E --concurrency=3 --max-memory-per-child=2000000 --max-tasks-per-child=200 --optimization=fair'
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout

--- a/deployment/prod/convo-server/Jenkinsfile_Convo_Prod
+++ b/deployment/prod/convo-server/Jenkinsfile_Convo_Prod
@@ -20,7 +20,7 @@ pipeline {
                     // Determine environment based on branch
                     def branch = env.GIT_BRANCH
 
-                    /*if (branch == "origin/dir-restruct") {
+                    if (branch == "origin/dir-restruct") {
                         env.ENVIRONMENT = 'dir-restruct'
                     } else if (branch == "origin/main") {
                         env.ENVIRONMENT = 'main'
@@ -28,9 +28,7 @@ pipeline {
                         env.ENVIORNMENT = 'devops'
                     } else {
                         error("Unknown branch: ${branch}. This pipeline only supports main and staging branches.")
-                    }*/
-
-                    env.ENVIORNMENT = branch
+                    }
 
                     checkout scm
                     // Capture the short Git commit hash to use as the image tag
@@ -127,7 +125,7 @@ pipeline {
 
                     if (!imageDeploySucceeded) {
                         echo 'Rolling back to previous revision...'
-                        sh "kubectl rollout undo deployment/conversation-server-deployment -n ${params.namespace}"
+                        sh 'kubectl rollout undo deployment/conversation-server-deployment -n ${params.namespace}'
                     }
                 }
             }

--- a/deployment/prod/convo-server/convo-api-supervisord.conf
+++ b/deployment/prod/convo-server/convo-api-supervisord.conf
@@ -3,9 +3,7 @@ nodaemon=true
 loglevel=debug
 
 [program:gunicorn]
-# Do not source /app/.env in shell: keys with hyphens (e.g. META-LLAMA_API_KEY) break bash.
-# The app and alembic load .env via load_dotenv().
-command=/bin/bash -c 'alembic upgrade heads && echo "Starting Gunicorn..." && newrelic-admin run-program gunicorn --workers 1 --worker-class uvicorn.workers.UvicornWorker --timeout 1800 --bind 0.0.0.0:8001 --log-level debug app.main:app'
+command=/bin/bash -c 'source /app/.env && alembic upgrade heads && echo "Starting Gunicorn..." && newrelic-admin run-program gunicorn --workers $(nproc) --worker-class uvicorn.workers.UvicornWorker --timeout 1800 --bind 0.0.0.0:8001 --log-level debug app.main:app'
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout

--- a/deployment/prod/mom-api/Jenkinsfile_API_Prod
+++ b/deployment/prod/mom-api/Jenkinsfile_API_Prod
@@ -20,15 +20,13 @@ pipeline {
                     // Determine environment based on branch
                     def branch = env.GIT_BRANCH
 
-                    /*if (branch == "origin/dir-restruct") {
+                    if (branch == "origin/dir-restruct") {
                         env.ENVIRONMENT = 'dir-restruct'
                     } else if (branch == "origin/main"){
                         env.ENVIORNMENT = 'main'
                     } else {
                         error("Unknown branch: ${branch}. This pipeline only supports main and staging branches.")
-                    }*/
-
-                    env.ENVIORNMENT = branch;
+                    }
 
                     checkout scm
                     // Capture the short Git commit hash to use as the image tag
@@ -125,7 +123,7 @@ pipeline {
 
                     if (!imageDeploySucceeded) {
                         echo 'Rolling back to previous revision...'
-                        sh "kubectl rollout undo deployment/mom-api-deployment -n ${params.namespace}"
+                        sh 'kubectl rollout undo deployment/mom-api-deployment -n ${params.namespace}'
                     }
                 }
             }

--- a/deployment/prod/mom-api/mom-api-supervisord.conf
+++ b/deployment/prod/mom-api/mom-api-supervisord.conf
@@ -3,9 +3,7 @@ nodaemon=true
 loglevel=debug
 
 [program:gunicorn]
-# Do not source /app/.env in shell: keys with hyphens (e.g. META-LLAMA_API_KEY) break bash.
-# The app and alembic load .env via load_dotenv().
-command=/bin/bash -c 'alembic upgrade heads && echo "Starting Gunicorn..." && newrelic-admin run-program gunicorn --workers 1 --worker-class uvicorn.workers.UvicornWorker --timeout 1800 --bind 0.0.0.0:8001 --log-level debug app.main:app'
+command=/bin/bash -c 'source /app/.env && alembic upgrade heads && echo "Starting Gunicorn..." && newrelic-admin run-program gunicorn --workers $(nproc) --worker-class uvicorn.workers.UvicornWorker --timeout 1800 --bind 0.0.0.0:8001 --log-level debug app.main:app'
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
Restore source /app/.env in supervisord configs to fix CELERY_QUEUE_NAME loading. The removal in PR #600 broke celery queue alignment - workers were listening on _process_repository/_agent_tasks while mom-api sent to potpieProdMicroSVC_process_repository/potpieProdMicroSVC_agent_tasks.

Also reverts Jenkinsfile changes (branch handling, rollout undo quoting).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated production deployment configurations for improved stability and resource utilization
  * Enabled dynamic worker scaling based on available CPU cores for better performance
  * Enhanced logging output with configurable log rotation and standard stream redirection
  * Refined environment variable sourcing at startup to ensure proper configuration loading
  * Standardized deployment script syntax for consistency across services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->