### PR TITLE
Add local development CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,39 @@ To stop all services:
 ./scripts/stop.sh
 ```
 
+### Local CLI
+
+After installing the project, the `potpie` command is available for local development:
+
+```bash
+potpie start
+potpie stop
+```
+
+Use an API key from the app, or set `POTPIE_API_KEY` once:
+
+```bash
+export POTPIE_API_KEY=your-api-key
+```
+
+Parse a local repository and wait until it is ready:
+
+```bash
+potpie parse /path/to/repo --branch main
+```
+
+Start a chat session with an agent:
+
+```bash
+potpie chat <project-id> --agent codebase_qna_agent
+```
+
+For one-off automation, pass a single message:
+
+```bash
+potpie chat <project-id> --agent codebase_qna_agent --message "Where is authentication handled?"
+```
+
 #### Now set up Potpie Frontend
 
 ```bash

--- a/app/src/context-engine/adapters/inbound/cli/local_dev.py
+++ b/app/src/context-engine/adapters/inbound/cli/local_dev.py
@@ -1,0 +1,451 @@
+from __future__ import annotations
+
+import json
+import os
+import platform
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+import typer
+
+
+app = typer.Typer(
+    help="Local development CLI for starting Potpie, parsing repositories, and chatting with agents."
+)
+
+READY_STATUSES = {"ready"}
+FAILED_STATUSES = {"error"}
+IN_PROGRESS_STATUSES = {
+    "created",
+    "submitted",
+    "cloned",
+    "parsed",
+    "processing",
+    "inferring",
+}
+
+
+def _repo_root() -> Path:
+    env_root = os.getenv("POTPIE_REPO_ROOT")
+    if env_root:
+        root = Path(env_root).expanduser().resolve()
+        if (root / "scripts" / "start.sh").exists():
+            return root
+
+    cwd = Path.cwd().resolve()
+    for candidate in (cwd, *cwd.parents):
+        if (candidate / "scripts" / "start.sh").exists():
+            return candidate
+
+    source = Path(__file__).resolve()
+    for candidate in source.parents:
+        if (candidate / "scripts" / "start.sh").exists():
+            return candidate
+
+    typer.secho(
+        "Could not find the Potpie repository root. Run this command from the repo root "
+        "or set POTPIE_REPO_ROOT.",
+        fg=typer.colors.RED,
+        err=True,
+    )
+    raise typer.Exit(code=1)
+
+
+def _normalize_base_url(base_url: str) -> str:
+    return base_url.rstrip("/")
+
+
+def _headers(api_key: str | None, user_id: str | None) -> dict[str, str]:
+    if not api_key:
+        typer.secho(
+            "Missing API key. Pass --api-key or set POTPIE_API_KEY.",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    headers = {"X-API-Key": api_key}
+    if user_id:
+        headers["X-User-Id"] = user_id
+    return headers
+
+
+def _response_detail(response: httpx.Response) -> str:
+    try:
+        data = response.json()
+    except ValueError:
+        return response.text
+
+    if isinstance(data, dict):
+        detail = data.get("detail")
+        if detail:
+            return str(detail)
+    return json.dumps(data, indent=2)
+
+
+def _request(
+    method: str,
+    path: str,
+    *,
+    base_url: str,
+    api_key: str | None,
+    user_id: str | None,
+    json_body: dict[str, Any] | None = None,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    try:
+        with httpx.Client(
+            base_url=_normalize_base_url(base_url), timeout=timeout
+        ) as client:
+            response = client.request(
+                method,
+                path,
+                headers=_headers(api_key, user_id),
+                json=json_body,
+            )
+            response.raise_for_status()
+    except httpx.ConnectError as exc:
+        typer.secho(
+            f"Could not connect to Potpie at {base_url}. Run `potpie start` first or pass --url.",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=1) from exc
+    except httpx.HTTPStatusError as exc:
+        typer.secho(
+            f"API error {exc.response.status_code}: {_response_detail(exc.response)}",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=1) from exc
+    except httpx.HTTPError as exc:
+        typer.secho(f"Request failed: {exc}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=1) from exc
+
+    if not response.content:
+        return {}
+    try:
+        data = response.json()
+    except ValueError as exc:
+        typer.secho("API returned a non-JSON response.", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=1) from exc
+    if not isinstance(data, dict):
+        return {"data": data}
+    return data
+
+
+def _run_project_command(command: list[str]) -> None:
+    exit_code = subprocess.call(command, cwd=_repo_root())
+    raise typer.Exit(code=exit_code)
+
+
+def _script_command(
+    script_name: str, windows_script_name: str | None = None
+) -> list[str]:
+    root = _repo_root()
+    is_windows = platform.system().lower().startswith("win")
+    if is_windows and windows_script_name:
+        script_path = root / "scripts" / windows_script_name
+        if script_path.exists():
+            return [
+                "powershell",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                str(script_path),
+            ]
+
+    bash = shutil.which("bash")
+    if not bash:
+        typer.secho(
+            "Could not find bash. Install Git Bash or run the scripts manually.",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    return [bash, str(root / "scripts" / script_name)]
+
+
+@app.command()
+def start() -> None:
+    """Start Docker services, the API server, and the Celery worker."""
+    _run_project_command(_script_command("start.sh"))
+
+
+@app.command()
+def stop() -> None:
+    """Stop the API server, Celery worker, and Docker services."""
+    _run_project_command(_script_command("stop.sh", "stop.ps1"))
+
+
+@app.command()
+def parse(
+    repo_path: Path = typer.Argument(
+        ...,
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        readable=True,
+        resolve_path=True,
+        help="Local repository path to submit for parsing.",
+    ),
+    branch: str | None = typer.Option(
+        None, "--branch", "-b", help="Branch name to parse."
+    ),
+    wait: bool = typer.Option(
+        True, "--wait/--no-wait", help="Poll until the project is ready."
+    ),
+    interval: float = typer.Option(
+        5.0, "--interval", min=0.1, help="Polling interval in seconds."
+    ),
+    timeout: float = typer.Option(
+        1800.0, "--timeout", min=1.0, help="Maximum time to wait."
+    ),
+    base_url: str = typer.Option(
+        "http://localhost:8001",
+        "--url",
+        envvar="POTPIE_BASE_URL",
+        help="Potpie API base URL.",
+    ),
+    api_key: str | None = typer.Option(
+        None,
+        "--api-key",
+        envvar="POTPIE_API_KEY",
+        help="Potpie API key.",
+    ),
+    user_id: str | None = typer.Option(
+        None,
+        "--user-id",
+        envvar="POTPIE_USER_ID",
+        help="User id for INTERNAL_ADMIN_SECRET impersonation.",
+    ),
+) -> None:
+    """Submit a local repository for parsing and wait until it is ready."""
+    payload: dict[str, Any] = {"repo_path": str(repo_path)}
+    if branch:
+        payload["branch_name"] = branch
+
+    typer.echo(f"Submitting {repo_path} for parsing...")
+    result = _request(
+        "POST",
+        "/api/v1/parse",
+        base_url=base_url,
+        api_key=api_key,
+        user_id=user_id,
+        json_body=payload,
+    )
+
+    project_id = result.get("project_id") or result.get("id")
+    status = str(result.get("status", "unknown"))
+    if not project_id:
+        typer.secho(
+            "Parse response did not include a project id.",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    typer.echo(f"Project: {project_id}")
+    typer.echo(f"Status: {status}")
+
+    if not wait:
+        return
+
+    deadline = time.monotonic() + timeout
+    last_status = status
+    while status not in READY_STATUSES:
+        if status in FAILED_STATUSES:
+            typer.secho(
+                f"Parsing failed with status: {status}",
+                fg=typer.colors.RED,
+                err=True,
+            )
+            raise typer.Exit(code=1)
+        if status not in IN_PROGRESS_STATUSES and status != "unknown":
+            typer.secho(f"Unexpected parsing status: {status}", fg=typer.colors.YELLOW)
+        if time.monotonic() >= deadline:
+            typer.secho(
+                "Timed out waiting for parsing to finish.",
+                fg=typer.colors.RED,
+                err=True,
+            )
+            raise typer.Exit(code=1)
+
+        time.sleep(interval)
+        status_result = _request(
+            "GET",
+            f"/api/v1/parsing-status/{project_id}",
+            base_url=base_url,
+            api_key=api_key,
+            user_id=user_id,
+            timeout=15.0,
+        )
+        status = str(status_result.get("status", "unknown"))
+        if status != last_status:
+            latest = status_result.get("latest")
+            suffix = f" (latest={latest})" if latest is not None else ""
+            typer.echo(f"Status: {status}{suffix}")
+            last_status = status
+
+    typer.secho("Parsing complete. Project is ready.", fg=typer.colors.GREEN)
+
+
+def _ensure_project_ready(
+    project_id: str,
+    *,
+    base_url: str,
+    api_key: str | None,
+    user_id: str | None,
+) -> None:
+    status_result = _request(
+        "GET",
+        f"/api/v1/parsing-status/{project_id}",
+        base_url=base_url,
+        api_key=api_key,
+        user_id=user_id,
+        timeout=15.0,
+    )
+    status = str(status_result.get("status", "unknown"))
+    if status not in READY_STATUSES:
+        typer.secho(
+            f"Project {project_id} is not ready yet (status: {status}).",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+
+def _create_conversation(
+    project_id: str,
+    agent: str,
+    *,
+    base_url: str,
+    api_key: str | None,
+    user_id: str | None,
+) -> str:
+    result = _request(
+        "POST",
+        "/api/v1/conversations/",
+        base_url=base_url,
+        api_key=api_key,
+        user_id=user_id,
+        json_body={"project_ids": [project_id], "agent_ids": [agent]},
+    )
+    conversation_id = result.get("conversation_id")
+    if not conversation_id:
+        typer.secho(
+            "Conversation response did not include a conversation id.",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    return str(conversation_id)
+
+
+def _send_message(
+    conversation_id: str,
+    content: str,
+    *,
+    base_url: str,
+    api_key: str | None,
+    user_id: str | None,
+) -> None:
+    result = _request(
+        "POST",
+        f"/api/v1/conversations/{conversation_id}/message/",
+        base_url=base_url,
+        api_key=api_key,
+        user_id=user_id,
+        json_body={"content": content},
+        timeout=300.0,
+    )
+    message = result.get("message")
+    if message:
+        typer.echo(message)
+        return
+    typer.echo(json.dumps(result, indent=2))
+
+
+@app.command()
+def chat(
+    project_id: str = typer.Argument(..., help="Parsed Potpie project id."),
+    agent: str = typer.Option(..., "--agent", "-a", help="Agent name to chat with."),
+    branch: str | None = typer.Option(
+        None,
+        "--branch",
+        "-b",
+        help="Accepted for local workflow compatibility; project readiness is checked by id.",
+    ),
+    message: str | None = typer.Option(
+        None,
+        "--message",
+        "-m",
+        help="Send one message and exit instead of starting an interactive session.",
+    ),
+    base_url: str = typer.Option(
+        "http://localhost:8001",
+        "--url",
+        envvar="POTPIE_BASE_URL",
+        help="Potpie API base URL.",
+    ),
+    api_key: str | None = typer.Option(
+        None,
+        "--api-key",
+        envvar="POTPIE_API_KEY",
+        help="Potpie API key.",
+    ),
+    user_id: str | None = typer.Option(
+        None,
+        "--user-id",
+        envvar="POTPIE_USER_ID",
+        help="User id for INTERNAL_ADMIN_SECRET impersonation.",
+    ),
+) -> None:
+    """Validate a project, open a conversation, and chat with an agent."""
+    _ensure_project_ready(
+        project_id, base_url=base_url, api_key=api_key, user_id=user_id
+    )
+    if branch:
+        typer.echo(f"Using project {project_id}; branch option received: {branch}")
+
+    conversation_id = _create_conversation(
+        project_id,
+        agent,
+        base_url=base_url,
+        api_key=api_key,
+        user_id=user_id,
+    )
+    typer.echo(f"Conversation: {conversation_id}")
+
+    if message:
+        _send_message(
+            conversation_id,
+            message,
+            base_url=base_url,
+            api_key=api_key,
+            user_id=user_id,
+        )
+        return
+
+    typer.echo("Type /exit or /quit to end the session.")
+    while True:
+        try:
+            user_message = typer.prompt("you")
+        except (EOFError, KeyboardInterrupt):
+            typer.echo()
+            return
+        if user_message.strip().lower() in {"/exit", "/quit"}:
+            return
+        if not user_message.strip():
+            continue
+        _send_message(
+            conversation_id,
+            user_message,
+            base_url=base_url,
+            api_key=api_key,
+            user_id=user_id,
+        )

--- a/app/src/context-engine/adapters/inbound/cli/local_dev.py
+++ b/app/src/context-engine/adapters/inbound/cli/local_dev.py
@@ -29,6 +29,10 @@ IN_PROGRESS_STATUSES = {
 }
 
 
+def _normalize_status(value: Any) -> str:
+    return str(value or "").strip().lower() or "unknown"
+
+
 def _repo_root() -> Path:
     env_root = os.getenv("POTPIE_REPO_ROOT")
     if env_root:
@@ -240,7 +244,7 @@ def parse(
     )
 
     project_id = result.get("project_id") or result.get("id")
-    status = str(result.get("status", "unknown"))
+    status = _normalize_status(result.get("status", "unknown"))
     if not project_id:
         typer.secho(
             "Parse response did not include a project id.",
@@ -284,7 +288,7 @@ def parse(
             user_id=user_id,
             timeout=15.0,
         )
-        status = str(status_result.get("status", "unknown"))
+        status = _normalize_status(status_result.get("status", "unknown"))
         if status != last_status:
             latest = status_result.get("latest")
             suffix = f" (latest={latest})" if latest is not None else ""
@@ -309,7 +313,7 @@ def _ensure_project_ready(
         user_id=user_id,
         timeout=15.0,
     )
-    status = str(status_result.get("status", "unknown"))
+    status = _normalize_status(status_result.get("status", "unknown"))
     if status not in READY_STATUSES:
         typer.secho(
             f"Project {project_id} is not ready yet (status: {status}).",

--- a/app/src/context-engine/adapters/inbound/cli/main.py
+++ b/app/src/context-engine/adapters/inbound/cli/main.py
@@ -51,6 +51,10 @@ from adapters.inbound.cli.potpie_api_config import (
     resolve_potpie_api_base_url,
     resolve_potpie_api_key,
 )
+from adapters.inbound.cli.local_dev import chat as local_chat
+from adapters.inbound.cli.local_dev import parse as local_parse
+from adapters.inbound.cli.local_dev import start as local_start
+from adapters.inbound.cli.local_dev import stop as local_stop
 from adapters.outbound.http.potpie_context_api_client import (
     IngestRejectedError,
     PotpieContextApiClient,
@@ -1725,6 +1729,12 @@ def ingest_cmd(
         raise typer.Exit(code=1)
 
     print_ingest_result(out, as_json=j)
+
+
+app.command(name="start")(local_start)
+app.command(name="stop")(local_stop)
+app.command(name="parse")(local_parse)
+app.command(name="chat")(local_chat)
 
 
 def main() -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -141,7 +141,7 @@ def test_start_uses_start_script(monkeypatch):
     )
     monkeypatch.setattr(
         "adapters.inbound.cli.local_dev._repo_root",
-        lambda: Path("C:/Users/frogc/potpie-bounty-work"),
+        lambda: Path("/home/frogc/potpie-bounty-work"),
     )
 
     def fake_call(command, cwd):
@@ -179,9 +179,13 @@ def test_stop_uses_stop_script(
     monkeypatch.setattr(
         "adapters.inbound.cli.local_dev.platform.system", lambda: system_name
     )
-    monkeypatch.setattr(
-        "adapters.inbound.cli.local_dev.shutil.which", lambda name: "/bin/bash"
-    )
+
+    def fake_which(name):
+        if system_name == "Windows":
+            return "powershell" if name == "powershell" else None
+        return "/bin/bash" if name == "bash" else None
+
+    monkeypatch.setattr("adapters.inbound.cli.local_dev.shutil.which", fake_which)
     monkeypatch.setattr("adapters.inbound.cli.local_dev._repo_root", lambda: tmp_path)
 
     def fake_call(command, cwd):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -24,9 +24,9 @@ def test_parse_submits_repo_and_polls_until_ready(monkeypatch, tmp_path: Path):
                 "repo_path": str(tmp_path.resolve()),
                 "branch_name": "main",
             }
-            return {"project_id": "project-1", "status": "submitted"}
+            return {"project_id": "project-1", "status": " submitted "}
         if method == "GET" and path == "/api/v1/parsing-status/project-1":
-            return {"status": "ready", "latest": True}
+            return {"status": "READY", "latest": True}
         raise AssertionError(f"Unexpected request {method} {path}")
 
     monkeypatch.setattr("adapters.inbound.cli.local_dev._request", fake_request)
@@ -70,7 +70,7 @@ def test_chat_creates_conversation_and_sends_single_message(monkeypatch):
     def fake_request(method, path, **kwargs):
         requests.append((method, path, kwargs.get("json_body")))
         if method == "GET" and path == "/api/v1/parsing-status/project-1":
-            return {"status": "ready", "latest": True}
+            return {"status": " READY ", "latest": True}
         if method == "POST" and path == "/api/v1/conversations/":
             assert kwargs["json_body"] == {
                 "project_ids": ["project-1"],
@@ -158,6 +158,46 @@ def test_start_uses_start_script(monkeypatch):
     script_path = Path(called["command"][1])
     assert script_path.parts[-2:] == ("scripts", "start.sh")
     assert called["cwd"].name == "potpie-bounty-work"
+
+
+@pytest.mark.parametrize(
+    ("system_name", "expected_engine", "expected_script"),
+    [
+        ("Linux", "/bin/bash", "stop.sh"),
+        ("Windows", "powershell", "stop.ps1"),
+    ],
+)
+def test_stop_uses_stop_script(
+    monkeypatch, tmp_path: Path, system_name, expected_engine, expected_script
+):
+    called = {}
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "stop.sh").write_text("")
+    (scripts_dir / "stop.ps1").write_text("")
+
+    monkeypatch.setattr(
+        "adapters.inbound.cli.local_dev.platform.system", lambda: system_name
+    )
+    monkeypatch.setattr(
+        "adapters.inbound.cli.local_dev.shutil.which", lambda name: "/bin/bash"
+    )
+    monkeypatch.setattr("adapters.inbound.cli.local_dev._repo_root", lambda: tmp_path)
+
+    def fake_call(command, cwd):
+        called["command"] = command
+        called["cwd"] = cwd
+        return 0
+
+    monkeypatch.setattr(subprocess, "call", fake_call)
+
+    result = runner.invoke(app, ["stop"])
+
+    assert result.exit_code == 0
+    assert called["command"][0] == expected_engine
+    script_path = Path(called["command"][-1])
+    assert script_path.parts[-2:] == ("scripts", expected_script)
+    assert called["cwd"] == tmp_path
 
 
 def test_context_cli_registers_local_dev_commands():

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from adapters.inbound.cli.local_dev import app
+
+
+pytestmark = pytest.mark.unit
+
+runner = CliRunner()
+
+
+def test_parse_submits_repo_and_polls_until_ready(monkeypatch, tmp_path: Path):
+    calls = []
+
+    def fake_request(method, path, **kwargs):
+        calls.append((method, path, kwargs))
+        if method == "POST" and path == "/api/v1/parse":
+            assert kwargs["json_body"] == {
+                "repo_path": str(tmp_path.resolve()),
+                "branch_name": "main",
+            }
+            return {"project_id": "project-1", "status": "submitted"}
+        if method == "GET" and path == "/api/v1/parsing-status/project-1":
+            return {"status": "ready", "latest": True}
+        raise AssertionError(f"Unexpected request {method} {path}")
+
+    monkeypatch.setattr("adapters.inbound.cli.local_dev._request", fake_request)
+    monkeypatch.setattr("adapters.inbound.cli.local_dev.time.sleep", lambda _: None)
+
+    result = runner.invoke(
+        app,
+        [
+            "parse",
+            str(tmp_path),
+            "--branch",
+            "main",
+            "--api-key",
+            "test-key",
+            "--interval",
+            "0.1",
+            "--timeout",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Project: project-1" in result.output
+    assert "Parsing complete" in result.output
+    assert len(calls) == 2
+
+
+def test_parse_rejects_file_path(tmp_path: Path):
+    file_path = tmp_path / "README.md"
+    file_path.write_text("not a repo")
+
+    result = runner.invoke(app, ["parse", str(file_path), "--api-key", "test-key"])
+
+    assert result.exit_code != 0
+    assert "Directory" in result.output or "Invalid" in result.output
+
+
+def test_chat_creates_conversation_and_sends_single_message(monkeypatch):
+    requests = []
+
+    def fake_request(method, path, **kwargs):
+        requests.append((method, path, kwargs.get("json_body")))
+        if method == "GET" and path == "/api/v1/parsing-status/project-1":
+            return {"status": "ready", "latest": True}
+        if method == "POST" and path == "/api/v1/conversations/":
+            assert kwargs["json_body"] == {
+                "project_ids": ["project-1"],
+                "agent_ids": ["codebase_qna_agent"],
+            }
+            return {"conversation_id": "conversation-1"}
+        if method == "POST" and path == "/api/v1/conversations/conversation-1/message/":
+            assert kwargs["json_body"] == {"content": "What does this repo do?"}
+            return {"message": "It answers questions about code."}
+        raise AssertionError(f"Unexpected request {method} {path}")
+
+    monkeypatch.setattr("adapters.inbound.cli.local_dev._request", fake_request)
+
+    result = runner.invoke(
+        app,
+        [
+            "chat",
+            "project-1",
+            "--agent",
+            "codebase_qna_agent",
+            "--message",
+            "What does this repo do?",
+            "--api-key",
+            "test-key",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Conversation: conversation-1" in result.output
+    assert "It answers questions about code." in result.output
+    assert [request[0] for request in requests] == ["GET", "POST", "POST"]
+
+
+def test_chat_rejects_project_that_is_not_ready(monkeypatch):
+    def fake_request(method, path, **kwargs):
+        assert method == "GET"
+        assert path == "/api/v1/parsing-status/project-1"
+        return {"status": "submitted", "latest": False}
+
+    monkeypatch.setattr("adapters.inbound.cli.local_dev._request", fake_request)
+
+    result = runner.invoke(
+        app,
+        [
+            "chat",
+            "project-1",
+            "--agent",
+            "codebase_qna_agent",
+            "--message",
+            "Hello",
+            "--api-key",
+            "test-key",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "not ready yet" in result.output
+
+
+def test_start_uses_start_script(monkeypatch):
+    called = {}
+
+    monkeypatch.setattr(
+        "adapters.inbound.cli.local_dev.platform.system", lambda: "Linux"
+    )
+    monkeypatch.setattr(
+        "adapters.inbound.cli.local_dev.shutil.which", lambda name: "/bin/bash"
+    )
+    monkeypatch.setattr(
+        "adapters.inbound.cli.local_dev._repo_root",
+        lambda: Path("C:/Users/frogc/potpie-bounty-work"),
+    )
+
+    def fake_call(command, cwd):
+        called["command"] = command
+        called["cwd"] = cwd
+        return 0
+
+    monkeypatch.setattr(subprocess, "call", fake_call)
+
+    result = runner.invoke(app, ["start"])
+
+    assert result.exit_code == 0
+    assert called["command"][0] == "/bin/bash"
+    script_path = Path(called["command"][1])
+    assert script_path.parts[-2:] == ("scripts", "start.sh")
+    assert called["cwd"].name == "potpie-bounty-work"
+
+
+def test_context_cli_registers_local_dev_commands():
+    from adapters.inbound.cli.main import app as context_app
+
+    command_names = {command.name for command in context_app.registered_commands}
+
+    assert {"start", "stop", "parse", "chat"}.issubset(command_names)


### PR DESCRIPTION
## Summary

- Adds local development CLI commands to the existing `potpie` Typer CLI:
  - `potpie start`
  - `potpie stop`
  - `potpie parse <repo-path> [--branch <branch-name>]`
  - `potpie chat <project-id> --agent <agent-name> [--branch <branch-name>]`
- Implements API-key based local API calls with `POTPIE_API_KEY`, `POTPIE_BASE_URL`, and optional `POTPIE_USER_ID`.
- Adds parsing status polling, project readiness validation, one-shot chat messages, and interactive chat sessions.
- Documents the local CLI flow in the README.

## Tests

```bash
uv run pytest tests/unit/test_cli.py -q
uv run ruff check app/src/context-engine/adapters/inbound/cli/main.py app/src/context-engine/adapters/inbound/cli/local_dev.py tests/unit/test_cli.py
uv run ruff format --check app/src/context-engine/adapters/inbound/cli/main.py app/src/context-engine/adapters/inbound/cli/local_dev.py tests/unit/test_cli.py
uv run potpie start --help
uv run potpie parse --help
uv run potpie chat --help
```

## Demo

The local CLI commands are registered on the existing `potpie` entrypoint and render command-specific help:

```bash
uv run potpie start --help
uv run potpie parse --help
uv run potpie chat --help
```

`parse` validates that `repo_path` is a readable directory, submits `POST /api/v1/parse`, polls `GET /api/v1/parsing-status/{project_id}`, and exits when the project reaches `ready`.

`chat` validates project readiness through `GET /api/v1/parsing-status/{project_id}`, creates a conversation with the requested agent, and supports both one-shot `--message` usage and an interactive prompt.

/claim #224


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local development CLI added with start, stop, parse, and chat commands
  * Interactive agent chat mode plus single-message send
  * Repository parsing with configurable polling interval and timeout

* **Tests**
  * Unit tests added for parsing, chat flows, start/stop behavior, and CLI registration

* **Documentation**
  * README updated with Local CLI setup and example commands

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/potpie-ai/potpie/pull/769)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->