### PR TITLE
Additional context from QnA being sent to workflows through internal route

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -202,3 +202,6 @@ PRIVATE_TEST_REPO_NAME=<yourGithubUsername>/potpie-private-test-repo
 
 #stripe-potpie url for dodo payments
 STRIPE_POTPIE_URL=http://localhost:8003
+
+#Internal route between potpie and workflows.
+WORKFLOWS_MEDIA_INTERNAL_SECRET=

--- a/app/core/config_provider.py
+++ b/app/core/config_provider.py
@@ -248,5 +248,9 @@ class ConfigProvider:
         """Get code provider password (for Basic Auth)."""
         return os.getenv("CODE_PROVIDER_PASSWORD")
 
+    def get_workflows_media_internal_secret(self) -> str:
+        """Shared secret for workflows->potpie internal media fetch."""
+        return os.getenv("WORKFLOWS_MEDIA_INTERNAL_SECRET", "").strip()
+
 
 config_provider = ConfigProvider()

--- a/app/modules/media/media_controller.py
+++ b/app/modules/media/media_controller.py
@@ -254,6 +254,32 @@ class MediaController:
             logger.error(f"Error downloading attachment: {str(e)}")
             raise HTTPException(status_code=500, detail="Failed to download attachment")
 
+    async def download_attachment_internal(self, attachment_id: str) -> StreamingResponse:
+        """Download attachment for internal services without conversation access checks."""
+        try:
+            attachment = await self.media_service.get_attachment(attachment_id)
+            if not attachment:
+                raise HTTPException(status_code=404, detail="Attachment not found")
+
+            file_data = await self.media_service.get_attachment_data(attachment_id)
+            safe_filename = _safe_content_disposition_filename(attachment.file_name)
+            headers = {
+                "Content-Disposition": f'inline; filename="{safe_filename}"',
+                "Content-Type": attachment.mime_type,
+                "Content-Length": str(len(file_data)),
+            }
+
+            return StreamingResponse(
+                io.BytesIO(file_data), media_type=attachment.mime_type, headers=headers
+            )
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error(f"Error downloading internal attachment: {str(e)}")
+            raise HTTPException(
+                status_code=500, detail="Failed to download internal attachment"
+            )
+
     async def get_attachment_info(self, attachment_id: str) -> AttachmentInfo:
         """Get attachment information"""
         try:

--- a/app/modules/media/media_router.py
+++ b/app/modules/media/media_router.py
@@ -1,6 +1,7 @@
+import hmac
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, File, Query, UploadFile, HTTPException
+from fastapi import APIRouter, Depends, File, Query, UploadFile, HTTPException, Header
 from sqlalchemy.orm import Session
 
 from app.core.config_provider import config_provider
@@ -18,6 +19,38 @@ router = APIRouter()
 
 
 class MediaAPI:
+    @staticmethod
+    @router.get("/internal/media/{attachment_id}/raw")
+    async def download_attachment_internal_raw(
+        attachment_id: str,
+        workflows_media_token: Optional[str] = Header(
+            None, alias="X-Workflows-Media-Token"
+        ),
+        db: Session = Depends(get_db),
+    ):
+        """
+        Internal endpoint for workflows service to fetch raw attachment bytes.
+        Authenticated only via shared media token; does not require message linkage.
+        """
+        expected_secret = config_provider.get_workflows_media_internal_secret()
+        if not expected_secret:
+            raise HTTPException(
+                status_code=503,
+                detail="Internal media secret is not configured",
+            )
+
+        if not workflows_media_token or not hmac.compare_digest(
+            workflows_media_token, expected_secret
+        ):
+            raise HTTPException(status_code=401, detail="Invalid media token")
+
+        controller = MediaController(
+            db=db,
+            user_id="workflows-internal",
+            user_email="workflows-internal@potpie.local",
+        )
+        return await controller.download_attachment_internal(attachment_id)
+
     @staticmethod
     @router.post("/media/upload", response_model=AttachmentUploadResponse)
     async def upload_file(

--- a/tests/unit/media/test_media_controller_internal.py
+++ b/tests/unit/media/test_media_controller_internal.py
@@ -1,0 +1,41 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.modules.media.media_controller import MediaController
+
+
+@pytest.mark.asyncio
+async def test_download_attachment_internal_success():
+    controller = object.__new__(MediaController)
+    controller.media_service = SimpleNamespace(
+        get_attachment=AsyncMock(
+            return_value=SimpleNamespace(
+                file_name="diagram.png",
+                mime_type="image/png",
+            )
+        ),
+        get_attachment_data=AsyncMock(return_value=b"png-bytes"),
+    )
+
+    response = await controller.download_attachment_internal("att-123")
+
+    assert response.status_code == 200
+    assert response.media_type == "image/png"
+    assert "Content-Disposition" in response.headers
+    assert response.headers["Content-Length"] == str(len(b"png-bytes"))
+
+
+@pytest.mark.asyncio
+async def test_download_attachment_internal_not_found():
+    controller = object.__new__(MediaController)
+    controller.media_service = SimpleNamespace(
+        get_attachment=AsyncMock(return_value=None),
+        get_attachment_data=AsyncMock(return_value=b""),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await controller.download_attachment_internal("missing")
+    assert exc_info.value.status_code == 404


### PR DESCRIPTION
Successfully uploads the media attached in additional context in QnA page and sends it to workflows through an internal route. Saves additional context data in DB. 
<img width="899" height="393" alt="Screenshot 2026-04-29 at 6 02 38 PM" src="https://github.com/user-attachments/assets/09a662fd-9724-4917-af65-59baefa37b7d" />
<img width="794" height="210" alt="Screenshot 2026-04-29 at 6 28 45 PM" src="https://github.com/user-attachments/assets/b6e2deaa-af55-4411-8c3a-16bf6253ef04" />
<img width="1920" height="1079" alt="Screenshot 2026-04-29 at 6 01 57 PM" src="https://github.com/user-attachments/assets/cef005dd-187d-4f3a-99d8-55f629baf5fa" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced internal media download endpoint with token-based authentication for secure service-to-service communication.
  * Added configuration support for internal authentication secrets.

* **Tests**
  * Added comprehensive unit tests for internal media download scenarios including success and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->