### PR TITLE
fix: cap traceback to last 10 lines in production logs

### DIFF
--- a/app/modules/utils/logger.py
+++ b/app/modules/utils/logger.py
@@ -124,6 +124,13 @@ def production_log_sink(message):
     exception = None
     exc = record.get("exception")
     if exc:
+        # Cap traceback to last 10 lines to avoid bloating production logs
+        raw_traceback = str(exc.get("traceback", ""))
+        traceback_lines = raw_traceback.splitlines()
+        if len(traceback_lines) > 10:
+            traceback_lines = traceback_lines[-10:]
+        truncated_traceback = "\n".join(traceback_lines)
+
         exception = {
             "type": (
                 exc.get("type", {}).get("name", "Exception")
@@ -131,7 +138,7 @@ def production_log_sink(message):
                 else str(exc.get("type", "Exception"))
             ),
             "value": filter_sensitive_data(str(exc.get("value", ""))),
-            "traceback": filter_sensitive_data(str(exc.get("traceback", ""))),
+            "traceback": filter_sensitive_data(truncated_traceback),
         }
 
     # Build flat JSON structure - easier for log parsers


### PR DESCRIPTION
## Summary

Fixes #675 (and the originally claimed fix in #645 that was never applied).

The `production_log_sink` in `app/modules/utils/logger.py` was passing the full traceback string to `filter_sensitive_data()` without any truncation. This meant every exception wrote the complete traceback — often 60–100 lines from SQLAlchemy, httpx, or async chains — to production logs.

## Changes

**File:** `app/modules/utils/logger.py` (lines 127–132)

- Extract the raw traceback string before building the exception dict
- Split on newlines, keep only the **last 10 lines** (the most relevant frames near the failure point)
- Rejoin and pass the truncated string to `filter_sensitive_data()`

## Before

```python
"traceback": filter_sensitive_data(str(exc.get("traceback", ""))),
```

## After

```python
raw_traceback = str(exc.get("traceback", ""))
traceback_lines = raw_traceback.splitlines()
if len(traceback_lines) > 10:
    traceback_lines = traceback_lines[-10:]
truncated_traceback = "\n".join(traceback_lines)
# ...
"traceback": filter_sensitive_data(truncated_traceback),
```

## Why tail, not head

Taking `[-10:]` preserves the frames closest to the actual failure, which are the most actionable in production. The top of the traceback (entry point, middleware, etc.) is rarely needed for quick triage.

## Testing

- Change is localized to the production sink — no other code paths affected
- Truncation only applies when `len(traceback_lines) > 10`, so short tracebacks pass through unchanged
- No changes to log format, filtering behavior, or development-mode logging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Exception tracebacks in production logs are now truncated to display only the most relevant information, improving log readability while maintaining proper sensitive data redaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->