### PR TITLE
fix: remove duplicate create_user call in setup_dummy_user (#726)

### DIFF
--- a/app/modules/users/user_service.py
+++ b/app/modules/users/user_service.py
@@ -110,9 +110,7 @@ class UserService:
                 provider_username="self",
             )
             uid, message, error = user_service.create_user(user)
-
-        uid, _, _ = user_service.create_user(user)
-        logger.info(f"Created dummy user with uid: {uid}")
+            logger.info(f"Created dummy user with uid: {uid}")
 
     def get_user_by_uid(self, uid: str):
         try:

--- a/tests/unit/users/test_user_service.py
+++ b/tests/unit/users/test_user_service.py
@@ -109,3 +109,56 @@ class TestUserServiceUpdateLastLogin:
         message, error = user_service.update_last_login("nonexistent", "token")
         assert error is True
         assert "not found" in message.lower()
+
+
+class TestSetupDummyUser:
+    def test_create_user_called_once_when_user_does_not_exist(self, mock_db, monkeypatch):
+        """create_user must be called exactly once — the duplicate call bug (issue #726)."""
+        import os
+        monkeypatch.setenv("defaultUsername", "dummy-uid")
+
+        # get_user_by_uid returns None → user doesn't exist yet
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        service = UserService(mock_db)
+
+        call_count = 0
+
+        def fake_create_user(user):
+            nonlocal call_count
+            call_count += 1
+            return ("dummy-uid", "User created successfully", False)
+
+        monkeypatch.setattr(service, "create_user", lambda u: fake_create_user(u))
+
+        # We need the inner UserService (created inside setup_dummy_user) to also use
+        # the patched create_user, so patch at the class level.
+        monkeypatch.setattr(UserService, "create_user", lambda self, u: fake_create_user(u))
+
+        service.setup_dummy_user()
+
+        assert call_count == 1, (
+            f"create_user was called {call_count} time(s); expected exactly 1 (duplicate call bug #726)"
+        )
+
+    def test_setup_skips_creation_when_user_already_exists(self, mock_db, monkeypatch):
+        """setup_dummy_user must be a no-op when the user already exists."""
+        import os
+        monkeypatch.setenv("defaultUsername", "dummy-uid")
+
+        existing_user = User(uid="dummy-uid", email="defaultuser@potpie.ai", display_name="Dummy User")
+        mock_db.query.return_value.filter.return_value.first.return_value = existing_user
+
+        service = UserService(mock_db)
+        call_count = 0
+
+        def fake_create_user(user):
+            nonlocal call_count
+            call_count += 1
+            return ("dummy-uid", "User created successfully", False)
+
+        monkeypatch.setattr(UserService, "create_user", lambda self, u: fake_create_user(u))
+
+        service.setup_dummy_user()
+
+        assert call_count == 0, "create_user should not be called when user already exists"


### PR DESCRIPTION
### fix: remove duplicate `[create_user]` call in `[setup_dummy_user]`

`[setup_dummy_user]` was calling [create_user] twice with the same user object. The second call would either raise an `IntegrityError` (unique constraint) or silently overwrite [uid] with an empty string — either way breaking dev-mode initialization.

### What changed

- Removed the duplicate [create_user]call in `user_service.py`
- Moved the log line inside the else block so it only fires when a user is actually created

### Tests
Added two unit tests to [TestSetupDummyUser]:
  - Asserts `[create_user]` is called exactly once for a new user
  - Asserts `[create_user]` is skipped entirely when the user already exists

Fixes #726 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved duplicate user creation that occurred during system initialization, ensuring users are created only once.

* **Tests**
  * Added comprehensive test coverage for user setup functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->