### PR TITLE
fix: JSON content-type in auth routes + traceback truncation (#634, #675)

### DIFF
--- a/app/modules/auth/auth_router.py
+++ b/app/modules/auth/auth_router.py
@@ -139,12 +139,12 @@ class AuthAPI:
 
         # Validate
         if not uid:
-            return Response(
-                content=json.dumps({"error": "Missing uid"}), status_code=400
+            return JSONResponse(
+                content={"error": "Missing uid"}, status_code=400
             )
         if not email:
-            return Response(
-                content=json.dumps({"error": "Missing email"}), status_code=400
+            return JSONResponse(
+                content={"error": "Missing email"}, status_code=400
             )
 
         async_user_service = AsyncUserService(async_db)
@@ -175,10 +175,10 @@ class AuthAPI:
 
             if not user:
                 logger.error(f"SSO user {link_to_user_id} not found in database!")
-                return Response(
-                    content=json.dumps(
+                return JSONResponse(
+                    content=
                         {"error": "User not found. Please sign in again."}
-                    ),
+                    ,
                     status_code=404,
                 )
 
@@ -196,8 +196,8 @@ class AuthAPI:
 
             if existing_github:
                 logger.info(f"GitHub already linked to user {user.uid}")
-                return Response(
-                    content=json.dumps(
+                return JSONResponse(
+                    content=
                         _signup_response_with_custom_token(
                             {
                                 "uid": user.uid,
@@ -205,7 +205,7 @@ class AuthAPI:
                                 "needs_github_linking": False,
                             }
                         )
-                    ),
+                    ,
                     status_code=200,
                 )
 
@@ -231,13 +231,13 @@ class AuthAPI:
                     f"GitHub account {provider_uid} is already linked to user {existing_provider_with_uid.user_id}, "
                     f"cannot link to user {user.uid}"
                 )
-                return Response(
-                    content=json.dumps(
+                return JSONResponse(
+                    content=
                         {
                             "error": error_message,
                             "details": f"GitHub account {provider_uid} is already linked to user {existing_provider_with_uid.user_id}, cannot link to user {user.uid}",
                         }
-                    ),
+                    ,
                     status_code=409,  # Conflict
                 )
 
@@ -270,13 +270,13 @@ class AuthAPI:
                     logger.error(
                         f"GitHub account {provider_uid} is already linked to another user: {e}"
                     )
-                    return Response(
-                        content=json.dumps(
+                    return JSONResponse(
+                        content=
                             {
                                 "error": error_message,
                                 "details": f"GitHub account {provider_uid} is already linked to another user. Database constraint violation: {str(e)}",
                             }
-                        ),
+                        ,
                         status_code=409,  # Conflict
                     )
                 # Re-raise other IntegrityErrors (e.g., unique_user_provider)
@@ -289,8 +289,8 @@ class AuthAPI:
                 raise
 
             logger.info(f"Successfully linked GitHub to user {user.uid}")
-            return Response(
-                content=json.dumps(
+            return JSONResponse(
+                content=
                     _signup_response_with_custom_token(
                         {
                             "uid": user.uid,
@@ -298,7 +298,7 @@ class AuthAPI:
                             "needs_github_linking": False,
                         }
                     )
-                ),
+                ,
                 status_code=200,
             )
 
@@ -327,13 +327,13 @@ class AuthAPI:
                 logger.warning(
                     f"Blocked new GitHub signup attempt: GitHub UID {provider_uid} is not linked to any user"
                 )
-                return Response(
-                    content=json.dumps(
+                return JSONResponse(
+                    content=
                         {
                             "error": "GitHub sign-up is no longer supported. Please use 'Continue with Google' with your work email address.",
                             "details": "New GitHub signups are disabled. Existing GitHub users can still sign in.",
                         }
-                    ),
+                    ,
                     status_code=403,  # Forbidden
                 )
 
@@ -355,8 +355,8 @@ class AuthAPI:
                             user.uid, encrypt_token(oauth_token)
                         )
 
-                    return Response(
-                        content=json.dumps(
+                    return JSONResponse(
+                        content=
                             _signup_response_with_custom_token(
                                 {
                                     "uid": user.uid,
@@ -364,7 +364,7 @@ class AuthAPI:
                                     "needs_github_linking": False,
                                 }
                             )
-                        ),
+                        ,
                         status_code=200,
                     )
 
@@ -395,8 +395,8 @@ class AuthAPI:
                     },
                 )
 
-                return Response(
-                    content=json.dumps(
+                return JSONResponse(
+                    content=
                         _signup_response_with_custom_token(
                             {
                                 "uid": new_user.uid,
@@ -404,14 +404,14 @@ class AuthAPI:
                                 "needs_github_linking": False,  # They signed up with GitHub
                             }
                         )
-                    ),
+                    ,
                     status_code=201,
                 )
             except Exception as e:
                 db.rollback()
                 logger.error(f"Failed to create user: {e}", exc_info=True)
-                return Response(
-                    content=json.dumps({"error": f"Signup failed: {str(e)}"}),
+                return JSONResponse(
+                    content={"error": f"Signup failed: {str(e)}"},
                     status_code=500,
                 )
 
@@ -429,8 +429,8 @@ class AuthAPI:
             # Check GitHub linking
             has_github, _ = unified_auth.check_github_linked(user.uid)
 
-            return Response(
-                content=json.dumps(
+            return JSONResponse(
+                content=
                     _signup_response_with_custom_token(
                         {
                             "uid": user.uid,
@@ -438,7 +438,7 @@ class AuthAPI:
                             "needs_github_linking": not has_github,
                         }
                     )
-                ),
+                ,
                 status_code=200,
             )
         else:
@@ -455,8 +455,8 @@ class AuthAPI:
 
                 logger.info(f"Created email/password user: {new_user.uid}")
 
-                return Response(
-                    content=json.dumps(
+                return JSONResponse(
+                    content=
                         _signup_response_with_custom_token(
                             {
                                 "uid": new_user.uid,
@@ -464,14 +464,14 @@ class AuthAPI:
                                 "needs_github_linking": True,  # Email users always need GitHub
                             }
                         )
-                    ),
+                    ,
                     status_code=201,
                 )
             except Exception as e:
                 db.rollback()
                 logger.error(f"Email/password signup failed: {e}", exc_info=True)
-                return Response(
-                    content=json.dumps({"error": str(e)}),
+                return JSONResponse(
+                    content={"error": str(e)},
                     status_code=500,
                 )
 
@@ -484,18 +484,18 @@ class AuthAPI:
         """
         uid = user.get("uid") or user.get("user_id")
         if not uid:
-            return Response(
-                content=json.dumps({"error": "Missing uid in token"}),
+            return JSONResponse(
+                content={"error": "Missing uid in token"},
                 status_code=401,
             )
         custom_token = AuthService.create_custom_token(uid)
         if not custom_token:
-            return Response(
-                content=json.dumps({"error": "Failed to create custom token"}),
+            return JSONResponse(
+                content={"error": "Failed to create custom token"},
                 status_code=500,
             )
-        return Response(
-            content=json.dumps({"customToken": custom_token}),
+        return JSONResponse(
+            content={"customToken": custom_token},
             status_code=200,
         )
 

--- a/app/modules/auth/auth_router.py
+++ b/app/modules/auth/auth_router.py
@@ -5,7 +5,7 @@ import os
 import httpx
 from dotenv import load_dotenv
 from fastapi import Depends, Request
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import JSONResponse
 from fastapi.exceptions import HTTPException
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
@@ -232,12 +232,12 @@ class AuthAPI:
                     f"cannot link to user {user.uid}"
                 )
                 return JSONResponse(
-                    content=
+                    content={
                         {
                             "error": error_message,
                             "details": f"GitHub account {provider_uid} is already linked to user {existing_provider_with_uid.user_id}, cannot link to user {user.uid}",
                         }
-                    ,
+                    },
                     status_code=409,  # Conflict
                 )
 
@@ -271,12 +271,10 @@ class AuthAPI:
                         f"GitHub account {provider_uid} is already linked to another user: {e}"
                     )
                     return JSONResponse(
-                        content=
-                            {
-                                "error": error_message,
-                                "details": f"GitHub account {provider_uid} is already linked to another user. Database constraint violation: {str(e)}",
-                            }
-                        ,
+                        content={
+                            "error": error_message,
+                            "details": f"GitHub account {provider_uid} is already linked to another user. Database constraint violation: {str(e)}",
+                        },
                         status_code=409,  # Conflict
                     )
                 # Re-raise other IntegrityErrors (e.g., unique_user_provider)
@@ -328,12 +326,12 @@ class AuthAPI:
                     f"Blocked new GitHub signup attempt: GitHub UID {provider_uid} is not linked to any user"
                 )
                 return JSONResponse(
-                    content=
+                    content={
                         {
                             "error": "GitHub sign-up is no longer supported. Please use 'Continue with Google' with your work email address.",
                             "details": "New GitHub signups are disabled. Existing GitHub users can still sign in.",
                         }
-                    ,
+                    },
                     status_code=403,  # Forbidden
                 )
 

--- a/app/modules/auth/auth_router.py
+++ b/app/modules/auth/auth_router.py
@@ -11,8 +11,6 @@ from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-logger = logging.getLogger(__name__)
-
 from app.core.database import get_async_db, get_db
 from app.modules.auth.auth_schema import (
     LoginRequest,
@@ -176,9 +174,7 @@ class AuthAPI:
             if not user:
                 logger.error(f"SSO user {link_to_user_id} not found in database!")
                 return JSONResponse(
-                    content=
-                        {"error": "User not found. Please sign in again."}
-                    ,
+                    content={"error": "User not found. Please sign in again."},
                     status_code=404,
                 )
 
@@ -197,15 +193,13 @@ class AuthAPI:
             if existing_github:
                 logger.info(f"GitHub already linked to user {user.uid}")
                 return JSONResponse(
-                    content=
-                        _signup_response_with_custom_token(
-                            {
-                                "uid": user.uid,
-                                "exists": True,
-                                "needs_github_linking": False,
-                            }
-                        )
-                    ,
+                    content=_signup_response_with_custom_token(
+                        {
+                            "uid": user.uid,
+                            "exists": True,
+                            "needs_github_linking": False,
+                        }
+                    ),
                     status_code=200,
                 )
 
@@ -233,10 +227,8 @@ class AuthAPI:
                 )
                 return JSONResponse(
                     content={
-                        {
-                            "error": error_message,
-                            "details": f"GitHub account {provider_uid} is already linked to user {existing_provider_with_uid.user_id}, cannot link to user {user.uid}",
-                        }
+                        "error": error_message,
+                        "details": f"GitHub account {provider_uid} is already linked to user {existing_provider_with_uid.user_id}, cannot link to user {user.uid}",
                     },
                     status_code=409,  # Conflict
                 )
@@ -288,15 +280,13 @@ class AuthAPI:
 
             logger.info(f"Successfully linked GitHub to user {user.uid}")
             return JSONResponse(
-                content=
-                    _signup_response_with_custom_token(
-                        {
-                            "uid": user.uid,
-                            "exists": True,
-                            "needs_github_linking": False,
-                        }
-                    )
-                ,
+                content=_signup_response_with_custom_token(
+                    {
+                        "uid": user.uid,
+                        "exists": True,
+                        "needs_github_linking": False,
+                    }
+                ),
                 status_code=200,
             )
 
@@ -354,15 +344,13 @@ class AuthAPI:
                         )
 
                     return JSONResponse(
-                        content=
-                            _signup_response_with_custom_token(
-                                {
-                                    "uid": user.uid,
-                                    "exists": True,
-                                    "needs_github_linking": False,
-                                }
-                            )
-                        ,
+                        content=_signup_response_with_custom_token(
+                            {
+                                "uid": user.uid,
+                                "exists": True,
+                                "needs_github_linking": False,
+                            }
+                        ),
                         status_code=200,
                     )
 
@@ -394,15 +382,13 @@ class AuthAPI:
                 )
 
                 return JSONResponse(
-                    content=
-                        _signup_response_with_custom_token(
-                            {
-                                "uid": new_user.uid,
-                                "exists": False,
-                                "needs_github_linking": False,  # They signed up with GitHub
-                            }
-                        )
-                    ,
+                    content=_signup_response_with_custom_token(
+                        {
+                            "uid": new_user.uid,
+                            "exists": False,
+                            "needs_github_linking": False,  # They signed up with GitHub
+                        }
+                    ),
                     status_code=201,
                 )
             except Exception as e:
@@ -428,15 +414,13 @@ class AuthAPI:
             has_github, _ = unified_auth.check_github_linked(user.uid)
 
             return JSONResponse(
-                content=
-                    _signup_response_with_custom_token(
-                        {
-                            "uid": user.uid,
-                            "exists": True,
-                            "needs_github_linking": not has_github,
-                        }
-                    )
-                ,
+                content=_signup_response_with_custom_token(
+                    {
+                        "uid": user.uid,
+                        "exists": True,
+                        "needs_github_linking": not has_github,
+                    }
+                ),
                 status_code=200,
             )
         else:
@@ -454,15 +438,13 @@ class AuthAPI:
                 logger.info(f"Created email/password user: {new_user.uid}")
 
                 return JSONResponse(
-                    content=
-                        _signup_response_with_custom_token(
-                            {
-                                "uid": new_user.uid,
-                                "exists": False,
-                                "needs_github_linking": True,  # Email users always need GitHub
-                            }
-                        )
-                    ,
+                    content=_signup_response_with_custom_token(
+                        {
+                            "uid": new_user.uid,
+                            "exists": False,
+                            "needs_github_linking": True,  # Email users always need GitHub
+                        }
+                    ),
                     status_code=201,
                 )
             except Exception as e:

--- a/app/modules/utils/logger.py
+++ b/app/modules/utils/logger.py
@@ -131,7 +131,7 @@ def production_log_sink(message):
                 else str(exc.get("type", "Exception"))
             ),
             "value": filter_sensitive_data(str(exc.get("value", ""))),
-            "traceback": filter_sensitive_data(str(exc.get("traceback", ""))),
+            "traceback": filter_sensitive_data("\n".join(str(exc.get("traceback", "")).split("\n")[-10:])),
         }
 
     # Build flat JSON structure - easier for log parsers

--- a/app/modules/utils/logger.py
+++ b/app/modules/utils/logger.py
@@ -131,7 +131,9 @@ def production_log_sink(message):
                 else str(exc.get("type", "Exception"))
             ),
             "value": filter_sensitive_data(str(exc.get("value", ""))),
-            "traceback": filter_sensitive_data("\n".join(str(exc.get("traceback", "")).split("\n")[-10:])),
+            "traceback": filter_sensitive_data(
+                "\n".join(str(exc.get("traceback", "")).split("\n")[-10:])
+            ),
         }
 
     # Build flat JSON structure - easier for log parsers


### PR DESCRIPTION
## Fixes

### #634: Signup endpoint returns JSON body with text/plain content-type header
- Replaced 17 instances of `Response(content=json.dumps(...))` with `JSONResponse(content=...)` in `app/modules/auth/auth_router.py`
- All auth endpoints now correctly return `Content-Type: application/json`
- Consistent with login/SSO endpoints that already used `JSONResponse`

### #675: Stack Trace Not Truncated in Production Logs
- Truncated traceback output to last 10 lines in `app/modules/utils/logger.py`
- Reduces log volume from 60-100 line tracebacks per exception
- Limits exposure of internal file paths and third-party library frames

## Changes
- `app/modules/auth/auth_router.py`: 17 Response→JSONResponse replacements
- `app/modules/utils/logger.py`: traceback truncation to 10 lines

Fixes #634, Fixes #675

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Signup and custom-token endpoints now return proper JSON payloads (native objects), fixing inconsistent/serialized responses and ensuring clients receive consistent, parseable responses across success and error cases.
  * Adjusted a GitHub-related signup error payload to correct its structure for clearer client handling.

* **Refactor**
  * Error logging now truncates tracebacks to the last 10 lines, reducing log noise while preserving relevant context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->