### PR TITLE
fix: remove credential exposure and system token fallback (#727)

### DIFF
--- a/app/modules/auth/auth_service.py
+++ b/app/modules/auth/auth_service.py
@@ -133,52 +133,39 @@ class AuthService:
             else:
                 credential = None
 
-        logging.info("DEBUG: AuthService.check_auth called")
-        logging.info("DEBUG: Development mode: %s", os.getenv("isDevelopmentMode"))
-        logging.info("DEBUG: Credential provided: %s", credential is not None)
-
         # Check if the application is in debug mode
         if os.getenv("isDevelopmentMode") == "enabled" and credential is None:
             request.state.user = {"user_id": os.getenv("defaultUsername")}
-            logging.info("DEBUG: Development mode enabled. Using Mock Authentication.")
+            logging.info("Development mode enabled. Using Mock Authentication.")
             return {
                 "user_id": os.getenv("defaultUsername"),
                 "email": "defaultuser@potpie.ai",
             }
         else:
             if credential is None:
-                logging.error(
-                    "DEBUG: No credential provided and not in development mode"
-                )
+                logging.warning("No credential provided and not in development mode")
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED,
                     detail="Bearer authentication is needed",
                     headers={"WWW-Authenticate": 'Bearer realm="auth_required"'},
                 )
             try:
-                logging.info(
-                    "DEBUG: Verifying Firebase token: %s...",
-                    credential.credentials[:20],
-                )
                 decoded_token = auth.verify_id_token(credential.credentials)
                 # Normalize token to always include "user_id" for consistency across environments
                 # Firebase tokens use "uid", but our codebase expects "user_id"
                 if "uid" in decoded_token and "user_id" not in decoded_token:
                     decoded_token["user_id"] = decoded_token["uid"]
+                user_id = decoded_token.get("user_id", decoded_token.get("uid", "unknown"))
                 logging.info(
-                    "DEBUG: Successfully verified token for user: %s",
-                    decoded_token.get("user_id", decoded_token.get("uid", "unknown")),
-                )
-                logging.info(
-                    "DEBUG: Token email: %s",
-                    decoded_token.get("email", "unknown"),
+                    "Audit: Firebase token verified successfully for user_id=%s",
+                    user_id,
                 )
                 request.state.user = decoded_token
             except Exception as err:
-                logging.error("DEBUG: Firebase token verification failed: %s", str(err))
+                logging.error("Firebase token verification failed")
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail=f"Invalid authentication from Firebase. {err}",
+                    detail="Invalid authentication from Firebase.",
                     headers={"WWW-Authenticate": 'Bearer error="invalid_token"'},
                 )
             if res is not None:

--- a/app/modules/auth/auth_service.py
+++ b/app/modules/auth/auth_service.py
@@ -161,20 +161,17 @@ class AuthService:
                     user_id,
                 )
                 request.state.user = decoded_token
-            except (ValueError, FirebaseError) as err:
+            except (ValueError, FirebaseError):
                 # Handle specific token validation errors
                 # Firebase tokens can raise: InvalidIdTokenError, ExpiredIdTokenError, RevokedIdTokenError
                 # All are subclasses of FirebaseError or ValueError
-                logging.warning(
-                    "Firebase token verification failed: %s",
-                    type(err).__name__,
-                )
+                logging.warning("Firebase token verification failed")
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED,
                     detail="Invalid authentication from Firebase.",
                     headers={"WWW-Authenticate": 'Bearer error="invalid_token"'},
                 )
-            except Exception as err:
+            except Exception:
                 # Re-raise unexpected exceptions - don't hide bugs
                 logging.exception("Unexpected error in Firebase token verification")
                 raise

--- a/app/modules/auth/auth_service.py
+++ b/app/modules/auth/auth_service.py
@@ -161,13 +161,23 @@ class AuthService:
                     user_id,
                 )
                 request.state.user = decoded_token
-            except Exception as err:
-                logging.error("Firebase token verification failed")
+            except (ValueError, FirebaseError) as err:
+                # Handle specific token validation errors
+                # Firebase tokens can raise: InvalidIdTokenError, ExpiredIdTokenError, RevokedIdTokenError
+                # All are subclasses of FirebaseError or ValueError
+                logging.warning(
+                    "Firebase token verification failed: %s",
+                    type(err).__name__,
+                )
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED,
                     detail="Invalid authentication from Firebase.",
                     headers={"WWW-Authenticate": 'Bearer error="invalid_token"'},
                 )
+            except Exception as err:
+                # Re-raise unexpected exceptions - don't hide bugs
+                logging.exception("Unexpected error in Firebase token verification")
+                raise
             if res is not None:
                 res.headers["WWW-Authenticate"] = 'Bearer realm="auth_required"'
             return decoded_token

--- a/app/modules/code_provider/github/github_service.py
+++ b/app/modules/code_provider/github/github_service.py
@@ -567,31 +567,12 @@ class GithubService:
                     detail="GitHub username not found. Please ensure your GitHub account is properly linked.",
                 )
 
-            # Fall back to system tokens if user OAuth token not available
+            # Require user OAuth token - no system token fallback (tenant isolation)
             if not github_oauth_token:
-                logger.info(
-                    f"No user OAuth token for {firebase_uid}, falling back to system tokens"
+                raise HTTPException(
+                    status_code=400,
+                    detail="GitHub account not linked. Please link your GitHub account to access repositories.",
                 )
-                # Try GH_TOKEN_LIST first
-                token_list_str = os.getenv("GH_TOKEN_LIST", "")
-                if token_list_str:
-                    tokens = [t.strip() for t in token_list_str.split(",") if t.strip()]
-                    if tokens:
-                        github_oauth_token = secrets.choice(tokens)
-                        logger.info("Using token from GH_TOKEN_LIST as fallback")
-
-                # Fall back to CODE_PROVIDER_TOKEN if GH_TOKEN_LIST not available
-                if not github_oauth_token:
-                    github_oauth_token = os.getenv("CODE_PROVIDER_TOKEN")
-                    if github_oauth_token:
-                        logger.info("Using CODE_PROVIDER_TOKEN as fallback")
-
-                # If still no token, raise error
-                if not github_oauth_token:
-                    raise HTTPException(
-                        status_code=400,
-                        detail="No GitHub authentication available (user OAuth token, GH_TOKEN_LIST, or CODE_PROVIDER_TOKEN)",
-                    )
 
             user_github = Github(github_oauth_token)
 
@@ -1091,6 +1072,9 @@ class GithubService:
                     status_code=e.status if hasattr(e, "status") else 500,
                     detail=f"GitHub API error: {error_str}",
                 ) from e
+        except HTTPException:
+            # Re-raise HTTPExceptions (e.g., "GitHub account not linked" 400 error)
+            raise
         except Exception as e:
             # Check if this is a 414 error that might have been wrapped
             error_str = str(e)

--- a/app/modules/code_provider/github/github_service.py
+++ b/app/modules/code_provider/github/github_service.py
@@ -873,9 +873,7 @@ class GithubService:
                                 )
                                 # Fix invalid query string if per_page was the first param
                                 # If query string now starts with & (e.g., ?&other=value), remove the &
-                                repos_url_cleaned = re.sub(
-                                    r"\?&", "?", repos_url_cleaned
-                                )
+                                repos_url_cleaned = repos_url_cleaned.replace("?&", "?")
                                 # Ensure we have proper separator
                                 separator = "&" if "?" in repos_url_cleaned else "?"
                                 first_page_url = (
@@ -1360,7 +1358,7 @@ class GithubService:
             )
 
         try:
-            github, repo = await asyncio.to_thread(self.get_repo, repo_name)
+            _, repo = await asyncio.to_thread(self.get_repo, repo_name)
 
             # If path is provided, verify it exists
             if path:


### PR DESCRIPTION
## Summary

This PR fixes two security vulnerabilities reported in Issue #727:

1. **Issue A - Firebase JWT Token Logging (CRITICAL)**: Firebase JWT tokens (even partial) were logged at INFO level with "DEBUG:" prefix, exposing credentials in log aggregators.

2. **Issue B - Shared System OAuth Token Fallback (HIGH)**: When a user had no personal GitHub token, the system fell back to shared `GH_TOKEN_LIST` and `CODE_PROVIDER_TOKEN` system tokens, violating tenant isolation.

## Changes

### Issue A Fix - `app/modules/auth/auth_service.py`
- Removed DEBUG-prefixed log statements exposing:
  - `credential.credentials[:20]` (partial JWT token)
  - `decoded_token.get("email")` (PII)
  - Detailed error messages with `str(err)`
- Replaced with secure audit logging using only user_id
- Error messages to client now generic (no internal details)

### Issue B Fix - `app/modules/code_provider/github/github_service.py`
- Removed fallback to `GH_TOKEN_LIST` system token pool
- Removed fallback to `CODE_PROVIDER_TOKEN` system token
- Users without personal tokens now receive clear error requiring GitHub account link
- Added HTTPException re-raise to prevent 400 errors being swallowed

## Security Principles Applied

| Principle | Application |
|-----------|-------------|
| **Least Privilege** | Users only get tokens they own |
| **Defense in Depth** | Fallback chain removed |
| **Secure by Default** | System tokens never used for user ops |
| **Fail Securely** | Clear error messages with remediation |

## OWASP Compliance

- [Logging Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html): Credentials must not be in logs
- [Multi-Tenant Security](https://cheatsheetseries.owasp.org/cheatsheets/Multi_Tenant_Security_Cheat_Sheet.html): No cross-tenant credential sharing

## Files Changed

```
app/modules/auth/auth_service.py                   | 27 +++++--------------
app/modules/code_provider/github/github_service.py | 30 +++++-----------------
2 files changed, 14 insertions(+), 43 deletions(-)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub OAuth account linking is now required for repository access; environment fallback tokens are no longer used.

* **Bug Fixes**
  * Clearer handling and messaging for missing or invalid authentication, preserving specific HTTP error responses for account linking and auth failures.

* **Other**
  * Refined authentication logging, tightened error handling with a generic invalid-auth response, and unexpected errors now surface for investigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->