### PR TITLE
fix(auth): change isDevelopmentMode default from "enabled" to "disabled"

### DIFF
--- a/app/modules/auth/api_key_service.py
+++ b/app/modules/auth/api_key_service.py
@@ -24,7 +24,7 @@ class APIKeyService:
     def get_client_and_project():
         """Get Secret Manager client and project ID based on environment."""
         # Check if development mode is enabled
-        is_dev_mode = os.getenv("isDevelopmentMode", "enabled") == "enabled"
+        is_dev_mode = os.getenv("isDevelopmentMode", "disabled") == "enabled"
         if is_dev_mode:
             logger.info("Development mode enabled - skipping GCP Secret Manager")
             return None, None


### PR DESCRIPTION
## Summary

`os.getenv("isDevelopmentMode", "enabled")` in `api_key_service.py` means any deployment that omits this env var silently runs in development mode — bypassing Firebase authentication and GCP Secret Manager entirely, falling back to local Fernet-only key storage with no auth enforcement.

All other call sites in the codebase already use the safe pattern:
```python
os.getenv("isDevelopmentMode") == "enabled"   # falsy/False when unset
```

This PR aligns `api_key_service.py` with that convention.

## Change

```diff
- is_dev_mode = os.getenv("isDevelopmentMode", "enabled") == "enabled"
+ is_dev_mode = os.getenv("isDevelopmentMode", "disabled") == "enabled"
```

One character change. No logic change for deployments that explicitly set the env var either way.

## Impact

| Scenario | Before | After |
|---|---|---|
| `isDevelopmentMode` not set | dev mode ON (bypass auth) | dev mode OFF (correct) |
| `isDevelopmentMode=enabled` | dev mode ON | dev mode ON |
| `isDevelopmentMode=disabled` | dev mode OFF | dev mode OFF |

## Test plan

- [ ] Deploy without `isDevelopmentMode` set — GCP Secret Manager should be used, auth should be enforced
- [ ] Set `isDevelopmentMode=enabled` explicitly — behaviour unchanged (dev mode active)
- [ ] Set `isDevelopmentMode=disabled` explicitly — behaviour unchanged (dev mode inactive)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Development mode is now disabled by default. Previously, development mode was automatically enabled by default, which could potentially pose security and stability risks in production environments. Users must now explicitly configure the appropriate environment variable to activate development mode, ensuring the application runs in a production-ready state unless intentionally configured otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->