### PR TITLE
fix: remove DEBUG log statements left at INFO/WARNING/ERROR level

### DIFF
--- a/app/modules/users/user_service.py
+++ b/app/modules/users/user_service.py
@@ -120,19 +120,14 @@ class UserService:
             return None
 
     def get_user_id_by_email(self, email: str) -> str:
-        logger.info(f"DEBUG: get_user_id_by_email called for email: {email}")
         try:
             user = self.db.query(User).filter(User.email == email).first()
             if user:
-                logger.info(
-                    f"DEBUG: Found user with uid: {user.uid} for email: {email}"
-                )
                 return user.uid
             else:
-                logger.warning(f"DEBUG: No user found for email: {email}")
                 return None
         except Exception as e:
-            logger.error(f"DEBUG: Error fetching user ID by email {email}: {e}")
+            logger.error(f"Error fetching user ID by email: {e}")
             return None
 
     async def get_user_by_email(self, email: str) -> User:
@@ -152,18 +147,15 @@ class UserService:
             return None
 
     def get_user_ids_by_emails(self, emails: List[str]) -> List[str]:
-        logger.info(f"DEBUG: get_user_ids_by_emails called for emails: {emails}")
         try:
             users = self.db.query(User).filter(User.email.in_(emails)).all()
             if users:
                 user_ids = [user.uid for user in users]
-                logger.info(f"DEBUG: Found user IDs: {user_ids} for emails: {emails}")
                 return user_ids
             else:
-                logger.warning(f"DEBUG: No users found for emails: {emails}")
                 return None
         except Exception as e:
-            logger.error(f"DEBUG: Error fetching user ID by emails {emails}: {e}")
+            logger.error(f"Error fetching user IDs by emails: {e}")
             return None
 
     async def get_user_profile_pic(self, uid: str) -> UserProfileResponse:


### PR DESCRIPTION
Fixes #633

## What

Removes 15 `DEBUG:` prefixed log statements from `auth_service.py` and 
`user_service.py` that were accidentally logged at `INFO`, `WARNING`, and 
`ERROR` level instead of `DEBUG`, causing them to appear in production logs.

## Changes

- **`app/modules/auth/auth_service.py`** — removed 7 statements, including
  the security issue on line 104 where the first 20 characters of a Firebase
  auth token were being written to logs at INFO level on every authenticated
  request
- **`app/modules/users/user_service.py`** — removed 8 statements that were
  leaking user emails and UIDs (PII) into production logs on every user lookup

## Why

These were debug statements using `logging.info/warning/error("DEBUG: ...")`
instead of `logging.debug(...)`, so they bypassed log level filtering and ran
in production. Standard auth and user lookup operations don't need verbose
logging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unnecessary debug logging statements from authentication and user management services.
  * Enhanced error handling with clearer diagnostic messages for different exception types.
  * Improved separation of error logging across service methods.
  * All existing functionality preserved with cleaner internal logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->