### PR TITLE
Validate repository name format in get_branch_list() and check_public_repo()

### DIFF
--- a/app/modules/code_provider/code_provider_controller.py
+++ b/app/modules/code_provider/code_provider_controller.py
@@ -241,6 +241,14 @@ class CodeProviderController:
         from app.modules.utils.logger import setup_logger
 
         logger = setup_logger(__name__)
+
+        provider_type = os.getenv("CODE_PROVIDER", "github").lower()
+        if provider_type == "github" and not os.path.isdir(repo_name):
+            try:
+                GithubService._validate_repo_name_format(repo_name)
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
+
         search_query = self._normalize_search_query(search)
 
         # Fast path: check cache (async Redis when available)
@@ -341,6 +349,12 @@ class CodeProviderController:
         Check if a repository is public using the configured provider.
         GitHub API call runs in a thread pool to avoid blocking the event loop.
         """
+        provider_type = os.getenv("CODE_PROVIDER", "github").lower()
+        if provider_type == "github":
+            try:
+                GithubService._validate_repo_name_format(repo_name)
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
         try:
             return await asyncio.to_thread(self._check_public_repo_sync, repo_name)
         except Exception:

--- a/app/modules/code_provider/github/github_service.py
+++ b/app/modules/code_provider/github/github_service.py
@@ -49,6 +49,10 @@ except ImportError:
 
 logger = setup_logger(__name__)
 
+REPO_NAME_PATTERN = re.compile(
+    r"^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?/[a-zA-Z0-9._-]{1,100}$"
+)
+
 # Lazy async Redis client for project structure cache (shared across instances)
 _async_redis_cache: Optional[Any] = None
 _async_redis_cache_lock = asyncio.Lock()
@@ -88,6 +92,28 @@ async def close_github_async_redis_cache() -> None:
 class GithubService:
     gh_token_list: List[str] = []
     _shared_executor: ClassVar[Optional[ThreadPoolExecutor]] = None
+
+    @staticmethod
+    def _validate_repo_name_format(repo_name: str) -> None:
+        if not REPO_NAME_PATTERN.match(repo_name):
+            raise ValueError(
+                f"Invalid repository name format: '{repo_name}'. "
+                "Expected format: 'owner/repo' where owner is alphanumeric "
+                "with optional hyphens (max 39 characters) and repo is "
+                "alphanumeric with optional hyphens, underscores, or periods "
+                "(max 100 characters)."
+            )
+        owner, repo = repo_name.split("/", 1)
+        if "--" in owner:
+            raise ValueError(
+                f"Invalid repository name format: '{repo_name}'. "
+                "Owner segment must not contain consecutive hyphens."
+            )
+        if repo in (".", "..") or repo.endswith(".git"):
+            raise ValueError(
+                f"Invalid repository name format: '{repo_name}'. "
+                "Repository name must not be '.', '..', or end with '.git'."
+            )
 
     @classmethod
     def _get_executor(cls) -> ThreadPoolExecutor:
@@ -1235,7 +1261,7 @@ class GithubService:
                         detail=f"Error fetching branches for local repo: {str(e)}",
                     )
             else:
-                # Handle GitHub repository (existing functionality)
+                self._validate_repo_name_format(repo_name)
                 github, repo = self.get_repo(repo_name)
                 default_branch = repo.default_branch
                 branches = repo.get_branches()
@@ -1558,6 +1584,7 @@ class GithubService:
         return "\n".join(_format_node(structure))
 
     async def check_public_repo(self, repo_name: str) -> bool:
+        self._validate_repo_name_format(repo_name)
         try:
             github = self.get_public_github_instance()
             github.get_repo(repo_name)

--- a/tests/unit/code_provider/test_repo_name_validation.py
+++ b/tests/unit/code_provider/test_repo_name_validation.py
@@ -1,0 +1,142 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.modules.code_provider.github.github_service import GithubService
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestValidateRepoNameFormat:
+
+    @pytest.mark.parametrize(
+        "repo_name",
+        [
+            "owner/repo",
+            "my-org/my-repo",
+            "user123/project-name",
+            "a/b",
+            "octocat/Hello-World",
+            "org/repo_with_underscores",
+            "org/repo.with.dots",
+            "org/repo-with-mixed_chars.v2",
+            "A/B",
+            "user-1/repo-2",
+            "a" * 39 + "/repo",
+        ],
+    )
+    def test_valid_repo_names(self, repo_name):
+        GithubService._validate_repo_name_format(repo_name)
+
+    @pytest.mark.parametrize(
+        "repo_name",
+        [
+            "",
+            "noslash",
+            "/repo",
+            "owner/",
+            "owner/repo/extra",
+            "owner//repo",
+            "-owner/repo",
+            "owner-/repo",
+            "my--org/repo",
+            "owner/repo name",
+            "owner name/repo",
+            "owner/@repo",
+            "owner/repo!",
+            ".owner/repo",
+            "_owner/repo",
+            "a" * 40 + "/repo",
+            "owner/.",
+            "owner/..",
+            "owner/repo.git",
+            "owner/my-project.git",
+        ],
+    )
+    def test_invalid_repo_names(self, repo_name):
+        with pytest.raises(ValueError, match="Invalid repository name format"):
+            GithubService._validate_repo_name_format(repo_name)
+
+
+class TestGetBranchListValidation:
+
+    @pytest.fixture
+    def service(self):
+        with patch.object(GithubService, "__init__", lambda self, db: None):
+            svc = GithubService.__new__(GithubService)
+            return svc
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_repo_name(self, service):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await service.get_branch_list("not-a-valid-name")
+        assert "Invalid repository name format" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_owner(self, service):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await service.get_branch_list("/repo")
+        assert "Invalid repository name format" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_rejects_consecutive_hyphens_in_owner(self, service):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await service.get_branch_list("my--org/repo")
+        assert "consecutive hyphens" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_valid_name_proceeds_to_api(self, service):
+        mock_repo = MagicMock()
+        mock_repo.default_branch = "main"
+        mock_branch = MagicMock()
+        mock_branch.name = "dev"
+        mock_repo.get_branches.return_value = [mock_branch]
+
+        with patch.object(service, "get_repo", return_value=(MagicMock(), mock_repo)):
+            result = await service.get_branch_list("owner/repo")
+            assert result == {"branches": ["main", "dev"]}
+
+
+class TestCheckPublicRepoValidation:
+
+    @pytest.fixture
+    def service(self):
+        with patch.object(GithubService, "__init__", lambda self, db: None):
+            svc = GithubService.__new__(GithubService)
+            return svc
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_repo_name(self, service):
+        with pytest.raises(ValueError, match="Invalid repository name format"):
+            await service.check_public_repo("not-a-valid-name")
+
+    @pytest.mark.asyncio
+    async def test_rejects_repo_ending_with_dot_git(self, service):
+        with pytest.raises(ValueError, match="end with '.git'"):
+            await service.check_public_repo("owner/repo.git")
+
+    @pytest.mark.asyncio
+    async def test_valid_name_proceeds_to_api(self, service):
+        mock_github = MagicMock()
+        with patch.object(
+            GithubService, "get_public_github_instance", return_value=mock_github
+        ):
+            result = await service.check_public_repo("owner/repo")
+            assert result is True
+            mock_github.get_repo.assert_called_once_with("owner/repo")
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_api_error(self, service):
+        mock_github = MagicMock()
+        mock_github.get_repo.side_effect = Exception("not found")
+        with patch.object(
+            GithubService, "get_public_github_instance", return_value=mock_github
+        ):
+            result = await service.check_public_repo("owner/repo")
+            assert result is False

--- a/tests/unit/code_provider/test_repo_name_validation.py
+++ b/tests/unit/code_provider/test_repo_name_validation.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -140,3 +142,75 @@ class TestCheckPublicRepoValidation:
         ):
             result = await service.check_public_repo("owner/repo")
             assert result is False
+
+
+class TestCodeProviderControllerValidation:
+
+    @pytest.fixture
+    def controller(self):
+        from app.modules.code_provider.code_provider_controller import CodeProviderController
+        with patch.object(CodeProviderController, "__init__", lambda self, db: None):
+            ctrl = CodeProviderController.__new__(CodeProviderController)
+            ctrl.branch_cache = MagicMock()
+            ctrl.branch_cache.get_branches_async = AsyncMock(return_value=None)
+            return ctrl
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"CODE_PROVIDER": "github"})
+    async def test_get_branch_list_rejects_invalid_name(self, controller):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await controller.get_branch_list("invalid-no-slash")
+        assert exc_info.value.status_code == 400
+        assert "Invalid repository name format" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"CODE_PROVIDER": "github"})
+    async def test_get_branch_list_rejects_consecutive_hyphens(self, controller):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await controller.get_branch_list("my--org/repo")
+        assert exc_info.value.status_code == 400
+        assert "consecutive hyphens" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"CODE_PROVIDER": "github"})
+    async def test_get_branch_list_rejects_dot_git(self, controller):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await controller.get_branch_list("owner/repo.git")
+        assert exc_info.value.status_code == 400
+        assert ".git" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"CODE_PROVIDER": "github"})
+    async def test_check_public_repo_rejects_invalid_name(self, controller):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await controller.check_public_repo("nope")
+        assert exc_info.value.status_code == 400
+        assert "Invalid repository name format" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"CODE_PROVIDER": "github"})
+    async def test_check_public_repo_rejects_reserved_name(self, controller):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await controller.check_public_repo("owner/.")
+        assert exc_info.value.status_code == 400
+        assert "must not be" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"CODE_PROVIDER": "gitbucket"})
+    async def test_get_branch_list_skips_validation_for_non_github(self, controller):
+        controller.branch_cache.get_branches_async = AsyncMock(return_value=["main"])
+        controller._filter_branches = MagicMock(return_value=["main"])
+        controller._paginate_branches = MagicMock(return_value={"branches": ["main"]})
+
+        result = await controller.get_branch_list("anything-goes-here")
+        assert result == {"branches": ["main"]}


### PR DESCRIPTION
## Summary

Adds input validation to `get_branch_list()` and `check_public_repo()` to ensure the `repo_name` parameter follows GitHub's `owner/repo` naming conventions before making API calls. Invalid names are rejected early with HTTP 400 and a descriptive error message.

Closes #354

## Changes

### Validation Logic (`github_service.py`)

- Added a compiled `REPO_NAME_PATTERN` regex at module level for efficient reuse
- Added `GithubService._validate_repo_name_format()` static method that enforces:
  - **Owner segment**: alphanumeric + hyphens, no leading/trailing/consecutive hyphens, max 39 characters (matches GitHub username/org rules)
  - **Repo segment**: alphanumeric + hyphens, underscores, periods, max 100 characters
  - **Reserved names**: rejects `.`, `..`, and names ending with `.git`
- Raises `ValueError` with a descriptive message on invalid input

### Controller Integration (`code_provider_controller.py`)

- Added validation in `CodeProviderController.get_branch_list()` and `check_public_repo()` — the actual HTTP endpoint code path
- Validation only runs for `CODE_PROVIDER=github` (skipped for gitbucket/local providers)
- Local filesystem paths bypass validation in `get_branch_list()`
- Invalid names return HTTP 400 with clear error message before any GitHub API calls

### Tests (`test_repo_name_validation.py`)

45 unit tests covering:
- 11 valid repo name formats (standard, single-char, dots, underscores, max-length owner)
- 20 invalid repo name formats (missing slash, empty segments, special chars, consecutive hyphens, leading/trailing hyphens, reserved names, `.git` suffix, length overflow)
- `GithubService` integration tests for both methods
- `CodeProviderController` integration tests verifying HTTP 400 responses and non-GitHub provider bypass

## Verification

- **Unit tests**: 45/45 pass
- **Live server tests**: Booted the full app (Docker + Postgres + Neo4j + Redis + gunicorn), hit endpoints with curl:

| Input | Endpoint | Expected | Result |
|-------|----------|----------|--------|
| `invalid-no-slash` | get-branch-list | 400 | ✅ 400 |
| `my--org/repo` | get-branch-list | 400 | ✅ 400 |
| `owner/repo.git` | get-branch-list | 400 | ✅ 400 |
| `-owner/repo` | get-branch-list | 400 | ✅ 400 |
| `octocat/Hello-World` | get-branch-list | 200 | ✅ 200 + branches |
| `nope` | check-public-repo | 400 | ✅ 400 |
| `owner/.` | check-public-repo | 400 | ✅ 400 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation for GitHub repository names to prevent processing of malformed references. Invalid repository names now return a 400 error with descriptive feedback, covering formats, consecutive hyphens, and reserved suffixes.

* **Tests**
  * Added comprehensive test coverage for repository name validation across multiple layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->