### PR TITLE
intelligence: add guard to skip redundant file structure fetches in QnAAgent

### DIFF
--- a/app/modules/intelligence/agents/chat_agents/system_agents/qna_agent.py
+++ b/app/modules/intelligence/agents/chat_agents/system_agents/qna_agent.py
@@ -144,12 +144,18 @@ class QnAAgent(ChatAgent):
                 f"Code context of the node_ids in query:\n {code_results}"
             )
 
-        file_structure = (
-            await self.tools_provider.file_structure_tool.fetch_repo_structure(
-                ctx.project_id
+        # Avoid redundant file structure fetches if already present in history or additional_context
+        # This reduces token usage and latency for follow-up questions
+        file_structure_marker = "File Structure of the project:"
+        if file_structure_marker not in ctx.additional_context and not any(
+            file_structure_marker in h for h in ctx.history
+        ):
+            file_structure = (
+                await self.tools_provider.file_structure_tool.fetch_repo_structure(
+                    ctx.project_id
+                )
             )
-        )
-        ctx.additional_context += f"File Structure of the project:\n {file_structure}"
+            ctx.additional_context += f"{file_structure_marker}\n {file_structure}"
 
         return ctx
 


### PR DESCRIPTION
This PR addresses issue #627 by adding a guard condition to `QnAAgent._enriched_context()` to skip the `fetch_repo_structure()` call if the file structure is already present in the conversation history or additional context.

This reduces redundant API/tunnel calls, especially during follow-up questions, which decreases latency and token overhead.

Fixes #627

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized follow-up question handling in Q&A interactions to reduce unnecessary data fetching and token usage, resulting in faster response times for subsequent queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->