### PR TITLE
Add local Potpie CLI

### DIFF
--- a/potpie_cli.py
+++ b/potpie_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import socket
 import subprocess
 import sys
 from pathlib import Path
@@ -38,10 +39,10 @@ def _print_health(api_url: str, timeout: float) -> int:
         print(f"Potpie API health check failed: HTTP {exc.code}", file=sys.stderr)
         return 1
     except URLError as exc:
+        if isinstance(exc.reason, (TimeoutError, socket.timeout)):
+            print(f"Potpie API health check timed out at {url}", file=sys.stderr)
+            return 1
         print(f"Potpie API is not reachable at {url}: {exc.reason}", file=sys.stderr)
-        return 1
-    except TimeoutError:
-        print(f"Potpie API health check timed out at {url}", file=sys.stderr)
         return 1
 
     if body:

--- a/potpie_cli.py
+++ b/potpie_cli.py
@@ -1,0 +1,137 @@
+"""Command line helpers for running Potpie locally."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
+
+
+DEFAULT_API_URL = "http://localhost:8001"
+
+
+def _project_root(path: str | None) -> Path:
+    return Path(path or ".").expanduser().resolve()
+
+
+def _script_path(root: Path, script_name: str) -> Path:
+    script = root / "scripts" / script_name
+    if not script.exists():
+        raise FileNotFoundError(f"{script} does not exist")
+    return script
+
+
+def _run(command: list[str], root: Path) -> int:
+    return subprocess.run(command, cwd=root).returncode
+
+
+def _print_health(api_url: str, timeout: float) -> int:
+    url = f"{api_url.rstrip('/')}/health"
+    try:
+        with urlopen(url, timeout=timeout) as response:
+            body = response.read().decode("utf-8").strip()
+    except HTTPError as exc:
+        print(f"Potpie API health check failed: HTTP {exc.code}", file=sys.stderr)
+        return 1
+    except URLError as exc:
+        print(f"Potpie API is not reachable at {url}: {exc.reason}", file=sys.stderr)
+        return 1
+    except TimeoutError:
+        print(f"Potpie API health check timed out at {url}", file=sys.stderr)
+        return 1
+
+    if body:
+        try:
+            parsed = json.loads(body)
+            print(json.dumps(parsed, indent=2, sort_keys=True))
+        except json.JSONDecodeError:
+            print(body)
+    else:
+        print("Potpie API is healthy.")
+    return 0
+
+
+def _add_root_option(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--root",
+        help="Path to the Potpie repository root. Defaults to the current directory.",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="potpie",
+        description="Run and inspect a local Potpie development stack.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    start_parser = subparsers.add_parser(
+        "start",
+        help="Start the local Potpie stack using scripts/start.sh.",
+    )
+    _add_root_option(start_parser)
+
+    stop_parser = subparsers.add_parser(
+        "stop",
+        help="Stop the local Potpie stack using scripts/stop.sh.",
+    )
+    _add_root_option(stop_parser)
+
+    status_parser = subparsers.add_parser(
+        "status",
+        help="Show Docker Compose service status for the local stack.",
+    )
+    _add_root_option(status_parser)
+
+    health_parser = subparsers.add_parser(
+        "health",
+        help="Check the local Potpie API health endpoint.",
+    )
+    health_parser.add_argument(
+        "--api-url",
+        default=DEFAULT_API_URL,
+        help=f"Base URL for the Potpie API. Defaults to {DEFAULT_API_URL}.",
+    )
+    health_parser.add_argument(
+        "--timeout",
+        type=float,
+        default=5.0,
+        help="Health check timeout in seconds.",
+    )
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command == "start":
+            root = _project_root(args.root)
+            return _run(["bash", str(_script_path(root, "start.sh"))], root)
+
+        if args.command == "stop":
+            root = _project_root(args.root)
+            return _run(["bash", str(_script_path(root, "stop.sh"))], root)
+
+        if args.command == "status":
+            root = _project_root(args.root)
+            return _run(["docker", "compose", "ps"], root)
+
+        if args.command == "health":
+            return _print_health(args.api_url, args.timeout)
+    except FileNotFoundError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    parser.error(f"Unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/potpie_cli.py
+++ b/potpie_cli.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 from pathlib import Path
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
 from urllib.request import urlopen
 
 
@@ -16,10 +17,12 @@ DEFAULT_API_URL = "http://localhost:8001"
 
 
 def _project_root(path: str | None) -> Path:
+    """Resolve the Potpie repository root from a user-provided path."""
     return Path(path or ".").expanduser().resolve()
 
 
 def _script_path(root: Path, script_name: str) -> Path:
+    """Return the requested script path or raise when it is unavailable."""
     script = root / "scripts" / script_name
     if not script.exists():
         raise FileNotFoundError(f"{script} does not exist")
@@ -27,10 +30,24 @@ def _script_path(root: Path, script_name: str) -> Path:
 
 
 def _run(command: list[str], root: Path) -> int:
+    """Run a local command from the Potpie repository root."""
     return subprocess.run(command, cwd=root).returncode
 
 
 def _print_health(api_url: str, timeout: float) -> int:
+    """Call the Potpie API health endpoint and print a human-readable result."""
+    if timeout <= 0:
+        print("Health check timeout must be greater than 0.", file=sys.stderr)
+        return 1
+
+    parsed_api_url = urlparse(api_url)
+    if parsed_api_url.scheme not in {"http", "https"} or not parsed_api_url.netloc:
+        print(
+            f"Invalid API URL: {api_url}. Expected an http(s) base URL.",
+            file=sys.stderr,
+        )
+        return 1
+
     url = f"{api_url.rstrip('/')}/health"
     try:
         with urlopen(url, timeout=timeout) as response:
@@ -43,6 +60,9 @@ def _print_health(api_url: str, timeout: float) -> int:
             print(f"Potpie API health check timed out at {url}", file=sys.stderr)
             return 1
         print(f"Potpie API is not reachable at {url}: {exc.reason}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        print(f"Invalid health check configuration: {exc}", file=sys.stderr)
         return 1
 
     if body:
@@ -57,6 +77,7 @@ def _print_health(api_url: str, timeout: float) -> int:
 
 
 def _add_root_option(parser: argparse.ArgumentParser) -> None:
+    """Add the shared repository root option to a subcommand parser."""
     parser.add_argument(
         "--root",
         help="Path to the Potpie repository root. Defaults to the current directory.",
@@ -64,6 +85,7 @@ def _add_root_option(parser: argparse.ArgumentParser) -> None:
 
 
 def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for the Potpie local development CLI."""
     parser = argparse.ArgumentParser(
         prog="potpie",
         description="Run and inspect a local Potpie development stack.",
@@ -108,6 +130,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Run the Potpie CLI with optional explicit arguments."""
     parser = build_parser()
     args = parser.parse_args(argv)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ potpie-sandbox = { path = "app/src/sandbox", editable = true }
 
 [project.scripts]
 potpie-seed = "seed.cli:main"
+potpie = "potpie_cli:main"
 
 [dependency-groups]
 dev = [
@@ -119,6 +120,9 @@ dev = [
     "pytest-cov>=6.0.0",
     "ruff>=0.14.3",
 ]
+
+[tool.setuptools]
+py-modules = ["potpie_cli"]
 
 [tool.setuptools.packages.find]
 include = ["potpie*", "app*", "seed*"]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 import potpie_cli as cli
 
 
@@ -65,7 +67,7 @@ def test_status_runs_docker_compose_ps(monkeypatch, tmp_path: Path) -> None:
 def test_health_prints_json_response(monkeypatch, capsys) -> None:
     def fake_urlopen(url, *, timeout):
         assert url == "http://localhost:8001/health"
-        assert timeout == 5.0
+        assert timeout == pytest.approx(5.0)
         return FakeResponse(b'{"status":"ok"}')
 
     monkeypatch.setattr(cli, "urlopen", fake_urlopen)
@@ -77,7 +79,7 @@ def test_health_prints_json_response(monkeypatch, capsys) -> None:
 
 def test_health_reports_unreachable_api(monkeypatch, capsys) -> None:
     def fake_urlopen(_url, *, timeout):
-        assert timeout == 5.0
+        assert timeout == pytest.approx(5.0)
         raise cli.URLError("connection refused")
 
     monkeypatch.setattr(cli, "urlopen", fake_urlopen)
@@ -89,7 +91,7 @@ def test_health_reports_unreachable_api(monkeypatch, capsys) -> None:
 
 def test_health_reports_timeout(monkeypatch, capsys) -> None:
     def fake_urlopen(_url, *, timeout):
-        assert timeout == 5.0
+        assert timeout == pytest.approx(5.0)
         raise cli.URLError(TimeoutError("timed out"))
 
     monkeypatch.setattr(cli, "urlopen", fake_urlopen)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import potpie_cli as cli
+
+
+class FakeResponse:
+    def __init__(self, body: bytes):
+        self.body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def read(self) -> bytes:
+        return self.body
+
+
+def test_start_runs_start_script(monkeypatch, tmp_path: Path) -> None:
+    script = tmp_path / "scripts" / "start.sh"
+    script.parent.mkdir()
+    script.write_text("#!/bin/bash\n")
+    calls = []
+
+    def fake_run(command, cwd):
+        calls.append((command, cwd))
+
+        class Result:
+            returncode = 0
+
+        return Result()
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    assert cli.main(["start", "--root", str(tmp_path)]) == 0
+    assert calls == [(["bash", str(script)], tmp_path.resolve())]
+
+
+def test_stop_reports_missing_script(tmp_path: Path, capsys) -> None:
+    assert cli.main(["stop", "--root", str(tmp_path)]) == 1
+    captured = capsys.readouterr()
+    assert "scripts/stop.sh" in captured.err
+
+
+def test_status_runs_docker_compose_ps(monkeypatch, tmp_path: Path) -> None:
+    calls = []
+
+    def fake_run(command, cwd):
+        calls.append((command, cwd))
+
+        class Result:
+            returncode = 0
+
+        return Result()
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    assert cli.main(["status", "--root", str(tmp_path)]) == 0
+    assert calls == [(["docker", "compose", "ps"], tmp_path.resolve())]
+
+
+def test_health_prints_json_response(monkeypatch, capsys) -> None:
+    def fake_urlopen(url, timeout):
+        assert url == "http://localhost:8001/health"
+        assert timeout == 5.0
+        return FakeResponse(b'{"status":"ok"}')
+
+    monkeypatch.setattr(cli, "urlopen", fake_urlopen)
+
+    assert cli.main(["health"]) == 0
+    captured = capsys.readouterr()
+    assert '"status": "ok"' in captured.out
+
+
+def test_health_reports_unreachable_api(monkeypatch, capsys) -> None:
+    def fake_urlopen(_url, _timeout):
+        raise cli.URLError("connection refused")
+
+    monkeypatch.setattr(cli, "urlopen", fake_urlopen)
+
+    assert cli.main(["health", "--api-url", "http://127.0.0.1:9999"]) == 1
+    captured = capsys.readouterr()
+    assert "not reachable" in captured.err

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -97,3 +97,15 @@ def test_health_reports_timeout(monkeypatch, capsys) -> None:
     assert cli.main(["health"]) == 1
     captured = capsys.readouterr()
     assert "timed out" in captured.err
+
+
+def test_health_rejects_non_positive_timeout(capsys) -> None:
+    assert cli.main(["health", "--timeout", "0"]) == 1
+    captured = capsys.readouterr()
+    assert "timeout must be greater than 0" in captured.err
+
+
+def test_health_rejects_invalid_api_url(capsys) -> None:
+    assert cli.main(["health", "--api-url", "localhost:8001"]) == 1
+    captured = capsys.readouterr()
+    assert "Invalid API URL" in captured.err

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -63,7 +63,7 @@ def test_status_runs_docker_compose_ps(monkeypatch, tmp_path: Path) -> None:
 
 
 def test_health_prints_json_response(monkeypatch, capsys) -> None:
-    def fake_urlopen(url, timeout):
+    def fake_urlopen(url, *, timeout):
         assert url == "http://localhost:8001/health"
         assert timeout == 5.0
         return FakeResponse(b'{"status":"ok"}')
@@ -76,7 +76,8 @@ def test_health_prints_json_response(monkeypatch, capsys) -> None:
 
 
 def test_health_reports_unreachable_api(monkeypatch, capsys) -> None:
-    def fake_urlopen(_url, _timeout):
+    def fake_urlopen(_url, *, timeout):
+        assert timeout == 5.0
         raise cli.URLError("connection refused")
 
     monkeypatch.setattr(cli, "urlopen", fake_urlopen)
@@ -84,3 +85,15 @@ def test_health_reports_unreachable_api(monkeypatch, capsys) -> None:
     assert cli.main(["health", "--api-url", "http://127.0.0.1:9999"]) == 1
     captured = capsys.readouterr()
     assert "not reachable" in captured.err
+
+
+def test_health_reports_timeout(monkeypatch, capsys) -> None:
+    def fake_urlopen(_url, *, timeout):
+        assert timeout == 5.0
+        raise cli.URLError(TimeoutError("timed out"))
+
+    monkeypatch.setattr(cli, "urlopen", fake_urlopen)
+
+    assert cli.main(["health"]) == 1
+    captured = capsys.readouterr()
+    assert "timed out" in captured.err


### PR DESCRIPTION
## Summary
- add a `potpie` console script for local development workflows
- support `start`, `stop`, `status`, and `health` commands
- add unit tests for command dispatch and health output/error handling

## Bounty
/claim #224

## Test plan
- `PYTHONPYCACHEPREFIX=/private/tmp/python-cache python3 -m py_compile potpie_cli.py tests/unit/test_cli.py`
- `PYTHONPATH=. python3 potpie_cli.py --help`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a potpie CLI to manage local stacks with start, stop, status and health-check commands. Health-check accepts --api-url (default http://localhost:8001) and --timeout, validates inputs, returns success/failure exit codes, and prints pretty JSON, raw body, or a fixed healthy message.

* **Packaging**
  * Added a console entry so the potpie CLI is installable as a command-line tool.

* **Tests**
  * Added unit tests covering start/stop/status flows and health-check success, timeouts, and validation errors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/potpie-ai/potpie/pull/772)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->