### PR TITLE
fix: use AsyncSession in fetch_parsing_status to prevent event loop blocking

### DIFF
--- a/app/modules/parsing/graph_construction/parsing_controller.py
+++ b/app/modules/parsing/graph_construction/parsing_controller.py
@@ -396,7 +396,7 @@ class ParsingController:
 
     @staticmethod
     async def fetch_parsing_status(
-        project_id: str, db: Session, user: Dict[str, Any]
+        project_id: str, db: AsyncSession, user: Dict[str, Any]
     ):
         try:
             project_query = (
@@ -415,7 +415,7 @@ class ParsingController:
                 .limit(1)
             )
 
-            result = db.execute(project_query)
+            result = await db.execute(project_query)
             project_status = result.scalars().first()
 
             if not project_status:

--- a/app/modules/parsing/graph_construction/parsing_router.py
+++ b/app/modules/parsing/graph_construction/parsing_router.py
@@ -1,7 +1,8 @@
 from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
-from app.core.database import get_db
+from app.core.database import get_async_db, get_db
 from app.modules.auth.auth_service import AuthService
 from app.modules.parsing.graph_construction.parsing_controller import ParsingController
 from app.modules.parsing.graph_construction.parsing_schema import (
@@ -24,7 +25,9 @@ async def parse_directory(
 
 @router.get("/parsing-status/{project_id}")
 async def get_parsing_status(
-    project_id: str, db: Session = Depends(get_db), user=Depends(AuthService.check_auth)
+    project_id: str,
+    db: AsyncSession = Depends(get_async_db),
+    user=Depends(AuthService.check_auth),
 ):
     return await ParsingController.fetch_parsing_status(project_id, db, user)
 
@@ -32,7 +35,7 @@ async def get_parsing_status(
 @router.post("/parsing-status")
 async def get_parsing_status_by_repo(
     request: ParsingStatusRequest,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
     user=Depends(AuthService.check_auth),
 ):
     return await ParsingController.fetch_parsing_status_by_repo(request, db, user)


### PR DESCRIPTION
## Summary

Fixes #639

`fetch_parsing_status` was declared `async` but used a synchronous SQLAlchemy `Session`, which blocks the event loop on every database call. Under concurrent load this serializes requests and degrades API performance.

## Changes

- Changed `fetch_parsing_status` in `parsing_controller.py` to accept `AsyncSession` instead of `Session`
- Added `await` to the `db.execute(project_query)` call inside the method
- Updated the `/parsing-status/{project_id}` route in `parsing_router.py` to inject `AsyncSession` via `get_async_db` instead of the synchronous `get_db`
- Updated the `/parsing-status` POST route in `parsing_router.py` the same way, since `fetch_parsing_status_by_repo` already expected `AsyncSession`

## Reference

The adjacent `fetch_parsing_status_by_repo` method in the same file already implements this pattern correctly and was used as the reference implementation. Both methods now follow the same async database access pattern.

## Testing

- Verified the method signature matches the async pattern used throughout the codebase
- The `get_async_db` dependency is already defined in `app/core/database.py` and used by other routes
- No new dependencies were introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced database operations for parsing status endpoints with improved asynchronous handling to optimize performance and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->