### PR TITLE
fix(tests): repair CI failures after context-engine merge

### DIFF
--- a/tests/integration-tests/parsing/test_parsing_service.py
+++ b/tests/integration-tests/parsing/test_parsing_service.py
@@ -1,5 +1,5 @@
 """
-Integration tests for ParsingService (parse_directory, analyze_directory) with mocks.
+Integration tests for ParsingService.parse_directory with mocks.
 
 Heavy mocking of ParseHelper, CodeGraphService, InferenceService, ProjectService;
 no real Neo4j/Git/RepoManager required.
@@ -11,7 +11,6 @@ import pytest
 from neo4j.exceptions import ServiceUnavailable
 
 from app.modules.parsing.graph_construction.parsing_helper import (
-    ParsingFailedError,
     ParsingServiceError,
 )
 from app.modules.parsing.graph_construction.parsing_schema import ParsingRequest
@@ -168,94 +167,6 @@ class TestParseDirectory:
                 )
 
 
-class TestAnalyzeDirectory:
-    """Test ParsingService.analyze_directory behavior with mocks."""
-
-    @pytest.mark.asyncio
-    async def test_analyze_directory_invalid_extracted_dir_type(self, db_session):
-        """Pass non-string extracted_dir; expect ValueError."""
-        service = ParsingService(db_session, "test-user")
-        with pytest.raises(ValueError) as exc_info:
-            await service.analyze_directory(
-                extracted_dir=12345,  # type: ignore
-                project_id="proj-1",
-                user_id="test-user",
-                db=db_session,
-                language="python",
-                user_email="test@example.com",
-            )
-        assert "string" in str(exc_info.value).lower() or "type" in str(exc_info.value).lower()
-
-    @pytest.mark.asyncio
-    async def test_analyze_directory_directory_missing(self, db_session):
-        """Path does not exist; expect FileNotFoundError."""
-        service = ParsingService(db_session, "test-user")
-        with pytest.raises(FileNotFoundError) as exc_info:
-            await service.analyze_directory(
-                extracted_dir="/nonexistent/path/12345",
-                project_id="proj-1",
-                user_id="test-user",
-                db=db_session,
-                language="python",
-                user_email="test@example.com",
-            )
-        assert "nonexistent" in str(exc_info.value).lower() or "not exist" in str(exc_info.value).lower() or "not found" in str(exc_info.value).lower()
-
-    @pytest.mark.asyncio
-    async def test_analyze_directory_project_not_in_db(self, db_session, tmp_path):
-        """get_project_from_db_by_id returns None; expect ParsingServiceError or HTTPException 404."""
-        (tmp_path / "dummy").mkdir(exist_ok=True)
-        mock_project_service = MagicMock()
-        mock_project_service.get_project_from_db_by_id = AsyncMock(return_value=None)
-        with patch(
-            "app.modules.parsing.graph_construction.parsing_service.ProjectService",
-            return_value=mock_project_service,
-        ):
-            service = ParsingService(
-                db_session, "test-user", raise_library_exceptions=True
-            )
-            with pytest.raises((ParsingServiceError, Exception)) as exc_info:
-                await service.analyze_directory(
-                    extracted_dir=str(tmp_path / "dummy"),
-                    project_id="nonexistent-proj",
-                    user_id="test-user",
-                    db=db_session,
-                    language="python",
-                    user_email="test@example.com",
-                )
-            assert "not found" in str(exc_info.value).lower() or "404" in str(exc_info.value)
-
-    @pytest.mark.asyncio
-    async def test_analyze_directory_language_other(self, db_session, tmp_path):
-        """language 'other'; expect status ERROR and ParsingFailedError."""
-        (tmp_path / "dummy").mkdir(exist_ok=True)
-        mock_project_service = MagicMock()
-        mock_project_service.get_project_from_db_by_id = AsyncMock(
-            return_value={"project_name": "repo", "branch_name": "main"}
-        )
-        mock_project_service.update_project_status = AsyncMock()
-        with patch(
-            "app.modules.parsing.graph_construction.parsing_service.ProjectService",
-            return_value=mock_project_service,
-        ):
-            service = ParsingService(
-                db_session, "test-user", raise_library_exceptions=True
-            )
-            with pytest.raises(ParsingFailedError) as exc_info:
-                await service.analyze_directory(
-                    extracted_dir=str(tmp_path / "dummy"),
-                    project_id="proj-1",
-                    user_id="test-user",
-                    db=db_session,
-                    language="other",
-                    user_email="test@example.com",
-                )
-            assert "supported" in str(exc_info.value).lower() or "language" in str(exc_info.value).lower()
-            mock_project_service.update_project_status.assert_called_once()
-            call_args = mock_project_service.update_project_status.call_args
-            assert call_args[0][1] == ProjectStatusEnum.ERROR or str(call_args[0][1]).lower() == "error"
-
-
 class TestNeo4jFailures:
     """Test Neo4j connection and operation failures (Part 4.4 of plan)."""
 
@@ -297,53 +208,6 @@ class TestNeo4jFailures:
                     project_id=project_id,
                     cleanup_graph=True,
                 )
-
-    @pytest.mark.asyncio
-    async def test_inference_service_failure(self, db_session, tmp_path):
-        """InferenceService.run_inference failure → status ERROR."""
-        (tmp_path / "dummy").mkdir(exist_ok=True)
-        (tmp_path / "dummy" / "test.py").write_text("print('hello')")
-
-        mock_project_service = MagicMock()
-        mock_project_service.get_project_from_db_by_id = AsyncMock(
-            return_value={"project_name": "repo", "branch_name": "main"}
-        )
-        mock_project_service.update_project_status = AsyncMock()
-
-        mock_code_graph = MagicMock()
-        mock_code_graph.create_and_store_graph = MagicMock()
-        mock_code_graph.close = MagicMock()
-
-        mock_inference = MagicMock()
-        mock_inference.run_inference = AsyncMock(
-            side_effect=RuntimeError("LLM provider timeout")
-        )
-        mock_inference.log_graph_stats = MagicMock()
-        mock_inference.close = MagicMock()
-
-        with patch(
-            "app.modules.parsing.graph_construction.parsing_service.ProjectService",
-            return_value=mock_project_service,
-        ), patch(
-            "app.modules.parsing.graph_construction.parsing_service.CodeGraphService",
-            return_value=mock_code_graph,
-        ), patch(
-            "app.modules.parsing.graph_construction.parsing_service.InferenceService",
-            return_value=mock_inference,
-        ):
-            service = ParsingService(
-                db_session, "test-user", raise_library_exceptions=True
-            )
-            with pytest.raises((ParsingServiceError, RuntimeError, Exception)):
-                await service.analyze_directory(
-                    extracted_dir=str(tmp_path / "dummy"),
-                    project_id="proj-inference-fail",
-                    user_id="test-user",
-                    db=db_session,
-                    language="python",
-                    user_email="test@example.com",
-                )
-
 
 class TestProjectServiceOwnership:
     """Test ProjectService ownership checks (Part 4.6 of plan)."""

--- a/tests/integration-tests/sandbox_e2e/test_local_sandbox.py
+++ b/tests/integration-tests/sandbox_e2e/test_local_sandbox.py
@@ -172,7 +172,8 @@ class TestWorkspaceLifecycle:
         # README.md from the fixture upstream made it through.
         assert (worktree / "README.md").read_text() == "hello sandbox\n"
         # The branch the handle reports should match what git thinks.
-        head = subprocess.run(
+        head = await asyncio.to_thread(
+            subprocess.run,
             ["git", "-C", str(worktree), "rev-parse", "--abbrev-ref", "HEAD"],
             capture_output=True, text=True, check=True,
         )
@@ -187,17 +188,17 @@ class TestWorkspaceLifecycle:
         second message of a conversation must land on the same worktree
         the first one created, with the same files and the same id.
         """
-        kwargs = dict(
-            user_id="u1",
-            project_id="p1",
-            repo=REPO_NAME,
-            repo_url=str(upstream_repo),
-            branch="agent/edits-conv1",
-            base_ref="main",
-            create_branch=True,
-            mode=WorkspaceMode.EDIT,
-            conversation_id="conv1",
-        )
+        kwargs = {
+            "user_id": "u1",
+            "project_id": "p1",
+            "repo": REPO_NAME,
+            "repo_url": str(upstream_repo),
+            "branch": "agent/edits-conv1",
+            "base_ref": "main",
+            "create_branch": True,
+            "mode": WorkspaceMode.EDIT,
+            "conversation_id": "conv1",
+        }
         h1 = await local_client.acquire_session(**kwargs)
         h2 = await local_client.acquire_session(**kwargs)
         assert h1.workspace_id == h2.workspace_id
@@ -386,11 +387,7 @@ class TestConversationIsolation:
 
         await local_client.write_file(h_a, "ONLY_IN_A.txt", b"a-only\n")
         # h_b's directory must not have it.
-        listing = subprocess.run(
-            ["ls", h_b.local_path],
-            capture_output=True, text=True, check=True,
-        )
-        assert "ONLY_IN_A.txt" not in listing.stdout
+        assert "ONLY_IN_A.txt" not in os.listdir(h_b.local_path)
 
     async def test_same_branch_two_conversations_surfaces_typed_error(
         self, local_client: SandboxClient, upstream_repo: Path
@@ -505,7 +502,7 @@ class TestPathSafety:
         with pytest.raises(InvalidWorkspacePath):
             await local_client.read_file(handle, "/etc/passwd")
         with pytest.raises(InvalidWorkspacePath):
-            await local_client.write_file(handle, "/tmp/x", b"x")
+            await local_client.write_file(handle, "/etc/x", b"x")
 
     async def test_dotdot_traversal_is_rejected(
         self, local_client: SandboxClient, upstream_repo: Path

--- a/tests/integration-tests/sandbox_e2e/test_local_sandbox.py
+++ b/tests/integration-tests/sandbox_e2e/test_local_sandbox.py
@@ -413,7 +413,7 @@ class TestConversationIsolation:
             branch=common_branch, base_ref="main", create_branch=True,
             mode=WorkspaceMode.EDIT, conversation_id="conv-x",
         )
-        with pytest.raises(RepoCacheUnavailable, match="already checked out"):
+        with pytest.raises(RepoCacheUnavailable, match=r"already (checked out|used by worktree)"):
             await local_client.acquire_session(
                 user_id="u1", project_id="p1",
                 repo=REPO_NAME, repo_url=str(upstream_repo),


### PR DESCRIPTION
## Summary
Two CI failures introduced by the recent context-engine merge (#749), plus the SonarQube findings the PR surfaced on the freshly-added test file.

### Test fixes
- **`tests/integration-tests/parsing/test_parsing_service.py`** — drop the legacy `TestAnalyzeDirectory` class (4 tests) and the obsolete `test_inference_service_failure`. `ParsingService.analyze_directory` was removed in #749 and replaced with `analyze_workspace` (different signature: `WorkspaceHandle` instead of `extracted_dir` / `language`). Equivalent coverage already lives in `tests/unit/parsing/test_sandbox_parse_flow.py` (`test_analyze_workspace_happy_path`, `_rejects_repo_with_no_parseable_code`, `_propagates_parser_failure`).
- **`tests/integration-tests/sandbox_e2e/test_local_sandbox.py:416`** — loosen the worktree-collision regex to match both legacy (`already checked out`) and modern (`already used by worktree`) git phrasings, so the assertion passes regardless of CI's git version.

### SonarQube fixes (same file)
SonarQube treated the entire newly-added `test_local_sandbox.py` as "new code" against this PR's baseline and surfaced four findings on it. All addressed:
- **S7487 ×2 (MAJOR, reliability)** — synchronous `subprocess.run` inside `async def`. Wrapped the `git rev-parse` call in `asyncio.to_thread`, and replaced `subprocess.run(["ls", …])` with `os.listdir` (cleaner, no shell-out).
- **S7498 (MINOR, maintainability)** — `dict(...)` constructor → literal `{...}` in the kwargs fixture.
- **S5443 (security hotspot)** — hardcoded `/tmp/x` in the absolute-path-rejection test → `/etc/x`. The test only cares that an absolute path is refused.

## Test plan
- [ ] Integration phase passes (was 5 failures: 4 in `TestAnalyzeDirectory` + 1 worktree-regex).
- [ ] SonarQube quality gate flips to passing on the PR (new reliability/maintainability ratings back to A; hotspot cleared).
- [ ] `tests/unit/parsing/test_sandbox_parse_flow.py` continues to cover `analyze_workspace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored integration tests for clearer focus and organization; removed obsolete test cases.
  * Converted a blocking operation to be async-safe to stabilize test execution.
  * Broadened error expectations to accept multiple message variants for robustness.
  * Strengthened path-safety checks by validating rejection of an absolute system path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->