### PR TITLE
fix: sync/timeout fixes for auth, GitHub, parsing, Slack

### DIFF
--- a/app/modules/auth/auth_service.py
+++ b/app/modules/auth/auth_service.py
@@ -24,6 +24,7 @@ class AuthService:
                 "password": password,
                 "returnSecureToken": True,
             },
+            timeout=30,
         )
 
         try:

--- a/app/modules/code_provider/github/github_service.py
+++ b/app/modules/code_provider/github/github_service.py
@@ -80,7 +80,7 @@ class GithubService:
             "Authorization": f"Bearer {jwt}",
             "X-GitHub-Api-Version": "2022-11-28",
         }
-        response = requests.get(url, headers=headers)
+        response = requests.get(url, headers=headers, timeout=30)
         if response.status_code == 401:
             detail = (
                 f"Failed to get installation for {repo_name}: GitHub returned 401 (JWT could not be decoded). "

--- a/app/modules/utils/parse_webhook_helper.py
+++ b/app/modules/utils/parse_webhook_helper.py
@@ -20,6 +20,7 @@ class ParseWebhookHelper:
                     self.url,
                     data=json.dumps(message),
                     headers={"Content-Type": "application/json"},
+                    timeout=30,
                 )
 
                 if response.status_code != 200:


### PR DESCRIPTION
Auth: login and Slack
- auth_service: add timeout=30 to requests.post (Firebase login)
- auth_router: wrap auth_handler.login in asyncio.to_thread; send_slack_message uses asyncio.to_thread(requests.post, ..., timeout=30)
- 
GitHub: get_github_repo_details
- github_service: add timeout=30 to requests.get (installation API)

Parsing status: avoid blocking event loop (Issue #639)
- parsing_controller: run fetch_parsing_status DB query in thread via _query_parsing_status_sync + asyncio.to_thread

Slack parse webhook
- parse_webhook_helper: add timeout=30 to requests.post