### PR TITLE
fix: truncate stack traces to 10 lines in production logs

### DIFF
--- a/app/modules/utils/logger.py
+++ b/app/modules/utils/logger.py
@@ -131,7 +131,10 @@ def production_log_sink(message):
                 else str(exc.get("type", "Exception"))
             ),
             "value": filter_sensitive_data(str(exc.get("value", ""))),
-            "traceback": filter_sensitive_data(str(exc.get("traceback", ""))),
+            "traceback": filter_sensitive_data(
+                "
+".join(str(exc.get("traceback", "")).splitlines()[:10])
+            ),
         }
 
     # Build flat JSON structure - easier for log parsers


### PR DESCRIPTION
Closes #675

Truncates stack traces to 10 lines before filtering to prevent excessively large log entries in production. Implements the fix referenced in #645.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized error logging to reduce file size by truncating traceback content to the most relevant lines.
  * Enhanced security by ensuring sensitive data redaction occurs efficiently after traceback processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->