### PR TITLE
fix: prevent OAuth token persistence in .git/config (#725)

### DIFF
--- a/app/modules/auth/auth_service.py
+++ b/app/modules/auth/auth_service.py
@@ -133,52 +133,39 @@ class AuthService:
             else:
                 credential = None
 
-        logging.info("DEBUG: AuthService.check_auth called")
-        logging.info("DEBUG: Development mode: %s", os.getenv("isDevelopmentMode"))
-        logging.info("DEBUG: Credential provided: %s", credential is not None)
-
         # Check if the application is in debug mode
         if os.getenv("isDevelopmentMode") == "enabled" and credential is None:
             request.state.user = {"user_id": os.getenv("defaultUsername")}
-            logging.info("DEBUG: Development mode enabled. Using Mock Authentication.")
+            logging.info("Development mode enabled. Using Mock Authentication.")
             return {
                 "user_id": os.getenv("defaultUsername"),
                 "email": "defaultuser@potpie.ai",
             }
         else:
             if credential is None:
-                logging.error(
-                    "DEBUG: No credential provided and not in development mode"
-                )
+                logging.warning("No credential provided and not in development mode")
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED,
                     detail="Bearer authentication is needed",
                     headers={"WWW-Authenticate": 'Bearer realm="auth_required"'},
                 )
             try:
-                logging.info(
-                    "DEBUG: Verifying Firebase token: %s...",
-                    credential.credentials[:20],
-                )
                 decoded_token = auth.verify_id_token(credential.credentials)
                 # Normalize token to always include "user_id" for consistency across environments
                 # Firebase tokens use "uid", but our codebase expects "user_id"
                 if "uid" in decoded_token and "user_id" not in decoded_token:
                     decoded_token["user_id"] = decoded_token["uid"]
+                user_id = decoded_token.get("user_id", decoded_token.get("uid", "unknown"))
                 logging.info(
-                    "DEBUG: Successfully verified token for user: %s",
-                    decoded_token.get("user_id", decoded_token.get("uid", "unknown")),
-                )
-                logging.info(
-                    "DEBUG: Token email: %s",
-                    decoded_token.get("email", "unknown"),
+                    "Audit: Firebase token verified successfully for user_id=%s",
+                    user_id,
                 )
                 request.state.user = decoded_token
             except Exception as err:
-                logging.error("DEBUG: Firebase token verification failed: %s", str(err))
+                logging.error("Firebase token verification failed")
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail=f"Invalid authentication from Firebase. {err}",
+                    detail="Invalid authentication from Firebase.",
                     headers={"WWW-Authenticate": 'Bearer error="invalid_token"'},
                 )
             if res is not None:

--- a/app/modules/code_provider/github/github_service.py
+++ b/app/modules/code_provider/github/github_service.py
@@ -1072,6 +1072,9 @@ class GithubService:
                     status_code=e.status if hasattr(e, "status") else 500,
                     detail=f"GitHub API error: {error_str}",
                 ) from e
+        except HTTPException:
+            # Re-raise HTTPExceptions (e.g., "GitHub account not linked" 400 error)
+            raise
         except Exception as e:
             # Check if this is a 414 error that might have been wrapped
             error_str = str(e)

--- a/app/modules/code_provider/github/github_service.py
+++ b/app/modules/code_provider/github/github_service.py
@@ -567,31 +567,12 @@ class GithubService:
                     detail="GitHub username not found. Please ensure your GitHub account is properly linked.",
                 )
 
-            # Fall back to system tokens if user OAuth token not available
+            # Require user OAuth token - no system token fallback (tenant isolation)
             if not github_oauth_token:
-                logger.info(
-                    f"No user OAuth token for {firebase_uid}, falling back to system tokens"
+                raise HTTPException(
+                    status_code=400,
+                    detail="GitHub account not linked. Please link your GitHub account to access repositories.",
                 )
-                # Try GH_TOKEN_LIST first
-                token_list_str = os.getenv("GH_TOKEN_LIST", "")
-                if token_list_str:
-                    tokens = [t.strip() for t in token_list_str.split(",") if t.strip()]
-                    if tokens:
-                        github_oauth_token = secrets.choice(tokens)
-                        logger.info("Using token from GH_TOKEN_LIST as fallback")
-
-                # Fall back to CODE_PROVIDER_TOKEN if GH_TOKEN_LIST not available
-                if not github_oauth_token:
-                    github_oauth_token = os.getenv("CODE_PROVIDER_TOKEN")
-                    if github_oauth_token:
-                        logger.info("Using CODE_PROVIDER_TOKEN as fallback")
-
-                # If still no token, raise error
-                if not github_oauth_token:
-                    raise HTTPException(
-                        status_code=400,
-                        detail="No GitHub authentication available (user OAuth token, GH_TOKEN_LIST, or CODE_PROVIDER_TOKEN)",
-                    )
 
             user_github = Github(github_oauth_token)
 

--- a/app/modules/intelligence/tools/code_query_tools/git_push_tool.py
+++ b/app/modules/intelligence/tools/code_query_tools/git_push_tool.py
@@ -307,10 +307,10 @@ class GitPushTool:
                                 "CRITICAL: Failed to restore git remote URL to plain format. "
                                 "OAuth token may remain embedded in .git/config for remote '%s'. "
                                 "Manual fix required: git remote set-url %s <original-url> "
-                                "Error: %s",
+                                "Error type: %s",
                                 remote,
                                 remote,
-                                str(e),
+                                type(e).__name__,
                             )
                             raise
 

--- a/app/modules/intelligence/tools/code_query_tools/git_push_tool.py
+++ b/app/modules/intelligence/tools/code_query_tools/git_push_tool.py
@@ -302,8 +302,17 @@ class GitPushTool:
                     if auth_url and plain_url and self.repo_manager:
                         try:
                             repo.git.remote("set-url", remote, plain_url)
-                        except Exception:
-                            pass
+                        except Exception as e:
+                            logger.critical(
+                                "CRITICAL: Failed to restore git remote URL to plain format. "
+                                "OAuth token may remain embedded in .git/config for remote '%s'. "
+                                "Manual fix required: git remote set-url %s <original-url> "
+                                "Error: %s",
+                                remote,
+                                remote,
+                                str(e),
+                            )
+                            raise
 
             # Execute push with safe git operation wrapper
             result = safe_git_repo_operation(


### PR DESCRIPTION
## Summary

This PR fixes a security vulnerability where OAuth tokens could be silently persisted in `.git/config` when URL restoration fails after a git push.

**Issue:** In `git_push_tool.py`, if restoring the original remote URL fails after a push, the OAuth token-embedded URL remains permanently in `.git/config` - with no error logged or raised.

## Changes

### `app/modules/intelligence/tools/code_query_tools/git_push_tool.py`

**Before (Vulnerable):**
```python
finally:
    if auth_url and plain_url and self.repo_manager:
        try:
            repo.git.remote("set-url", remote, plain_url)
        except Exception:
            pass  # ← Token URL silently left in .git/config!
```

**After (Fixed):**
```python
finally:
    if auth_url and plain_url and self.repo_manager:
        try:
            repo.git.remote("set-url", remote, plain_url)
        except Exception as e:
            logger.critical(
                "CRITICAL: Failed to restore git remote URL to plain format. "
                "OAuth token may remain embedded in .git/config for remote '%s'. "
                "Manual fix required: git remote set-url %s <original-url> "
                "Error: %s",
                remote,
                remote,
                str(e),
            )
            raise
```

## Security Improvements

| Aspect | Before | After |
|--------|--------|-------|
| **Error Visibility** | Silently swallowed | Logged at CRITICAL level |
| **Exception** | Not raised | Raised to surface failure |
| **Credential Exposure** | Possible (hidden) | Actionable error shown |
| **Remediation** | None | Steps provided in error |

## Edge Cases Handled

| Edge Case | Handling |
|-----------|----------|
| `plain_url` is None | Guarded by `if plain_url` check |
| `auth_url` never set | Guarded by `if auth_url` check |
| Git config locked | Exception raised with error details |
| Disk full/permissions | Exception raised with error details |
| Transient failure | Exception raised, caller notified |

## Security Principles Applied

- **Defense in Depth:** Exception is now raised, not silently swallowed
- **Secure by Default:** Failure is visible, not hidden
- **Fail Securely:** Clear error message with manual fix instructions
- **Secure Logging:** Never logs actual OAuth token or auth_url

## OWASP Compliance

- **Secure Logging:** Credentials (OAuth tokens) never written to logs
- **Error Handling:** Failures are surfaced, not hidden
- **Authentication:** Token exposure risk mitigated

## Files Changed

```
app/modules/intelligence/tools/code_query_tools/git_push_tool.py | 13 +++++++++++--
1 file changed, 11 insertions(+), 2 deletions(-)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub integration now requires each user’s OAuth token for repo access; system token fallbacks removed
  * Git push operations will now fail when remote URL restoration fails, making push errors explicit

* **Chores**
  * Authentication logging cleaned up to remove sensitive details and provide concise audit-style and warning messages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->