### PR TITLE
Fix: duplicate_graph defined at module level instead of as ParsingService method

### DIFF
--- a/app/modules/parsing/graph_construction/parsing_service.py
+++ b/app/modules/parsing/graph_construction/parsing_service.py
@@ -618,93 +618,93 @@ class ParsingService:
             )
 
 
-async def duplicate_graph(self, old_repo_id: str, new_repo_id: str):
-    await self.search_service.clone_search_indices(old_repo_id, new_repo_id)
-    node_batch_size = 3000  # Fixed batch size for nodes
-    relationship_batch_size = 3000  # Fixed batch size for relationships
-    try:
-        # Step 1: Fetch and duplicate nodes in batches
-        with self.inference_service.driver.session() as session:
-            offset = 0
-            while True:
-                nodes_query = """
-                    MATCH (n:NODE {repoId: $old_repo_id})
-                    RETURN n.node_id AS node_id, n.text AS text, n.file_path AS file_path,
-                           n.start_line AS start_line, n.end_line AS end_line, n.name AS name,
-                           COALESCE(n.docstring, '') AS docstring,
-                           COALESCE(n.embedding, []) AS embedding,
-                           labels(n) AS labels
-                    SKIP $offset LIMIT $limit
-                    """
-                nodes_result = session.run(
-                    nodes_query,
-                    old_repo_id=old_repo_id,
-                    offset=offset,
-                    limit=node_batch_size,
-                )
-                nodes = [dict(record) for record in nodes_result]
+    async def duplicate_graph(self, old_repo_id: str, new_repo_id: str):
+        await self.search_service.clone_search_indices(old_repo_id, new_repo_id)
+        node_batch_size = 3000  # Fixed batch size for nodes
+        relationship_batch_size = 3000  # Fixed batch size for relationships
+        try:
+            # Step 1: Fetch and duplicate nodes in batches
+            with self.inference_service.driver.session() as session:
+                offset = 0
+                while True:
+                    nodes_query = """
+                        MATCH (n:NODE {repoId: $old_repo_id})
+                        RETURN n.node_id AS node_id, n.text AS text, n.file_path AS file_path,
+                               n.start_line AS start_line, n.end_line AS end_line, n.name AS name,
+                               COALESCE(n.docstring, '') AS docstring,
+                               COALESCE(n.embedding, []) AS embedding,
+                               labels(n) AS labels
+                        SKIP $offset LIMIT $limit
+                        """
+                    nodes_result = session.run(
+                        nodes_query,
+                        old_repo_id=old_repo_id,
+                        offset=offset,
+                        limit=node_batch_size,
+                    )
+                    nodes = [dict(record) for record in nodes_result]
 
-                if not nodes:
-                    break
+                    if not nodes:
+                        break
 
-                # Insert nodes under the new repo ID, preserving labels, docstring, and embedding
-                create_query = """
-                    UNWIND $batch AS node
-                    CALL apoc.create.node(node.labels, {
-                        repoId: $new_repo_id,
-                        node_id: node.node_id,
-                        text: node.text,
-                        file_path: node.file_path,
-                        start_line: node.start_line,
-                        end_line: node.end_line,
-                        name: node.name,
-                        docstring: node.docstring,
-                        embedding: node.embedding
-                    }) YIELD node AS new_node
-                    RETURN new_node
-                    """
-                session.run(create_query, new_repo_id=new_repo_id, batch=nodes)
-                offset += node_batch_size
+                    # Insert nodes under the new repo ID, preserving labels, docstring, and embedding
+                    create_query = """
+                        UNWIND $batch AS node
+                        CALL apoc.create.node(node.labels, {
+                            repoId: $new_repo_id,
+                            node_id: node.node_id,
+                            text: node.text,
+                            file_path: node.file_path,
+                            start_line: node.start_line,
+                            end_line: node.end_line,
+                            name: node.name,
+                            docstring: node.docstring,
+                            embedding: node.embedding
+                        }) YIELD node AS new_node
+                        RETURN new_node
+                        """
+                    session.run(create_query, new_repo_id=new_repo_id, batch=nodes)
+                    offset += node_batch_size
 
-        # Step 2: Fetch and duplicate relationships in batches
-        with self.inference_service.driver.session() as session:
-            offset = 0
-            while True:
-                relationships_query = """
-                    MATCH (n:NODE {repoId: $old_repo_id})-[r]->(m:NODE)
-                    RETURN n.node_id AS start_node_id, type(r) AS relationship_type, m.node_id AS end_node_id
-                    SKIP $offset LIMIT $limit
-                    """
-                relationships_result = session.run(
-                    relationships_query,
-                    old_repo_id=old_repo_id,
-                    offset=offset,
-                    limit=relationship_batch_size,
-                )
-                relationships = [dict(record) for record in relationships_result]
+            # Step 2: Fetch and duplicate relationships in batches
+            with self.inference_service.driver.session() as session:
+                offset = 0
+                while True:
+                    relationships_query = """
+                        MATCH (n:NODE {repoId: $old_repo_id})-[r]->(m:NODE)
+                        RETURN n.node_id AS start_node_id, type(r) AS relationship_type, m.node_id AS end_node_id
+                        SKIP $offset LIMIT $limit
+                        """
+                    relationships_result = session.run(
+                        relationships_query,
+                        old_repo_id=old_repo_id,
+                        offset=offset,
+                        limit=relationship_batch_size,
+                    )
+                    relationships = [dict(record) for record in relationships_result]
 
-                if not relationships:
-                    break
+                    if not relationships:
+                        break
 
-                relationship_query = """
-                    UNWIND $batch AS relationship
-                    MATCH (a:NODE {repoId: $new_repo_id, node_id: relationship.start_node_id}),
-                          (b:NODE {repoId: $new_repo_id, node_id: relationship.end_node_id})
-                    CALL apoc.create.relationship(a, relationship.relationship_type, {}, b) YIELD rel
-                    RETURN rel
-                    """
-                session.run(
-                    relationship_query, new_repo_id=new_repo_id, batch=relationships
-                )
-                offset += relationship_batch_size
+                    relationship_query = """
+                        UNWIND $batch AS relationship
+                        MATCH (a:NODE {repoId: $new_repo_id, node_id: relationship.start_node_id}),
+                              (b:NODE {repoId: $new_repo_id, node_id: relationship.end_node_id})
+                        CALL apoc.create.relationship(a, relationship.relationship_type, {}, b) YIELD rel
+                        RETURN rel
+                        """
+                    session.run(
+                        relationship_query, new_repo_id=new_repo_id, batch=relationships
+                    )
+                    offset += relationship_batch_size
 
-        logger.info(
-            f"Successfully duplicated graph from {old_repo_id} to {new_repo_id}"
-        )
+            logger.info(
+                f"Successfully duplicated graph from {old_repo_id} to {new_repo_id}"
+            )
 
-    except Exception:
-        logger.exception(
-            "Error duplicating graph",
-            old_repo_id=old_repo_id,
-            new_repo_id=new_repo_id,
-        )
+        except Exception:
+            logger.exception(
+                "Error duplicating graph",
+                old_repo_id=old_repo_id,
+                new_repo_id=new_repo_id,
+            )

--- a/app/modules/parsing/graph_construction/parsing_service.py
+++ b/app/modules/parsing/graph_construction/parsing_service.py
@@ -619,10 +619,10 @@ class ParsingService:
 
 
     async def duplicate_graph(self, old_repo_id: str, new_repo_id: str):
-        await self.search_service.clone_search_indices(old_repo_id, new_repo_id)
         node_batch_size = 3000  # Fixed batch size for nodes
         relationship_batch_size = 3000  # Fixed batch size for relationships
         try:
+            await self.search_service.clone_search_indices(old_repo_id, new_repo_id)
             # Step 1: Fetch and duplicate nodes in batches
             with self.inference_service.driver.session() as session:
                 offset = 0

--- a/app/modules/parsing/graph_construction/parsing_service.py
+++ b/app/modules/parsing/graph_construction/parsing_service.py
@@ -702,9 +702,12 @@ class ParsingService:
                 f"Successfully duplicated graph from {old_repo_id} to {new_repo_id}"
             )
 
-        except Exception:
+        except Exception as e:
             logger.exception(
                 "Error duplicating graph",
                 old_repo_id=old_repo_id,
                 new_repo_id=new_repo_id,
             )
+            raise ParsingServiceError(
+                f"Failed to duplicate graph from {old_repo_id} to {new_repo_id}: {e}"
+            ) from e

--- a/tests/unit/parsing/test_parsing_service_method.py
+++ b/tests/unit/parsing/test_parsing_service_method.py
@@ -1,0 +1,17 @@
+"""
+Regression test for duplicate_graph indentation bug.
+
+duplicate_graph was defined at module level (0 indentation) instead of
+inside the ParsingService class (4-space indent), making it an unreachable
+standalone function rather than an instance method. Any caller doing
+`service.duplicate_graph(...)` would get AttributeError at runtime.
+"""
+
+from app.modules.parsing.graph_construction.parsing_service import ParsingService
+
+
+def test_duplicate_graph_is_a_method_of_parsing_service():
+    assert hasattr(ParsingService, "duplicate_graph"), (
+        "duplicate_graph is not a method of ParsingService. "
+        "It is defined at module level due to missing indentation."
+    )


### PR DESCRIPTION
## Summary

Fixes a silent structural bug where `duplicate_graph` was accidentally defined
as a module-level function instead of as a method of the `ParsingService` class,
making it completely unreachable through normal usage.

## Root Cause

In `app/modules/parsing/graph_construction/parsing_service.py`, the
`duplicate_graph` function was defined at **column 0** (no indentation), placing
it outside the `ParsingService` class body. Every other method in the class is
correctly indented at 4 spaces.

```python
# BEFORE (broken) — defined at module level, outside the class
async def duplicate_graph(self, old_repo_id: str, new_repo_id: str):
    await self.search_service.clone_search_indices(old_repo_id, new_repo_id)
    ...

# AFTER (fixed) — correctly indented as a class method
    async def duplicate_graph(self, old_repo_id: str, new_repo_id: str):
        await self.search_service.clone_search_indices(old_repo_id, new_repo_id)
        ...
```
## What Breaks at Runtime
Two failure modes result from this bug:

1. `AttributeError` **on the class** - Any caller doing
`service.duplicate_graph(old_id, new_id)` on a `ParsingService` instance
would immediately get:


`AttributeError: 'ParsingService' object has no attribute 'duplicate_graph'`

because the method simply does not exist on the class.

2. `AttributeError` **inside the function** — If somehow called directly as a
standalone function (e.g. `duplicate_graph(some_obj, old_id, new_id)`), both
`self.search_service` and `self.inference_service` would raise `AttributeError`
unless the caller manually passed a `ParsingService` instance as the first
argument — which is not how it was ever intended to be called.

The function references `self.search_service` (line 622) and
`self.inference_service` (lines 627, 670) — both are instance attributes set in
`ParsingService.__init__` - confirming it was always intended to be a class method.

## Fix
Re-indented the entire `duplicate_graph` function body (lines 621–711) by 4
spaces so it is correctly nested inside the `ParsingService` class.

## Test Added
Added a regression test in `tests/unit/parsing/test_parsing_service_method.py`
that directly proves the bug and guards against regression:


`def test_duplicate_graph_is_a_method_of_parsing_service():
    assert hasattr(ParsingService, "duplicate_graph"), (
        "duplicate_graph is not a method of ParsingService. "
        "It is defined at module level due to missing indentation."
    )`

This test **fails** on the original code and **passes** after the fix. It requires
no external dependencies (no database, no Neo4j, no mocks) — it purely validates
class structure.

## Files Changed
- `app/modules/parsing/graph_construction/parsing_service.py` - indentation fix
- `tests/unit/parsing/test_parsing_service_method.py` - new regression test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of repository graph duplication with robust error propagation and clearer diagnostics for failures.

* **Tests**
  * Added regression tests to verify graph duplication behavior and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->