### PR TITLE
feat(parsing): incremental knowledge-graph updates (#221)

### DIFF
--- a/app/modules/parsing/graph_construction/code_graph_service.py
+++ b/app/modules/parsing/graph_construction/code_graph_service.py
@@ -95,6 +95,46 @@ class CodeGraphService:
             relationship_count=relationship_count,
         )
         self._store_graph(nx_graph, project_id, user_id)
+        # Seed per-file content hashes so the *next* parse can run
+        # incrementally. Done after the full rebuild succeeds — if the
+        # rebuild fails we don't want stale hashes pointing at a
+        # half-written graph.
+        self._write_file_content_hashes(artifacts, project_id)
+
+    def _write_file_content_hashes(self, artifacts, project_id: str) -> None:
+        """Stamp ``content_hash`` on the FILE nodes we just inserted.
+
+        Invoked from the full-rebuild path so the incremental path has a
+        baseline to diff against on the next run. Imported here rather
+        than at module top to keep the incremental layer optional —
+        if the import fails for any reason the full rebuild itself is
+        unaffected.
+        """
+        try:
+            from app.modules.parsing.graph_construction.incremental_graph_service import (  # noqa: E501
+                compute_file_hashes,
+            )
+        except ImportError:
+            logger.warning(
+                "[GRAPH GENERATION] incremental_graph_service unavailable; "
+                "skipping content_hash seeding",
+                project_id=project_id,
+            )
+            return
+        hashes = compute_file_hashes(artifacts)
+        if not hashes:
+            return
+        rows = [{"file_path": fp, "content_hash": h} for fp, h in hashes.items()]
+        with self.driver.session() as session:
+            session.run(
+                """
+                UNWIND $rows AS row
+                MATCH (n:FILE {repoId: $project_id, file_path: row.file_path})
+                SET n.content_hash = row.content_hash
+                """,
+                project_id=project_id,
+                rows=rows,
+            )
 
     def _store_graph(
         self,

--- a/app/modules/parsing/graph_construction/incremental_graph_service.py
+++ b/app/modules/parsing/graph_construction/incremental_graph_service.py
@@ -220,11 +220,26 @@ class IncrementalGraphService:
         existing_hashes = self._read_existing_file_hashes(project_id)
         new_hashes = compute_file_hashes(artifacts)
 
-        if not existing_hashes:
+        # Fall back to a full rebuild when hashes are absent *or* when
+        # coverage is partial (some FILE nodes lack content_hash). A
+        # partial-seeding gap means files without hashes are treated as
+        # "added", so their old nodes are never deleted and
+        # apoc.create.node() will duplicate them on the next incremental
+        # run. Comparing against the total FILE count in the graph lets
+        # us detect this case and force a clean slate.
+        total_file_count = self._count_file_nodes(project_id)
+        is_unseeded = (
+            not existing_hashes
+            or len(existing_hashes) != total_file_count
+        )
+        if is_unseeded:
             logger.info(
-                "[INCREMENTAL] No existing file hashes for project %s — "
-                "running full rebuild and seeding hashes",
+                "[INCREMENTAL] Incomplete hash coverage for project %s "
+                "(hashed=%d, total_files=%d) — running full rebuild and "
+                "seeding hashes",
                 project_id,
+                len(existing_hashes),
+                total_file_count,
             )
             self.graph_service.store_graph_from_artifacts(
                 artifacts, project_id, user_id
@@ -247,16 +262,27 @@ class IncrementalGraphService:
             return delta
 
         start = time.time()
-        self._apply_delta(
+        qdrant_ok = self._apply_delta(
             artifacts=artifacts,
             project_id=project_id,
             user_id=user_id,
             delta=delta,
         )
-        # Persist hashes for the next run. We update *all* files'
-        # hashes — including unchanged ones — so a corrupted hash on
-        # any file (e.g. from an aborted previous run) self-heals.
-        self._write_file_hashes(project_id, new_hashes)
+        if qdrant_ok:
+            # Persist hashes for the next run. We update *all* files'
+            # hashes — including unchanged ones — so a corrupted hash on
+            # any file (e.g. from an aborted previous run) self-heals.
+            self._write_file_hashes(project_id, new_hashes)
+        else:
+            # Qdrant sync failed. Skip writing hashes so the next parse
+            # sees the same delta and retries the vector update. The
+            # Neo4j graph is already consistent — only the search index
+            # is stale until the retry succeeds.
+            logger.warning(
+                "[INCREMENTAL] Skipping hash write for project %s because "
+                "Qdrant sync failed — will retry on next parse",
+                project_id,
+            )
 
         logger.info(
             "[INCREMENTAL] Applied delta in %.2fs",
@@ -289,6 +315,26 @@ class IncrementalGraphService:
     # ------------------------------------------------------------------
     # Neo4j operations
     # ------------------------------------------------------------------
+
+    def _count_file_nodes(self, project_id: str) -> int:
+        """Return the total number of FILE nodes for *project_id* in Neo4j.
+
+        Used to detect partial hash-seeding: if the count of FILE nodes
+        with a ``content_hash`` differs from the total FILE count, some
+        files were never hashed and the incremental path must not be used
+        (it would treat those files as "added" rather than "unchanged",
+        creating duplicates via apoc.create.node()).
+        """
+        with self.graph_service.driver.session() as session:
+            result = session.run(
+                """
+                MATCH (n:FILE {repoId: $project_id})
+                RETURN count(n) AS total
+                """,
+                project_id=project_id,
+            )
+            record = result.single()
+            return int(record["total"]) if record else 0
 
     def _read_existing_file_hashes(self, project_id: str) -> dict[str, str]:
         with self.graph_service.driver.session() as session:
@@ -469,7 +515,13 @@ class IncrementalGraphService:
         project_id: str,
         user_id: str,
         delta: GraphDelta,
-    ) -> None:
+    ) -> bool:
+        """Apply the delta to Neo4j and Qdrant.
+
+        Returns ``True`` when Qdrant sync completed without error, ``False``
+        when it failed (Neo4j is always updated regardless).  The return
+        value lets the caller decide whether to advance ``content_hash``.
+        """
         # Step 1: drop nodes (and their edges) for deleted + modified files.
         files_to_delete = delta.removed | delta.modified
         deleted = self._delete_files(project_id, files_to_delete)
@@ -492,7 +544,7 @@ class IncrementalGraphService:
 
         # Step 3: keep Qdrant in sync with the graph. Drop points for
         # nodes we removed; index the new dirty-file nodes.
-        self._update_qdrant(
+        return self._update_qdrant(
             artifacts=artifacts,
             project_id=project_id,
             user_id=user_id,
@@ -509,13 +561,15 @@ class IncrementalGraphService:
         project_id: str,
         user_id: str,
         delta: GraphDelta,
-    ) -> None:
+    ) -> bool:
         """Apply the delta to the project's Qdrant collection.
 
-        Best-effort: a failure here is logged but doesn't roll back the
-        Neo4j writes — same posture as the full-rebuild path, where
-        Qdrant errors are swallowed (the next parse rebuilds it from
-        scratch anyway).
+        Returns ``True`` on success, ``False`` on failure.  Failures are
+        logged but do not roll back Neo4j writes.  The return value is
+        threaded back to ``store_graph_from_artifacts_incremental`` so it
+        can decide whether to advance ``content_hash``: if we skip the
+        hash write on failure, the next parse will see the same delta and
+        retry the vector update automatically.
         """
         try:
             from app.modules.parsing.knowledge_graph.qdrant_indexing_service import (  # noqa: E501
@@ -532,7 +586,7 @@ class IncrementalGraphService:
                 "[INCREMENTAL] qdrant helper missing; skipping vector update",
                 project_id=project_id,
             )
-            return
+            return True  # Not a Qdrant error — no retry needed.
 
         collection_alias = self.graph_service.get_qdrant_collection_alias(
             project_id
@@ -561,9 +615,11 @@ class IncrementalGraphService:
                 )
             except Exception:
                 logger.exception(
-                    "[INCREMENTAL] Qdrant delete failed (non-fatal)",
+                    "[INCREMENTAL] Qdrant delete failed — hash write "
+                    "deferred to allow retry on next parse",
                     project_id=project_id,
                 )
+                return False
 
         # Index new/modified nodes into Qdrant.
         nodes_to_index = []
@@ -587,7 +643,7 @@ class IncrementalGraphService:
                 }
             )
         if not nodes_to_index:
-            return
+            return True
         try:
             index_nodes_to_qdrant(
                 self.graph_service.qdrant_client,
@@ -609,9 +665,12 @@ class IncrementalGraphService:
             )
         except Exception:
             logger.exception(
-                "[INCREMENTAL] Qdrant indexing failed (non-fatal)",
+                "[INCREMENTAL] Qdrant indexing failed — hash write "
+                "deferred to allow retry on next parse",
                 project_id=project_id,
             )
+            return False
+        return True
 
 
 # ---------------------------------------------------------------------------

--- a/app/modules/parsing/graph_construction/incremental_graph_service.py
+++ b/app/modules/parsing/graph_construction/incremental_graph_service.py
@@ -47,6 +47,7 @@ Why diff at the file level?
 from __future__ import annotations
 
 import hashlib
+import re
 import time
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -71,6 +72,11 @@ _INDEXABLE_NODE_TYPES = {"CLASS", "FUNCTION", "INTERFACE"}
 # CodeGraphService._store_graph so an incrementally-inserted node
 # carries the same label set a full-rebuild node would.
 _TYPED_LABELS = {"FILE", "CLASS", "FUNCTION", "INTERFACE"}
+
+# Relationship types must be safe Neo4j identifiers: uppercase ASCII letters,
+# digits, and underscores only.  Any other value would allow Cypher injection
+# because rel_type is interpolated directly into the query string.
+_REL_TYPE_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
 
 
 @dataclass(slots=True)
@@ -143,8 +149,8 @@ def compute_file_hashes(artifacts) -> dict[str, str]:
     if edges is None:
         edges = getattr(artifacts, "edges", [])
     for edge in edges:
-        source_id = getattr(edge, "source_id")
-        target_id = getattr(edge, "target_id")
+        source_id = edge.source_id
+        target_id = edge.target_id
         rel_type = getattr(edge, "relationship_type", None) or getattr(
             edge, "edge_type", "REFERENCES"
         )
@@ -479,8 +485,8 @@ class IncrementalGraphService:
                 edges = getattr(artifacts, "edges", [])
             edges_by_type: dict[str, list[dict]] = defaultdict(list)
             for edge in edges:
-                source_id = getattr(edge, "source_id")
-                target_id = getattr(edge, "target_id")
+                source_id = edge.source_id
+                target_id = edge.target_id
                 source_file = node_id_to_file.get(source_id, "")
                 target_file = node_id_to_file.get(target_id, "")
                 if (
@@ -491,6 +497,15 @@ class IncrementalGraphService:
                 rel_type = getattr(edge, "relationship_type", None) or getattr(
                     edge, "edge_type", "REFERENCES"
                 )
+                if not _REL_TYPE_RE.match(rel_type):
+                    logger.warning(
+                        "[INCREMENTAL] skipping edge with unsafe rel_type %r "
+                        "(source=%s target=%s)",
+                        rel_type,
+                        source_id,
+                        target_id,
+                    )
+                    continue
                 edges_by_type[rel_type].append(
                     {
                         "source_id": CodeGraphService.generate_node_id(

--- a/app/modules/parsing/graph_construction/incremental_graph_service.py
+++ b/app/modules/parsing/graph_construction/incremental_graph_service.py
@@ -534,10 +534,16 @@ class IncrementalGraphService:
             )
             return
 
-        collection_name = self.graph_service.get_qdrant_collection_name(project_id)
         collection_alias = self.graph_service.get_qdrant_collection_alias(
             project_id
         )
+        # After a staged full-rebuild, the alias points at the new
+        # staging collection and the original base collection name has
+        # been deleted. Always target the alias so incremental writes
+        # land in whatever collection currently holds the active
+        # index. Qdrant routes alias names transparently for both
+        # delete and upsert operations.
+        active_collection_name = collection_alias
 
         # Delete vector points for nodes we removed (deleted + modified
         # files). We re-derive the node_ids from the *old* graph state
@@ -550,7 +556,7 @@ class IncrementalGraphService:
             try:
                 delete_points_by_node_ids(
                     self.graph_service.qdrant_client,
-                    collection_name,
+                    active_collection_name,
                     file_paths=list(files_to_drop),
                 )
             except Exception:
@@ -585,13 +591,21 @@ class IncrementalGraphService:
         try:
             index_nodes_to_qdrant(
                 self.graph_service.qdrant_client,
-                collection_name,
+                # Target the alias, not the (possibly deleted) base
+                # collection name; same reasoning as the delete path.
+                active_collection_name,
                 nodes_to_index,
                 # Don't recreate — we want to add to the existing
                 # collection. The full-rebuild path passes
                 # recreate_collection=True.
                 recreate_collection=False,
                 alias_name=collection_alias,
+                # Preserve the persisted BM25 token vocabulary built
+                # during the full rebuild instead of overwriting it
+                # with one derived from only the dirty nodes. This
+                # keeps sparse term indices stable across older,
+                # already-indexed points.
+                preserve_bm25_vocabulary=True,
             )
         except Exception:
             logger.exception(

--- a/app/modules/parsing/graph_construction/incremental_graph_service.py
+++ b/app/modules/parsing/graph_construction/incremental_graph_service.py
@@ -165,7 +165,7 @@ def compute_file_hashes(artifacts) -> dict[str, str]:
     for file_path in all_files:
         if not file_path:
             continue
-        h = hashlib.sha1()
+        h = hashlib.sha1(usedforsecurity=False)  # noqa: S324 — content-change fingerprint, not a security hash
         for tup in sorted(by_file_nodes.get(file_path, [])):
             h.update(repr(tup).encode("utf-8"))
             h.update(b"\x00")
@@ -577,16 +577,18 @@ class IncrementalGraphService:
                 index_nodes_to_qdrant,
             )
         except ImportError:
-            # Older builds may not expose delete_points_by_node_ids;
-            # fall back to a full Qdrant rebuild via
-            # CodeGraphService._store_graph's path. We keep this fallback
-            # narrow — only triggered when the helper genuinely doesn't
-            # exist.
+            # The Qdrant helper is not present in this build.  We cannot
+            # sync the vector index at all, so we must signal failure
+            # (return False) to prevent content_hash from advancing.
+            # Advancing the hash would permanently hide the stale search
+            # state; returning False ensures the caller skips the hash
+            # write and retries on the next parse.
             logger.warning(
-                "[INCREMENTAL] qdrant helper missing; skipping vector update",
+                "[INCREMENTAL] qdrant helper missing; "
+                "vector sync skipped — hash write deferred",
                 project_id=project_id,
             )
-            return True  # Not a Qdrant error — no retry needed.
+            return False
 
         collection_alias = self.graph_service.get_qdrant_collection_alias(
             project_id

--- a/app/modules/parsing/graph_construction/incremental_graph_service.py
+++ b/app/modules/parsing/graph_construction/incremental_graph_service.py
@@ -241,6 +241,12 @@ class IncrementalGraphService:
                 len(existing_hashes),
                 total_file_count,
             )
+            # Wipe the existing graph before the full rebuild so stale
+            # nodes from a partially-seeded (or interrupted) previous run
+            # are removed.  Without this, store_graph_from_artifacts()
+            # would encounter existing nodes and apoc.create.node() would
+            # duplicate them.
+            self.graph_service.cleanup_graph(project_id)
             self.graph_service.store_graph_from_artifacts(
                 artifacts, project_id, user_id
             )
@@ -522,8 +528,14 @@ class IncrementalGraphService:
         when it failed (Neo4j is always updated regardless).  The return
         value lets the caller decide whether to advance ``content_hash``.
         """
-        # Step 1: drop nodes (and their edges) for deleted + modified files.
-        files_to_delete = delta.removed | delta.modified
+        # Step 1: drop nodes (and their edges) for deleted + modified files,
+        # and also for *added* files.  Including added files makes the whole
+        # pipeline idempotent: if _update_qdrant() fails and hashes are not
+        # advanced, the next parse will see the same delta (including the same
+        # "added" set) and re-enter _apply_delta.  Without this, nodes for
+        # delta.added would already exist in Neo4j from the first attempt, and
+        # apoc.create.node() in step 2 would insert duplicates.
+        files_to_delete = delta.removed | delta.dirty  # dirty = added | modified
         deleted = self._delete_files(project_id, files_to_delete)
         logger.info(
             "[INCREMENTAL] Deleted %d nodes for %d files",
@@ -719,25 +731,39 @@ def reconstruct_subgraph(
     want to drag in tree_sitter / grep_ast just to build a subgraph.
     """
     graph = nx.MultiDiGraph()
+    # node_lookup lets us materialise boundary nodes (nodes whose file is NOT
+    # dirty but that are referenced by an edge crossing into a dirty file).
+    # Without this, graph.add_edge() would auto-create those nodes with empty
+    # attrs, producing a graph with a different shape from the full pipeline.
+    node_lookup: dict[str, object] = {}
     node_id_to_file: dict[str, str] = {}
-    for node in artifacts.nodes:
+
+    def _add_node(node) -> None:
+        """Add *node* to the graph if it isn't there yet."""
+        if graph.has_node(node.id):
+            return
         file_path = getattr(node, "file", "") or ""
-        node_id_to_file[node.id] = file_path
-        if file_path not in dirty_files:
-            continue
-        node_attrs = {
+        attrs = {
             "file": file_path,
             "line": getattr(node, "line", -1),
             "end_line": getattr(node, "end_line", -1),
             "type": getattr(node, "node_type", "UNKNOWN"),
             "name": getattr(node, "name", "") or "",
         }
-        if node_attrs["type"] != "FILE":
-            node_attrs["class_name"] = getattr(node, "class_name", None)
+        if attrs["type"] != "FILE":
+            attrs["class_name"] = getattr(node, "class_name", None)
         text = getattr(node, "text", None)
         if text is not None:
-            node_attrs["text"] = text
-        graph.add_node(node.id, **node_attrs)
+            attrs["text"] = text
+        graph.add_node(node.id, **attrs)
+
+    for node in artifacts.nodes:
+        file_path = getattr(node, "file", "") or ""
+        node_id_to_file[node.id] = file_path
+        node_lookup[node.id] = node
+        if file_path not in dirty_files:
+            continue
+        _add_node(node)
 
     edges = getattr(artifacts, "relationships", None)
     if edges is None:
@@ -747,6 +773,15 @@ def reconstruct_subgraph(
         target_file = node_id_to_file.get(edge.target_id, "")
         if source_file not in dirty_files and target_file not in dirty_files:
             continue
+        # Ensure both endpoints exist in the graph with proper attrs before
+        # calling add_edge.  For unchanged-file endpoints, this is the first
+        # time we materialise them — skipping this step lets nx auto-create
+        # the node with empty attrs and breaks neighbour metadata lookups in
+        # the inference layer.
+        if edge.source_id in node_lookup:
+            _add_node(node_lookup[edge.source_id])
+        if edge.target_id in node_lookup:
+            _add_node(node_lookup[edge.target_id])
         edge_type = getattr(edge, "edge_type", None) or getattr(
             edge, "relationship_type", "REFERENCES"
         )

--- a/app/modules/parsing/graph_construction/incremental_graph_service.py
+++ b/app/modules/parsing/graph_construction/incremental_graph_service.py
@@ -1,0 +1,689 @@
+"""Incremental Knowledge Graph updates (issue #221).
+
+Given a fresh :class:`ParseArtifacts` from the in-sandbox parser, this
+service applies only the *delta* against the project's existing graph
+in Neo4j, instead of the full clean-and-rebuild path used by
+:class:`CodeGraphService.store_graph_from_artifacts`.
+
+Pipeline
+--------
+
+1. Compute a per-file content fingerprint from the incoming artifacts
+   (deterministic SHA-1 over the sorted (node_id, line, end_line, text)
+   tuples that belong to each file, plus edges originating in that file).
+2. Read the previously-persisted fingerprints off the existing FILE
+   nodes in Neo4j (``FILE.content_hash``). On a project that has never
+   been parsed incrementally, this returns an empty mapping and the
+   caller falls back to a full rebuild — the full rebuild also writes
+   hashes, so the next run is incremental.
+3. Diff the two maps into ``added`` / ``modified`` / ``deleted`` /
+   ``unchanged`` buckets.
+4. Apply the delta:
+   * For every *modified* and *deleted* file, ``DETACH DELETE`` all
+     nodes whose ``file_path`` matches that file. This drops every
+     edge attached to those nodes (inbound *and* outbound) in one hop.
+   * For every *added* and *modified* file, insert the fresh nodes
+     for that file from the artifacts.
+   * Re-insert every edge from the artifacts whose source *or* target
+     file is in the changed set. Edges between two unchanged files
+     are left untouched (they were never deleted in step 4a).
+5. Update / write ``content_hash`` on each affected FILE node so the
+   next run can diff against this build.
+
+Inference is run *only* over the affected node IDs — see
+:meth:`InferenceService.run_incremental_inference`.
+
+Why diff at the file level?
+---------------------------
+
+* Node-level diffs would need stable cross-version node IDs that
+  survive a function being moved within its file; file-level granularity
+  sidesteps that and matches how source-control changes actually arrive.
+* Edge integrity reduces to a single rule: an edge is dirty iff its
+  source-file or target-file is dirty. The parser already emits the
+  full edge set on every run, so we just filter rather than re-resolve.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Iterable, Mapping
+
+import networkx as nx
+
+from app.modules.parsing.graph_construction.code_graph_service import (
+    CodeGraphService,
+)
+from app.modules.utils.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+
+# Node types we route into Qdrant; mirrors INDEXABLE_NODE_TYPES in
+# qdrant_indexing_service so we can update the Qdrant collection
+# incrementally without re-importing the constant in every caller.
+_INDEXABLE_NODE_TYPES = {"CLASS", "FUNCTION", "INTERFACE"}
+
+# Node-type → Neo4j label mapping. Mirrors the assembly logic in
+# CodeGraphService._store_graph so an incrementally-inserted node
+# carries the same label set a full-rebuild node would.
+_TYPED_LABELS = {"FILE", "CLASS", "FUNCTION", "INTERFACE"}
+
+
+@dataclass(slots=True)
+class GraphDelta:
+    """Result of diffing new artifacts against the persisted graph."""
+
+    added: set[str] = field(default_factory=set)
+    modified: set[str] = field(default_factory=set)
+    deleted: set[str] = field(default_factory=set)
+    unchanged: set[str] = field(default_factory=set)
+
+    @property
+    def dirty(self) -> set[str]:
+        """Files whose nodes/edges need to be (re)written."""
+        return self.added | self.modified
+
+    @property
+    def removed(self) -> set[str]:
+        """Files whose nodes need to be deleted with no replacement."""
+        return self.deleted
+
+    @property
+    def has_changes(self) -> bool:
+        return bool(self.added or self.modified or self.deleted)
+
+    def summary(self) -> dict[str, int]:
+        return {
+            "added": len(self.added),
+            "modified": len(self.modified),
+            "deleted": len(self.deleted),
+            "unchanged": len(self.unchanged),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Hashing
+# ---------------------------------------------------------------------------
+
+
+def compute_file_hashes(artifacts) -> dict[str, str]:
+    """Compute a per-file SHA-1 fingerprint from the parser artifacts.
+
+    The fingerprint is over a deterministic projection of every node
+    attached to the file plus every edge originating in it. We hash
+    line numbers and node text rather than re-reading source from disk
+    because the artifacts are the canonical view the host process sees
+    — anything not represented there can't affect the resulting graph.
+    """
+    by_file_nodes: dict[str, list[tuple]] = defaultdict(list)
+    by_file_edges: dict[str, list[tuple]] = defaultdict(list)
+
+    # Build a node_id -> file lookup so we can attribute edges to the
+    # source node's file (edges aren't directly tagged with a file).
+    node_to_file: dict[str, str] = {}
+    for node in artifacts.nodes:
+        file_path = getattr(node, "file", "") or ""
+        node_to_file[node.id] = file_path
+        by_file_nodes[file_path].append(
+            (
+                node.id,
+                getattr(node, "node_type", "UNKNOWN"),
+                getattr(node, "line", -1),
+                getattr(node, "end_line", -1),
+                getattr(node, "name", "") or "",
+                getattr(node, "text", "") or "",
+            )
+        )
+
+    edges = getattr(artifacts, "relationships", None)
+    if edges is None:
+        edges = getattr(artifacts, "edges", [])
+    for edge in edges:
+        source_id = getattr(edge, "source_id")
+        target_id = getattr(edge, "target_id")
+        rel_type = getattr(edge, "relationship_type", None) or getattr(
+            edge, "edge_type", "REFERENCES"
+        )
+        file_path = node_to_file.get(source_id, "")
+        by_file_edges[file_path].append(
+            (
+                source_id,
+                target_id,
+                rel_type,
+                getattr(edge, "ident", "") or "",
+                getattr(edge, "ref_line", -1),
+                getattr(edge, "end_ref_line", -1),
+            )
+        )
+
+    hashes: dict[str, str] = {}
+    all_files = set(by_file_nodes) | set(by_file_edges)
+    for file_path in all_files:
+        if not file_path:
+            continue
+        h = hashlib.sha1()
+        for tup in sorted(by_file_nodes.get(file_path, [])):
+            h.update(repr(tup).encode("utf-8"))
+            h.update(b"\x00")
+        h.update(b"|edges|")
+        for tup in sorted(by_file_edges.get(file_path, [])):
+            h.update(repr(tup).encode("utf-8"))
+            h.update(b"\x00")
+        hashes[file_path] = h.hexdigest()
+    return hashes
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class IncrementalGraphService:
+    """Apply file-level deltas to the persisted graph.
+
+    Holds a reference to the underlying :class:`CodeGraphService` rather
+    than subclassing it: the orchestrator (``ParsingService``) already
+    constructs a ``CodeGraphService`` for cleanup / writes and we don't
+    want a second Neo4j driver per parse.
+    """
+
+    def __init__(self, graph_service: CodeGraphService):
+        self.graph_service = graph_service
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    def store_graph_from_artifacts_incremental(
+        self,
+        artifacts,
+        project_id: str,
+        user_id: str,
+    ) -> GraphDelta:
+        """Apply ``artifacts`` to the project's existing graph as a delta.
+
+        Returns the :class:`GraphDelta` so the caller can decide what to
+        do with downstream pipelines (skip inference if no changes,
+        run partial inference on dirty files, etc.).
+
+        If the project has no persisted ``content_hash`` data yet (first
+        incremental run on a previously full-rebuilt or empty project),
+        we fall through to a full rebuild via
+        :meth:`CodeGraphService.store_graph_from_artifacts`. The full
+        rebuild now also writes hashes, so subsequent runs are
+        incremental.
+        """
+        existing_hashes = self._read_existing_file_hashes(project_id)
+        new_hashes = compute_file_hashes(artifacts)
+
+        if not existing_hashes:
+            logger.info(
+                "[INCREMENTAL] No existing file hashes for project %s — "
+                "running full rebuild and seeding hashes",
+                project_id,
+            )
+            self.graph_service.store_graph_from_artifacts(
+                artifacts, project_id, user_id
+            )
+            self._write_file_hashes(project_id, new_hashes)
+            return GraphDelta(added=set(new_hashes))
+
+        delta = self._diff(existing_hashes, new_hashes)
+        logger.info(
+            "[INCREMENTAL] Delta for project %s: %s",
+            project_id,
+            delta.summary(),
+        )
+
+        if not delta.has_changes:
+            logger.info(
+                "[INCREMENTAL] No file-level changes — graph untouched",
+                project_id=project_id,
+            )
+            return delta
+
+        start = time.time()
+        self._apply_delta(
+            artifacts=artifacts,
+            project_id=project_id,
+            user_id=user_id,
+            delta=delta,
+        )
+        # Persist hashes for the next run. We update *all* files'
+        # hashes — including unchanged ones — so a corrupted hash on
+        # any file (e.g. from an aborted previous run) self-heals.
+        self._write_file_hashes(project_id, new_hashes)
+
+        logger.info(
+            "[INCREMENTAL] Applied delta in %.2fs",
+            time.time() - start,
+            project_id=project_id,
+        )
+        return delta
+
+    # ------------------------------------------------------------------
+    # Diff
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _diff(
+        old: Mapping[str, str], new: Mapping[str, str]
+    ) -> GraphDelta:
+        delta = GraphDelta()
+        for file_path, h in new.items():
+            if file_path not in old:
+                delta.added.add(file_path)
+            elif old[file_path] != h:
+                delta.modified.add(file_path)
+            else:
+                delta.unchanged.add(file_path)
+        for file_path in old:
+            if file_path not in new:
+                delta.deleted.add(file_path)
+        return delta
+
+    # ------------------------------------------------------------------
+    # Neo4j operations
+    # ------------------------------------------------------------------
+
+    def _read_existing_file_hashes(self, project_id: str) -> dict[str, str]:
+        with self.graph_service.driver.session() as session:
+            result = session.run(
+                """
+                MATCH (n:FILE {repoId: $project_id})
+                WHERE n.content_hash IS NOT NULL
+                RETURN n.file_path AS file_path, n.content_hash AS content_hash
+                """,
+                project_id=project_id,
+            )
+            return {
+                record["file_path"]: record["content_hash"]
+                for record in result
+                if record["file_path"]
+            }
+
+    def _write_file_hashes(
+        self, project_id: str, hashes: Mapping[str, str]
+    ) -> None:
+        if not hashes:
+            return
+        rows = [
+            {"file_path": fp, "content_hash": h}
+            for fp, h in hashes.items()
+        ]
+        with self.graph_service.driver.session() as session:
+            session.run(
+                """
+                UNWIND $rows AS row
+                MATCH (n:FILE {repoId: $project_id, file_path: row.file_path})
+                SET n.content_hash = row.content_hash
+                """,
+                project_id=project_id,
+                rows=rows,
+            )
+
+    def _delete_files(
+        self, project_id: str, files: Iterable[str]
+    ) -> int:
+        """``DETACH DELETE`` every node whose ``file_path`` is in ``files``.
+
+        ``DETACH DELETE`` removes inbound edges as well as outbound, so
+        we don't need a separate edge cleanup pass — that's the whole
+        reason file-level granularity buys us correctness here.
+        """
+        files = list(files)
+        if not files:
+            return 0
+        with self.graph_service.driver.session() as session:
+            result = session.run(
+                """
+                MATCH (n:NODE {repoId: $project_id})
+                WHERE n.file_path IN $files
+                WITH n, count(n) AS _placeholder
+                DETACH DELETE n
+                RETURN count(_placeholder) AS deleted
+                """,
+                project_id=project_id,
+                files=files,
+            )
+            record = result.single()
+            return int(record["deleted"]) if record else 0
+
+    def _insert_delta_nodes_and_edges(
+        self,
+        artifacts,
+        project_id: str,
+        user_id: str,
+        dirty_files: set[str],
+    ) -> None:
+        """Insert the artifacts' nodes/edges that touch ``dirty_files``.
+
+        Reuses the same node-shape and label assembly logic as
+        :meth:`CodeGraphService._store_graph` so an incrementally-
+        written node is indistinguishable from one written by the full
+        rebuild path. Re-implementing rather than calling ``_store_graph``
+        because we need the *subset* of the artifacts that intersects
+        ``dirty_files``.
+        """
+        if not dirty_files:
+            return
+
+        # Bucket nodes by file so we can filter with one pass through
+        # the artifacts.
+        nodes_to_insert: list[dict] = []
+        node_id_to_file: dict[str, str] = {}
+        for node in artifacts.nodes:
+            file_path = getattr(node, "file", "") or ""
+            node_id_to_file[node.id] = file_path
+            if file_path not in dirty_files:
+                continue
+            node_type = getattr(node, "node_type", "UNKNOWN")
+            if node_type == "UNKNOWN":
+                continue
+            labels = ["NODE"]
+            if node_type in _TYPED_LABELS:
+                labels.append(node_type)
+            processed = {
+                "name": getattr(node, "name", None) or node.id,
+                "file_path": file_path,
+                "start_line": getattr(node, "line", -1),
+                "end_line": getattr(node, "end_line", -1),
+                "repoId": project_id,
+                "node_id": CodeGraphService.generate_node_id(node.id, user_id),
+                "entityId": user_id,
+                "type": node_type,
+                "text": getattr(node, "text", "") or "",
+                "labels": labels,
+            }
+            processed = {k: v for k, v in processed.items() if v is not None}
+            nodes_to_insert.append(processed)
+
+        with self.graph_service.driver.session() as session:
+            session.run(
+                """
+                CREATE INDEX node_id_repo_idx IF NOT EXISTS
+                FOR (n:NODE) ON (n.node_id, n.repoId)
+                """
+            )
+            if nodes_to_insert:
+                session.run(
+                    """
+                    UNWIND $nodes AS node
+                    CALL apoc.create.node(node.labels, node) YIELD node AS n
+                    RETURN count(*)
+                    """,
+                    nodes=nodes_to_insert,
+                )
+
+            # Edges: include any edge whose source or target lives in a
+            # dirty file. Edges between two unchanged files were never
+            # deleted, so we skip them to avoid duplicates.
+            edges = getattr(artifacts, "relationships", None)
+            if edges is None:
+                edges = getattr(artifacts, "edges", [])
+            edges_by_type: dict[str, list[dict]] = defaultdict(list)
+            for edge in edges:
+                source_id = getattr(edge, "source_id")
+                target_id = getattr(edge, "target_id")
+                source_file = node_id_to_file.get(source_id, "")
+                target_file = node_id_to_file.get(target_id, "")
+                if (
+                    source_file not in dirty_files
+                    and target_file not in dirty_files
+                ):
+                    continue
+                rel_type = getattr(edge, "relationship_type", None) or getattr(
+                    edge, "edge_type", "REFERENCES"
+                )
+                edges_by_type[rel_type].append(
+                    {
+                        "source_id": CodeGraphService.generate_node_id(
+                            source_id, user_id
+                        ),
+                        "target_id": CodeGraphService.generate_node_id(
+                            target_id, user_id
+                        ),
+                        "repoId": project_id,
+                    }
+                )
+
+            for rel_type, edge_rows in edges_by_type.items():
+                # MERGE the edge so we don't double-insert when an
+                # unchanged file's outbound edge happens to also be
+                # in the artifacts (parser emits the full set every run).
+                query = f"""
+                    UNWIND $edges AS edge
+                    MATCH (source:NODE {{node_id: edge.source_id, repoId: edge.repoId}})
+                    MATCH (target:NODE {{node_id: edge.target_id, repoId: edge.repoId}})
+                    MERGE (source)-[r:{rel_type} {{repoId: edge.repoId}}]->(target)
+                """
+                session.run(query, edges=edge_rows)
+
+    def _apply_delta(
+        self,
+        artifacts,
+        project_id: str,
+        user_id: str,
+        delta: GraphDelta,
+    ) -> None:
+        # Step 1: drop nodes (and their edges) for deleted + modified files.
+        files_to_delete = delta.removed | delta.modified
+        deleted = self._delete_files(project_id, files_to_delete)
+        logger.info(
+            "[INCREMENTAL] Deleted %d nodes for %d files",
+            deleted,
+            len(files_to_delete),
+            project_id=project_id,
+        )
+
+        # Step 2: insert nodes / edges for added + modified files. Edges
+        # whose other endpoint is unchanged but whose endpoint here is
+        # dirty are also (re)inserted so cross-file references hold.
+        self._insert_delta_nodes_and_edges(
+            artifacts=artifacts,
+            project_id=project_id,
+            user_id=user_id,
+            dirty_files=delta.dirty,
+        )
+
+        # Step 3: keep Qdrant in sync with the graph. Drop points for
+        # nodes we removed; index the new dirty-file nodes.
+        self._update_qdrant(
+            artifacts=artifacts,
+            project_id=project_id,
+            user_id=user_id,
+            delta=delta,
+        )
+
+    # ------------------------------------------------------------------
+    # Qdrant
+    # ------------------------------------------------------------------
+
+    def _update_qdrant(
+        self,
+        artifacts,
+        project_id: str,
+        user_id: str,
+        delta: GraphDelta,
+    ) -> None:
+        """Apply the delta to the project's Qdrant collection.
+
+        Best-effort: a failure here is logged but doesn't roll back the
+        Neo4j writes — same posture as the full-rebuild path, where
+        Qdrant errors are swallowed (the next parse rebuilds it from
+        scratch anyway).
+        """
+        try:
+            from app.modules.parsing.knowledge_graph.qdrant_indexing_service import (  # noqa: E501
+                delete_points_by_node_ids,
+                index_nodes_to_qdrant,
+            )
+        except ImportError:
+            # Older builds may not expose delete_points_by_node_ids;
+            # fall back to a full Qdrant rebuild via
+            # CodeGraphService._store_graph's path. We keep this fallback
+            # narrow — only triggered when the helper genuinely doesn't
+            # exist.
+            logger.warning(
+                "[INCREMENTAL] qdrant helper missing; skipping vector update",
+                project_id=project_id,
+            )
+            return
+
+        collection_name = self.graph_service.get_qdrant_collection_name(project_id)
+        collection_alias = self.graph_service.get_qdrant_collection_alias(
+            project_id
+        )
+
+        # Delete vector points for nodes we removed (deleted + modified
+        # files). We re-derive the node_ids from the *old* graph state
+        # is impossible at this point — they're already gone from Neo4j.
+        # Instead we delete by file_path filter, which Qdrant supports
+        # via a payload index. The collection stores `file` payload,
+        # added at index time below.
+        files_to_drop = delta.removed | delta.modified
+        if files_to_drop:
+            try:
+                delete_points_by_node_ids(
+                    self.graph_service.qdrant_client,
+                    collection_name,
+                    file_paths=list(files_to_drop),
+                )
+            except Exception:
+                logger.exception(
+                    "[INCREMENTAL] Qdrant delete failed (non-fatal)",
+                    project_id=project_id,
+                )
+
+        # Index new/modified nodes into Qdrant.
+        nodes_to_index = []
+        for node in artifacts.nodes:
+            file_path = getattr(node, "file", "") or ""
+            if file_path not in delta.dirty:
+                continue
+            if getattr(node, "node_type", "") not in _INDEXABLE_NODE_TYPES:
+                continue
+            nodes_to_index.append(
+                {
+                    "node_id": CodeGraphService.generate_node_id(
+                        node.id, user_id
+                    ),
+                    "name": getattr(node, "name", "") or "",
+                    "file": file_path,
+                    "type": getattr(node, "node_type", ""),
+                    "line": getattr(node, "line", -1),
+                    "end_line": getattr(node, "end_line", -1),
+                    "text": getattr(node, "text", "") or "",
+                }
+            )
+        if not nodes_to_index:
+            return
+        try:
+            index_nodes_to_qdrant(
+                self.graph_service.qdrant_client,
+                collection_name,
+                nodes_to_index,
+                # Don't recreate — we want to add to the existing
+                # collection. The full-rebuild path passes
+                # recreate_collection=True.
+                recreate_collection=False,
+                alias_name=collection_alias,
+            )
+        except Exception:
+            logger.exception(
+                "[INCREMENTAL] Qdrant indexing failed (non-fatal)",
+                project_id=project_id,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Helpers exposed for the orchestrator
+# ---------------------------------------------------------------------------
+
+
+def affected_node_ids_for_inference(
+    artifacts, delta: GraphDelta, user_id: str
+) -> list[str]:
+    """Return the persisted node IDs that need (re-)inference after
+    applying ``delta``.
+
+    Used by :class:`InferenceService` to scope docstring regeneration to
+    just the changed components instead of the whole graph.
+    """
+    affected: list[str] = []
+    dirty = delta.dirty
+    if not dirty:
+        return affected
+    for node in artifacts.nodes:
+        file_path = getattr(node, "file", "") or ""
+        if file_path not in dirty:
+            continue
+        node_type = getattr(node, "node_type", "UNKNOWN")
+        if node_type == "UNKNOWN" or node_type == "FILE":
+            continue
+        affected.append(CodeGraphService.generate_node_id(node.id, user_id))
+    return affected
+
+
+def reconstruct_subgraph(
+    artifacts, dirty_files: set[str]
+) -> nx.MultiDiGraph:
+    """Build an nx graph over just the dirty files' nodes/edges.
+
+    Used by the inference layer for the partial pass: we want the same
+    nx shape the full pipeline consumes, but only over the slice the
+    delta covers.
+
+    Re-implements the small ``build_node_attrs`` / ``build_edge_attrs``
+    bodies from :mod:`parsing_repomap` rather than importing them, so
+    this helper stays light enough to be used from contexts that don't
+    want to drag in tree_sitter / grep_ast just to build a subgraph.
+    """
+    graph = nx.MultiDiGraph()
+    node_id_to_file: dict[str, str] = {}
+    for node in artifacts.nodes:
+        file_path = getattr(node, "file", "") or ""
+        node_id_to_file[node.id] = file_path
+        if file_path not in dirty_files:
+            continue
+        node_attrs = {
+            "file": file_path,
+            "line": getattr(node, "line", -1),
+            "end_line": getattr(node, "end_line", -1),
+            "type": getattr(node, "node_type", "UNKNOWN"),
+            "name": getattr(node, "name", "") or "",
+        }
+        if node_attrs["type"] != "FILE":
+            node_attrs["class_name"] = getattr(node, "class_name", None)
+        text = getattr(node, "text", None)
+        if text is not None:
+            node_attrs["text"] = text
+        graph.add_node(node.id, **node_attrs)
+
+    edges = getattr(artifacts, "relationships", None)
+    if edges is None:
+        edges = getattr(artifacts, "edges", [])
+    for edge in edges:
+        source_file = node_id_to_file.get(edge.source_id, "")
+        target_file = node_id_to_file.get(edge.target_id, "")
+        if source_file not in dirty_files and target_file not in dirty_files:
+            continue
+        edge_type = getattr(edge, "edge_type", None) or getattr(
+            edge, "relationship_type", "REFERENCES"
+        )
+        edge_attrs = {"type": edge_type}
+        ident = getattr(edge, "ident", None)
+        if ident is not None:
+            edge_attrs["ident"] = ident
+        ref_line = getattr(edge, "ref_line", None)
+        if ref_line is not None:
+            edge_attrs["ref_line"] = ref_line
+        end_ref_line = getattr(edge, "end_ref_line", None)
+        if end_ref_line is not None:
+            edge_attrs["end_ref_line"] = end_ref_line
+        graph.add_edge(edge.source_id, edge.target_id, **edge_attrs)
+    return graph

--- a/app/modules/parsing/graph_construction/parsing_schema.py
+++ b/app/modules/parsing/graph_construction/parsing_schema.py
@@ -8,6 +8,14 @@ class ParsingRequest(BaseModel):
     repo_path: Optional[str] = Field(default=None)
     branch_name: Optional[str] = Field(default=None)
     commit_id: Optional[str] = Field(default=None)
+    full_rebuild: bool = Field(
+        default=False,
+        description=(
+            "Force a full graph rebuild instead of the default incremental "
+            "update. Set to True when the previously-persisted graph is "
+            "known to be inconsistent (e.g. after a schema change)."
+        ),
+    )
 
     def __init__(self, **data):
         super().__init__(**data)

--- a/app/modules/parsing/graph_construction/parsing_service.py
+++ b/app/modules/parsing/graph_construction/parsing_service.py
@@ -207,9 +207,16 @@ class ParsingService:
                 # required when the caller explicitly asks for a full
                 # rebuild (``full_rebuild=True``) so a corrupted or
                 # schema-mismatched graph can be recovered cleanly.
+                #
+                # ``full_rebuild=True`` must always force the wipe even
+                # when the caller passed ``cleanup_graph=False``;
+                # otherwise the "force full rebuild" contract breaks
+                # and stale/duplicate nodes can survive the rebuild.
                 full_rebuild = bool(
                     getattr(repo_details, "full_rebuild", False)
                 )
+                if full_rebuild:
+                    cleanup_graph = True
                 if cleanup_graph and full_rebuild:
                     neo4j_config = self._get_neo4j_config()
                     code_graph_service = None

--- a/app/modules/parsing/graph_construction/parsing_service.py
+++ b/app/modules/parsing/graph_construction/parsing_service.py
@@ -201,7 +201,16 @@ class ParsingService:
                             "id": project_id,
                         }
 
-                if cleanup_graph:
+                # Skip the wholesale graph wipe when we're running an
+                # incremental update — the incremental path performs
+                # surgical deletes per changed file. The wipe is still
+                # required when the caller explicitly asks for a full
+                # rebuild (``full_rebuild=True``) so a corrupted or
+                # schema-mismatched graph can be recovered cleanly.
+                full_rebuild = bool(
+                    getattr(repo_details, "full_rebuild", False)
+                )
+                if cleanup_graph and full_rebuild:
                     neo4j_config = self._get_neo4j_config()
                     code_graph_service = None
                     try:
@@ -503,6 +512,10 @@ class ParsingService:
 
         neo4j_config = self._get_neo4j_config()
         service: CodeGraphService | None = None
+        # Pulled off the request schema (set by router/library callers).
+        # Defaults to incremental for both routes; ``full_rebuild=True``
+        # routes through the legacy path (cleanup_graph already ran).
+        full_rebuild = bool(getattr(repo_details, "full_rebuild", False))
         try:
             service = CodeGraphService(
                 neo4j_config["uri"],
@@ -511,11 +524,37 @@ class ParsingService:
                 self.db,
             )
             graph_gen_start = time.time()
-            logger.info(
-                "[PARSING] Step 2/3: writing graph to neo4j + qdrant",
-                project_id=project_id,
-            )
-            service.store_graph_from_artifacts(artifacts, str(project_id), user_id)
+            delta = None
+            if full_rebuild:
+                logger.info(
+                    "[PARSING] Step 2/3: full rebuild → writing graph to "
+                    "neo4j + qdrant",
+                    project_id=project_id,
+                )
+                service.store_graph_from_artifacts(
+                    artifacts, str(project_id), user_id
+                )
+            else:
+                # Lazy import to keep the incremental layer optional —
+                # the full-rebuild path is unaffected if it fails to
+                # import for any reason.
+                from app.modules.parsing.graph_construction.incremental_graph_service import (  # noqa: E501
+                    IncrementalGraphService,
+                )
+
+                logger.info(
+                    "[PARSING] Step 2/3: incremental update → diff + apply",
+                    project_id=project_id,
+                )
+                incremental = IncrementalGraphService(service)
+                delta = incremental.store_graph_from_artifacts_incremental(
+                    artifacts, str(project_id), user_id
+                )
+                logger.info(
+                    "[PARSING] Incremental delta: %s",
+                    delta.summary(),
+                    project_id=project_id,
+                )
             graph_gen_time = time.time() - graph_gen_start
 
             await self.project_service.update_project_status(
@@ -527,9 +566,26 @@ class ParsingService:
                 project_id=project_id,
             )
             inference_start = time.time()
-            cache_stats = await self.inference_service.run_inference(
-                str(project_id)
-            )
+            # Skip inference entirely when we know nothing changed —
+            # the existing graph (and its docstrings) are still valid.
+            if delta is not None and not delta.has_changes:
+                logger.info(
+                    "[PARSING] No graph changes detected; skipping inference",
+                    project_id=project_id,
+                )
+                await self.project_service.update_project_status(
+                    project_id, ProjectStatusEnum.READY
+                )
+                cache_stats = {
+                    "cache_hits": 0,
+                    "cache_misses": 0,
+                    "uncacheable_nodes": 0,
+                    "skipped_unchanged": True,
+                }
+            else:
+                cache_stats = await self.inference_service.run_inference(
+                    str(project_id)
+                )
             inference_time = time.time() - inference_start
             self.inference_service.log_graph_stats(project_id)
 

--- a/app/modules/parsing/knowledge_graph/qdrant_indexing_service.py
+++ b/app/modules/parsing/knowledge_graph/qdrant_indexing_service.py
@@ -184,23 +184,31 @@ def delete_points_by_node_ids(
     if not client.collection_exists(collection_name):
         return 0
 
-    must = []
+    # Conditions are OR'ed: a point matches if its node_id is in
+    # ``node_ids`` *or* its file_path is in ``file_paths``. Using
+    # ``must`` here would only delete points satisfying both
+    # predicates simultaneously, leaving stale points behind when
+    # callers pass both arguments.
+    should = []
     if node_ids:
-        must.append(
+        should.append(
             models.FieldCondition(
                 key="node_id",
                 match=models.MatchAny(any=list(node_ids)),
             )
         )
     if file_paths:
-        must.append(
+        should.append(
             models.FieldCondition(
                 key="file_path",
                 match=models.MatchAny(any=list(file_paths)),
             )
         )
 
-    selector = models.FilterSelector(filter=models.Filter(must=must))
+    # ``Filter(should=[...])`` matches when at least one ``should``
+    # clause is satisfied (Qdrant's default for ``should`` is OR
+    # semantics with an implicit minimum-match of 1).
+    selector = models.FilterSelector(filter=models.Filter(should=should))
     client.delete(collection_name=collection_name, points_selector=selector)
     return 1
 
@@ -753,6 +761,7 @@ def index_nodes_to_qdrant(
     nodes: List[Dict[str, Any]],
     recreate_collection: bool = False,
     alias_name: Optional[str] = None,
+    preserve_bm25_vocabulary: bool = False,
 ) -> Tuple[int, int, int]:
     """
     Full pipeline: build all three embedding types and upsert to Qdrant.
@@ -763,6 +772,11 @@ def index_nodes_to_qdrant(
         nodes: list of node dicts from create_graph()
         recreate_collection: whether to recreate the collection schema
         alias_name: optional stable alias name for staged rebuilds
+        preserve_bm25_vocabulary: when True, keep the persisted BM25
+            token vocabulary as the authoritative term-index mapping
+            and only extend it with new tokens from ``nodes``. Used by
+            the incremental update path so sparse term indices remain
+            stable across previously-indexed points.
 
     Returns:
         Tuple of (num_nodes_indexed, num_bm25_tokens, num_colbert_dims)
@@ -789,7 +803,27 @@ def index_nodes_to_qdrant(
         bm25_vecs = build_bm25_vectors(nodes)
         colbert_vecs = build_colbert_embeddings(nodes)
 
-        if "__token_vocabulary__" in bm25_vecs:
+        # When preserving the existing vocabulary (incremental path),
+        # resolve the underlying collection name behind the alias so
+        # we read/write the right on-disk vocab file, then merge any
+        # new tokens at the end (preserving prior token→index slots).
+        if preserve_bm25_vocabulary and "__token_vocabulary__" in bm25_vecs:
+            vocab_collection_name = target_collection_name
+            if alias_name:
+                resolved = _get_alias_target(client, alias_name)
+                if resolved is not None:
+                    vocab_collection_name = resolved
+            existing_vocab = _load_token_vocabulary(vocab_collection_name) or []
+            existing_set = set(existing_vocab)
+            new_tokens = [
+                t
+                for t in bm25_vecs["__token_vocabulary__"]
+                if t not in existing_set
+            ]
+            merged_vocab = existing_vocab + sorted(new_tokens)
+            bm25_vecs["__token_vocabulary__"] = merged_vocab
+            _save_token_vocabulary(vocab_collection_name, merged_vocab)
+        elif "__token_vocabulary__" in bm25_vecs:
             _save_token_vocabulary(
                 target_collection_name, bm25_vecs["__token_vocabulary__"]
             )

--- a/app/modules/parsing/knowledge_graph/qdrant_indexing_service.py
+++ b/app/modules/parsing/knowledge_graph/qdrant_indexing_service.py
@@ -161,6 +161,50 @@ def _activate_collection_alias(
     return previous_collection
 
 
+def delete_points_by_node_ids(
+    client: Any,
+    collection_name: str,
+    *,
+    node_ids: Optional[List[str]] = None,
+    file_paths: Optional[List[str]] = None,
+) -> int:
+    """Delete points from a hybrid collection by node_id or file_path.
+
+    Used by the incremental update path to drop vector points that
+    correspond to graph nodes which were just removed (deleted/modified
+    files). At least one of ``node_ids`` or ``file_paths`` must be given.
+
+    Returns 0 silently if the collection doesn't exist — keeps the
+    incremental orchestrator's error path simple.
+    """
+    from qdrant_client import models  # type: ignore
+
+    if not node_ids and not file_paths:
+        return 0
+    if not client.collection_exists(collection_name):
+        return 0
+
+    must = []
+    if node_ids:
+        must.append(
+            models.FieldCondition(
+                key="node_id",
+                match=models.MatchAny(any=list(node_ids)),
+            )
+        )
+    if file_paths:
+        must.append(
+            models.FieldCondition(
+                key="file_path",
+                match=models.MatchAny(any=list(file_paths)),
+            )
+        )
+
+    selector = models.FilterSelector(filter=models.Filter(must=must))
+    client.delete(collection_name=collection_name, points_selector=selector)
+    return 1
+
+
 def delete_hybrid_collection(
     client: Any,
     collection_name: str,

--- a/tests/integration-tests/parsing/test_parsing_service.py
+++ b/tests/integration-tests/parsing/test_parsing_service.py
@@ -116,7 +116,11 @@ class TestParseDirectory:
             service = ParsingService(
                 db_session, "test-user", raise_library_exceptions=True
             )
-            repo_details = ParsingRequest(repo_name="owner/repo")
+            # ``full_rebuild=True`` forces the legacy cleanup-then-rebuild
+            # path; the default (incremental) path skips ``cleanup_graph``
+            # entirely, so this test wouldn't reach the failure point
+            # without the explicit opt-in.
+            repo_details = ParsingRequest(repo_name="owner/repo", full_rebuild=True)
             with pytest.raises(ParsingServiceError) as exc_info:
                 await service.parse_directory(
                     repo_details,
@@ -199,7 +203,10 @@ class TestNeo4jFailures:
             service = ParsingService(
                 db_session, "test-user", raise_library_exceptions=True
             )
-            repo_details = ParsingRequest(repo_name="owner/repo")
+            # The cleanup-graph path is the legacy full-rebuild route;
+            # the incremental default doesn't invoke it. Exercise the
+            # legacy path explicitly here.
+            repo_details = ParsingRequest(repo_name="owner/repo", full_rebuild=True)
             with pytest.raises((ParsingServiceError, ServiceUnavailable, Exception)):
                 await service.parse_directory(
                     repo_details,

--- a/tests/unit/parsing/test_incremental_update.py
+++ b/tests/unit/parsing/test_incremental_update.py
@@ -1,0 +1,560 @@
+"""Unit tests for incremental knowledge-graph updates (issue #221).
+
+Covers the three pieces that make the incremental path work:
+
+* ``compute_file_hashes`` — stable per-file fingerprints derived from
+  the parser artifacts.
+* ``GraphDelta`` / ``IncrementalGraphService._diff`` — bucketing files
+  into added / modified / deleted / unchanged.
+* ``IncrementalGraphService.store_graph_from_artifacts_incremental`` —
+  the orchestration that:
+    - falls back to a full rebuild on first run (no prior hashes)
+    - is a no-op when nothing changed
+    - issues file-scoped deletes for modified/deleted files
+    - re-inserts only the dirty subset of nodes/edges
+    - re-inserts cross-file edges so inbound references survive
+
+The tests stub the Neo4j session and the Qdrant client so they don't
+need infra; the goal is to lock in the contract between the diff and
+the DB writes, not to retest neo4j itself.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.parsing.graph_construction.incremental_graph_service import (
+    GraphDelta,
+    IncrementalGraphService,
+    affected_node_ids_for_inference,
+    compute_file_hashes,
+    reconstruct_subgraph,
+)
+from sandbox.api.parser_wire import ParseArtifacts
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _node(node_id: str, file: str, node_type: str = "FUNCTION", **kw):
+    base = dict(
+        id=node_id,
+        node_type=node_type,
+        file=file,
+        line=1,
+        end_line=10,
+        name=node_id.split(":")[-1],
+        class_name=None,
+        text=f"# code for {node_id}",
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _edge(source_id: str, target_id: str, rel: str = "CALLS", **kw):
+    base = dict(
+        source_id=source_id,
+        target_id=target_id,
+        relationship_type=rel,
+        ident=None,
+        ref_line=None,
+        end_ref_line=None,
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _artifacts(nodes, edges) -> ParseArtifacts:
+    return ParseArtifacts(nodes=list(nodes), relationships=list(edges))
+
+
+def _three_file_repo() -> ParseArtifacts:
+    """Three files; A.foo calls B.bar; C is standalone."""
+    return _artifacts(
+        nodes=[
+            _node("A.py", "A.py", node_type="FILE"),
+            _node("A.py:foo", "A.py"),
+            _node("B.py", "B.py", node_type="FILE"),
+            _node("B.py:bar", "B.py"),
+            _node("C.py", "C.py", node_type="FILE"),
+            _node("C.py:baz", "C.py"),
+        ],
+        edges=[
+            _edge("A.py:foo", "B.py:bar"),
+            _edge("A.py", "A.py:foo", rel="CONTAINS"),
+            _edge("B.py", "B.py:bar", rel="CONTAINS"),
+            _edge("C.py", "C.py:baz", rel="CONTAINS"),
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hash + diff building blocks
+# ---------------------------------------------------------------------------
+
+
+class TestComputeFileHashes:
+    def test_per_file_hashes_are_stable_and_distinct(self):
+        artifacts = _three_file_repo()
+        hashes = compute_file_hashes(artifacts)
+        assert set(hashes) == {"A.py", "B.py", "C.py"}
+        # Re-running should produce identical hashes.
+        assert compute_file_hashes(artifacts) == hashes
+        # Different files should differ.
+        assert hashes["A.py"] != hashes["B.py"] != hashes["C.py"]
+
+    def test_modifying_a_file_changes_only_that_files_hash(self):
+        original = _three_file_repo()
+        original_hashes = compute_file_hashes(original)
+
+        # Change the body of A.foo (different `text` value).
+        modified_nodes = list(original.nodes)
+        for i, node in enumerate(modified_nodes):
+            if node.id == "A.py:foo":
+                modified_nodes[i] = _node(
+                    "A.py:foo", "A.py", text="# DIFFERENT body"
+                )
+        modified = _artifacts(modified_nodes, original.relationships)
+        new_hashes = compute_file_hashes(modified)
+
+        assert new_hashes["A.py"] != original_hashes["A.py"]
+        assert new_hashes["B.py"] == original_hashes["B.py"]
+        assert new_hashes["C.py"] == original_hashes["C.py"]
+
+    def test_edges_originating_in_a_file_count_toward_its_hash(self):
+        """If A.foo's call target changes, A's hash changes (A's outbound
+        edges contributed to its fingerprint), but B's hash doesn't."""
+        before = _three_file_repo()
+        before_hashes = compute_file_hashes(before)
+        modified_edges = []
+        for edge in before.relationships:
+            if (
+                edge.source_id == "A.py:foo"
+                and edge.target_id == "B.py:bar"
+            ):
+                modified_edges.append(_edge("A.py:foo", "C.py:baz"))
+            else:
+                modified_edges.append(edge)
+        after = _artifacts(before.nodes, modified_edges)
+        after_hashes = compute_file_hashes(after)
+        assert after_hashes["A.py"] != before_hashes["A.py"]
+        assert after_hashes["B.py"] == before_hashes["B.py"]
+
+
+class TestGraphDeltaDiff:
+    def test_diff_buckets(self):
+        old = {"A.py": "a1", "B.py": "b1", "C.py": "c1"}
+        new = {"A.py": "a1", "B.py": "b2", "D.py": "d1"}
+        delta = IncrementalGraphService._diff(old, new)
+        assert delta.added == {"D.py"}
+        assert delta.modified == {"B.py"}
+        assert delta.deleted == {"C.py"}
+        assert delta.unchanged == {"A.py"}
+        assert delta.has_changes is True
+        assert delta.dirty == {"D.py", "B.py"}
+        assert delta.removed == {"C.py"}
+
+    def test_no_changes(self):
+        delta = IncrementalGraphService._diff(
+            {"A.py": "a"}, {"A.py": "a"}
+        )
+        assert delta.has_changes is False
+
+
+# ---------------------------------------------------------------------------
+# Service orchestration
+# ---------------------------------------------------------------------------
+
+
+class _FakeNeo4jSession:
+    """Captures Cypher calls so we can assert on them."""
+
+    def __init__(self, hash_rows=None):
+        self._hash_rows = hash_rows or []
+        self.calls: list[tuple[str, dict]] = []
+        # Return value for the read-hashes query — overridden via
+        # set_hash_rows when the test wants to simulate prior state.
+
+    def set_hash_rows(self, rows):
+        self._hash_rows = rows
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def run(self, query, **params):
+        self.calls.append((query, params))
+        return _FakeNeo4jResult(self._results_for(query, params))
+
+    def _results_for(self, query, params):
+        # The hash-read query is the only one tests inspect the rows of.
+        if "RETURN n.file_path AS file_path, n.content_hash AS content_hash" in query:
+            return self._hash_rows
+        return []
+
+
+class _FakeNeo4jResult:
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def __iter__(self):
+        return iter(self._rows)
+
+    def single(self):
+        return self._rows[0] if self._rows else None
+
+
+class _FakeDriver:
+    def __init__(self):
+        self.session_obj = _FakeNeo4jSession()
+
+    def session(self):
+        # Return the same session every time so tests can inspect
+        # the full call log across the whole orchestration.
+        return self.session_obj
+
+
+def _make_graph_service():
+    """Hand-built CodeGraphService stand-in.
+
+    The real class binds Neo4j + Qdrant in __init__. We bypass the
+    constructor so we can inject our fakes without spinning up infra.
+    """
+    from app.modules.parsing.graph_construction.code_graph_service import (
+        CodeGraphService,
+    )
+
+    svc = CodeGraphService.__new__(CodeGraphService)
+    svc.driver = _FakeDriver()
+    svc.qdrant_client = MagicMock(name="qdrant_client")
+    svc.qdrant_client.collection_exists = MagicMock(return_value=False)
+    svc.db = MagicMock(name="db_session")
+    return svc
+
+
+class TestStoreGraphFromArtifactsIncremental:
+    def test_first_run_falls_back_to_full_rebuild_and_seeds_hashes(self):
+        graph = _make_graph_service()
+        graph.store_graph_from_artifacts = MagicMock(name="full_rebuild")
+        artifacts = _three_file_repo()
+
+        service = IncrementalGraphService(graph)
+        delta = service.store_graph_from_artifacts_incremental(
+            artifacts, "p1", "u1"
+        )
+
+        # Full rebuild was called exactly once.
+        graph.store_graph_from_artifacts.assert_called_once_with(
+            artifacts, "p1", "u1"
+        )
+        # Every file is reported as added (the seed view).
+        assert delta.added == {"A.py", "B.py", "C.py"}
+        assert delta.modified == set()
+        assert delta.deleted == set()
+        # Hashes were written: confirm a SET n.content_hash query was issued.
+        hash_writes = [
+            (q, p)
+            for q, p in graph.driver.session_obj.calls
+            if "SET n.content_hash" in q
+        ]
+        assert hash_writes, "expected a content_hash write after full rebuild"
+
+    def test_no_changes_is_a_noop(self):
+        graph = _make_graph_service()
+        graph.store_graph_from_artifacts = MagicMock(name="full_rebuild")
+        artifacts = _three_file_repo()
+
+        # Pre-populate the session with hashes that match what the
+        # current artifacts would produce → no changes.
+        existing = compute_file_hashes(artifacts)
+        graph.driver.session_obj.set_hash_rows(
+            [{"file_path": fp, "content_hash": h} for fp, h in existing.items()]
+        )
+
+        service = IncrementalGraphService(graph)
+        delta = service.store_graph_from_artifacts_incremental(
+            artifacts, "p1", "u1"
+        )
+
+        assert delta.has_changes is False
+        assert delta.unchanged == {"A.py", "B.py", "C.py"}
+        # Did NOT trigger a full rebuild and did NOT issue any
+        # DETACH DELETE.
+        graph.store_graph_from_artifacts.assert_not_called()
+        delete_calls = [
+            q for q, _ in graph.driver.session_obj.calls if "DETACH DELETE" in q
+        ]
+        assert not delete_calls
+
+    def test_modified_file_drops_only_that_file(self):
+        graph = _make_graph_service()
+        graph.store_graph_from_artifacts = MagicMock(name="full_rebuild")
+
+        original = _three_file_repo()
+        original_hashes = compute_file_hashes(original)
+        graph.driver.session_obj.set_hash_rows(
+            [
+                {"file_path": fp, "content_hash": h}
+                for fp, h in original_hashes.items()
+            ]
+        )
+
+        # Modify B.py: rewrite B.bar's body.
+        modified_nodes = []
+        for node in original.nodes:
+            if node.id == "B.py:bar":
+                modified_nodes.append(
+                    _node("B.py:bar", "B.py", text="# rewritten body")
+                )
+            else:
+                modified_nodes.append(node)
+        artifacts = _artifacts(modified_nodes, original.relationships)
+
+        service = IncrementalGraphService(graph)
+        delta = service.store_graph_from_artifacts_incremental(
+            artifacts, "p1", "u1"
+        )
+
+        assert delta.modified == {"B.py"}
+        assert delta.added == set()
+        assert delta.deleted == set()
+        assert "A.py" in delta.unchanged
+        assert "C.py" in delta.unchanged
+
+        # The DETACH DELETE call should have only B.py in its files list.
+        delete_calls = [
+            (q, p)
+            for q, p in graph.driver.session_obj.calls
+            if "DETACH DELETE" in q
+        ]
+        assert delete_calls, "expected a delete pass for the modified file"
+        _, params = delete_calls[0]
+        assert set(params["files"]) == {"B.py"}
+
+        # Full rebuild was NOT used.
+        graph.store_graph_from_artifacts.assert_not_called()
+
+    def test_added_file_is_inserted_with_no_delete(self):
+        graph = _make_graph_service()
+        original = _three_file_repo()
+        original_hashes = compute_file_hashes(original)
+        graph.driver.session_obj.set_hash_rows(
+            [
+                {"file_path": fp, "content_hash": h}
+                for fp, h in original_hashes.items()
+            ]
+        )
+
+        # Add D.py.
+        new_nodes = list(original.nodes) + [
+            _node("D.py", "D.py", node_type="FILE"),
+            _node("D.py:qux", "D.py"),
+        ]
+        new_edges = list(original.relationships) + [
+            _edge("D.py", "D.py:qux", rel="CONTAINS"),
+        ]
+        artifacts = _artifacts(new_nodes, new_edges)
+
+        service = IncrementalGraphService(graph)
+        delta = service.store_graph_from_artifacts_incremental(
+            artifacts, "p1", "u1"
+        )
+
+        assert delta.added == {"D.py"}
+        assert delta.modified == set()
+        assert delta.deleted == set()
+
+        # No DETACH DELETE — additions shouldn't drop existing nodes.
+        delete_calls = [
+            q for q, _ in graph.driver.session_obj.calls if "DETACH DELETE" in q
+        ]
+        assert not delete_calls
+
+        # Inserted nodes should include the D.py FILE node.
+        insert_calls = [
+            (q, p)
+            for q, p in graph.driver.session_obj.calls
+            if "apoc.create.node" in q
+        ]
+        assert insert_calls, "expected a node insert for the added file"
+        inserted_files = {
+            n["file_path"] for q, p in insert_calls for n in p["nodes"]
+        }
+        assert inserted_files == {"D.py"}
+
+    def test_deleted_file_is_removed_with_no_reinsert(self):
+        graph = _make_graph_service()
+        original = _three_file_repo()
+        original_hashes = compute_file_hashes(original)
+        graph.driver.session_obj.set_hash_rows(
+            [
+                {"file_path": fp, "content_hash": h}
+                for fp, h in original_hashes.items()
+            ]
+        )
+
+        # Drop C.py from the new artifacts.
+        kept_nodes = [n for n in original.nodes if n.file != "C.py"]
+        kept_edges = [
+            e
+            for e in original.relationships
+            # No edges out of C.py, but the CONTAINS edge from C.py file
+            # node → C.py:baz lives in C.py — drop it.
+            if not (
+                e.source_id.startswith("C.py")
+                or e.target_id.startswith("C.py")
+            )
+        ]
+        artifacts = _artifacts(kept_nodes, kept_edges)
+
+        service = IncrementalGraphService(graph)
+        delta = service.store_graph_from_artifacts_incremental(
+            artifacts, "p1", "u1"
+        )
+
+        assert delta.deleted == {"C.py"}
+        assert delta.added == set()
+        assert delta.modified == set()
+
+        delete_calls = [
+            (q, p)
+            for q, p in graph.driver.session_obj.calls
+            if "DETACH DELETE" in q
+        ]
+        _, params = delete_calls[0]
+        assert "C.py" in params["files"]
+
+        # No insert pass should have included C.py nodes.
+        insert_calls = [
+            (q, p)
+            for q, p in graph.driver.session_obj.calls
+            if "apoc.create.node" in q
+        ]
+        for _, p in insert_calls:
+            for node_row in p["nodes"]:
+                assert node_row["file_path"] != "C.py"
+
+    def test_cross_file_edge_is_reissued_when_target_file_changes(self):
+        """Modify B.py (which contains B.bar). A.foo calls B.bar.
+
+        The incremental path must re-emit the A.foo→B.bar edge so the
+        inbound reference survives B.bar being rewritten with a new
+        attribute set. Edges between two unchanged files are NOT
+        re-emitted (they were never deleted).
+        """
+        graph = _make_graph_service()
+        original = _three_file_repo()
+        original_hashes = compute_file_hashes(original)
+        graph.driver.session_obj.set_hash_rows(
+            [
+                {"file_path": fp, "content_hash": h}
+                for fp, h in original_hashes.items()
+            ]
+        )
+
+        modified_nodes = []
+        for node in original.nodes:
+            if node.id == "B.py:bar":
+                modified_nodes.append(
+                    _node("B.py:bar", "B.py", line=99, text="# new sig")
+                )
+            else:
+                modified_nodes.append(node)
+        artifacts = _artifacts(modified_nodes, original.relationships)
+
+        service = IncrementalGraphService(graph)
+        delta = service.store_graph_from_artifacts_incremental(
+            artifacts, "p1", "u1"
+        )
+
+        # Sanity: only B.py is dirty.
+        assert delta.modified == {"B.py"}
+
+        # The MERGE pass must include the cross-file CALLS edge.
+        merge_calls = [
+            (q, p)
+            for q, p in graph.driver.session_obj.calls
+            if "MERGE (source)" in q and ":CALLS" in q
+        ]
+        assert merge_calls, "expected a MERGE for CALLS edges"
+        # Every emitted CALLS edge must touch B.py (source or target).
+        # Specifically, A.foo → B.bar should be among them.
+        from app.modules.parsing.graph_construction.code_graph_service import (
+            CodeGraphService,
+        )
+
+        expected_source = CodeGraphService.generate_node_id("A.py:foo", "u1")
+        expected_target = CodeGraphService.generate_node_id("B.py:bar", "u1")
+        all_edge_rows = [
+            row for _, p in merge_calls for row in p["edges"]
+        ]
+        assert any(
+            r["source_id"] == expected_source
+            and r["target_id"] == expected_target
+            for r in all_edge_rows
+        ), (
+            "A.foo → B.bar should be re-emitted because B.py changed; "
+            "got: " + repr(all_edge_rows)
+        )
+
+        # CONTAINS edges between two unchanged files should NOT be
+        # re-emitted. C.py → C.py:baz was unchanged on both ends.
+        contains_calls = [
+            (q, p)
+            for q, p in graph.driver.session_obj.calls
+            if "MERGE (source)" in q and ":CONTAINS" in q
+        ]
+        c_source = CodeGraphService.generate_node_id("C.py", "u1")
+        for _, p in contains_calls:
+            for row in p["edges"]:
+                assert row["source_id"] != c_source, (
+                    "C.py → C.py:baz is between two unchanged files and "
+                    "should not be re-emitted"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Inference-side helper
+# ---------------------------------------------------------------------------
+
+
+class TestInferenceHelpers:
+    def test_affected_node_ids_only_returns_dirty_non_file_nodes(self):
+        from app.modules.parsing.graph_construction.code_graph_service import (
+            CodeGraphService,
+        )
+
+        artifacts = _three_file_repo()
+        delta = GraphDelta(modified={"B.py"})
+        ids = affected_node_ids_for_inference(artifacts, delta, "u1")
+        # Only B.py:bar is dirty and non-FILE.
+        assert ids == [
+            CodeGraphService.generate_node_id("B.py:bar", "u1")
+        ]
+
+    def test_affected_node_ids_empty_when_no_changes(self):
+        artifacts = _three_file_repo()
+        delta = GraphDelta()
+        assert affected_node_ids_for_inference(artifacts, delta, "u1") == []
+
+    def test_reconstruct_subgraph_keeps_only_dirty_nodes(self):
+        artifacts = _three_file_repo()
+        sub = reconstruct_subgraph(artifacts, {"B.py"})
+        # Nodes with full attributes only come from B.py.
+        nodes_with_type = {
+            n for n, attrs in sub.nodes(data=True) if attrs.get("type")
+        }
+        assert nodes_with_type == {"B.py", "B.py:bar"}
+        # Cross-file edge from A.foo → B.bar should be preserved
+        # (target file is dirty). nx.add_edge auto-creates the
+        # endpoint, so A.foo appears as a placeholder node without
+        # attributes — that's fine, the inference layer reads node
+        # data only off the attributed nodes.
+        assert sub.has_edge("A.py:foo", "B.py:bar")

--- a/tests/unit/parsing/test_incremental_update.py
+++ b/tests/unit/parsing/test_incremental_update.py
@@ -174,14 +174,21 @@ class TestGraphDeltaDiff:
 class _FakeNeo4jSession:
     """Captures Cypher calls so we can assert on them."""
 
-    def __init__(self, hash_rows=None):
+    def __init__(self, hash_rows=None, total_file_count: int = 0):
         self._hash_rows = hash_rows or []
+        self._total_file_count = total_file_count
         self.calls: list[tuple[str, dict]] = []
         # Return value for the read-hashes query — overridden via
         # set_hash_rows when the test wants to simulate prior state.
 
     def set_hash_rows(self, rows):
         self._hash_rows = rows
+        # Keep total file count in sync by default (full coverage).
+        self._total_file_count = len(rows)
+
+    def set_total_file_count(self, count: int):
+        """Override the FILE node count independently for partial-seeding tests."""
+        self._total_file_count = count
 
     def __enter__(self):
         return self
@@ -197,6 +204,9 @@ class _FakeNeo4jSession:
         # The hash-read query is the only one tests inspect the rows of.
         if "RETURN n.file_path AS file_path, n.content_hash AS content_hash" in query:
             return self._hash_rows
+        # The total-FILE-count query used by _count_file_nodes.
+        if "RETURN count(n) AS total" in query:
+            return [{"total": self._total_file_count}]
         return []
 
 
@@ -212,8 +222,8 @@ class _FakeNeo4jResult:
 
 
 class _FakeDriver:
-    def __init__(self):
-        self.session_obj = _FakeNeo4jSession()
+    def __init__(self, total_file_count: int = 0):
+        self.session_obj = _FakeNeo4jSession(total_file_count=total_file_count)
 
     def session(self):
         # Return the same session every time so tests can inspect
@@ -518,6 +528,96 @@ class TestStoreGraphFromArtifactsIncremental:
                     "C.py → C.py:baz is between two unchanged files and "
                     "should not be re-emitted"
                 )
+
+
+    def test_partial_seeding_forces_full_rebuild(self):
+        """If only some FILE nodes have content_hash, treat project as unseeded.
+
+        Verifies fix for: partial seeding gap where files without hashes
+        are treated as "added" → old nodes never deleted → duplicates.
+        """
+        graph = _make_graph_service()
+        graph.store_graph_from_artifacts = MagicMock(name="full_rebuild")
+        artifacts = _three_file_repo()
+
+        # Pre-seed only ONE of the three files' hashes.
+        existing = compute_file_hashes(artifacts)
+        only_a = [{"file_path": "A.py", "content_hash": existing["A.py"]}]
+        graph.driver.session_obj.set_hash_rows(only_a)
+        # But there are 3 FILE nodes in the graph (partial coverage).
+        graph.driver.session_obj.set_total_file_count(3)
+
+        service = IncrementalGraphService(graph)
+        delta = service.store_graph_from_artifacts_incremental(
+            artifacts, "p1", "u1"
+        )
+
+        # Must have fallen back to a full rebuild, not incremental.
+        graph.store_graph_from_artifacts.assert_called_once_with(
+            artifacts, "p1", "u1"
+        )
+        # Hashes are seeded for all files.
+        hash_writes = [
+            (q, p)
+            for q, p in graph.driver.session_obj.calls
+            if "SET n.content_hash" in q
+        ]
+        assert hash_writes, "expected a content_hash write after fallback rebuild"
+
+    def test_qdrant_failure_defers_hash_write(self):
+        """When Qdrant sync fails, content_hash must NOT be advanced.
+
+        Verifies fix for: Qdrant errors were swallowed but hashes were
+        written anyway, so the next parse saw "no changes" and skipped
+        the retry.
+        """
+        graph = _make_graph_service()
+        graph.store_graph_from_artifacts = MagicMock(name="full_rebuild")
+        original = _three_file_repo()
+        original_hashes = compute_file_hashes(original)
+        graph.driver.session_obj.set_hash_rows(
+            [
+                {"file_path": fp, "content_hash": h}
+                for fp, h in original_hashes.items()
+            ]
+        )
+
+        # Modify B.py so there's an actual delta to process.
+        modified_nodes = []
+        for node in original.nodes:
+            if node.id == "B.py:bar":
+                modified_nodes.append(
+                    _node("B.py:bar", "B.py", text="# changed")
+                )
+            else:
+                modified_nodes.append(node)
+        artifacts = _artifacts(modified_nodes, original.relationships)
+
+        service = IncrementalGraphService(graph)
+        # Make _update_qdrant fail by having qdrant_client raise on delete.
+        graph.qdrant_client.collection_exists = MagicMock(return_value=True)
+
+        with patch(
+            "app.modules.parsing.graph_construction.incremental_graph_service"
+            ".IncrementalGraphService._update_qdrant",
+            return_value=False,
+        ):
+            delta = service.store_graph_from_artifacts_incremental(
+                artifacts, "p1", "u1"
+            )
+
+        # Content hash must NOT have been written — retry must be possible.
+        hash_writes = [
+            (q, p)
+            for q, p in graph.driver.session_obj.calls
+            if "SET n.content_hash" in q
+        ]
+        assert not hash_writes, (
+            "content_hash must NOT be written when Qdrant sync fails — "
+            "next parse must be able to retry the vector update"
+        )
+        # Delta is still returned so the caller knows what happened.
+        assert delta.modified == {"B.py"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
/claim #221

Re-attempts issue #221 per maintainer's [reopen invitation](https://github.com/potpie-ai/potpie/pull/232#issuecomment-2706192005) on the previously-stale PR #232.

## Approach

Different from PR #232 (which used a snapshot/restore mechanism) â€” this PR runs a direct file-level diff against the persisted graph and applies only the changed parts. The full re-parse still happens inside the sandbox runner (we don't touch `parsing_rs`), but the expensive Neo4j cleanup-and-reinsert + Qdrant rebuild + inference docstring regeneration are scoped to the dirty files.

## Pipeline

1. **Hash per file** from parser artifacts. Each file's fingerprint is a SHA-1 over its sorted `(id, type, line, end_line, name, text)` node-tuples plus the edges originating in it. Hashes are persisted as a `content_hash` attribute on the FILE nodes in Neo4j â€” no new schema/migration. The existing full-rebuild path now also seeds these hashes, so the next run on the same project is automatically incremental.

2. **Diff** new vs persisted hashes into `added` / `modified` / `deleted` / `unchanged` buckets.

3. **Apply delta**:
   - `DETACH DELETE` every node whose `file_path` is in the deleted-or-modified set. `DETACH DELETE` drops all attached edges in one hop, so we don't need a separate edge-cleanup pass.
   - Insert the artifacts' nodes whose file is in the added-or-modified set, using the same label assembly the full path uses.
   - `MERGE` every edge whose source or target file is dirty â€” this is the "relationship integrity" requirement from the issue. Cross-file references where one side moved get re-resolved against the freshly-inserted target nodes. Edges between two unchanged files are left alone (they were never deleted).

4. **Update Qdrant** in lock-step: drop points by `file_path` for removed files; index the dirty files' new nodes into the existing collection (no `recreate_collection`).

5. **Skip inference entirely** when no file-level changes are detected.

## Wiring

- `ParsingRequest` gains `full_rebuild: bool = False`. Default route is incremental; callers can opt back into the legacy clean-and-rebuild via `full_rebuild=True`.
- `ParsingService.parse_directory` skips `cleanup_graph` unless `full_rebuild=True`. The incremental path performs surgical deletes per dirty file instead of wiping the whole project.
- First incremental run on a project that has no `content_hash` data falls back to a full rebuild and seeds hashes â€” no migration step required.

## Tests

`tests/unit/parsing/test_incremental_update.py` â€” 14 cases:

- Per-file hashing is stable across runs and bucket-scoped (modifying one file's body or one of its outbound edges only moves that file's hash).
- Diff buckets: added / modified / deleted / unchanged.
- First-run fallback to full rebuild + hash seeding.
- No-op when nothing changed (no DELETE, no INSERT, no inference).
- Modified file scopes the DETACH DELETE to that file's `file_path` only.
- Added file inserts without touching existing nodes.
- Deleted file removes its nodes with no re-insert.
- Cross-file edge `A.foo â†’ B.bar` is re-emitted when `B.py` changes (issue #221's relationship-integrity requirement). CONTAINS edges between two unchanged files are NOT re-emitted (no double-write).
- `affected_node_ids_for_inference` returns only dirty non-FILE nodes â€” used by the inference layer when scoping docstring regeneration.
- `reconstruct_subgraph` keeps only dirty-file nodes with full attributes; cross-file inbound edges survive.

The two existing integration tests in `test_parsing_service.py` that asserted on `cleanup_graph` behaviour are updated to set `full_rebuild=True`, since the incremental default doesn't invoke that path.

## Out of scope

- The in-sandbox parser still parses the whole repo each run; making the parser itself incremental is a much larger lift inside `parsing_rs` / `parser_runner` and the issue body's "minimize parsing operations to affected components only" goal is met for the host-side pipeline (which is where the wall-clock goes).
- Rollback / partial-failure recovery is the same as the existing path: a failed Neo4j write leaves the graph in whatever partial state Neo4j accepts, and the next parse with `full_rebuild=True` recovers cleanly. The hashes are written *after* the delta succeeds, so a crashed run won't fool the next diff into thinking the changes already landed.

## Constraints respected

- No `.github/workflows/*` changes.
- No new feature flags beyond the documented `full_rebuild` opt-out.
- No backwards-compat shims â€” this is the new default and the legacy path is one boolean away.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incremental graph update pipeline for file-scoped sync and an explicit full-rebuild option.

* **Improvements**
  * Deterministic per-file content hashing to detect changed files and avoid unnecessary work; inference is skipped when no changes.
  * Targeted vector index deletions and optional BM25 vocabulary preservation for safer index updates; vector sync is best-effort.

* **Tests**
  * New and updated tests covering incremental updates, hashing, delta application, and inference behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->