### PR TITLE
Truncate large tool results & removed persistance in db

### DIFF
--- a/app/modules/conversations/conversations_router.py
+++ b/app/modules/conversations/conversations_router.py
@@ -94,7 +94,7 @@ class ConversationAPI:
         user=Depends(AuthService.check_auth),
     ):
         user_agent = request.headers.get("user-agent", "")
-        local_mode = user_agent == "Potpie-VSCode-Extension/1.0.1"
+        local_mode = "Potpie-VSCode-Extension" in user_agent
 
         user_id = user["user_id"]
         await UsageService.check_usage_limit(user_id, async_db)
@@ -184,7 +184,7 @@ class ConversationAPI:
     ):
         # Check User-Agent header for local mode (same as regenerate_last_message)
         user_agent = http_request.headers.get("user-agent", "")
-        local_mode = user_agent == "Potpie-VSCode-Extension/1.0.1"
+        local_mode = "Potpie-VSCode-Extension" in user_agent
 
         # Validate message content
         if content == "" or content is None or content.isspace():
@@ -319,7 +319,7 @@ class ConversationAPI:
     ):
         # Check User-Agent header for local mode (same as post_message)
         user_agent = http_request.headers.get("user-agent", "")
-        local_mode = user_agent == "Potpie-VSCode-Extension/1.0.1"
+        local_mode = "Potpie-VSCode-Extension" in user_agent
 
         user_id = user["user_id"]
         await UsageService.check_usage_limit(user_id, async_db)

--- a/app/modules/conversations/conversations_router.py
+++ b/app/modules/conversations/conversations_router.py
@@ -1,5 +1,6 @@
 import json
-from typing import Any, AsyncGenerator, List, Optional, Union, Literal
+import re
+from typing import Annotated, Any, AsyncGenerator, List, Literal, Optional, Union
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile
 from fastapi.responses import StreamingResponse
@@ -47,14 +48,30 @@ from app.modules.conversations.utils.conversation_routing import (
     start_celery_task_and_stream,
 )
 from app.modules.conversations.utils.redis_streaming import AsyncRedisStreamManager
+from app.modules.conversations.session.session_service import AsyncSessionService
 
 router = APIRouter()
 logger = setup_logger(__name__)
+_VSCODE_EXT_PATTERN = re.compile(r"\bPotpie-VSCode-Extension/\d+\.\d+(?:\.\d+)?\b")
+
+AuthenticatedUser = Annotated[dict[str, Any], Depends(AuthService.check_auth)]
+DbSession = Annotated[Session, Depends(get_db)]
+AsyncDbSession = Annotated[AsyncSession, Depends(get_async_db)]
+RedisStreamManagerDep = Annotated[
+    AsyncRedisStreamManager, Depends(get_async_redis_stream_manager)
+]
+AsyncSessionServiceDep = Annotated[
+    AsyncSessionService, Depends(get_async_session_service)
+]
 
 
 async def get_stream(data_stream: AsyncGenerator[Any, None]):
     async for chunk in data_stream:
         yield json.dumps(chunk.dict())
+
+
+def _is_vscode_extension_user_agent(user_agent: str) -> bool:
+    return bool(_VSCODE_EXT_PATTERN.search(user_agent or ""))
 
 
 class ConversationAPI:
@@ -65,15 +82,15 @@ class ConversationAPI:
         description="Get a list of conversations for the current user with sorting options.",
     )
     async def get_conversations_for_user(
-        user=Depends(AuthService.check_auth),
+        user: AuthenticatedUser,
+        db: DbSession,
+        async_db: AsyncDbSession,
         start: int = Query(0, ge=0),
         limit: int = Query(10, ge=1),
         sort: Literal["updated_at", "created_at"] = Query(
             "updated_at", description="Field to sort by"
         ),
         order: Literal["asc", "desc"] = Query("desc", description="Direction of sort"),
-        db: Session = Depends(get_db),
-        async_db: AsyncSession = Depends(get_async_db),
     ):
         """Get a list of conversations for the current user with sorting options."""
         user_id = user["user_id"]
@@ -86,15 +103,15 @@ class ConversationAPI:
     async def create_conversation(
         conversation: CreateConversationRequest,
         request: Request,
+        db: DbSession,
+        async_db: AsyncDbSession,
+        user: AuthenticatedUser,
         hidden: bool = Query(
             False, description="Whether to hide this conversation from the web UI"
         ),
-        db: Session = Depends(get_db),
-        async_db: AsyncSession = Depends(get_async_db),
-        user=Depends(AuthService.check_auth),
     ):
         user_agent = request.headers.get("user-agent", "")
-        local_mode = "Potpie-VSCode-Extension" in user_agent
+        local_mode = _is_vscode_extension_user_agent(user_agent)
 
         user_id = user["user_id"]
         await UsageService.check_usage_limit(user_id, async_db)
@@ -111,9 +128,9 @@ class ConversationAPI:
     )
     async def get_conversation_info(
         conversation_id: str,
-        db: Session = Depends(get_db),
-        async_db: AsyncSession = Depends(get_async_db),
-        user=Depends(AuthService.check_auth),
+        db: DbSession,
+        async_db: AsyncDbSession,
+        user: AuthenticatedUser,
     ):
         user_id = user["user_id"]
         user_email = user["email"]
@@ -137,11 +154,11 @@ class ConversationAPI:
     )
     async def get_conversation_messages(
         conversation_id: str,
+        db: DbSession,
+        async_db: AsyncDbSession,
+        user: AuthenticatedUser,
         start: int = Query(0, ge=0),
         limit: int = Query(10, ge=1),
-        db: Session = Depends(get_db),
-        async_db: AsyncSession = Depends(get_async_db),
-        user=Depends(AuthService.check_auth),
     ):
         user_id = user["user_id"]
         user_email = user["email"]
@@ -165,9 +182,15 @@ class ConversationAPI:
     async def post_message(
         conversation_id: str,
         http_request: Request,
+        db: DbSession,
+        async_db: AsyncDbSession,
+        user: AuthenticatedUser,
+        async_redis: RedisStreamManagerDep,
         content: str = Form(...),
         node_ids: Optional[str] = Form(None),
-        tunnel_url: Optional[str] = Form(None, description="Tunnel URL from VS Code extension for local server routing"),
+        tunnel_url: Optional[str] = Form(
+            None, description="Tunnel URL from VS Code extension for local server routing"
+        ),
         images: Optional[List[UploadFile]] = File(None),
         stream: bool = Query(True, description="Whether to stream the response"),
         session_id: Optional[str] = Query(
@@ -177,14 +200,10 @@ class ConversationAPI:
             None, description="Previous human message ID for deterministic session ID"
         ),
         cursor: Optional[str] = Query(None, description="Stream cursor for replay"),
-        db: Session = Depends(get_db),
-        async_db: AsyncSession = Depends(get_async_db),
-        user=Depends(AuthService.check_auth),
-        async_redis: AsyncRedisStreamManager = Depends(get_async_redis_stream_manager),
     ):
         # Check User-Agent header for local mode (same as regenerate_last_message)
         user_agent = http_request.headers.get("user-agent", "")
-        local_mode = "Potpie-VSCode-Extension" in user_agent
+        local_mode = _is_vscode_extension_user_agent(user_agent)
 
         # Validate message content
         if content == "" or content is None or content.isspace():
@@ -301,6 +320,10 @@ class ConversationAPI:
         conversation_id: str,
         request: RegenerateRequest,
         http_request: Request,
+        db: DbSession,
+        async_db: AsyncDbSession,
+        user: AuthenticatedUser,
+        async_redis: RedisStreamManagerDep,
         stream: bool = Query(True, description="Whether to stream the response"),
         session_id: Optional[str] = Query(
             None, description="Session ID for reconnection"
@@ -312,14 +335,10 @@ class ConversationAPI:
         background: bool = Query(
             True, description="Use background execution (recommended)"
         ),
-        db: Session = Depends(get_db),
-        async_db: AsyncSession = Depends(get_async_db),
-        user=Depends(AuthService.check_auth),
-        async_redis: AsyncRedisStreamManager = Depends(get_async_redis_stream_manager),
     ):
         # Check User-Agent header for local mode (same as post_message)
         user_agent = http_request.headers.get("user-agent", "")
-        local_mode = "Potpie-VSCode-Extension" in user_agent
+        local_mode = _is_vscode_extension_user_agent(user_agent)
 
         user_id = user["user_id"]
         await UsageService.check_usage_limit(user_id, async_db)
@@ -419,9 +438,9 @@ class ConversationAPI:
     @router.delete("/conversations/{conversation_id}", response_model=dict)
     async def delete_conversation(
         conversation_id: str,
-        db: Session = Depends(get_db),
-        async_db: AsyncSession = Depends(get_async_db),
-        user=Depends(AuthService.check_auth),
+        db: DbSession,
+        async_db: AsyncDbSession,
+        user: AuthenticatedUser,
     ):
         user_id = user["user_id"]
         user_email = user["email"]
@@ -432,12 +451,12 @@ class ConversationAPI:
     @router.post("/conversations/{conversation_id}/stop", response_model=dict)
     async def stop_generation(
         conversation_id: str,
+        db: DbSession,
+        async_db: AsyncDbSession,
+        user: AuthenticatedUser,
+        async_redis: RedisStreamManagerDep,
+        async_session_service: AsyncSessionServiceDep,
         session_id: Optional[str] = Query(None, description="Session ID to stop"),
-        db: Session = Depends(get_db),
-        async_db: AsyncSession = Depends(get_async_db),
-        user=Depends(AuthService.check_auth),
-        async_redis: AsyncRedisStreamManager = Depends(get_async_redis_stream_manager),
-        async_session_service=Depends(get_async_session_service),
     ):
         user_id = user["user_id"]
         user_email = user["email"]
@@ -456,9 +475,9 @@ class ConversationAPI:
     async def rename_conversation(
         conversation_id: str,
         request: RenameConversationRequest,
-        db: Session = Depends(get_db),
-        async_db: AsyncSession = Depends(get_async_db),
-        user=Depends(AuthService.check_auth),
+        db: DbSession,
+        async_db: AsyncDbSession,
+        user: AuthenticatedUser,
     ):
         user_id = user["user_id"]
         user_email = user["email"]
@@ -469,10 +488,10 @@ class ConversationAPI:
     @router.get("/conversations/{conversation_id}/active-session")
     async def get_active_session(
         conversation_id: str,
-        db: Session = Depends(get_db),
-        async_db: AsyncSession = Depends(get_async_db),
-        user=Depends(AuthService.check_auth),
-        async_session_service=Depends(get_async_session_service),
+        db: DbSession,
+        async_db: AsyncDbSession,
+        user: AuthenticatedUser,
+        async_session_service: AsyncSessionServiceDep,
     ) -> Union[ActiveSessionResponse, ActiveSessionErrorResponse]:
         """Get active session information for a conversation"""
         user_id = user["user_id"]
@@ -497,10 +516,10 @@ class ConversationAPI:
     @router.get("/conversations/{conversation_id}/task-status")
     async def get_task_status(
         conversation_id: str,
-        db: Session = Depends(get_db),
-        async_db: AsyncSession = Depends(get_async_db),
-        user=Depends(AuthService.check_auth),
-        async_session_service=Depends(get_async_session_service),
+        db: DbSession,
+        async_db: AsyncDbSession,
+        user: AuthenticatedUser,
+        async_session_service: AsyncSessionServiceDep,
     ) -> Union[TaskStatusResponse, TaskStatusErrorResponse]:
         """Get background task status for a conversation"""
         user_id = user["user_id"]
@@ -526,13 +545,13 @@ class ConversationAPI:
     async def resume_session(
         conversation_id: str,
         session_id: str,
+        db: DbSession,
+        async_db: AsyncDbSession,
+        user: AuthenticatedUser,
+        async_redis: RedisStreamManagerDep,
         cursor: Optional[str] = Query(
             "0-0", description="Stream cursor position to resume from"
         ),
-        db: Session = Depends(get_db),
-        async_db: AsyncSession = Depends(get_async_db),
-        user=Depends(AuthService.check_auth),
-        async_redis: AsyncRedisStreamManager = Depends(get_async_redis_stream_manager),
     ):
         """Resume streaming from an existing session"""
         user_id = user["user_id"]
@@ -567,8 +586,8 @@ class ConversationAPI:
 @router.post("/conversations/share", response_model=ShareChatResponse, status_code=201)
 async def share_chat(
     request: ShareChatRequest,
-    async_db: AsyncSession = Depends(get_async_db),
-    user=Depends(AuthService.check_auth),
+    async_db: AsyncDbSession,
+    user: AuthenticatedUser,
 ):
     user_id = user["user_id"]
     service = AsyncShareChatService(async_db)
@@ -589,8 +608,8 @@ async def share_chat(
 @router.get("/conversations/{conversation_id}/shared-emails", response_model=List[str])
 async def get_shared_emails(
     conversation_id: str,
-    async_db: AsyncSession = Depends(get_async_db),
-    user=Depends(AuthService.check_auth),
+    async_db: AsyncDbSession,
+    user: AuthenticatedUser,
 ):
     user_id = user["user_id"]
     service = AsyncShareChatService(async_db)
@@ -602,8 +621,8 @@ async def get_shared_emails(
 async def remove_access(
     conversation_id: str,
     request: RemoveAccessRequest,
-    user: str = Depends(AuthService.check_auth),
-    async_db: AsyncSession = Depends(get_async_db),
+    user: AuthenticatedUser,
+    async_db: AsyncDbSession,
 ) -> dict:
     """Remove access for specified emails from a conversation."""
     share_service = AsyncShareChatService(async_db)
@@ -623,8 +642,8 @@ async def remove_access(
 async def sync_code_change_from_local(
     conversation_id: str,
     change: dict,
-    user=Depends(AuthService.check_auth),
-    db: Session = Depends(get_db),
+    user: AuthenticatedUser,
+    db: DbSession,
 ) -> dict:
     """Receive code changes that were applied locally and sync to CodeChangesManager.
     

--- a/app/modules/intelligence/agents/chat_agent.py
+++ b/app/modules/intelligence/agents/chat_agent.py
@@ -39,6 +39,14 @@ class ToolCallResponse(BaseModel):
         default=True,
         description="Whether this tool call response is complete (False for streaming parts)",
     )
+    is_truncated: bool = Field(
+        default=False,
+        description="True if tool_response was truncated before streaming to browser",
+    )
+    original_length: Optional[int] = Field(
+        default=None,
+        description="Original char length of tool result content before truncation",
+    )
 
     class Config:
         use_enum_values = True

--- a/app/modules/intelligence/agents/chat_agents/multi_agent/delegation_manager.py
+++ b/app/modules/intelligence/agents/chat_agents/multi_agent/delegation_manager.py
@@ -567,14 +567,23 @@ class DelegationManager:
             # Use async version to avoid blocking the event loop
             if call_id:
                 try:
-                    stored_response, _, _ = truncate_result_content(full_response)
+                    (
+                        stored_response,
+                        is_truncated,
+                        original_length,
+                    ) = truncate_result_content(full_response)
                     logger.info(
                         f"[SUBAGENT STREAM] Publishing final complete response to Redis: "
-                        f"call_id={call_id}, response_length={len(stored_response)}"
+                        f"call_id={call_id}, response_length={len(stored_response)}, "
+                        f"is_truncated={is_truncated}, original_length={original_length}"
                     )
                     await self.tool_call_stream_manager.publish_complete_async(
                         call_id=call_id,
                         tool_response=stored_response,
+                        tool_call_details={
+                            "is_truncated": is_truncated,
+                            "original_length": original_length,
+                        },
                     )
                     logger.info(
                         f"[SUBAGENT STREAM] Successfully published final complete response to Redis: call_id={call_id}"

--- a/app/modules/intelligence/agents/chat_agents/multi_agent/delegation_manager.py
+++ b/app/modules/intelligence/agents/chat_agents/multi_agent/delegation_manager.py
@@ -16,6 +16,7 @@ from .utils.delegation_utils import (
 )
 from .utils.context_utils import create_project_context_info
 from .utils.tool_call_stream_manager import ToolCallStreamManager
+from .utils.tool_utils import truncate_result_content
 from app.modules.intelligence.agents.chat_agent import ChatContext, ChatAgentResponse
 from app.modules.utils.logger import setup_logger
 
@@ -566,13 +567,14 @@ class DelegationManager:
             # Use async version to avoid blocking the event loop
             if call_id:
                 try:
+                    stored_response, _, _ = truncate_result_content(full_response)
                     logger.info(
                         f"[SUBAGENT STREAM] Publishing final complete response to Redis: "
-                        f"call_id={call_id}, response_length={len(full_response)}"
+                        f"call_id={call_id}, response_length={len(stored_response)}"
                     )
                     await self.tool_call_stream_manager.publish_complete_async(
                         call_id=call_id,
-                        tool_response=full_response,
+                        tool_response=stored_response,
                     )
                     logger.info(
                         f"[SUBAGENT STREAM] Successfully published final complete response to Redis: call_id={call_id}"

--- a/app/modules/intelligence/agents/chat_agents/multi_agent/stream_processor.py
+++ b/app/modules/intelligence/agents/chat_agents/multi_agent/stream_processor.py
@@ -35,6 +35,7 @@ from app.modules.intelligence.agents.chat_agent import (
 )
 from app.modules.intelligence.agents.chat_agents.tool_helpers import (
     get_tool_call_info_content,
+    try_extract_streaming_preview,
 )
 from app.modules.utils.logger import setup_logger
 
@@ -123,6 +124,8 @@ class StreamProcessor:
         # Track current tool call for request deltas (model writing tool name/args)
         current_tool_call_id: str = ""
         current_tool_name: str = ""
+        tool_args_buffers: Dict[str, str] = {}
+        tool_preview_cache: Dict[str, str] = {}
         async for event in request_stream:
             events_seen += 1
             if isinstance(event, PartStartEvent) and isinstance(event.part, TextPart):
@@ -198,6 +201,25 @@ class StreamProcessor:
                     if isinstance(part.args, str)
                     else json.dumps(part.args or {}, default=str)
                 )
+                if current_tool_call_id:
+                    tool_args_buffers[current_tool_call_id] = args_str or ""
+                command_tools = {"search_bash", "bash_command", "execute_terminal_command"}
+                command = str(args_dict.get("command", "") or "").strip()
+                tool_response = (
+                    command
+                    if current_tool_name in command_tools and command
+                    else get_tool_call_info_content(current_tool_name, args_dict)
+                )
+                tool_call_details = (
+                    {"command": command}
+                    if current_tool_name in command_tools and command
+                    else {"summary": args_str[:500]}
+                )
+                stream_part = (
+                    command
+                    if current_tool_name in command_tools and command
+                    else (args_str if args_str else None)
+                )
                 yield ChatAgentResponse(
                     response="",
                     tool_calls=[
@@ -205,11 +227,9 @@ class StreamProcessor:
                             call_id=current_tool_call_id,
                             event_type=ToolCallEventType.CALL,
                             tool_name=current_tool_name,
-                            tool_response=get_tool_call_info_content(
-                                current_tool_name, args_dict
-                            ),
-                            tool_call_details={"summary": args_str[:500]},
-                            stream_part=args_str if args_str else None,
+                            tool_response=tool_response,
+                            tool_call_details=tool_call_details,
+                            stream_part=stream_part,
                             is_complete=False,
                         )
                     ],
@@ -226,6 +246,9 @@ class StreamProcessor:
                         delta.tool_name_delta or ""
                     )
                 args_delta = getattr(delta, "args_delta", None)
+                if current_tool_call_id and args_delta is not None:
+                    existing = tool_args_buffers.get(current_tool_call_id, "")
+                    tool_args_buffers[current_tool_call_id] = existing + str(args_delta)
                 stream_part = (
                     args_delta if isinstance(args_delta, str) else str(args_delta)
                 ) if args_delta is not None else ""
@@ -248,6 +271,28 @@ class StreamProcessor:
                         ],
                         citations=[],
                     )
+                if current_tool_call_id and current_tool_name:
+                    args_buffer = tool_args_buffers.get(current_tool_call_id, "")
+                    preview = try_extract_streaming_preview(current_tool_name, args_buffer)
+                    last_preview = tool_preview_cache.get(current_tool_call_id, "")
+                    if preview and preview != last_preview:
+                        tool_preview_cache[current_tool_call_id] = preview
+                        chunks_yielded += 1
+                        yield ChatAgentResponse(
+                            response="",
+                            tool_calls=[
+                                ToolCallResponse(
+                                    call_id=current_tool_call_id,
+                                    event_type=ToolCallEventType.CALL,
+                                    tool_name=current_tool_name,
+                                    tool_response=preview,
+                                    tool_call_details={"summary": preview},
+                                    stream_part=None,
+                                    is_complete=False,
+                                )
+                            ],
+                            citations=[],
+                        )
 
     def handle_stream_error(
         self, error: Exception, context: str = "model request stream"

--- a/app/modules/intelligence/agents/chat_agents/multi_agent/utils/tool_utils.py
+++ b/app/modules/intelligence/agents/chat_agents/multi_agent/utils/tool_utils.py
@@ -2,6 +2,7 @@
 
 import copy
 import functools
+import hashlib
 import inspect
 import json
 import re
@@ -100,6 +101,13 @@ def _safe_parse_tool_args(
         raw_str = str(raw_args) if raw_args != "N/A" else ""
         repaired = _repair_truncated_tool_args_json(raw_str)
         if repaired is not None:
+            if not isinstance(repaired, dict):
+                logger.warning(
+                    "Repaired JSON for tool call '%s' is not a dict (type=%s); normalizing to {}",
+                    tool_name,
+                    type(repaired).__name__,
+                )
+                repaired = {}
             try:
                 setattr(event.part, "args", json.dumps(repaired))
             except Exception as sanitize_error:
@@ -115,13 +123,15 @@ def _safe_parse_tool_args(
             )
             return repaired
 
+        raw_digest = hashlib.sha256(raw_str.encode()).hexdigest()
         logger.error(
             "JSON parsing error in tool call '%s': %s. "
-            "Tool args (raw, first 300 chars): %s. "
+            "Tool args payload size=%d bytes, sha256=%s. "
             "This may cause issues when pydantic_ai tries to serialize the message history.",
             tool_name,
             json_error,
-            raw_str[:300],
+            len(raw_str),
+            raw_digest,
         )
         try:
             setattr(event.part, "args", "{}")
@@ -211,11 +221,25 @@ def create_tool_result_response(event: FunctionToolResultEvent) -> ToolCallRespo
     if is_delegation_tool(tool_name):
         agent_type = extract_agent_type_from_delegation_tool(tool_name)
         full_result_content = str(event.result.content) if event.result.content else ""
-        (
-            truncated_result_content,
-            is_truncated,
-            original_length,
-        ) = truncate_result_content(full_result_content)
+
+        # Detect if the event already carries truncation metadata to avoid double-truncating
+        result_is_truncated = getattr(event.result, "is_truncated", None)
+        result_original_length = getattr(event.result, "original_length", None)
+        already_truncated = result_is_truncated or (
+            result_original_length is not None
+            and result_original_length > len(full_result_content)
+        )
+
+        if already_truncated:
+            truncated_result_content = full_result_content
+            is_truncated = bool(result_is_truncated)
+            original_length = result_original_length
+        else:
+            (
+                truncated_result_content,
+                is_truncated,
+                original_length,
+            ) = truncate_result_content(full_result_content)
 
         return ToolCallResponse(
             call_id=event.result.tool_call_id or "",

--- a/app/modules/intelligence/agents/chat_agents/multi_agent/utils/tool_utils.py
+++ b/app/modules/intelligence/agents/chat_agents/multi_agent/utils/tool_utils.py
@@ -89,6 +89,51 @@ def _repair_truncated_tool_args_json(raw: str) -> dict | None:
         return None
 
 
+def _safe_parse_tool_args(
+    event: FunctionToolCallEvent, tool_name: str
+) -> dict[str, Any]:
+    """Parse streamed tool args defensively and sanitize malformed payloads."""
+    try:
+        return event.part.args_as_dict()
+    except (ValueError, json.JSONDecodeError) as json_error:
+        raw_args = getattr(event.part, "args", "N/A")
+        raw_str = str(raw_args) if raw_args != "N/A" else ""
+        repaired = _repair_truncated_tool_args_json(raw_str)
+        if repaired is not None:
+            try:
+                setattr(event.part, "args", json.dumps(repaired))
+            except Exception as sanitize_error:
+                logger.warning(
+                    "Unable to sanitize repaired tool call arguments for '%s': %s",
+                    tool_name,
+                    sanitize_error,
+                )
+            logger.info(
+                "Repaired truncated JSON for tool call '%s' (recovered %d keys)",
+                tool_name,
+                len(repaired),
+            )
+            return repaired
+
+        logger.error(
+            "JSON parsing error in tool call '%s': %s. "
+            "Tool args (raw, first 300 chars): %s. "
+            "This may cause issues when pydantic_ai tries to serialize the message history.",
+            tool_name,
+            json_error,
+            raw_str[:300],
+        )
+        try:
+            setattr(event.part, "args", "{}")
+        except Exception as sanitize_error:
+            logger.warning(
+                "Unable to sanitize malformed tool call arguments for '%s': %s",
+                tool_name,
+                sanitize_error,
+            )
+        return {}
+
+
 def handle_exception(tool_func):
     # After _adapt_func_for_from_schema the wrapper is always async.
     # Guard here as well in case handle_exception is called on a raw sync func.
@@ -119,50 +164,7 @@ def handle_exception(tool_func):
 def create_tool_call_response(event: FunctionToolCallEvent) -> ToolCallResponse:
     """Create appropriate tool call response for regular or delegation tools"""
     tool_name = event.part.tool_name
-
-    # Safely parse tool arguments with error handling for malformed/truncated JSON
-    try:
-        args_dict = event.part.args_as_dict()
-    except (ValueError, json.JSONDecodeError) as json_error:
-        raw_args = getattr(event.part, "args", "N/A")
-        raw_str = str(raw_args) if raw_args != "N/A" else ""
-
-        # Try to repair truncated JSON (common when tool args are streamed and cut off)
-        repaired = _repair_truncated_tool_args_json(raw_str)
-        if repaired is not None:
-            args_dict = repaired
-            try:
-                setattr(event.part, "args", json.dumps(repaired))
-            except Exception as sanitize_error:
-                logger.warning(
-                    "Unable to sanitize repaired tool call arguments for '%s': %s",
-                    tool_name,
-                    sanitize_error,
-                )
-            logger.info(
-                "Repaired truncated JSON for tool call '%s' (recovered %d keys)",
-                tool_name,
-                len(args_dict),
-            )
-        else:
-            # Repair failed; use empty dict and log
-            logger.error(
-                "JSON parsing error in tool call '%s': %s. "
-                "Tool args (raw, first 300 chars): %s. "
-                "This may cause issues when pydantic_ai tries to serialize the message history.",
-                tool_name,
-                json_error,
-                raw_str[:300],
-            )
-            args_dict = {}
-            try:
-                setattr(event.part, "args", "{}")
-            except Exception as sanitize_error:
-                logger.warning(
-                    "Unable to sanitize malformed tool call arguments for '%s': %s",
-                    tool_name,
-                    sanitize_error,
-                )
+    args_dict = _safe_parse_tool_args(event, tool_name)
 
     command_tools = {"search_bash", "bash_command", "execute_terminal_command"}
     if tool_name in command_tools:
@@ -208,29 +210,41 @@ def create_tool_result_response(event: FunctionToolResultEvent) -> ToolCallRespo
 
     if is_delegation_tool(tool_name):
         agent_type = extract_agent_type_from_delegation_tool(tool_name)
-        result_content = str(event.result.content) if event.result.content else ""
-        result_content, is_truncated, original_length = truncate_result_content(result_content)
+        full_result_content = str(event.result.content) if event.result.content else ""
+        (
+            truncated_result_content,
+            is_truncated,
+            original_length,
+        ) = truncate_result_content(full_result_content)
 
         return ToolCallResponse(
             call_id=event.result.tool_call_id or "",
             event_type=ToolCallEventType.DELEGATION_RESULT,
             tool_name=tool_name,
             tool_response=get_delegation_response_message(agent_type),
-            tool_call_details={"summary": get_delegation_result_content(agent_type, result_content)},
+            tool_call_details={
+                "summary": get_delegation_result_content(
+                    agent_type, full_result_content
+                ),
+                "content": truncated_result_content,
+            },
             is_complete=True,
             is_truncated=is_truncated,
             original_length=original_length,
         )
     else:
-        raw_str = str(event.result.content) if event.result.content else ""
-        raw_str, is_truncated, original_length = truncate_result_content(raw_str)
+        full_raw = str(event.result.content) if event.result.content else ""
+        truncated_raw, is_truncated, original_length = truncate_result_content(full_raw)
 
         return ToolCallResponse(
             call_id=event.result.tool_call_id or "",
             event_type=ToolCallEventType.RESULT,
             tool_name=tool_name,
-            tool_response=get_tool_response_message(tool_name, result=raw_str),
-            tool_call_details={"summary": get_tool_result_info_content(tool_name, raw_str)},
+            tool_response=get_tool_response_message(tool_name, result=full_raw),
+            tool_call_details={
+                "summary": get_tool_result_info_content(tool_name, full_raw),
+                "content": truncated_raw,
+            },
             is_truncated=is_truncated,
             original_length=original_length,
         )

--- a/app/modules/intelligence/agents/chat_agents/multi_agent/utils/tool_utils.py
+++ b/app/modules/intelligence/agents/chat_agents/multi_agent/utils/tool_utils.py
@@ -34,6 +34,28 @@ from app.modules.utils.logger import setup_logger
 
 logger = setup_logger(__name__)
 
+# Max chars of tool result content streamed to browser (prevents OOM on large codebases)
+_MAX_TOOL_RESULT_STREAM_CHARS = 10_000
+
+
+def truncate_result_content(content: str) -> tuple[str, bool, int | None]:
+    """Truncate raw tool result content to browser-safe length.
+    Returns: (content, is_truncated, original_length_or_None)
+    """
+    if not content or len(content) <= _MAX_TOOL_RESULT_STREAM_CHARS:
+        return content, False, None
+    original_length = len(content)
+    truncated = (
+        content[:_MAX_TOOL_RESULT_STREAM_CHARS]
+        + f"\n... [truncated — {original_length:,} chars total, showing first {_MAX_TOOL_RESULT_STREAM_CHARS:,}]"
+    )
+    logger.info(
+        "Tool result truncated for browser stream: %d → %d chars",
+        original_length,
+        _MAX_TOOL_RESULT_STREAM_CHARS,
+    )
+    return truncated, True, original_length
+
 
 def _repair_truncated_tool_args_json(raw: str) -> dict | None:
     """Attempt to repair truncated JSON from streamed tool call args. Returns parsed dict or None."""
@@ -187,28 +209,30 @@ def create_tool_result_response(event: FunctionToolResultEvent) -> ToolCallRespo
     if is_delegation_tool(tool_name):
         agent_type = extract_agent_type_from_delegation_tool(tool_name)
         result_content = str(event.result.content) if event.result.content else ""
+        result_content, is_truncated, original_length = truncate_result_content(result_content)
 
         return ToolCallResponse(
             call_id=event.result.tool_call_id or "",
             event_type=ToolCallEventType.DELEGATION_RESULT,
             tool_name=tool_name,
             tool_response=get_delegation_response_message(agent_type),
-            tool_call_details={
-                "summary": get_delegation_result_content(agent_type, result_content)
-            },
-            is_complete=True,  # Explicitly mark delegation results as complete
+            tool_call_details={"summary": get_delegation_result_content(agent_type, result_content)},
+            is_complete=True,
+            is_truncated=is_truncated,
+            original_length=original_length,
         )
     else:
+        raw_str = str(event.result.content) if event.result.content else ""
+        raw_str, is_truncated, original_length = truncate_result_content(raw_str)
+
         return ToolCallResponse(
             call_id=event.result.tool_call_id or "",
             event_type=ToolCallEventType.RESULT,
             tool_name=tool_name,
-            tool_response=get_tool_response_message(
-                tool_name, result=event.result.content
-            ),
-            tool_call_details={
-                "summary": get_tool_result_info_content(tool_name, event.result.content)
-            },
+            tool_response=get_tool_response_message(tool_name, result=raw_str),
+            tool_call_details={"summary": get_tool_result_info_content(tool_name, raw_str)},
+            is_truncated=is_truncated,
+            original_length=original_length,
         )
 
 

--- a/app/modules/intelligence/agents/chat_agents/multi_agent/utils/tool_utils.py
+++ b/app/modules/intelligence/agents/chat_agents/multi_agent/utils/tool_utils.py
@@ -142,6 +142,16 @@ def create_tool_call_response(event: FunctionToolCallEvent) -> ToolCallResponse:
                     sanitize_error,
                 )
 
+    command_tools = {"search_bash", "bash_command", "execute_terminal_command"}
+    if tool_name in command_tools:
+        command = str(args_dict.get("command", "") or "").strip()
+        return ToolCallResponse(
+            call_id=event.part.tool_call_id or "",
+            event_type=ToolCallEventType.CALL,
+            tool_name=tool_name,
+            tool_response=command or get_tool_run_message(tool_name, args_dict),
+            tool_call_details={"command": command} if command else {},
+        )
     if is_delegation_tool(tool_name):
         agent_type = extract_agent_type_from_delegation_tool(tool_name)
         task_description = args_dict.get("task_description", "")

--- a/app/modules/intelligence/agents/chat_agents/tool_helpers.py
+++ b/app/modules/intelligence/agents/chat_agents/tool_helpers.py
@@ -1,4 +1,5 @@
 import re
+import json
 from typing import Any, Dict, List
 
 # Import todo management for streaming todo list state
@@ -282,6 +283,90 @@ def get_tool_run_message(tool_name: str, args: Dict[str, Any] | None = None):
             return "Adding comment to Confluence page"
         case _:
             return "Querying data"
+
+
+def _parse_partial_args_buffer(args_buffer: str) -> Dict[str, Any] | None:
+    """Best-effort parser for partially streamed tool args JSON."""
+    if not args_buffer or not isinstance(args_buffer, str):
+        return None
+
+    s = args_buffer.strip()
+    if not s:
+        return None
+
+    try:
+        parsed = json.loads(s)
+        return parsed if isinstance(parsed, dict) else None
+    except json.JSONDecodeError:
+        pass
+
+    open_braces = s.count("{") - s.count("}")
+    open_brackets = s.count("[") - s.count("]")
+    repaired = s + ("}" * max(open_braces, 0)) + ("]" * max(open_brackets, 0))
+    try:
+        parsed = json.loads(repaired)
+        return parsed if isinstance(parsed, dict) else None
+    except json.JSONDecodeError:
+        return None
+
+
+def _extract_string_field(args_buffer: str, field_name: str) -> str | None:
+    """Extract a string field from partial JSON text via regex fallback."""
+    m = re.search(rf'"{re.escape(field_name)}"\s*:\s*"([^"]+)', args_buffer)
+    if m and m.group(1).strip():
+        return m.group(1).strip()
+    return None
+
+
+def try_extract_streaming_preview(tool_name: str, args_buffer: str) -> str | None:
+    """Return an early meaningful preview from streaming tool args, when possible."""
+    args: Dict[str, Any] = _parse_partial_args_buffer(args_buffer) or {}
+
+    if tool_name == "fetch_file":
+        file_path = args.get("file_path") or _extract_string_field(args_buffer, "file_path")
+        if file_path:
+            return get_tool_run_message(tool_name, {"file_path": file_path})
+        return None
+
+    if tool_name == "fetch_files_batch":
+        paths = args.get("paths")
+        if isinstance(paths, list) and len(paths) > 0:
+            return get_tool_run_message(tool_name, {"paths": paths})
+        return None
+
+    if tool_name in {
+        "search_text",
+        "search_workspace_symbols",
+        "semantic_search",
+    }:
+        query = args.get("query") or _extract_string_field(args_buffer, "query")
+        if query:
+            return get_tool_run_message(tool_name, {"query": query})
+        return None
+
+    if tool_name == "search_files":
+        pattern = args.get("pattern") or _extract_string_field(args_buffer, "pattern")
+        if pattern:
+            return get_tool_run_message(tool_name, {"pattern": pattern})
+        return None
+
+    if tool_name == "search_symbols":
+        file_path = args.get("file_path") or _extract_string_field(args_buffer, "file_path")
+        if file_path:
+            return get_tool_run_message(tool_name, {"file_path": file_path})
+        return None
+
+    if tool_name in {"search_bash", "bash_command", "execute_terminal_command"}:
+        command = args.get("command") or _extract_string_field(args_buffer, "command")
+        if command:
+            payload: Dict[str, Any] = {"command": command}
+            mode = args.get("mode")
+            if mode:
+                payload["mode"] = mode
+            return get_tool_run_message(tool_name, payload)
+        return None
+
+    return None
 
 
 def _parse_terminal_result_string(content: str) -> tuple[str | None, int | None, bool]:

--- a/app/modules/intelligence/agents/chat_agents/tool_helpers.py
+++ b/app/modules/intelligence/agents/chat_agents/tool_helpers.py
@@ -302,7 +302,7 @@ def _parse_partial_args_buffer(args_buffer: str) -> Dict[str, Any] | None:
 
     open_braces = s.count("{") - s.count("}")
     open_brackets = s.count("[") - s.count("]")
-    repaired = s + ("}" * max(open_braces, 0)) + ("]" * max(open_brackets, 0))
+    repaired = s + ("]" * max(open_brackets, 0)) + ("}" * max(open_braces, 0))
     try:
         parsed = json.loads(repaired)
         return parsed if isinstance(parsed, dict) else None

--- a/app/modules/intelligence/memory/chat_history_service.py
+++ b/app/modules/intelligence/memory/chat_history_service.py
@@ -123,7 +123,7 @@ class ChatHistoryService:
                     citations=(
                         ",".join(set(citations)) if citations else None
                     ),  # Use set to remove duplicates
-                    tool_calls=tool_calls if tool_calls else None,
+                    tool_calls=None,
                     thinking=thinking,
                 )
                 self.db.add(new_message)
@@ -192,7 +192,7 @@ class ChatHistoryService:
                 status=MessageStatus.ACTIVE,
                 created_at=datetime.now(timezone.utc),
                 citations=(",".join(set(citations)) if citations else None),
-                tool_calls=tool_calls if tool_calls else None,
+                tool_calls=None,
                 thinking=thinking,
             )
             self.db.add(new_message)
@@ -354,7 +354,7 @@ class AsyncChatHistoryService:
                     citations=(
                         ",".join(set(citations)) if citations else None
                     ),
-                    tool_calls=tool_calls if tool_calls else None,
+                    tool_calls=None,
                     thinking=thinking,
                 )
                 self.session.add(new_message)
@@ -413,7 +413,7 @@ class AsyncChatHistoryService:
                 status=MessageStatus.ACTIVE,
                 created_at=datetime.now(timezone.utc),
                 citations=(",".join(set(citations)) if citations else None),
-                tool_calls=tool_calls if tool_calls else None,
+                tool_calls=None,
                 thinking=thinking,
             )
             self.session.add(new_message)

--- a/tests/unit/conversations/test_conversations_router_helpers.py
+++ b/tests/unit/conversations/test_conversations_router_helpers.py
@@ -1,0 +1,24 @@
+import pytest
+
+from app.modules.conversations.conversations_router import (
+    _is_vscode_extension_user_agent,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    ("user_agent", "expected"),
+    [
+        ("Potpie-VSCode-Extension/1.0", True),
+        ("Potpie-VSCode-Extension/1.0.0", True),
+        ("Mozilla Potpie-VSCode-Extension/12.34 tail", True),
+        ("Potpie-VSCode-Extension", False),
+        ("Potpie-VSCode-Extension/abc", False),
+        ("NotPotpie-VSCode-Extension/1.0", False),
+        ("Potpie-VSCode-Extension/1", False),
+    ],
+)
+def test_is_vscode_extension_user_agent(user_agent, expected):
+    assert _is_vscode_extension_user_agent(user_agent) is expected

--- a/tests/unit/intelligence/test_chat_agent_context.py
+++ b/tests/unit/intelligence/test_chat_agent_context.py
@@ -1,0 +1,59 @@
+import pytest
+
+from app.modules.intelligence.agents.chat_agent import ChatContext
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_chat_context_image_helpers_merge_and_preserve_original_data():
+    current = {"img-1": {"mime_type": "image/png", "file_size": 10}}
+    history = {"img-2": {"mime_type": "image/jpeg", "file_size": 20}}
+    ctx = ChatContext(
+        project_id="project-1",
+        project_name="Project",
+        curr_agent_id="agent-1",
+        history=["hello"],
+        query="find issue",
+        image_attachments=current,
+        context_images=history,
+    )
+
+    all_images = ctx.get_all_images()
+
+    assert ctx.has_images() is True
+    assert all_images["img-1"]["context_type"] == "current_message"
+    assert all_images["img-1"]["relevance"] == "high"
+    assert all_images["img-2"]["context_type"] == "conversation_history"
+    assert all_images["img-2"]["relevance"] == "medium"
+    assert current["img-1"] == {"mime_type": "image/png", "file_size": 10}
+    assert history["img-2"] == {"mime_type": "image/jpeg", "file_size": 20}
+
+
+def test_chat_context_helpers_return_empty_defaults_without_images():
+    ctx = ChatContext(
+        project_id="project-2",
+        project_name="Project",
+        curr_agent_id="agent-2",
+        history=[],
+        query="status",
+    )
+
+    assert ctx.is_inferring() is False
+    assert ctx.has_images() is False
+    assert ctx.get_all_images() == {}
+    assert ctx.get_current_images_only() == {}
+    assert ctx.get_context_images_only() == {}
+
+
+def test_chat_context_is_inferring_for_inferring_projects():
+    ctx = ChatContext(
+        project_id="project-3",
+        project_name="Project",
+        curr_agent_id="agent-3",
+        history=[],
+        query="status",
+        project_status="inferring",
+    )
+
+    assert ctx.is_inferring() is True

--- a/tests/unit/intelligence/test_message_helpers.py
+++ b/tests/unit/intelligence/test_message_helpers.py
@@ -1,0 +1,199 @@
+from types import SimpleNamespace
+
+import pytest
+from pydantic_ai.messages import ModelRequest, ModelResponse, SystemPromptPart, TextPart, UserPromptPart
+
+from app.modules.intelligence.agents.chat_agents import message_helpers
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_is_user_message_only_matches_model_requests_with_user_prompt():
+    user_msg = ModelRequest(parts=[UserPromptPart(content="hello")])
+    system_msg = ModelRequest(parts=[SystemPromptPart(content="system")])
+    response_msg = ModelResponse(parts=[TextPart(content="answer")])
+
+    assert message_helpers.is_user_message(user_msg) is True
+    assert message_helpers.is_user_message(system_msg) is False
+    assert message_helpers.is_user_message(response_msg) is False
+
+
+def test_tool_message_classification_for_request_and_response_shapes():
+    request_tool_call = ModelRequest(
+        parts=[SimpleNamespace(tool_name="search", tool_call_id="call-1", args={"q": "x"})]
+    )
+    request_tool_result = ModelRequest(
+        parts=[SimpleNamespace(tool_name="search", tool_call_id="call-1", content="done")]
+    )
+    nested_tool_call = ModelRequest(
+        parts=[
+            SimpleNamespace(
+                part=SimpleNamespace(tool_name="search", tool_call_id="call-2", args="{}")
+            )
+        ]
+    )
+    response_tool_call = ModelResponse(
+        parts=[SimpleNamespace(part_kind="tool-call", tool_name="search", tool_call_id="call-3")]
+    )
+    response_tool_result = ModelResponse(
+        parts=[SimpleNamespace(tool_name="search", tool_call_id="call-3", content="result")]
+    )
+
+    assert message_helpers.is_tool_call_message(request_tool_call) is True
+    assert message_helpers.is_tool_call_message(request_tool_result) is False
+    assert message_helpers.is_tool_call_message(nested_tool_call) is True
+    assert message_helpers.is_tool_call_message(response_tool_call) is True
+
+    assert message_helpers.is_tool_result_message(request_tool_result) is True
+    assert message_helpers.is_tool_result_message(request_tool_call) is False
+    assert message_helpers.is_tool_result_message(response_tool_result) is True
+    assert message_helpers.is_tool_result_message(response_tool_call) is False
+
+
+def test_is_llm_response_message_requires_non_empty_text():
+    assert (
+        message_helpers.is_llm_response_message(
+            ModelResponse(parts=[TextPart(content="  useful answer  ")])
+        )
+        is True
+    )
+    assert (
+        message_helpers.is_llm_response_message(
+            ModelResponse(parts=[TextPart(content="   ")])
+        )
+        is False
+    )
+    assert (
+        message_helpers.is_llm_response_message(
+            ModelRequest(parts=[UserPromptPart(content="hello")])
+        )
+        is False
+    )
+
+
+def test_extract_tool_call_ids_collects_top_level_and_nested_ids():
+    request_msg = ModelRequest(
+        parts=[
+            SimpleNamespace(tool_call_id="call-1"),
+            SimpleNamespace(part=SimpleNamespace(tool_call_id="call-2")),
+        ]
+    )
+    response_msg = ModelResponse(
+        parts=[
+            SimpleNamespace(tool_call_id="call-3"),
+            SimpleNamespace(result=SimpleNamespace(tool_call_id="call-4")),
+        ]
+    )
+
+    assert message_helpers.extract_tool_call_ids(request_msg) == {"call-1", "call-2"}
+    assert message_helpers.extract_tool_call_ids(response_msg) == {"call-3", "call-4"}
+
+
+def test_extract_tool_call_info_supports_request_nested_and_response_parts():
+    request_msg = ModelRequest(
+        parts=[SimpleNamespace(tool_name="search", tool_call_id="call-1", args={"q": "abc"})]
+    )
+    nested_request_msg = ModelRequest(
+        parts=[
+            SimpleNamespace(
+                part=SimpleNamespace(tool_name="bash", tool_call_id="call-2", args=["ls", "-la"])
+            )
+        ]
+    )
+    response_msg = ModelResponse(
+        parts=[SimpleNamespace(part_kind="tool-call", tool_name="open", tool_call_id="call-3", args="{}")]
+    )
+
+    assert message_helpers.extract_tool_call_info(request_msg) == (
+        "search",
+        '{"q": "abc"}',
+        "call-1",
+    )
+    assert message_helpers.extract_tool_call_info(nested_request_msg) == (
+        "bash",
+        "['ls', '-la']",
+        "call-2",
+    )
+    assert message_helpers.extract_tool_call_info(response_msg) == (
+        "open",
+        "{}",
+        "call-3",
+    )
+
+
+def test_extract_tool_result_info_supports_result_objects_and_content_strings():
+    request_msg = ModelRequest(
+        parts=[
+            SimpleNamespace(
+                tool_name="search",
+                tool_call_id="call-1",
+                result=SimpleNamespace(content="request result"),
+            )
+        ]
+    )
+    response_msg = ModelResponse(
+        parts=[SimpleNamespace(tool_name="search", tool_call_id="call-2", content="response result")]
+    )
+    empty_msg = ModelRequest(
+        parts=[SimpleNamespace(tool_name="search", tool_call_id="call-3", content="   ")]
+    )
+
+    assert message_helpers.extract_tool_result_info(request_msg) == (
+        "search",
+        "request result",
+        "call-1",
+    )
+    assert message_helpers.extract_tool_result_info(response_msg) == (
+        "search",
+        "response result",
+        "call-2",
+    )
+    assert message_helpers.extract_tool_result_info(empty_msg) is None
+
+
+def test_serialize_messages_to_text_includes_json_fallback_and_text_parts():
+    messages = [
+        ModelRequest(
+            parts=[
+                SystemPromptPart(content="system"),
+                UserPromptPart(content={"prompt": "user"}),
+                SimpleNamespace(tool_name="search", tool_call_id="call-1", args={"q": "abc"}),
+            ]
+        ),
+        ModelResponse(
+            parts=[
+                TextPart(content="answer"),
+                SimpleNamespace(tool_name="search", tool_call_id="call-1", content="done"),
+            ]
+        ),
+    ]
+
+    serialized = message_helpers.serialize_messages_to_text(messages)
+
+    assert "system" in serialized
+    assert "{'prompt': 'user'}" in serialized
+    assert '"tool_name": "search"' in serialized
+    assert "answer" in serialized
+
+
+def test_extract_system_prompt_and_ensure_history_ends_with_model_request():
+    messages = [
+        ModelRequest(parts=[SystemPromptPart(content="system one")]),
+        ModelRequest(parts=[SystemPromptPart(content={"note": "second"})]),
+        ModelResponse(parts=[TextPart(content="answer")]),
+    ]
+
+    system_prompt = message_helpers.extract_system_prompt_from_messages(messages)
+    ensured = message_helpers.ensure_history_ends_with_model_request(messages)
+
+    assert system_prompt == "system one\n{'note': 'second'}"
+    assert isinstance(ensured[-1], ModelRequest)
+    assert ensured[-1].parts[0].content == ""
+    assert message_helpers.ensure_history_ends_with_model_request([]) == []
+    assert (
+        message_helpers.ensure_history_ends_with_model_request(
+            [ModelRequest(parts=[UserPromptPart(content="keep me")])]
+        )[-1].parts[0].content
+        == "keep me"
+    )

--- a/tests/unit/intelligence/test_multi_agent_tool_utils.py
+++ b/tests/unit/intelligence/test_multi_agent_tool_utils.py
@@ -1,0 +1,113 @@
+from types import SimpleNamespace
+
+import pytest
+
+from app.modules.intelligence.agents.chat_agents.multi_agent.utils import tool_utils
+
+
+pytestmark = pytest.mark.unit
+
+
+class _ToolCallPart:
+    def __init__(self, tool_name: str, args: str, tool_call_id: str = "call-1"):
+        self.tool_name = tool_name
+        self.args = args
+        self.tool_call_id = tool_call_id
+
+    def args_as_dict(self):
+        raise ValueError("truncated json")
+
+
+def test_repair_truncated_tool_args_json_closes_brackets_before_braces():
+    repaired = tool_utils._repair_truncated_tool_args_json('{"paths":["a')
+
+    assert repaired == {"paths": ["a"]}
+
+
+def test_safe_parse_tool_args_repairs_and_sanitizes_event_part():
+    event = SimpleNamespace(part=_ToolCallPart("search_files", '{"paths":["a'))
+
+    parsed = tool_utils._safe_parse_tool_args(event, "search_files")
+
+    assert parsed == {"paths": ["a"]}
+    assert event.part.args == '{"paths": ["a"]}'
+
+
+def test_create_tool_result_response_uses_full_regular_result_for_summary(monkeypatch):
+    captured = {}
+    full_raw = "x" * (tool_utils._MAX_TOOL_RESULT_STREAM_CHARS + 25)
+
+    def fake_get_tool_response_message(tool_name, result):
+        captured["response_result"] = result
+        return "rendered response"
+
+    def fake_get_tool_result_info_content(tool_name, result):
+        captured["summary_result"] = result
+        return "rendered summary"
+
+    monkeypatch.setattr(
+        tool_utils, "get_tool_response_message", fake_get_tool_response_message
+    )
+    monkeypatch.setattr(
+        tool_utils, "get_tool_result_info_content", fake_get_tool_result_info_content
+    )
+
+    event = SimpleNamespace(
+        result=SimpleNamespace(
+            tool_name="search_files", content=full_raw, tool_call_id="call-2"
+        )
+    )
+
+    response = tool_utils.create_tool_result_response(event)
+
+    assert captured["response_result"] == full_raw
+    assert captured["summary_result"] == full_raw
+    assert response.tool_response == "rendered response"
+    assert response.tool_call_details["summary"] == "rendered summary"
+    assert response.tool_call_details["content"].startswith("x" * 50)
+    assert "[truncated" in response.tool_call_details["content"]
+    assert response.is_truncated is True
+    assert response.original_length == len(full_raw)
+
+
+def test_create_tool_result_response_uses_full_delegation_result_for_summary(
+    monkeypatch,
+):
+    captured = {}
+    full_raw = "delegated result " * 900
+
+    monkeypatch.setattr(tool_utils, "is_delegation_tool", lambda tool_name: True)
+    monkeypatch.setattr(
+        tool_utils,
+        "extract_agent_type_from_delegation_tool",
+        lambda tool_name: "codebase",
+    )
+    monkeypatch.setattr(
+        tool_utils, "get_delegation_response_message", lambda agent_type: "done"
+    )
+
+    def fake_get_delegation_result_content(agent_type, result):
+        captured["delegation_result"] = result
+        return "delegation summary"
+
+    monkeypatch.setattr(
+        tool_utils,
+        "get_delegation_result_content",
+        fake_get_delegation_result_content,
+    )
+
+    event = SimpleNamespace(
+        result=SimpleNamespace(
+            tool_name="delegate_to_codebase_agent",
+            content=full_raw,
+            tool_call_id="call-3",
+        )
+    )
+
+    response = tool_utils.create_tool_result_response(event)
+
+    assert captured["delegation_result"] == full_raw
+    assert response.tool_response == "done"
+    assert response.tool_call_details["summary"] == "delegation summary"
+    assert response.tool_call_details["content"]
+

--- a/tests/unit/intelligence/test_reasoning_manager.py
+++ b/tests/unit/intelligence/test_reasoning_manager.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+import pytest
+
+from app.modules.intelligence.tools import reasoning_manager
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_reasoning_manager_finalize_and_save_writes_hash_file(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    manager = reasoning_manager.ReasoningManager()
+    manager.append_content("alpha")
+    manager.append_content(" beta")
+
+    reasoning_hash = manager.finalize_and_save()
+
+    assert reasoning_hash == manager.get_reasoning_hash()
+    saved_path = tmp_path / ".data" / "reasoning" / f"{reasoning_hash}.txt"
+    assert saved_path.read_text(encoding="utf-8") == "alpha beta"
+
+
+def test_reasoning_manager_finalize_returns_none_when_empty():
+    manager = reasoning_manager.ReasoningManager()
+
+    assert manager.finalize_and_save() is None
+    assert manager.get_reasoning_hash() is None
+
+
+def test_get_and_reset_reasoning_manager_replaces_context_instance():
+    reasoning_manager._reset_reasoning_manager()
+    first = reasoning_manager._get_reasoning_manager()
+    first.append_content("hello")
+
+    same = reasoning_manager._get_reasoning_manager()
+    reasoning_manager._reset_reasoning_manager()
+    second = reasoning_manager._get_reasoning_manager()
+
+    assert same is first
+    assert second is not first
+    assert second.content == ""
+    assert second.get_reasoning_hash() is None

--- a/tests/unit/intelligence/test_tool_utils_general.py
+++ b/tests/unit/intelligence/test_tool_utils_general.py
@@ -1,0 +1,40 @@
+import pytest
+
+from app.modules.intelligence.tools import tool_utils
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_truncate_response_returns_original_when_short():
+    assert tool_utils.truncate_response("short", max_length=10) == "short"
+
+
+def test_truncate_response_appends_notice_when_content_is_long():
+    content = "abcdefghijXYZ"
+
+    truncated = tool_utils.truncate_response(content, max_length=10)
+
+    assert truncated.startswith("abcdefghij")
+    assert "[TRUNCATED]" in truncated
+    assert "13 total characters" in truncated
+
+
+def test_truncate_dict_response_truncates_nested_strings_and_lists():
+    long_value = "x" * 12
+    response = {
+        "text": long_value,
+        "nested": {"inner": long_value},
+        "items": [long_value, {"deep": long_value}, 7],
+        "count": 3,
+    }
+
+    truncated = tool_utils.truncate_dict_response(response, max_length=10)
+
+    assert truncated["text"].startswith("x" * 10)
+    assert "[TRUNCATED]" in truncated["text"]
+    assert truncated["nested"]["inner"].startswith("x" * 10)
+    assert truncated["items"][0].startswith("x" * 10)
+    assert truncated["items"][1]["deep"].startswith("x" * 10)
+    assert truncated["items"][2] == 7
+    assert truncated["count"] == 3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Earlier streaming previews for tool executions during argument streaming.
  * Tool responses now include truncation metadata (is_truncated, original_length) and truncated content for browser streaming.

* **Improvements**
  * More flexible VS Code extension detection for local-mode.
  * Generated summaries use full tool output while streamed payloads are trimmed for display.
  * Chat history persistence now omits stored tool-call payloads.

* **Tests**
  * Expanded unit tests covering routing, tool parsing, multi-agent flows, message helpers, and reasoning utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->