### PR TITLE
Fix inconsistent RepoManager base path in RepositoriesResource (Closes #640)

### DIFF
--- a/potpie/resources/repositories.py
+++ b/potpie/resources/repositories.py
@@ -60,7 +60,9 @@ class RepositoriesResource(BaseResource):
         try:
             from app.modules.repo_manager import RepoManager
 
-            self._repo_manager = RepoManager()
+            self._repo_manager = RepoManager(
+                repos_base_path=self._config.repos_base_path
+            )
             logger.info("RepositoriesResource: RepoManager initialized")
             return self._repo_manager
         except Exception as e:


### PR DESCRIPTION
RepositoriesResource initialized RepoManager without passing
RuntimeConfig.repos_base_path, causing worktree creation to use
a different repo directory than parsing/runtime flows.

This change wires repos_base_path into RepoManager initialization
so all runtime components use the same repository base path.

Closes #640

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository base path configuration to ensure proper settings are applied from configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->