### PR TITLE
feat: Add CLI for local development usage (#224)

### DIFF
--- a/potpie/cli.py
+++ b/potpie/cli.py
@@ -39,15 +39,27 @@ CONFIG_FILE = CONFIG_DIR / "config.json"
 def load_config() -> dict:
     """Load CLI configuration."""
     if CONFIG_FILE.exists():
-        with open(CONFIG_FILE) as f:
-            return json.load(f)
+        try:
+            with open(CONFIG_FILE) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError, IOError) as e:
+            print(f"⚠️  Config file is invalid/unreadable: {e}")
+            print("   Using empty configuration.")
+            return {}
     return {}
 
 
 def save_config(config: dict):
     """Save CLI configuration."""
+    import os
+    
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    with open(CONFIG_FILE, "w") as f:
+    # Set secure permissions for config directory
+    os.chmod(CONFIG_DIR, 0o700)
+    
+    # Write config file with secure permissions
+    fd = os.open(CONFIG_FILE, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, 'w') as f:
         json.dump(config, f, indent=2)
 
 
@@ -159,13 +171,38 @@ def cmd_stop(args):
 
 
 def cmd_status(args):
-    """Check server status."""
+    """Check server status and project details."""
     client = PotPieClient()
     try:
-        # Try to list projects as a health check
+        # Check server health
         result = client.request("GET", "/projects/list")
         print(f"✅ Server is running at {client.base_url}")
-        print(f"   Projects: {len(result) if isinstance(result, list) else 'N/A'}")
+        
+        if isinstance(result, list):
+            print(f"📊 Projects: {len(result)}")
+            
+            # Show project details if requested
+            if args.project_id:
+                for project in result:
+                    if project.get("project_id") == args.project_id or project.get("name") == args.project_id:
+                        print(f"\n📋 Project: {project.get('name', args.project_id)}")
+                        print(f"   ID: {project.get('project_id')}")
+                        print(f"   Status: {project.get('status', 'unknown')}")
+                        print(f"   Created: {project.get('created_at', 'N/A')}")
+                        print(f"   Updated: {project.get('updated_at', 'N/A')}")
+                        break
+                else:
+                    print(f"\n❌ Project not found: {args.project_id}")
+            else:
+                # Show summary
+                status_counts = {}
+                for project in result:
+                    status = project.get('status', 'unknown')
+                    status_counts[status] = status_counts.get(status, 0) + 1
+                
+                print(f"   Status summary: {', '.join([f'{k}: {v}' for k, v in status_counts.items()])}")
+        else:
+            print(f"   Projects: N/A")
     except SystemExit:
         pass
     finally:
@@ -257,6 +294,22 @@ def cmd_chat(args):
     print(f"💬 Starting chat session")
     print(f"   Project: {project_id}")
     print(f"   Agent: {agent_id}")
+
+    # Preflight check: verify project exists and is ready
+    try:
+        project_result = client.request("GET", f"/projects/{project_id}")
+        project_status = project_result.get("status", "unknown")
+        
+        if project_status not in ("ready", "completed", "success"):
+            print(f"\n❌ Project is not ready for chatting.")
+            print(f"   Current status: {project_status}")
+            print(f"   Please wait for parsing to complete or check with: potpie status")
+            return
+    except Exception as e:
+        print(f"\n❌ Failed to verify project: {e}")
+        print(f"   Project ID may be invalid or server unavailable.")
+        return
+
     print(f"   Type 'quit' or Ctrl+C to exit.\n")
 
     # Create conversation
@@ -368,9 +421,12 @@ def cmd_config(args):
 
     if args.set_key:
         config = load_config()
+        # Mask key in output for security
+        masked_key = args.set_key[:4] + "..." + args.set_key[-4:] if len(args.set_key) > 8 else "***"
         config["api_key"] = args.set_key
         save_config(config)
-        print("✅ API key saved.")
+        print(f"✅ API key saved ({masked_key}).")
+        print("   Note: API keys are stored with file permissions 600.")
 
     if not args.set_url and not args.set_key:
         config = load_config()
@@ -378,10 +434,13 @@ def cmd_config(args):
         print(f"  Server URL: {config.get('base_url', DEFAULT_BASE_URL)}")
         key = config.get("api_key", DEFAULT_API_KEY)
         if key:
-            print(f"  API Key: {key[:8]}...")
+            # Show masked API key for security
+            masked_key = key[:4] + "..." + key[-4:] if len(key) > 8 else "***"
+            print(f"  API Key: {masked_key}")
         else:
             print(f"  API Key: (not set)")
         print(f"\n  Config file: {CONFIG_FILE}")
+        print(f"  Config permissions: {oct(CONFIG_FILE.stat().st_mode)[-3:] if CONFIG_FILE.exists() else 'N/A'}")
 
 
 # ─── Main ────────────────────────────────────────────────────────────────────
@@ -407,6 +466,7 @@ def main():
 
     # status
     p_status = subparsers.add_parser("status", help="Check server status")
+    p_status.add_argument("project_id", nargs="?", help="Optional project ID to show details")
     p_status.set_defaults(func=cmd_status)
 
     # parse

--- a/potpie/cli.py
+++ b/potpie/cli.py
@@ -96,7 +96,12 @@ def get_headers() -> dict:
 
 def resolve_compose_file(compose_arg: Optional[str]) -> Path:
     """Resolve compose.yaml path from argument or default locations."""
-    compose_file = Path(compose_arg or DEFAULT_COMPOSE_FILE)
+    if compose_arg:
+        compose_file = Path(compose_arg)
+        if not compose_file.exists():
+            raise PotPieError(f"Compose file not found: {compose_file}")
+        return compose_file
+    compose_file = Path(DEFAULT_COMPOSE_FILE)
     if not compose_file.exists():
         cli_dir = Path(__file__).parent.parent
         compose_file = cli_dir / DEFAULT_COMPOSE_FILE
@@ -110,7 +115,7 @@ class PotPieClient:
         self.base_url = (base_url or get_base_url()).rstrip("/")
         if httpx is None:
             raise ImportError("httpx is required: pip install httpx")
-        self.client = httpx.Client(timeout=60.0, headers=get_headers())
+        self.client = httpx.Client(headers=get_headers())
 
     def request(self, method: str, path: str, **kwargs) -> dict:
         """Make an API request."""
@@ -262,7 +267,9 @@ def cmd_parse(args):
                     ["git", "ls-remote", "--heads", repo_path, branch],
                     capture_output=True, text=True, timeout=15,
                 )
-                if result.returncode != 0 or branch not in result.stdout:
+                if result.returncode != 0:
+                    raise PotPieError(f"git ls-remote failed: {result.stderr.strip() or result.stdout.strip()}")
+                if branch not in result.stdout:
                     raise PotPieError(f"Branch not found: {branch}")
             else:
                 result = subprocess.run(
@@ -270,9 +277,11 @@ def cmd_parse(args):
                     capture_output=True, text=True, timeout=15,
                 )
                 if result.returncode != 0:
-                    raise PotPieError(f"Not a valid git repository: {repo_path}")
+                    raise PotPieError(f"git ls-remote failed: {result.stderr.strip() or result.stdout.strip()}")
         except FileNotFoundError:
             raise PotPieError("git not found. Please install git.")
+        except subprocess.TimeoutExpired:
+            raise PotPieError("git ls-remote timed out. Check your network or the repository URL.")
 
     # Get repo name from path
     repo_name = Path(repo_path).name if not repo_path.startswith(("http", "git@")) else repo_path.split("/")[-1].replace(".git", "")
@@ -346,6 +355,7 @@ def cmd_chat(args):
     client = PotPieClient()
     project_id = args.project_id
     agent_id = args.agent or "codebase_qna_agent"
+    branch = getattr(args, "branch", None)
 
     try:
         print("💬 Starting chat session")
@@ -373,10 +383,13 @@ def cmd_chat(args):
         print("   Type 'quit' or Ctrl+C to exit.\n")
 
         # Create conversation
-        conv_result = client.request("POST", "/conversations/", json={
+        conv_payload = {
             "project_ids": [project_id],
             "agent_ids": [agent_id],
-        })
+        }
+        if branch:
+            conv_payload["branch"] = branch
+        conv_result = client.request("POST", "/conversations/", json=conv_payload)
         conversation_id = conv_result.get("conversation_id")
         print(f"   Session ID: {conversation_id}\n")
 
@@ -540,6 +553,7 @@ def main():
     p_chat = subparsers.add_parser("chat", help="Interactive chat with an agent")
     p_chat.add_argument("project_id", help="Project ID to chat about")
     p_chat.add_argument("--agent", "-a", help="Agent ID (default: codebase_qna_agent)")
+    p_chat.add_argument("--branch", "-b", help="Branch name")
     p_chat.set_defaults(func=cmd_chat)
 
     # projects

--- a/potpie/cli.py
+++ b/potpie/cli.py
@@ -69,6 +69,8 @@ def save_config(config: dict):
     fd = os.open(CONFIG_FILE, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     with os.fdopen(fd, 'w') as f:
         json.dump(config, f, indent=2)
+    # Force permissions in case file already existed with looser mode
+    os.chmod(CONFIG_FILE, 0o600)
 
 
 def get_base_url() -> str:
@@ -149,7 +151,10 @@ def cmd_start(args):
         cmd.append("--build")
 
     print(f"   Running: {' '.join(cmd)}")
-    result = subprocess.run(cmd, capture_output=False, check=False)
+    try:
+        result = subprocess.run(cmd, capture_output=False, check=False)
+    except FileNotFoundError:
+        raise PotPieError("docker not found. Please install Docker.")
 
     if result.returncode == 0:
         print("\n✅ PotPie server started!")
@@ -170,7 +175,10 @@ def cmd_stop(args):
     if args.volumes:
         cmd.append("-v")
 
-    result = subprocess.run(cmd, check=False)
+    try:
+        result = subprocess.run(cmd, check=False)
+    except FileNotFoundError:
+        raise PotPieError("docker not found. Please install Docker.")
     if result.returncode == 0:
         print("✅ PotPie server stopped.")
     else:
@@ -236,13 +244,35 @@ def cmd_parse(args):
             raise PotPieError(f"Not a git repository: {local_path}")
         # Validate branch if specified
         if branch:
-            result = subprocess.run(
-                ["git", "-C", str(local_path), "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}"],
-                capture_output=True,
-            )
+            try:
+                result = subprocess.run(
+                    ["git", "-C", str(local_path), "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}"],
+                    capture_output=True,
+                )
+            except FileNotFoundError:
+                raise PotPieError("git not found. Please install git.")
             if result.returncode != 0:
                 raise PotPieError(f"Branch not found: {branch}")
         repo_path = str(local_path)
+    else:
+        # Remote URL validation
+        try:
+            if branch:
+                result = subprocess.run(
+                    ["git", "ls-remote", "--heads", repo_path, branch],
+                    capture_output=True, text=True, timeout=15,
+                )
+                if result.returncode != 0 or branch not in result.stdout:
+                    raise PotPieError(f"Branch not found: {branch}")
+            else:
+                result = subprocess.run(
+                    ["git", "ls-remote", repo_path],
+                    capture_output=True, text=True, timeout=15,
+                )
+                if result.returncode != 0:
+                    raise PotPieError(f"Not a valid git repository: {repo_path}")
+        except FileNotFoundError:
+            raise PotPieError("git not found. Please install git.")
 
     # Get repo name from path
     repo_name = Path(repo_path).name if not repo_path.startswith(("http", "git@")) else repo_path.split("/")[-1].replace(".git", "")
@@ -317,29 +347,32 @@ def cmd_chat(args):
     project_id = args.project_id
     agent_id = args.agent or "codebase_qna_agent"
 
-    print("💬 Starting chat session")
-    print(f"   Project: {project_id}")
-    print(f"   Agent: {agent_id}")
-
-    # Preflight check: verify project exists and is ready
     try:
-        project_result = client.request("GET", f"/projects/{project_id}")
-        project_status = project_result.get("status", "unknown")
+        print("💬 Starting chat session")
+        print(f"   Project: {project_id}")
+        print(f"   Agent: {agent_id}")
 
-        if project_status not in ("ready", "completed", "success"):
-            print("\n❌ Project is not ready for chatting.")
-            print(f"   Current status: {project_status}")
-            print("   Please wait for parsing to complete or check with: potpie status")
-            return
-    except PotPieError as e:
-        print(f"\n❌ Failed to verify project: {e}")
-        print("   Project ID may be invalid or server unavailable.")
-        return
+        # Preflight check: verify project exists and is ready
+        try:
+            project_result = client.request("GET", f"/projects/{project_id}")
+            project_status = project_result.get("status", "unknown")
 
-    print("   Type 'quit' or Ctrl+C to exit.\n")
+            if project_status not in ("ready", "completed", "success"):
+                raise PotPieError(
+                    f"Project is not ready for chatting (status: {project_status}).\n"
+                    "   Please wait for parsing to complete or check with: potpie status"
+                )
+        except PotPieError:
+            raise
+        except Exception as e:
+            raise PotPieError(
+                f"Failed to verify project: {e}\n"
+                "   Project ID may be invalid or server unavailable."
+            )
 
-    # Create conversation
-    try:
+        print("   Type 'quit' or Ctrl+C to exit.\n")
+
+        # Create conversation
         conv_result = client.request("POST", "/conversations/", json={
             "project_ids": [project_id],
             "agent_ids": [agent_id],

--- a/potpie/cli.py
+++ b/potpie/cli.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""
+PotPie CLI — Local Development Interface
+========================================
+Command-line interface for local development interactions with PotPie.
+
+Usage:
+    potpie start                  # Start the local PotPie server
+    potpie stop                   # Stop the local PotPie server
+    potpie parse <repo-path>      # Parse a repository
+    potpie chat <project-id>      # Interactive chat with an agent
+    potpie status                 # Check server status
+    potpie projects               # List parsed projects
+    potpie agents                 # List available agents
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+try:
+    import httpx
+except ImportError:
+    httpx = None
+
+# ─── Configuration ───────────────────────────────────────────────────────────
+
+DEFAULT_BASE_URL = "http://localhost:8001"
+DEFAULT_API_KEY = os.environ.get("POTPIE_API_KEY", "")
+CONFIG_DIR = Path.home() / ".potpie"
+CONFIG_FILE = CONFIG_DIR / "config.json"
+
+
+def load_config() -> dict:
+    """Load CLI configuration."""
+    if CONFIG_FILE.exists():
+        with open(CONFIG_FILE) as f:
+            return json.load(f)
+    return {}
+
+
+def save_config(config: dict):
+    """Save CLI configuration."""
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    with open(CONFIG_FILE, "w") as f:
+        json.dump(config, f, indent=2)
+
+
+def get_base_url() -> str:
+    """Get the PotPie server URL."""
+    config = load_config()
+    return config.get("base_url", DEFAULT_BASE_URL)
+
+
+def get_api_key() -> str:
+    """Get the API key."""
+    config = load_config()
+    return config.get("api_key", DEFAULT_API_KEY)
+
+
+def get_headers() -> dict:
+    """Get request headers with API key."""
+    api_key = get_api_key()
+    headers = {"Content-Type": "application/json", "User-Agent": "PotPie-CLI/1.0"}
+    if api_key:
+        headers["X-API-Key"] = api_key
+    return headers
+
+
+# ─── HTTP Client ─────────────────────────────────────────────────────────────
+
+class PotPieClient:
+    def __init__(self, base_url: str = None):
+        self.base_url = (base_url or get_base_url()).rstrip("/")
+        if httpx is None:
+            raise ImportError("httpx is required: pip install httpx")
+        self.client = httpx.Client(timeout=60.0, headers=get_headers())
+
+    def request(self, method: str, path: str, **kwargs) -> dict:
+        """Make an API request."""
+        url = f"{self.base_url}{path}"
+        try:
+            resp = self.client.request(method, url, **kwargs)
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPStatusError as e:
+            error_body = e.response.text[:500] if e.response else str(e)
+            print(f"❌ HTTP {e.response.status_code}: {error_body}")
+            sys.exit(1)
+        except httpx.ConnectError:
+            print(f"❌ Cannot connect to {self.base_url}")
+            print("   Is the server running? Try: potpie start")
+            sys.exit(1)
+        except Exception as e:
+            print(f"❌ Error: {e}")
+            sys.exit(1)
+
+    def close(self):
+        self.client.close()
+
+
+# ─── Commands ────────────────────────────────────────────────────────────────
+
+def cmd_start(args):
+    """Start the local PotPie server using Docker Compose."""
+    print("🚀 Starting PotPie server...")
+
+    compose_file = Path(args.compose or "compose.yaml")
+    if not compose_file.exists():
+        # Try to find it relative to the CLI location
+        cli_dir = Path(__file__).parent.parent
+        compose_file = cli_dir / "compose.yaml"
+
+    if not compose_file.exists():
+        print("❌ compose.yaml not found. Run this from the potpie directory.")
+        sys.exit(1)
+
+    cmd = ["docker", "compose", "-f", str(compose_file), "up", "-d"]
+    if args.build:
+        cmd.append("--build")
+
+    print(f"   Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=False)
+
+    if result.returncode == 0:
+        print("\n✅ PotPie server started!")
+        print(f"   API: {get_base_url()}")
+        print(f"   UI:  http://localhost:3000")
+        print("\n   Run 'potpie status' to check readiness.")
+    else:
+        print("\n❌ Failed to start. Check Docker is running.")
+        sys.exit(1)
+
+
+def cmd_stop(args):
+    """Stop the local PotPie server."""
+    print("⏹️  Stopping PotPie server...")
+
+    compose_file = Path(args.compose or "compose.yaml")
+    if not compose_file.exists():
+        cli_dir = Path(__file__).parent.parent
+        compose_file = cli_dir / "compose.yaml"
+
+    cmd = ["docker", "compose", "-f", str(compose_file), "down"]
+    if args.volumes:
+        cmd.append("-v")
+
+    result = subprocess.run(cmd)
+    if result.returncode == 0:
+        print("✅ PotPie server stopped.")
+    else:
+        print("❌ Failed to stop.")
+        sys.exit(1)
+
+
+def cmd_status(args):
+    """Check server status."""
+    client = PotPieClient()
+    try:
+        # Try to list projects as a health check
+        result = client.request("GET", "/projects/list")
+        print(f"✅ Server is running at {client.base_url}")
+        print(f"   Projects: {len(result) if isinstance(result, list) else 'N/A'}")
+    except SystemExit:
+        pass
+    finally:
+        client.close()
+
+
+def cmd_parse(args):
+    """Parse a repository."""
+    client = PotPieClient()
+
+    repo_path = args.repo_path
+    branch = args.branch
+
+    # Validate repo path
+    if not repo_path.startswith(("http://", "https://", "git@")):
+        # Local path
+        local_path = Path(repo_path).resolve()
+        if not local_path.exists():
+            print(f"❌ Path not found: {local_path}")
+            sys.exit(1)
+        repo_path = str(local_path)
+
+    # Get repo name from path
+    repo_name = Path(repo_path).name if not repo_path.startswith(("http", "git@")) else repo_path.split("/")[-1].replace(".git", "")
+
+    print(f"📂 Parsing repository: {repo_name}")
+    if branch:
+        print(f"   Branch: {branch}")
+
+    # Submit parsing request
+    payload = {"repo_path": repo_path, "repo_name": repo_name}
+    if branch:
+        payload["branch_name"] = branch
+
+    try:
+        result = client.request("POST", "/parse", json=payload)
+        project_id = result.get("project_id")
+        status = result.get("status", "unknown")
+
+        print(f"   Project ID: {project_id}")
+        print(f"   Status: {status}")
+
+        if status == "ready":
+            print("✅ Parsing complete!")
+            return
+
+        # Poll for status
+        print("\n⏳ Waiting for parsing to complete...")
+        max_wait = args.timeout
+        start = time.time()
+
+        while time.time() - start < max_wait:
+            time.sleep(5)
+            elapsed = int(time.time() - start)
+
+            try:
+                status_result = client.request("GET", f"/parsing-status/{project_id}")
+                current_status = status_result.get("status", "unknown")
+                print(f"   [{elapsed}s] Status: {current_status}")
+
+                if current_status in ("ready", "completed", "success"):
+                    print(f"\n✅ Parsing complete! ({elapsed}s)")
+                    print(f"   Project ID: {project_id}")
+                    print(f"\n   Start chatting: potpie chat {project_id}")
+                    return
+                elif current_status in ("failed", "error"):
+                    print(f"\n❌ Parsing failed.")
+                    if "error" in status_result:
+                        print(f"   Error: {status_result['error']}")
+                    sys.exit(1)
+            except Exception:
+                pass  # Continue polling
+
+        print(f"\n⏱️  Timeout after {max_wait}s. Parsing may still be running.")
+        print(f"   Check later: potpie status")
+
+    except SystemExit:
+        pass
+    finally:
+        client.close()
+
+
+def cmd_chat(args):
+    """Interactive chat with an agent."""
+    client = PotPieClient()
+    project_id = args.project_id
+    agent_id = args.agent or "codebase_qna_agent"
+
+    print(f"💬 Starting chat session")
+    print(f"   Project: {project_id}")
+    print(f"   Agent: {agent_id}")
+    print(f"   Type 'quit' or Ctrl+C to exit.\n")
+
+    # Create conversation
+    try:
+        conv_result = client.request("POST", "/conversations/", json={
+            "project_ids": [project_id],
+            "agent_ids": [agent_id],
+        })
+        conversation_id = conv_result.get("conversation_id")
+        print(f"   Session ID: {conversation_id}\n")
+
+        # Interactive loop
+        while True:
+            try:
+                user_input = input("You: ").strip()
+            except (EOFError, KeyboardInterrupt):
+                print("\n👋 Goodbye!")
+                break
+
+            if not user_input:
+                continue
+            if user_input.lower() in ("quit", "exit", "q"):
+                print("👋 Goodbye!")
+                break
+
+            print("🤔 Thinking...", end="", flush=True)
+
+            try:
+                # Send message
+                msg_result = client.request(
+                    "POST",
+                    f"/conversations/{conversation_id}/message/",
+                    json={"content": user_input},
+                    params={"stream": False},
+                )
+
+                # Clear "Thinking..."
+                print("\r" + " " * 20 + "\r", end="")
+
+                # Display response
+                if isinstance(msg_result, dict):
+                    content = msg_result.get("content", str(msg_result))
+                    print(f"PotPie: {content}\n")
+                else:
+                    print(f"PotPie: {msg_result}\n")
+
+            except Exception as e:
+                print(f"\r❌ Error: {e}\n")
+
+    except SystemExit:
+        pass
+    finally:
+        client.close()
+
+
+def cmd_projects(args):
+    """List parsed projects."""
+    client = PotPieClient()
+    try:
+        result = client.request("GET", "/projects/list")
+        if isinstance(result, list) and result:
+            print(f"📋 Projects ({len(result)}):\n")
+            for p in result:
+                name = p.get("repo_name", p.get("name", "Unknown"))
+                pid = p.get("id", p.get("project_id", ""))
+                branch = p.get("branch_name", "")
+                print(f"  • {name} ({branch})")
+                print(f"    ID: {pid}")
+                print()
+        else:
+            print("📋 No projects found.")
+            print("   Parse one: potpie parse <repo-path>")
+    except SystemExit:
+        pass
+    finally:
+        client.close()
+
+
+def cmd_agents(args):
+    """List available agents."""
+    client = PotPieClient()
+    try:
+        result = client.request("GET", "/list-available-agents")
+        if isinstance(result, list):
+            print(f"🤖 Available Agents ({len(result)}):\n")
+            for a in result:
+                aid = a.get("id", a.get("agent_id", ""))
+                name = a.get("name", aid)
+                desc = a.get("description", "")[:80]
+                print(f"  • {name} ({aid})")
+                if desc:
+                    print(f"    {desc}")
+                print()
+        else:
+            print(result)
+    except SystemExit:
+        pass
+    finally:
+        client.close()
+
+
+def cmd_config(args):
+    """View or set configuration."""
+    if args.set_url:
+        config = load_config()
+        config["base_url"] = args.set_url
+        save_config(config)
+        print(f"✅ Server URL set to: {args.set_url}")
+
+    if args.set_key:
+        config = load_config()
+        config["api_key"] = args.set_key
+        save_config(config)
+        print("✅ API key saved.")
+
+    if not args.set_url and not args.set_key:
+        config = load_config()
+        print("📋 Current configuration:\n")
+        print(f"  Server URL: {config.get('base_url', DEFAULT_BASE_URL)}")
+        key = config.get("api_key", DEFAULT_API_KEY)
+        if key:
+            print(f"  API Key: {key[:8]}...")
+        else:
+            print(f"  API Key: (not set)")
+        print(f"\n  Config file: {CONFIG_FILE}")
+
+
+# ─── Main ────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="potpie",
+        description="PotPie CLI — Local Development Interface",
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # start
+    p_start = subparsers.add_parser("start", help="Start the local PotPie server")
+    p_start.add_argument("--compose", help="Path to compose.yaml")
+    p_start.add_argument("--build", action="store_true", help="Build images before starting")
+    p_start.set_defaults(func=cmd_start)
+
+    # stop
+    p_stop = subparsers.add_parser("stop", help="Stop the local PotPie server")
+    p_stop.add_argument("--compose", help="Path to compose.yaml")
+    p_stop.add_argument("-v", "--volumes", action="store_true", help="Also remove volumes")
+    p_stop.set_defaults(func=cmd_stop)
+
+    # status
+    p_status = subparsers.add_parser("status", help="Check server status")
+    p_status.set_defaults(func=cmd_status)
+
+    # parse
+    p_parse = subparsers.add_parser("parse", help="Parse a repository")
+    p_parse.add_argument("repo_path", help="Repository path or URL")
+    p_parse.add_argument("--branch", "-b", help="Branch name")
+    p_parse.add_argument("--timeout", "-t", type=int, default=300, help="Max wait time (seconds)")
+    p_parse.set_defaults(func=cmd_parse)
+
+    # chat
+    p_chat = subparsers.add_parser("chat", help="Interactive chat with an agent")
+    p_chat.add_argument("project_id", help="Project ID to chat about")
+    p_chat.add_argument("--agent", "-a", help="Agent ID (default: codebase_qna_agent)")
+    p_chat.set_defaults(func=cmd_chat)
+
+    # projects
+    p_projects = subparsers.add_parser("projects", help="List parsed projects")
+    p_projects.set_defaults(func=cmd_projects)
+
+    # agents
+    p_agents = subparsers.add_parser("agents", help="List available agents")
+    p_agents.set_defaults(func=cmd_agents)
+
+    # config
+    p_config = subparsers.add_parser("config", help="View or set configuration")
+    p_config.add_argument("--set-url", help="Set server URL")
+    p_config.add_argument("--set-key", help="Set API key")
+    p_config.set_defaults(func=cmd_config)
+
+    args = parser.parse_args()
+    if not args.command:
+        parser.print_help()
+        sys.exit(0)
+
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/potpie/cli.py
+++ b/potpie/cli.py
@@ -15,6 +15,7 @@ Usage:
 """
 
 import argparse
+import getpass
 import json
 import os
 import subprocess
@@ -32,8 +33,17 @@ except ImportError:
 
 DEFAULT_BASE_URL = "http://localhost:8001"
 DEFAULT_API_KEY = os.environ.get("POTPIE_API_KEY", "")
+DEFAULT_COMPOSE_FILE = "compose.yaml"
 CONFIG_DIR = Path.home() / ".potpie"
 CONFIG_FILE = CONFIG_DIR / "config.json"
+
+
+class PotPieError(Exception):
+    """CLI error with exit code."""
+
+    def __init__(self, message: str, exit_code: int = 1):
+        super().__init__(message)
+        self.exit_code = exit_code
 
 
 def load_config() -> dict:
@@ -51,12 +61,10 @@ def load_config() -> dict:
 
 def save_config(config: dict):
     """Save CLI configuration."""
-    import os
-    
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     # Set secure permissions for config directory
     os.chmod(CONFIG_DIR, 0o700)
-    
+
     # Write config file with secure permissions
     fd = os.open(CONFIG_FILE, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     with os.fdopen(fd, 'w') as f:
@@ -84,10 +92,19 @@ def get_headers() -> dict:
     return headers
 
 
+def resolve_compose_file(compose_arg: Optional[str]) -> Path:
+    """Resolve compose.yaml path from argument or default locations."""
+    compose_file = Path(compose_arg or DEFAULT_COMPOSE_FILE)
+    if not compose_file.exists():
+        cli_dir = Path(__file__).parent.parent
+        compose_file = cli_dir / DEFAULT_COMPOSE_FILE
+    return compose_file
+
+
 # ─── HTTP Client ─────────────────────────────────────────────────────────────
 
 class PotPieClient:
-    def __init__(self, base_url: str = None):
+    def __init__(self, base_url: Optional[str] = None):
         self.base_url = (base_url or get_base_url()).rstrip("/")
         if httpx is None:
             raise ImportError("httpx is required: pip install httpx")
@@ -102,15 +119,14 @@ class PotPieClient:
             return resp.json()
         except httpx.HTTPStatusError as e:
             error_body = e.response.text[:500] if e.response else str(e)
-            print(f"❌ HTTP {e.response.status_code}: {error_body}")
-            sys.exit(1)
+            raise PotPieError(f"HTTP {e.response.status_code}: {error_body}")
         except httpx.ConnectError:
-            print(f"❌ Cannot connect to {self.base_url}")
-            print("   Is the server running? Try: potpie start")
-            sys.exit(1)
+            raise PotPieError(
+                f"Cannot connect to {self.base_url}\n"
+                "   Is the server running? Try: potpie start"
+            )
         except Exception as e:
-            print(f"❌ Error: {e}")
-            sys.exit(1)
+            raise PotPieError(f"Error: {e}")
 
     def close(self):
         self.client.close()
@@ -122,52 +138,43 @@ def cmd_start(args):
     """Start the local PotPie server using Docker Compose."""
     print("🚀 Starting PotPie server...")
 
-    compose_file = Path(args.compose or "compose.yaml")
-    if not compose_file.exists():
-        # Try to find it relative to the CLI location
-        cli_dir = Path(__file__).parent.parent
-        compose_file = cli_dir / "compose.yaml"
+    compose_file = resolve_compose_file(args.compose)
 
     if not compose_file.exists():
         print("❌ compose.yaml not found. Run this from the potpie directory.")
-        sys.exit(1)
+        raise PotPieError("compose.yaml not found")
 
     cmd = ["docker", "compose", "-f", str(compose_file), "up", "-d"]
     if args.build:
         cmd.append("--build")
 
     print(f"   Running: {' '.join(cmd)}")
-    result = subprocess.run(cmd, capture_output=False, check=False)  # Safe: known strings, not user input
+    result = subprocess.run(cmd, capture_output=False, check=False)
 
     if result.returncode == 0:
         print("\n✅ PotPie server started!")
         print(f"   API: {get_base_url()}")
-        print(f"   UI:  http://localhost:3000")
+        print("   UI:  http://localhost:3000")
         print("\n   Run 'potpie status' to check readiness.")
     else:
-        print("\n❌ Failed to start. Check Docker is running.")
-        sys.exit(1)
+        raise PotPieError("Failed to start. Check Docker is running.")
 
 
 def cmd_stop(args):
     """Stop the local PotPie server."""
     print("⏹️  Stopping PotPie server...")
 
-    compose_file = Path(args.compose or "compose.yaml")
-    if not compose_file.exists():
-        cli_dir = Path(__file__).parent.parent
-        compose_file = cli_dir / "compose.yaml"
+    compose_file = resolve_compose_file(args.compose)
 
     cmd = ["docker", "compose", "-f", str(compose_file), "down"]
     if args.volumes:
         cmd.append("-v")
 
-    result = subprocess.run(cmd, check=False)  # Safe: known strings, not user input
+    result = subprocess.run(cmd, check=False)
     if result.returncode == 0:
         print("✅ PotPie server stopped.")
     else:
-        print("❌ Failed to stop.")
-        sys.exit(1)
+        raise PotPieError("Failed to stop.")
 
 
 def cmd_status(args):
@@ -177,10 +184,10 @@ def cmd_status(args):
         # Check server health
         result = client.request("GET", "/projects/list")
         print(f"✅ Server is running at {client.base_url}")
-        
+
         if isinstance(result, list):
             print(f"📊 Projects: {len(result)}")
-            
+
             # Show project details if requested
             if args.project_id:
                 for project in result:
@@ -199,12 +206,12 @@ def cmd_status(args):
                 for project in result:
                     status = project.get('status', 'unknown')
                     status_counts[status] = status_counts.get(status, 0) + 1
-                
+
                 print(f"   Status summary: {', '.join([f'{k}: {v}' for k, v in status_counts.items()])}")
         else:
-            print(f"   Projects: N/A")
-    except SystemExit:
-        pass
+            print("   Projects: N/A")
+    except PotPieError:
+        raise
     finally:
         client.close()
 
@@ -221,8 +228,20 @@ def cmd_parse(args):
         # Local path
         local_path = Path(repo_path).resolve()
         if not local_path.exists():
-            print(f"❌ Path not found: {local_path}")
-            sys.exit(1)
+            raise PotPieError(f"Path not found: {local_path}")
+        if not local_path.is_dir():
+            raise PotPieError(f"Path is not a directory: {local_path}")
+        # Check if it's a git repository
+        if not (local_path / ".git").exists():
+            raise PotPieError(f"Not a git repository: {local_path}")
+        # Validate branch if specified
+        if branch:
+            result = subprocess.run(
+                ["git", "-C", str(local_path), "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}"],
+                capture_output=True,
+            )
+            if result.returncode != 0:
+                raise PotPieError(f"Branch not found: {branch}")
         repo_path = str(local_path)
 
     # Get repo name from path
@@ -253,6 +272,7 @@ def cmd_parse(args):
         print("\n⏳ Waiting for parsing to complete...")
         max_wait = args.timeout
         start = time.time()
+        consecutive_failures = 0
 
         while time.time() - start < max_wait:
             time.sleep(5)
@@ -262,6 +282,7 @@ def cmd_parse(args):
                 status_result = client.request("GET", f"/parsing-status/{project_id}")
                 current_status = status_result.get("status", "unknown")
                 print(f"   [{elapsed}s] Status: {current_status}")
+                consecutive_failures = 0
 
                 if current_status in ("ready", "completed", "success"):
                     print(f"\n✅ Parsing complete! ({elapsed}s)")
@@ -269,18 +290,23 @@ def cmd_parse(args):
                     print(f"\n   Start chatting: potpie chat {project_id}")
                     return
                 elif current_status in ("failed", "error"):
-                    print(f"\n❌ Parsing failed.")
+                    print("\n❌ Parsing failed.")
                     if "error" in status_result:
                         print(f"   Error: {status_result['error']}")
-                    sys.exit(1)
-            except Exception:
-                pass  # Continue polling
+                    raise PotPieError("Parsing failed")
+            except PotPieError:
+                raise
+            except Exception as poll_err:
+                consecutive_failures += 1
+                print(f"   [{elapsed}s] Polling error (retry {consecutive_failures}): {poll_err}")
+                if consecutive_failures >= 5:
+                    raise PotPieError(f"Too many consecutive polling failures ({consecutive_failures})")
 
         print(f"\n⏱️  Timeout after {max_wait}s. Parsing may still be running.")
-        print(f"   Check later: potpie status")
+        print("   Check later: potpie status")
 
-    except SystemExit:
-        pass
+    except PotPieError:
+        raise
     finally:
         client.close()
 
@@ -291,7 +317,7 @@ def cmd_chat(args):
     project_id = args.project_id
     agent_id = args.agent or "codebase_qna_agent"
 
-    print(f"💬 Starting chat session")
+    print("💬 Starting chat session")
     print(f"   Project: {project_id}")
     print(f"   Agent: {agent_id}")
 
@@ -299,18 +325,18 @@ def cmd_chat(args):
     try:
         project_result = client.request("GET", f"/projects/{project_id}")
         project_status = project_result.get("status", "unknown")
-        
+
         if project_status not in ("ready", "completed", "success"):
-            print(f"\n❌ Project is not ready for chatting.")
+            print("\n❌ Project is not ready for chatting.")
             print(f"   Current status: {project_status}")
-            print(f"   Please wait for parsing to complete or check with: potpie status")
+            print("   Please wait for parsing to complete or check with: potpie status")
             return
-    except Exception as e:
+    except PotPieError as e:
         print(f"\n❌ Failed to verify project: {e}")
-        print(f"   Project ID may be invalid or server unavailable.")
+        print("   Project ID may be invalid or server unavailable.")
         return
 
-    print(f"   Type 'quit' or Ctrl+C to exit.\n")
+    print("   Type 'quit' or Ctrl+C to exit.\n")
 
     # Create conversation
     try:
@@ -359,8 +385,8 @@ def cmd_chat(args):
             except Exception as e:
                 print(f"\r❌ Error: {e}\n")
 
-    except SystemExit:
-        pass
+    except PotPieError:
+        raise
     finally:
         client.close()
 
@@ -382,8 +408,8 @@ def cmd_projects(args):
         else:
             print("📋 No projects found.")
             print("   Parse one: potpie parse <repo-path>")
-    except SystemExit:
-        pass
+    except PotPieError:
+        raise
     finally:
         client.close()
 
@@ -405,8 +431,8 @@ def cmd_agents(args):
                 print()
         else:
             print(result)
-    except SystemExit:
-        pass
+    except PotPieError:
+        raise
     finally:
         client.close()
 
@@ -420,10 +446,11 @@ def cmd_config(args):
         print(f"✅ Server URL set to: {args.set_url}")
 
     if args.set_key:
+        # Secure interactive input for API key
+        api_key = getpass.getpass("Enter API key: ")
         config = load_config()
-        # Mask key in output for security
-        masked_key = args.set_key[:4] + "..." + args.set_key[-4:] if len(args.set_key) > 8 else "***"
-        config["api_key"] = args.set_key
+        masked_key = api_key[:4] + "..." + api_key[-4:] if len(api_key) > 8 else "***"
+        config["api_key"] = api_key
         save_config(config)
         print(f"✅ API key saved ({masked_key}).")
         print("   Note: API keys are stored with file permissions 600.")
@@ -438,7 +465,7 @@ def cmd_config(args):
             masked_key = key[:4] + "..." + key[-4:] if len(key) > 8 else "***"
             print(f"  API Key: {masked_key}")
         else:
-            print(f"  API Key: (not set)")
+            print("  API Key: (not set)")
         print(f"\n  Config file: {CONFIG_FILE}")
         print(f"  Config permissions: {oct(CONFIG_FILE.stat().st_mode)[-3:] if CONFIG_FILE.exists() else 'N/A'}")
 
@@ -493,7 +520,7 @@ def main():
     # config
     p_config = subparsers.add_parser("config", help="View or set configuration")
     p_config.add_argument("--set-url", help="Set server URL")
-    p_config.add_argument("--set-key", help="Set API key")
+    p_config.add_argument("--set-key", action="store_true", help="Set API key (interactive prompt)")
     p_config.set_defaults(func=cmd_config)
 
     args = parser.parse_args()
@@ -501,7 +528,14 @@ def main():
         parser.print_help()
         sys.exit(0)
 
-    args.func(args)
+    try:
+        args.func(args)
+    except PotPieError as e:
+        print(f"❌ {e}")
+        sys.exit(e.exit_code)
+    except KeyboardInterrupt:
+        print("\nCancelled.")
+        sys.exit(130)
 
 
 if __name__ == "__main__":

--- a/potpie/cli.py
+++ b/potpie/cli.py
@@ -42,6 +42,7 @@ class PotPieError(Exception):
     """CLI error with exit code."""
 
     def __init__(self, message: str, exit_code: int = 1):
+        """Initialize error with message and exit code."""
         super().__init__(message)
         self.exit_code = exit_code
 
@@ -111,7 +112,10 @@ def resolve_compose_file(compose_arg: Optional[str]) -> Path:
 # ─── HTTP Client ─────────────────────────────────────────────────────────────
 
 class PotPieClient:
+    """HTTP client wrapper for PotPie API communication."""
+
     def __init__(self, base_url: Optional[str] = None):
+        """Initialize client with optional base URL override."""
         self.base_url = (base_url or get_base_url()).rstrip("/")
         if httpx is None:
             raise ImportError("httpx is required: pip install httpx")
@@ -136,6 +140,7 @@ class PotPieClient:
             raise PotPieError(f"Error: {e}")
 
     def close(self):
+        """Close the underlying HTTP client connection."""
         self.client.close()
 
 
@@ -519,6 +524,7 @@ def cmd_config(args):
 # ─── Main ────────────────────────────────────────────────────────────────────
 
 def main():
+    """Entry point for the PotPie CLI."""
     parser = argparse.ArgumentParser(
         prog="potpie",
         description="PotPie CLI — Local Development Interface",

--- a/potpie/cli.py
+++ b/potpie/cli.py
@@ -125,7 +125,7 @@ def cmd_start(args):
         cmd.append("--build")
 
     print(f"   Running: {' '.join(cmd)}")
-    result = subprocess.run(cmd, capture_output=False)
+    result = subprocess.run(cmd, capture_output=False, check=False)  # Safe: known strings, not user input
 
     if result.returncode == 0:
         print("\n✅ PotPie server started!")
@@ -150,7 +150,7 @@ def cmd_stop(args):
     if args.volumes:
         cmd.append("-v")
 
-    result = subprocess.run(cmd)
+    result = subprocess.run(cmd, check=False)  # Safe: known strings, not user input
     if result.returncode == 0:
         print("✅ PotPie server stopped.")
     else:
@@ -271,7 +271,7 @@ def cmd_chat(args):
         # Interactive loop
         while True:
             try:
-                user_input = input("You: ").strip()
+                user_input = input("You: ").strip()[:4000]  # Limit input length
             except (EOFError, KeyboardInterrupt):
                 print("\n👋 Goodbye!")
                 break

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,6 +247,9 @@ omit = [
     "app/celery/tasks/base_task.py",
 ]
 
+[project.scripts]
+potpie = "potpie.cli:main"
+
 [tool.coverage.report]
 exclude_lines = [
     "pragma: no cover",


### PR DESCRIPTION
## Summary

Implements a CLI tool for local PotPie development as described in #224.

## Commands

| Command | Description |
|---------|-------------|
| `potpie start` | Start local Docker Compose server |
| `potpie stop` | Stop local Docker Compose server |
| `potpie parse <repo-path>` | Submit repo for parsing with real-time status polling |
| `potpie chat <project-id>` | Interactive chat with codebase agents |
| `potpie projects` | List all parsed projects |
| `potpie agents` | List available agents |
| `potpie status` | Check server health |
| `potpie config` | View/set API key and server URL |

## Features

- **Docker Compose integration**: `start`/`stop` commands manage the full stack
- **Real-time parsing**: Submits repo and polls status until complete or timeout
- **Interactive chat**: Console-based chat with agent selection and session management
- **Configuration**: Stores API key and server URL in `~/.potpie/config.json`
- **Error handling**: Clear error messages for connection, auth, and parsing failures

## Usage

```bash
# Start the server
potpie start

# Parse a local repository
potpie parse /path/to/repo --branch main

# Chat with the parsed codebase
potpie chat <project-id>
```

## Changes

- Added `potpie/cli.py` — Main CLI implementation
- Updated `pyproject.toml` — Added `[project.scripts]` entry point

Fixes #224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local PotPie CLI for development with persistent local config (base URL and masked API key), improved error reporting, and configurable timeouts.
  * Commands to start/stop Docker orchestration, check service status, parse repositories with progress polling and timeouts, run interactive chat sessions, and list projects/agents.

* **Chores**
  * Added a console-script entrypoint to install the CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->