### PR TITLE
unbound local error while parsing using priority 3 github token

### DIFF
--- a/app/modules/parsing/graph_construction/parsing_helper.py
+++ b/app/modules/parsing/graph_construction/parsing_helper.py
@@ -1893,12 +1893,8 @@ class ParseHelper:
                 method="environment_token_bare_clone",
             )
 
-            # Import Repo before clone_from: a later `Repo = ...` assignment in this
-            # block would make `Repo` local for the whole function and cause
-            # UnboundLocalError on Repo.clone_from (see Priority 3 bare clone path).
-            _, _, Repo = _get_git_imports()
-
             try:
+                _, _, Repo = _get_git_imports()
                 # Clone as bare repository
                 Repo.clone_from(
                     clone_url,

--- a/app/modules/parsing/graph_construction/parsing_helper.py
+++ b/app/modules/parsing/graph_construction/parsing_helper.py
@@ -1893,6 +1893,11 @@ class ParseHelper:
                 method="environment_token_bare_clone",
             )
 
+            # Import Repo before clone_from: a later `Repo = ...` assignment in this
+            # block would make `Repo` local for the whole function and cause
+            # UnboundLocalError on Repo.clone_from (see Priority 3 bare clone path).
+            _, _, Repo = _get_git_imports()
+
             try:
                 # Clone as bare repository
                 Repo.clone_from(
@@ -1911,7 +1916,6 @@ class ParseHelper:
                 )
 
                 # Configure the bare repo to fetch all refs
-                _, _, Repo = _get_git_imports()
                 bare_repo = Repo(str(bare_repo_path))
                 if bare_repo.remotes:
                     origin = bare_repo.remotes.origin


### PR DESCRIPTION
Repo is assigned later in _clone_to_repo_manager, so Python treats it as local for the whole function. On the env-token path we never hit those assignments, but we still called Repo.clone_from before Repo was set — UnboundLocalError.

Fix: call _get_git_imports() before clone_from, and drop the duplicate import after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a cloning initialization issue that could cause failures in certain environment configurations.
  * Ensures repository cloning and subsequent bare-repo setup use a consistent initialization sequence.
  * Improves reliability of import and initialization steps during clone, reducing intermittent errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->