### PR TITLE
fix(ci): make pre-commit hooks read-only and remove auto-fix behavior in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,9 +15,10 @@ repos:
     rev: v0.8.2
     hooks:
       - id: ruff
-        args: ["--fix"]
+        args: ["--no-fix"]
         exclude: ^app/alembic/
       - id: ruff-format
+        args: ["--check"]
         exclude: ^app/alembic/
 
   - repo: https://github.com/PyCQA/bandit
@@ -27,3 +28,7 @@ repos:
         args: ["-c", "pyproject.toml"]
         additional_dependencies: ["bandit[toml]"]
         exclude: ^(tests|app/alembic)/
+
+ci:
+  autofix_commit_msg: ""
+  autofix_prs: false

--- a/docs/PRECOMMIT.md
+++ b/docs/PRECOMMIT.md
@@ -1,0 +1,79 @@
+# Pre-commit Guide
+
+## Setup
+
+Install pre-commit:
+
+```
+pip install pre-commit
+```
+
+Install hooks:
+
+```
+pre-commit install
+```
+
+---
+
+## Running Checks
+
+Run all hooks:
+
+```
+pre-commit run --all-files
+```
+
+Run specific hook:
+
+```
+pre-commit run <hook-id> --all-files
+```
+
+---
+
+## Auto-fixes
+
+Some hooks can automatically fix issues locally.
+
+Run:
+
+```
+pre-commit run --all-files
+```
+
+Then commit the changes.
+
+---
+
+## Skipping Hooks
+
+Skip a hook:
+
+```
+SKIP=<hook-id> git commit
+```
+
+---
+
+## Fixing Failures
+
+If checks fail:
+
+1. Run:
+
+```
+pre-commit run --all-files
+```
+
+2. Fix issues manually or apply auto-fixes
+
+3. Commit changes
+
+---
+
+## CI Behavior
+
+* CI runs only validation checks
+* No automatic fixes are applied in CI
+* Developers must fix issues locally before pushing


### PR DESCRIPTION
## Fixes #519 

### Summary

This PR updates the pre-commit configuration to ensure CI runs validation-only checks without modifying code.

### Changes

- Removed auto-fix behavior from Ruff (`--fix`)
- Configured Ruff and formatter to run in check-only mode (`--no-fix`, `--check`)
- Ensured all hooks validate code without modifying files in CI
- Added `ci` configuration to disable auto-fix commits in pre-commit CI
- Added developer documentation for pre-commit setup and usage

### Pre-commit CI

The configuration is prepared for integration with https://pre-commit.ci

Since enabling the service requires repository-level permissions

### Result

- CI is now deterministic and read-only
- No unintended code changes during CI runs
- Developers are responsible for applying fixes locally before pushing
- Improved reliability of the CI/CD pipeline

### Testing

- Ran `pre-commit run --all-files` locally
- Ruff reported lint issues as expected
- Ruff-format reported required changes without modifying files
- No hooks performed automatic fixes during execution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for using pre-commit hooks, including setup steps, commands, and workflow instructions.

* **Chores**
  * Updated code validation configuration to run in verification-only mode, with CI no longer applying automatic fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->