### PR TITLE
fix(auth): send Slack alerts for email/password signups

### DIFF
--- a/app/modules/auth/auth_router.py
+++ b/app/modules/auth/auth_router.py
@@ -39,8 +39,6 @@ from app.modules.utils.email_helper import is_personal_email_domain
 
 logger = logging.getLogger(__name__)
 
-SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL", None)
-
 auth_router = APIRouter()
 load_dotenv(override=True)
 
@@ -55,12 +53,25 @@ def _signup_response_with_custom_token(payload: dict) -> dict:
     return payload
 
 
+def _get_slack_webhook_url() -> str | None:
+    """Resolve Slack webhook URL at call time so dotenv/env changes are respected."""
+    return os.getenv("SLACK_WEBHOOK_URL")
+
+
 async def send_slack_message(message: str):
     payload = {"text": message}
-    if SLACK_WEBHOOK_URL:
+    webhook_url = _get_slack_webhook_url()
+    if webhook_url:
         try:
             async with httpx.AsyncClient(timeout=10.0) as client:
-                await client.post(SLACK_WEBHOOK_URL, json=payload)
+                response = await client.post(webhook_url, json=payload)
+                response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            logger.warning(
+                "Slack webhook returned non-2xx status: %s body=%s",
+                e.response.status_code,
+                e.response.text,
+            )
         except Exception as e:
             logger.warning("Failed to send Slack signup notification: %s", e)
 
@@ -454,6 +465,7 @@ class AuthAPI:
                 )
 
                 logger.info(f"Created email/password user: {new_user.uid}")
+                await send_slack_message(f"New signup: {email} ({display_name})")
 
                 return Response(
                     content=json.dumps(

--- a/app/modules/auth/auth_router.py
+++ b/app/modules/auth/auth_router.py
@@ -4,7 +4,7 @@ import os
 
 import httpx
 from dotenv import load_dotenv
-from fastapi import Depends, Request
+from fastapi import BackgroundTasks, Depends, Request
 from fastapi.responses import JSONResponse, Response
 from fastapi.exceptions import HTTPException
 from sqlalchemy.orm import Session
@@ -99,6 +99,7 @@ class AuthAPI:
     @auth_router.post("/signup")
     async def signup(
         request: Request,
+        background_tasks: BackgroundTasks,
         db: Session = Depends(get_db),
         async_db: AsyncSession = Depends(get_async_db),
     ):
@@ -395,7 +396,9 @@ class AuthAPI:
 
                 logger.info(f"Created new user {new_user.uid} with GitHub")
 
-                await send_slack_message(f"New signup: {email} ({display_name})")
+                background_tasks.add_task(
+                    send_slack_message, f"New signup: {email} ({display_name})"
+                )
                 PostHogClient().send_event(
                     new_user.uid,
                     "signup_event",
@@ -465,7 +468,9 @@ class AuthAPI:
                 )
 
                 logger.info(f"Created email/password user: {new_user.uid}")
-                await send_slack_message(f"New signup: {email} ({display_name})")
+                background_tasks.add_task(
+                    send_slack_message, f"New signup: {email} ({display_name})"
+                )
 
                 return Response(
                     content=json.dumps(

--- a/tests/unit/auth/test_auth_router_helpers.py
+++ b/tests/unit/auth/test_auth_router_helpers.py
@@ -33,13 +33,19 @@ class TestSignupResponseWithCustomToken:
 class TestSendSlackMessage:
     @pytest.mark.asyncio
     async def test_no_webhook_url_does_nothing(self):
-        with patch("app.modules.auth.auth_router.SLACK_WEBHOOK_URL", None):
+        with patch("app.modules.auth.auth_router._get_slack_webhook_url", return_value=None):
             await send_slack_message("test message")
 
     @pytest.mark.asyncio
     async def test_with_webhook_url_posts(self):
-        with patch("app.modules.auth.auth_router.SLACK_WEBHOOK_URL", "https://hooks.slack.com/x"):
+        with patch(
+            "app.modules.auth.auth_router._get_slack_webhook_url",
+            return_value="https://hooks.slack.com/x",
+        ):
             mock_post = AsyncMock()
+            mock_response = MagicMock()
+            mock_response.raise_for_status = MagicMock()
+            mock_post.return_value = mock_response
             mock_ctx = MagicMock()
             mock_ctx.post = mock_post
             mock_ctx.__aenter__ = AsyncMock(return_value=mock_ctx)
@@ -47,5 +53,6 @@ class TestSendSlackMessage:
             with patch("app.modules.auth.auth_router.httpx.AsyncClient", return_value=mock_ctx):
                 await send_slack_message("hello")
             mock_post.assert_called_once()
+            mock_response.raise_for_status.assert_called_once()
             call_args = mock_post.call_args
             assert call_args[1]["json"] == {"text": "hello"}


### PR DESCRIPTION
## Summary
- trigger Slack notifications for new email/password signups in the auth signup endpoint
- resolve `SLACK_WEBHOOK_URL` at send-time and validate webhook HTTP response status
- update auth router helper tests to match dynamic webhook lookup behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack notifications for email/password sign-ups are enabled and now sent in the background to make sign-ups feel faster.

* **Bug Fixes**
  * Webhook URL is resolved at request time allowing updated configurations to take effect.
  * Improved handling and logging for failed Slack deliveries so issues are detected reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->