### PR TITLE
fix: replace synchronous requests.post() with async httpx in slack notifications

### DIFF
--- a/app/modules/auth/auth_router.py
+++ b/app/modules/auth/auth_router.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 
-import requests
+import httpx
 from dotenv import load_dotenv
 from fastapi import Depends, Request
 from fastapi.responses import JSONResponse, Response
@@ -56,7 +56,8 @@ def _signup_response_with_custom_token(payload: dict) -> dict:
 async def send_slack_message(message: str):
     payload = {"text": message}
     if SLACK_WEBHOOK_URL:
-        requests.post(SLACK_WEBHOOK_URL, json=payload)
+        async with httpx.AsyncClient(timeout=10) as client:
+            await client.post(SLACK_WEBHOOK_URL, json=payload)
 
 
 class AuthAPI:

--- a/app/modules/utils/parse_webhook_helper.py
+++ b/app/modules/utils/parse_webhook_helper.py
@@ -1,7 +1,9 @@
-import json
+import logging
 import os
 
-import requests
+import httpx
+
+logger = logging.getLogger(__name__)
 
 
 class ParseWebhookHelper:
@@ -16,16 +18,13 @@ class ParseWebhookHelper:
 
         try:
             if self.url:
-                response = requests.post(
-                    self.url,
-                    data=json.dumps(message),
-                    headers={"Content-Type": "application/json"},
-                )
+                async with httpx.AsyncClient(timeout=10) as client:
+                    response = await client.post(self.url, json=message)
 
                 if response.status_code != 200:
-                    print(
+                    logger.warning(
                         f"Failed to send message to Slack: {response.status_code} {response.text}"
                     )
 
         except Exception as e:
-            print(f"Error sending message to Slack: {e}")
+            logger.error(f"Error sending message to Slack: {e}")


### PR DESCRIPTION
  ## Summary

  - Replace synchronous `requests.post()` with `httpx.AsyncClient` in two async functions
    that were blocking the FastAPI event loop
  - Add 10-second timeout to both calls
  - Replace `print()` with proper `logger` calls in `parse_webhook_helper.py`

  Fixes #631

  ## Files changed

  - `app/modules/auth/auth_router.py` — `send_slack_message()`
  - `app/modules/utils/parse_webhook_helper.py` — `send_slack_notification()`
  
  
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error logging for webhook notifications
  * Improved webhook delivery reliability and error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->