### PR TITLE
test: simulate user-repos payload mismatch + add WARN diagnostics for debugger demos

### DIFF
--- a/app/modules/code_provider/github/github_router.py
+++ b/app/modules/code_provider/github/github_router.py
@@ -78,26 +78,12 @@ async def get_user_repos(
     total_count = len(repos)
     paginated_repos = repos[offset : offset + limit] if limit is not None else repos[offset:]
     has_next_page = (offset + (limit or total_count)) < total_count
-    sample_full_names = [
-        fn
-        for r in paginated_repos[:10]
-        if isinstance(r, dict) and (fn := r.get("full_name"))
-    ]
-    logger.warning(
-        "github_user_repos_response",
-        path="/api/v1/github/user-repos",
-        pagination_offset=offset,
-        pagination_limit=limit,
-        page_repo_count=len(paginated_repos),
-        total_matching_repos=total_count,
-        has_next_page=has_next_page,
-        user_id=user.get("user_id"),
-        search=search if search else None,
-        payload_top_level_keys=["github_repositories", "has_next_page", "total_count"],
-        sample_repo_full_names=sample_full_names,
-    )
+    if paginated_repos:
+        primary = paginated_repos[0]
+        if isinstance(primary, dict):
+            _ = primary["repo_full_name"]
     return {
-        "github_repositories": paginated_repos,
+        "repositories": paginated_repos,
         "has_next_page": has_next_page,
         "total_count": total_count,
     }

--- a/app/modules/code_provider/github/github_router.py
+++ b/app/modules/code_provider/github/github_router.py
@@ -7,8 +7,10 @@ from app.core.database import get_async_db, get_db
 from app.modules.auth.auth_service import AuthService
 from app.modules.code_provider.code_provider_controller import CodeProviderController
 from app.modules.utils.APIRouter import APIRouter
+from app.modules.utils.logger import setup_logger
 
 router = APIRouter()
+logger = setup_logger(__name__)
 
 
 @router.get("/github/user-repos")
@@ -64,17 +66,38 @@ async def get_user_repos(
             # Re-raise HTTP exceptions (e.g., query too long)
             raise
         except Exception as e:
-            from app.modules.utils.logger import setup_logger
-            logger = setup_logger(__name__)
-            logger.warning(f"Error filtering repositories: {str(e)}")
+            logger.warning(
+                "github_user_repos_search_filter_failed",
+                error=str(e),
+                search=search,
+                user_id=user.get("user_id"),
+            )
 
     # Pagination: offset applied regardless of limit; always return same structure
     repos = user_repo_list["repositories"]
     total_count = len(repos)
     paginated_repos = repos[offset : offset + limit] if limit is not None else repos[offset:]
     has_next_page = (offset + (limit or total_count)) < total_count
+    sample_full_names = [
+        fn
+        for r in paginated_repos[:10]
+        if isinstance(r, dict) and (fn := r.get("full_name"))
+    ]
+    logger.warning(
+        "github_user_repos_response",
+        path="/api/v1/github/user-repos",
+        pagination_offset=offset,
+        pagination_limit=limit,
+        page_repo_count=len(paginated_repos),
+        total_matching_repos=total_count,
+        has_next_page=has_next_page,
+        user_id=user.get("user_id"),
+        search=search if search else None,
+        payload_top_level_keys=["github_repositories", "has_next_page", "total_count"],
+        sample_repo_full_names=sample_full_names,
+    )
     return {
-        "repositories": paginated_repos,
+        "github_repositories": paginated_repos,
         "has_next_page": has_next_page,
         "total_count": total_count,
     }


### PR DESCRIPTION
**Summary** 
 Intentionally dereference primary["repo_full_name"] after pagination when
  paginated_repos is non-empty. GitHub payloads use "full_name", so this raises
  KeyError → 500 from GET /api/v1/github/user-repos and a full ASGI traceback in
  logs. Users with zero repos are unaffected.
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error logging and reporting for repository search operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/potpie-ai/potpie/pull/775)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->