### PR TITLE
Consolidate repo_name and repo_path into a single repository identifier

### DIFF
--- a/app/modules/parsing/graph_construction/parsing_controller.py
+++ b/app/modules/parsing/graph_construction/parsing_controller.py
@@ -57,27 +57,12 @@ class ParsingController:
         parse_helper = ParseHelper(db)
         parsing_service = ParsingService(db, user_id)
 
-        # Auto-detect if repo_name is actually a filesystem path
-        if repo_details.repo_name and not repo_details.repo_path:
-            is_path = (
-                os.path.isabs(repo_details.repo_name)
-                or repo_details.repo_name.startswith(("~", "./", "../"))
-                or os.path.isdir(os.path.expanduser(repo_details.repo_name))
-            )
-            if is_path:
-                # Move from repo_name to repo_path
-                repo_details.repo_path = repo_details.repo_name
-                repo_details.repo_name = repo_details.repo_path.split("/")[-1]
-                logger.info(
-                    f"Auto-detected filesystem path: repo_path={repo_details.repo_path}, repo_name={repo_details.repo_name}"
-                )
+        # Repository identifier resolution (local vs remote) is handled
+        # in ParsingRequest.__init__ via RepositoryResolver. At this point
+        # repo_details.repo_name is always populated, and repo_details.repo_path
+        # is set only for local repositories.
 
-        if config_provider.get_is_development_mode():
-            # In dev mode: if both repo_path and repo_name are provided, prioritize repo_path (local)
-            if repo_details.repo_path and repo_details.repo_name:
-                repo_details.repo_name = None
-            # Otherwise keep whichever one is provided as-is
-        else:
+        if not config_provider.get_is_development_mode():
             # In non-dev mode: if repo_name is None but repo_path exists, extract repo_name from repo_path
             if not repo_details.repo_name and repo_details.repo_path:
                 repo_details.repo_name = repo_details.repo_path.split("/")[-1]
@@ -367,7 +352,9 @@ class ParsingController:
         }
 
         logger.info(f"Submitting parsing task for new project {new_project_id}")
-        repo_name = repo_details.repo_name or repo_details.repo_path.split("/")[-1]
+        repo_name = repo_details.repo_name or (
+            repo_details.repo_path.split("/")[-1] if repo_details.repo_path else "unknown"
+        )
         await project_manager.register_project(
             repo_name,
             repo_details.branch_name,

--- a/app/modules/parsing/graph_construction/parsing_schema.py
+++ b/app/modules/parsing/graph_construction/parsing_schema.py
@@ -2,8 +2,23 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
+from app.modules.parsing.utils.repository_resolver import RepositoryResolver
+from app.modules.utils.logger import setup_logger
+
+logger = setup_logger(__name__)
+
 
 class ParsingRequest(BaseModel):
+    repository_identifier: Optional[str] = Field(
+        default=None,
+        description=(
+            "Unified repository identifier. Can be a remote GitHub repo "
+            "(e.g. 'owner/repo') or a local filesystem path "
+            "(e.g. '/path/to/repo'). Preferred over the deprecated "
+            "repo_name / repo_path fields."
+        ),
+    )
+    # Deprecated
     repo_name: Optional[str] = Field(default=None)
     repo_path: Optional[str] = Field(default=None)
     branch_name: Optional[str] = Field(default=None)
@@ -11,8 +26,31 @@ class ParsingRequest(BaseModel):
 
     def __init__(self, **data):
         super().__init__(**data)
-        if not self.repo_name and not self.repo_path:
-            raise ValueError("Either repo_name or repo_path must be provided.")
+
+        if self.repository_identifier:
+            resolved = RepositoryResolver.classify(self.repository_identifier)
+            if resolved.is_local:
+                self.repo_path = resolved.repo_path
+                self.repo_name = resolved.repo_name
+            else:
+                self.repo_name = resolved.repo_name
+                self.repo_path = None
+        elif self.repo_name or self.repo_path:
+            # Backward-compatible
+            logger.warning(
+                "ParsingRequest: 'repo_name' and 'repo_path' are deprecated. "
+                "Use 'repository_identifier' instead."
+            )
+            if self.repo_name and not self.repo_path:
+                if RepositoryResolver.looks_like_path(self.repo_name):
+                    resolved = RepositoryResolver.classify(self.repo_name)
+                    self.repo_path = resolved.repo_path
+                    self.repo_name = resolved.repo_name
+        else:
+            raise ValueError(
+                "Either repository_identifier, repo_name, or repo_path "
+                "must be provided."
+            )
 
 
 class ParsingResponse(BaseModel):
@@ -26,6 +64,7 @@ class RepoDetails(BaseModel):
     branch_name: str
     repo_path: Optional[str] = None
     commit_id: Optional[str] = None
+    is_local: bool = False
 
 
 class ParsingStatusRequest(BaseModel):

--- a/app/modules/parsing/utils/repository_resolver.py
+++ b/app/modules/parsing/utils/repository_resolver.py
@@ -1,0 +1,135 @@
+"""
+Repository identifier resolution utilities.
+
+Centralizes the logic for classifying and resolving a single repository
+identifier into its component parts (repo_name, repo_path, is_local).
+
+This replaces the scattered auto-detection logic that was previously
+distributed across parsing_controller.py and other modules.
+"""
+
+import os
+from enum import Enum
+from typing import NamedTuple
+
+from app.modules.utils.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+
+class RepositoryType(Enum):
+    """Classification of a repository identifier."""
+
+    REMOTE = "remote"
+    LOCAL = "local"
+
+
+class ResolvedRepository(NamedTuple):
+    """Result of resolving a repository identifier.
+
+    Attributes:
+        repository_identifier: The original identifier string.
+        repo_name: Normalized repository name (e.g. 'owner/repo' or directory basename).
+        repo_path: Resolved local filesystem path, or None for remote repos.
+        is_local: True if the identifier refers to a local filesystem path.
+    """
+
+    repository_identifier: str
+    repo_name: str
+    repo_path: str | None
+    is_local: bool
+
+
+class RepositoryResolver:
+    """Centralized repository identifier classification and resolution.
+
+    A repository identifier is a single string that can represent either:
+    - A remote GitHub repository (e.g. ``owner/repo``)
+    - A local filesystem path (e.g. ``/path/to/repo``, ``~/repos/myproject``,
+      ``./myproject``)
+    """
+
+    @staticmethod
+    def looks_like_path(identifier: str) -> bool:
+        """Check if an identifier looks like a filesystem path.
+
+        Args:
+            identifier: The repository identifier string.
+
+        Returns:
+            True if the identifier appears to be a filesystem path.
+        """
+        if not identifier:
+            return False
+
+        # Absolute or home-relative paths
+        if os.path.isabs(identifier) or identifier.startswith(("~", "./", "../")):
+            return True
+
+        # Check if the identifier is an existing directory on the filesystem
+        expanded = os.path.expanduser(identifier)
+        if os.path.isdir(expanded):
+            return True
+
+        return False
+
+    @staticmethod
+    def classify(identifier: str) -> ResolvedRepository:
+        """Classify and resolve a repository identifier.
+
+        Determines whether the identifier refers to a local path or a remote
+        repository and returns a :class:`ResolvedRepository` with the resolved
+        fields populated.
+
+        Args:
+            identifier: The repository identifier string.
+
+        Returns:
+            A :class:`ResolvedRepository` with all fields populated.
+
+        Raises:
+            ValueError: If the identifier is empty or blank.
+        """
+        if not identifier or not identifier.strip():
+            raise ValueError("Repository identifier cannot be empty.")
+
+        identifier = identifier.strip()
+
+        if RepositoryResolver.looks_like_path(identifier):
+            repo_path = os.path.expanduser(identifier)
+            repo_name = RepositoryResolver.extract_repo_name_from_path(repo_path)
+            logger.info(
+                f"Resolved identifier as local path: "
+                f"repo_path={repo_path}, repo_name={repo_name}"
+            )
+            return ResolvedRepository(
+                repository_identifier=identifier,
+                repo_name=repo_name,
+                repo_path=repo_path,
+                is_local=True,
+            )
+
+        # Treat as remote repository identifier (e.g. 'owner/repo')
+        logger.info(f"Resolved identifier as remote repo: repo_name={identifier}")
+        return ResolvedRepository(
+            repository_identifier=identifier,
+            repo_name=identifier,
+            repo_path=None,
+            is_local=False,
+        )
+
+    @staticmethod
+    def extract_repo_name_from_path(path: str) -> str:
+        """Extract a repository name from a filesystem path.
+
+        Uses the last component of the path as the repository name.
+
+        Args:
+            path: A filesystem path string.
+
+        Returns:
+            The basename of the path.
+        """
+        # Normalize trailing slashes before extracting basename
+        normalized = path.rstrip("/").rstrip("\\")
+        return os.path.basename(normalized) or path

--- a/tests/unit/parsing/test_parsing_schema.py
+++ b/tests/unit/parsing/test_parsing_schema.py
@@ -16,8 +16,61 @@ from app.modules.parsing.graph_construction.parsing_schema import (
 pytestmark = pytest.mark.unit
 
 
-class TestParsingRequest:
-    """Test ParsingRequest validation."""
+class TestParsingRequestRepositoryIdentifier:
+    """Test ParsingRequest with the new repository_identifier field."""
+
+    def test_remote_repo_via_identifier(self):
+        """repository_identifier with remote repo resolves correctly."""
+        req = ParsingRequest(repository_identifier="owner/repo")
+        assert req.repository_identifier == "owner/repo"
+        assert req.repo_name == "owner/repo"
+        assert req.repo_path is None
+
+    def test_local_path_via_identifier(self):
+        """repository_identifier with absolute path resolves correctly."""
+        req = ParsingRequest(repository_identifier="/some/local/path")
+        assert req.repository_identifier == "/some/local/path"
+        assert req.repo_path == "/some/local/path"
+        assert req.repo_name == "path"
+
+    def test_home_relative_path_via_identifier(self):
+        """repository_identifier with ~ path resolves correctly."""
+        import os
+        req = ParsingRequest(repository_identifier="~/repos/myproject")
+        assert req.repo_path == os.path.expanduser("~/repos/myproject")
+        assert req.repo_name == "myproject"
+
+    def test_dot_relative_path_via_identifier(self):
+        """repository_identifier with ./ path resolves correctly."""
+        req = ParsingRequest(repository_identifier="./myproject")
+        assert req.repo_name == "myproject"
+        assert req.repo_path is not None
+
+    def test_identifier_with_branch_and_commit(self):
+        """repository_identifier works alongside branch_name and commit_id."""
+        req = ParsingRequest(
+            repository_identifier="owner/repo",
+            branch_name="main",
+            commit_id="abc123",
+        )
+        assert req.repo_name == "owner/repo"
+        assert req.branch_name == "main"
+        assert req.commit_id == "abc123"
+
+    def test_identifier_takes_precedence_over_legacy(self):
+        """repository_identifier takes precedence over repo_name/repo_path."""
+        req = ParsingRequest(
+            repository_identifier="owner/repo",
+            repo_name="other/repo",
+            repo_path="/some/path",
+        )
+        # repository_identifier should win
+        assert req.repo_name == "owner/repo"
+        assert req.repo_path is None
+
+
+class TestParsingRequestBackwardCompat:
+    """Test backward compatibility with deprecated repo_name/repo_path fields."""
 
     def test_valid_with_repo_name_only(self):
         """ParsingRequest with repo_name only is valid."""
@@ -37,14 +90,20 @@ class TestParsingRequest:
         assert req.repo_name == "owner/repo"
         assert req.repo_path == "/tmp/repo"
 
-    def test_invalid_when_both_missing(self):
-        """ParsingRequest raises ValueError when neither repo_name nor repo_path provided."""
-        with pytest.raises(ValueError, match="Either repo_name or repo_path must be provided"):
+    def test_invalid_when_all_missing(self):
+        """ParsingRequest raises ValueError when no identifier provided."""
+        with pytest.raises(
+            ValueError,
+            match="Either repository_identifier, repo_name, or repo_path must be provided",
+        ):
             ParsingRequest()
 
     def test_invalid_with_empty_strings_both_none(self):
         """repo_name='', repo_path=None triggers validation (both falsy)."""
-        with pytest.raises(ValueError, match="Either repo_name or repo_path must be provided"):
+        with pytest.raises(
+            ValueError,
+            match="Either repository_identifier, repo_name, or repo_path must be provided",
+        ):
             ParsingRequest(repo_name="", repo_path=None)
 
     def test_optional_branch_and_commit(self):
@@ -52,6 +111,12 @@ class TestParsingRequest:
         req = ParsingRequest(repo_name="a/b", branch_name="main", commit_id="abc123")
         assert req.branch_name == "main"
         assert req.commit_id == "abc123"
+
+    def test_repo_name_auto_detected_as_path(self):
+        """repo_name that looks like a path is auto-resolved to repo_path."""
+        req = ParsingRequest(repo_name="/absolute/path/to/myrepo")
+        assert req.repo_path == "/absolute/path/to/myrepo"
+        assert req.repo_name == "myrepo"
 
 
 class TestRepoDetails:
@@ -64,6 +129,7 @@ class TestRepoDetails:
         assert details.branch_name == "main"
         assert details.repo_path is None
         assert details.commit_id is None
+        assert details.is_local is False
 
     def test_construction_with_optional(self):
         """RepoDetails with optional repo_path and commit_id."""
@@ -75,6 +141,21 @@ class TestRepoDetails:
         )
         assert details.repo_path == "/local/repo"
         assert details.commit_id == "abc123"
+
+    def test_is_local_flag(self):
+        """RepoDetails is_local flag."""
+        details = RepoDetails(
+            repo_name="myrepo",
+            branch_name="main",
+            repo_path="/local/repo",
+            is_local=True,
+        )
+        assert details.is_local is True
+
+    def test_is_local_default_false(self):
+        """RepoDetails is_local defaults to False."""
+        details = RepoDetails(repo_name="owner/repo", branch_name="main")
+        assert details.is_local is False
 
 
 class TestParsingStatusRequest:
@@ -167,3 +248,20 @@ class TestInputEdgeCases:
         """repo_name with unicode characters."""
         req = ParsingRequest(repo_name="owner/репо")
         assert req.repo_name == "owner/репо"
+
+    def test_model_dump_includes_repository_identifier(self):
+        """model_dump() includes repository_identifier for Celery serialization."""
+        req = ParsingRequest(repository_identifier="owner/repo", branch_name="main")
+        dumped = req.model_dump()
+        assert "repository_identifier" in dumped
+        assert dumped["repository_identifier"] == "owner/repo"
+        assert dumped["repo_name"] == "owner/repo"
+
+    def test_model_dump_roundtrip(self):
+        """ParsingRequest can be reconstructed from model_dump()."""
+        req = ParsingRequest(repository_identifier="owner/repo", branch_name="main")
+        dumped = req.model_dump()
+        reconstructed = ParsingRequest(**dumped)
+        assert reconstructed.repo_name == req.repo_name
+        assert reconstructed.repo_path == req.repo_path
+        assert reconstructed.branch_name == req.branch_name

--- a/tests/unit/parsing/test_parsing_validator.py
+++ b/tests/unit/parsing/test_parsing_validator.py
@@ -88,3 +88,43 @@ class TestValidateParsingInput:
         repo_details = ParsingRequest(repo_name="owner/repo")
         result = await _wrapped_handler(repo_details=repo_details)
         assert result == {"ok": True}
+
+
+class TestValidateParsingInputWithIdentifier:
+    """Test validate_parsing_input decorator using repository_identifier."""
+
+    @pytest.mark.asyncio
+    async def test_allows_remote_via_identifier(self, monkeypatch):
+        """Validator allows request with repository_identifier for remote repo."""
+        monkeypatch.setenv("defaultUsername", "default-user")
+        monkeypatch.setenv("isDevelopmentMode", "enabled")
+        repo_details = ParsingRequest(repository_identifier="owner/repo")
+        result = await _wrapped_handler(
+            repo_details=repo_details,
+            user_id="other-user",
+        )
+        assert result == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_allows_local_via_identifier_in_dev_mode(self, monkeypatch):
+        """Validator allows request with local path identifier in dev mode."""
+        monkeypatch.setenv("isDevelopmentMode", "enabled")
+        repo_details = ParsingRequest(repository_identifier="/tmp/local/repo")
+        result = await _wrapped_handler(
+            repo_details=repo_details,
+            user_id="any-user",
+        )
+        assert result == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_403_local_via_identifier_non_dev(self, monkeypatch):
+        """Validator returns 403 when local path identifier is used outside dev mode."""
+        monkeypatch.setenv("isDevelopmentMode", "disabled")
+        repo_details = ParsingRequest(repository_identifier="/tmp/local/repo")
+        with pytest.raises(HTTPException) as exc_info:
+            await _wrapped_handler(
+                repo_details=repo_details,
+                user_id="any-user",
+            )
+        assert exc_info.value.status_code == 403
+        assert "Development mode" in exc_info.value.detail

--- a/tests/unit/parsing/test_repository_resolver.py
+++ b/tests/unit/parsing/test_repository_resolver.py
@@ -1,0 +1,153 @@
+"""
+Unit tests for RepositoryResolver.
+"""
+
+import os
+
+import pytest
+
+from app.modules.parsing.utils.repository_resolver import (
+    RepositoryResolver,
+    RepositoryType,
+    ResolvedRepository,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestLooksLikePath:
+    """Test RepositoryResolver.looks_like_path."""
+
+    def test_absolute_unix_path(self):
+        assert RepositoryResolver.looks_like_path("/home/user/repo") is True
+
+    def test_home_relative_path(self):
+        assert RepositoryResolver.looks_like_path("~/repos/myproject") is True
+
+    def test_dot_relative_path(self):
+        assert RepositoryResolver.looks_like_path("./myproject") is True
+
+    def test_parent_relative_path(self):
+        assert RepositoryResolver.looks_like_path("../myproject") is True
+
+    def test_remote_repo_identifier(self):
+        assert RepositoryResolver.looks_like_path("owner/repo") is False
+
+    def test_simple_name(self):
+        assert RepositoryResolver.looks_like_path("myrepo") is False
+
+    def test_empty_string(self):
+        assert RepositoryResolver.looks_like_path("") is False
+
+    def test_none_is_false(self):
+        # looks_like_path should handle None gracefully
+        assert RepositoryResolver.looks_like_path(None) is False
+
+
+class TestClassify:
+    """Test RepositoryResolver.classify."""
+
+    def test_remote_repo(self):
+        result = RepositoryResolver.classify("owner/repo")
+        assert result.is_local is False
+        assert result.repo_name == "owner/repo"
+        assert result.repo_path is None
+        assert result.repository_identifier == "owner/repo"
+
+    def test_absolute_local_path(self):
+        result = RepositoryResolver.classify("/home/user/myrepo")
+        assert result.is_local is True
+        assert result.repo_name == "myrepo"
+        assert result.repo_path == "/home/user/myrepo"
+        assert result.repository_identifier == "/home/user/myrepo"
+
+    def test_home_relative_path(self):
+        result = RepositoryResolver.classify("~/repos/myproject")
+        assert result.is_local is True
+        assert result.repo_name == "myproject"
+        # repo_path should be expanded
+        assert result.repo_path == os.path.expanduser("~/repos/myproject")
+        assert result.repository_identifier == "~/repos/myproject"
+
+    def test_dot_relative_path(self):
+        result = RepositoryResolver.classify("./myproject")
+        assert result.is_local is True
+        assert result.repo_name == "myproject"
+
+    def test_parent_relative_path(self):
+        result = RepositoryResolver.classify("../myproject")
+        assert result.is_local is True
+        assert result.repo_name == "myproject"
+
+    def test_empty_raises_value_error(self):
+        with pytest.raises(ValueError, match="cannot be empty"):
+            RepositoryResolver.classify("")
+
+    def test_whitespace_only_raises_value_error(self):
+        with pytest.raises(ValueError, match="cannot be empty"):
+            RepositoryResolver.classify("   ")
+
+    def test_strips_whitespace(self):
+        result = RepositoryResolver.classify("  owner/repo  ")
+        assert result.repo_name == "owner/repo"
+        assert result.is_local is False
+
+    def test_remote_with_dots_in_name(self):
+        result = RepositoryResolver.classify("my-org/my_repo.name")
+        assert result.is_local is False
+        assert result.repo_name == "my-org/my_repo.name"
+
+    def test_remote_with_multiple_slashes(self):
+        """GitLab-style paths with multiple levels."""
+        result = RepositoryResolver.classify("org/group/repo")
+        assert result.is_local is False
+        assert result.repo_name == "org/group/repo"
+
+
+class TestExtractRepoNameFromPath:
+    """Test RepositoryResolver.extract_repo_name_from_path."""
+
+    def test_simple_path(self):
+        assert RepositoryResolver.extract_repo_name_from_path("/path/to/myrepo") == "myrepo"
+
+    def test_trailing_slash(self):
+        assert RepositoryResolver.extract_repo_name_from_path("/path/to/myrepo/") == "myrepo"
+
+    def test_single_component(self):
+        assert RepositoryResolver.extract_repo_name_from_path("myrepo") == "myrepo"
+
+    def test_home_path(self):
+        assert RepositoryResolver.extract_repo_name_from_path("/home/user/project") == "project"
+
+    def test_dot_directory(self):
+        assert RepositoryResolver.extract_repo_name_from_path("/home/user/.hidden") == ".hidden"
+
+
+class TestResolvedRepositoryNamedTuple:
+    """Test ResolvedRepository is a proper NamedTuple."""
+
+    def test_fields(self):
+        resolved = ResolvedRepository(
+            repository_identifier="owner/repo",
+            repo_name="owner/repo",
+            repo_path=None,
+            is_local=False,
+        )
+        assert resolved.repository_identifier == "owner/repo"
+        assert resolved.repo_name == "owner/repo"
+        assert resolved.repo_path is None
+        assert resolved.is_local is False
+
+    def test_unpacking(self):
+        resolved = ResolvedRepository(
+            repository_identifier="/tmp/repo",
+            repo_name="repo",
+            repo_path="/tmp/repo",
+            is_local=True,
+        )
+        ident, name, path, is_local = resolved
+        assert ident == "/tmp/repo"
+        assert name == "repo"
+        assert path == "/tmp/repo"
+        assert is_local is True


### PR DESCRIPTION
  ## Changes

  - Added `RepositoryResolver` to classify repository identifiers as local paths
  or remote repos.
  - Added `repository_identifier` to `ParsingRequest`.
  - Kept legacy `repo_name` / `repo_path` support with a deprecation warning.
  - Moved path detection from `parsing_controller.py` into schema-level request
  normalization.
  - Added `is_local` to `RepoDetails`.
  - Updated controller logic so local dev requests keep the normalized
  `repo_name` instead of clearing it.
  - Rebased on latest `main` and kept the newer `ProjectSandbox.ensure()`
  parsing flow.

  ## Notes

  During rebase, `parsing_service.py` conflicted because this branch changed the
  old clone/setup flow, while `main` had replaced that flow with sandbox-based
  parsing. I kept the sandbox flow from `main` and dropped the stale legacy
  conversion because it is no longer used.

  ## Testing

  - `git diff --check`
  - `python3 -m py_compile app/modules/parsing/graph_construction/
  parsing_controller.py app/modules/parsing/graph_construction/parsing_schema.py
  app/modules/parsing/utils/repository_resolver.py`

  I also tried running the targeted parsing tests, but the local environment is
  missing `redis`, so pytest fails while loading `tests/conftest.py`.

  ## Follow-up work

  This does not fully remove downstream `repo_name` / `repo_path` usage yet. To
  fully close #517, we still need to:

  - Add `repository_identifier` to `RepoDetails`.
  - Add `is_local` to `ParsingRequest`.
  - Use `is_local` instead of checking `repo_path`.
  - Remove remaining fallback basename extraction from the controller.
  - Audit project registration and lookup paths that still depend on both
  `repo_name` and `repo_path`.
  - Update API docs and examples to prefer `repository_identifier`.
