### PR TITLE
fix: truncate stack trace to last 10 lines in production logs

### DIFF
--- a/app/modules/utils/logger.py
+++ b/app/modules/utils/logger.py
@@ -124,6 +124,13 @@ def production_log_sink(message):
     exception = None
     exc = record.get("exception")
     if exc:
+        # Truncate traceback to last 10 lines to reduce log volume
+        # while preserving the most relevant error frames
+        traceback_str = str(exc.get("traceback", ""))
+        traceback_lines = traceback_str.split("\n")
+        if len(traceback_lines) > 10:
+            traceback_str = "\n".join(traceback_lines[-10:])
+
         exception = {
             "type": (
                 exc.get("type", {}).get("name", "Exception")
@@ -131,7 +138,7 @@ def production_log_sink(message):
                 else str(exc.get("type", "Exception"))
             ),
             "value": filter_sensitive_data(str(exc.get("value", ""))),
-            "traceback": filter_sensitive_data(str(exc.get("traceback", ""))),
+            "traceback": filter_sensitive_data(traceback_str),
         }
 
     # Build flat JSON structure - easier for log parsers


### PR DESCRIPTION
Fixes #675

Truncate exception traceback to the last 10 lines before writing to
production logs. This reduces log volume from 60-100+ lines per
exception while preserving the most relevant error frames.

Changes:
- Split traceback by newlines and keep only the last 10 lines
- Apply truncation before sensitive data filtering
- No changes to log format or filtering behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced exception logging in production to automatically truncate lengthy error tracebacks, limiting display to only the final 10 lines. This improvement makes application logs significantly more readable and easier to manage while preserving sensitive data redaction for security compliance. Error context remains comprehensive and sufficient for effective debugging and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->