### PR TITLE
fix: pass repos_base_path to RepoManager and avoid blocking event loop

### DIFF
--- a/app/modules/parsing/graph_construction/parsing_controller.py
+++ b/app/modules/parsing/graph_construction/parsing_controller.py
@@ -441,8 +441,12 @@ class ParsingController:
                 )
 
             project_status = row.status
+            # Use asyncio.to_thread to avoid blocking the event loop with
+            # synchronous DB operations in ParseHelper
             parse_helper = ParseHelper(db)
-            is_latest = await parse_helper.check_commit_status(project_id)
+            is_latest = await asyncio.to_thread(
+                parse_helper.check_commit_status_sync, project_id
+            )
 
             # Auto-recover: if a project has been stuck in "submitted" with no active
             # Celery task (task was lost due to worker crash/restart), re-submit the

--- a/app/modules/parsing/graph_construction/parsing_helper.py
+++ b/app/modules/parsing/graph_construction/parsing_helper.py
@@ -107,6 +107,73 @@ class ParseHelper:
                 total_size += os.path.getsize(fp)
         return total_size
 
+    def check_commit_status_sync(self, project_id: str) -> bool:
+        """
+        Synchronous version of check_commit_status for use with asyncio.to_thread.
+        Avoids blocking the event loop when called from async contexts.
+        """
+        logger.info(
+            f"check_commit_status_sync: Checking commit status for project {project_id}"
+        )
+
+        project = self.project_manager.get_project_from_db_by_id_sync(int(project_id) if isinstance(project_id, str) else project_id)
+        if not project:
+            logger.error(f"Project with ID {project_id} not found")
+            return False
+
+        current_commit_id = project.get("commit_id")
+        repo_name = project.get("project_name")
+        branch_name = project.get("branch_name")
+
+        logger.info(
+            f"check_commit_status_sync: Project {project_id} - repo={repo_name}, "
+            f"branch={branch_name}, current_commit_id={current_commit_id}"
+        )
+
+        # If no branch, it's a pinned commit
+        if not branch_name:
+            logger.info(
+                f"check_commit_status_sync: Branch is empty (pinned commit parse) - "
+                f"sticking to commit and not updating it for: {project_id}"
+            )
+            return True
+
+        if not repo_name or len(repo_name.split("/")) < 2:
+            # Local repo, always parse local repos
+            logger.info("check_commit_status_sync: Local repo detected, forcing reparse")
+            return False
+
+        try:
+            if current_commit_id is None:
+                logger.info(
+                    f"check_commit_status_sync: Project {project_id} has no commit_id, will reparse"
+                )
+                return False
+
+            # Use HTTP-only GitHub API (synchronous version)
+            logger.info(
+                f"check_commit_status_sync: Branch-based parse - getting repo info for {repo_name}"
+            )
+            # Run the blocking HTTP call in a thread pool
+            latest_commit_id = _fetch_github_branch_head_sha_http(repo_name, branch_name)
+
+            is_up_to_date = current_commit_id == latest_commit_id
+            logger.info(
+                f"check_commit_status_sync: Project {project_id} commit status for branch {branch_name}: "
+                f"{'Up to date' if is_up_to_date else 'Outdated'} - "
+                f"Current: {current_commit_id}, Latest: {latest_commit_id}"
+            )
+
+            return is_up_to_date
+        except Exception:
+            logger.exception(
+                "check_commit_status_sync: Error fetching latest commit",
+                repo_name=repo_name,
+                branch_name=branch_name,
+                project_id=project_id,
+            )
+            return False
+
     async def clone_or_copy_repository(
         self,
         repo_details: RepoDetails,

--- a/potpie/resources/repositories.py
+++ b/potpie/resources/repositories.py
@@ -46,7 +46,7 @@ class RepositoriesResource(BaseResource):
         self._repo_manager = None
 
     def _get_repo_manager(self):
-        """Get RepoManager instance if enabled."""
+        """Get a RepoManager instance configured from RuntimeConfig."""
         if self._repo_manager is not None:
             return self._repo_manager
         enabled = os.getenv("REPO_MANAGER_ENABLED", "false").lower() in (
@@ -58,10 +58,10 @@ class RepositoriesResource(BaseResource):
         if not enabled:
             return None
         try:
-            from app.modules.repo_manager import RepoManager
+            from app.modules.repo_manager.repo_manager import RepoManager
 
-            self._repo_manager = RepoManager()
-            logger.info("RepositoriesResource: RepoManager initialized")
+            self._repo_manager = RepoManager(repos_base_path=self._config.repos_base_path)
+            logger.info("RepositoriesResource: RepoManager initialized with repos_base_path=%s", self._config.repos_base_path)
             return self._repo_manager
         except Exception as e:
             logger.warning(


### PR DESCRIPTION
## Summary

Fixes #640 and #639

### #640 - RepositoriesResource uses RepoManager with inconsistent base path
- Pass `repos_base_path` from RuntimeConfig to RepoManager in RepositoriesResource._get_repo_manager()
- This ensures RepositoriesResource uses the same repos_base_path as RepositoryResource

### #639 - Inconsistent async DB usage in fetch_parsing_status causes blocking
- Use asyncio.to_thread to wrap synchronous ParseHelper calls
- Add check_commit_status_sync method for non-blocking async usage
- This matches the pattern already used in fetch_parsing_status_by_repo

## Changes
- potpie/resources/repositories.py: Pass repos_base_path to RepoManager
- app/modules/parsing/graph_construction/parsing_controller.py: Use asyncio.to_thread
- app/modules/parsing/graph_construction/parsing_helper.py: Add check_commit_status_sync method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized parsing status checks to use background processing, reducing event loop blocking.

* **Refactor**
  * Enhanced commit status verification with improved error handling and logging.
  * Updated repository configuration handling to use centralized configuration-driven base paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->