### PR TITLE
feat: add local development CLI

### DIFF
--- a/potpie/cli.py
+++ b/potpie/cli.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import signal
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
@@ -23,6 +25,12 @@ app = typer.Typer(
 STATE_DIR = Path(".potpie")
 PID_FILE = STATE_DIR / "potpie.pid"
 LOG_FILE = STATE_DIR / "potpie.log"
+
+
+@dataclass(frozen=True)
+class TrackedProcess:
+    pid: int
+    command: list[str]
 
 
 def _run(coro):
@@ -45,11 +53,27 @@ def _repo_name_from_path(repo_path: Path) -> str:
     return f"{parent}/{repo_path.name}"
 
 
-def _read_pid() -> Optional[int]:
+def _read_tracked_process() -> Optional[TrackedProcess]:
     try:
-        return int(PID_FILE.read_text().strip())
-    except (FileNotFoundError, ValueError):
+        content = PID_FILE.read_text().strip()
+    except FileNotFoundError:
         return None
+
+    try:
+        data = json.loads(content)
+        return TrackedProcess(pid=int(data["pid"]), command=list(data["command"]))
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        try:
+            return TrackedProcess(pid=int(content), command=["make", "dev"])
+        except ValueError:
+            return None
+
+
+def _read_pid() -> Optional[int]:
+    tracked_process = _read_tracked_process()
+    if tracked_process is None:
+        return None
+    return tracked_process.pid
 
 
 def _is_running(pid: int) -> bool:
@@ -60,6 +84,22 @@ def _is_running(pid: int) -> bool:
     except PermissionError:
         return True
     return True
+
+
+def _matches_tracked_process(tracked_process: TrackedProcess) -> bool:
+    if not _is_running(tracked_process.pid):
+        return False
+
+    try:
+        command = subprocess.check_output(
+            ["ps", "-p", str(tracked_process.pid), "-o", "command="],
+            text=True,
+        ).strip()
+    except (subprocess.SubprocessError, OSError):
+        return False
+
+    expected = " ".join(tracked_process.command)
+    return expected in command
 
 
 @app.command()
@@ -88,7 +128,9 @@ def start(
         stderr=subprocess.STDOUT,
         start_new_session=True,
     )
-    PID_FILE.write_text(f"{process.pid}\n")
+    PID_FILE.write_text(
+        json.dumps({"pid": process.pid, "command": command}) + "\n"
+    )
 
     typer.echo(f"Started Potpie with PID {process.pid}.")
     typer.echo("Logs: .potpie/potpie.log")
@@ -97,10 +139,13 @@ def start(
 @app.command()
 def stop():
     """Stop local Potpie services started by `potpie start`."""
-    pid = _read_pid()
-    if pid and _is_running(pid):
-        os.killpg(pid, signal.SIGTERM)
-        typer.echo(f"Stopped Potpie process group for PID {pid}.")
+    tracked_process = _read_tracked_process()
+    if tracked_process and _matches_tracked_process(tracked_process):
+        try:
+            os.killpg(tracked_process.pid, signal.SIGTERM)
+            typer.echo(f"Stopped Potpie process group for PID {tracked_process.pid}.")
+        except ProcessLookupError:
+            typer.echo("No tracked Potpie process is running.")
     else:
         typer.echo("No tracked Potpie process is running.")
 

--- a/potpie/cli.py
+++ b/potpie/cli.py
@@ -111,9 +111,9 @@ def start(
     ),
 ):
     """Start local Potpie services in the background."""
-    existing_pid = _read_pid()
-    if existing_pid and _is_running(existing_pid):
-        typer.echo(f"Potpie is already running with PID {existing_pid}.")
+    tracked_process = _read_tracked_process()
+    if tracked_process and _matches_tracked_process(tracked_process):
+        typer.echo(f"Potpie is already running with PID {tracked_process.pid}.")
         return
 
     STATE_DIR.mkdir(exist_ok=True)
@@ -121,13 +121,13 @@ def start(
     if sandbox:
         command.append(f"SANDBOX={sandbox}")
 
-    log_file = LOG_FILE.open("a")
-    process = subprocess.Popen(
-        command,
-        stdout=log_file,
-        stderr=subprocess.STDOUT,
-        start_new_session=True,
-    )
+    with LOG_FILE.open("a") as log_file:
+        process = subprocess.Popen(
+            command,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
     PID_FILE.write_text(
         json.dumps({"pid": process.pid, "command": command}) + "\n"
     )
@@ -161,9 +161,9 @@ def stop():
 @app.command()
 def status():
     """Show whether a tracked local Potpie process is running."""
-    pid = _read_pid()
-    if pid and _is_running(pid):
-        typer.echo(f"Potpie is running with PID {pid}.")
+    tracked_process = _read_tracked_process()
+    if tracked_process and _matches_tracked_process(tracked_process):
+        typer.echo(f"Potpie is running with PID {tracked_process.pid}.")
         typer.echo("API: http://localhost:8001")
         return
     typer.echo("Potpie is not running.")
@@ -279,6 +279,8 @@ def chat(
 
                 if query.strip() in {"/exit", "/quit"}:
                     break
+                if not query.strip():
+                    continue
 
                 ctx = ChatContext(
                     project_id=project.id,

--- a/potpie/cli.py
+++ b/potpie/cli.py
@@ -1,0 +1,263 @@
+"""Command-line interface for local Potpie development."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from potpie import PotpieRuntime
+from potpie.agents import ChatContext
+from potpie.types.project import ProjectStatus
+
+app = typer.Typer(
+    help="Run and use Potpie locally.",
+    no_args_is_help=True,
+)
+
+STATE_DIR = Path(".potpie")
+PID_FILE = STATE_DIR / "potpie.pid"
+LOG_FILE = STATE_DIR / "potpie.log"
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _ensure_repo_path(repo_path: Path) -> Path:
+    resolved = repo_path.expanduser().resolve()
+    if not resolved.exists():
+        raise typer.BadParameter(f"Repository path does not exist: {resolved}")
+    if not resolved.is_dir():
+        raise typer.BadParameter(f"Repository path is not a directory: {resolved}")
+    if not (resolved / ".git").exists():
+        raise typer.BadParameter(f"Repository path is not a Git repository: {resolved}")
+    return resolved
+
+
+def _repo_name_from_path(repo_path: Path) -> str:
+    parent = repo_path.parent.name or "local"
+    return f"{parent}/{repo_path.name}"
+
+
+def _read_pid() -> Optional[int]:
+    try:
+        return int(PID_FILE.read_text().strip())
+    except (FileNotFoundError, ValueError):
+        return None
+
+
+def _is_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+@app.command()
+def start(
+    sandbox: Optional[str] = typer.Option(
+        None,
+        "--sandbox",
+        help="Sandbox mode passed to make dev: local, docker, or daytona.",
+    ),
+):
+    """Start local Potpie services in the background."""
+    existing_pid = _read_pid()
+    if existing_pid and _is_running(existing_pid):
+        typer.echo(f"Potpie is already running with PID {existing_pid}.")
+        return
+
+    STATE_DIR.mkdir(exist_ok=True)
+    command = ["make", "dev"]
+    if sandbox:
+        command.append(f"SANDBOX={sandbox}")
+
+    log_file = LOG_FILE.open("a")
+    process = subprocess.Popen(
+        command,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    PID_FILE.write_text(f"{process.pid}\n")
+
+    typer.echo(f"Started Potpie with PID {process.pid}.")
+    typer.echo("Logs: .potpie/potpie.log")
+
+
+@app.command()
+def stop():
+    """Stop local Potpie services started by `potpie start`."""
+    pid = _read_pid()
+    if pid and _is_running(pid):
+        os.killpg(pid, signal.SIGTERM)
+        typer.echo(f"Stopped Potpie process group for PID {pid}.")
+    else:
+        typer.echo("No tracked Potpie process is running.")
+
+    if PID_FILE.exists():
+        PID_FILE.unlink()
+
+    subprocess.run(["make", "infra-down"], check=False)
+
+
+@app.command()
+def status():
+    """Show whether a tracked local Potpie process is running."""
+    pid = _read_pid()
+    if pid and _is_running(pid):
+        typer.echo(f"Potpie is running with PID {pid}.")
+        typer.echo("API: http://localhost:8001")
+        return
+    typer.echo("Potpie is not running.")
+
+
+@app.command(name="agents")
+def list_agents():
+    """List available system agents."""
+
+    async def _list_agents():
+        async with PotpieRuntime.from_env() as runtime:
+            for agent in runtime.agents.list_agents():
+                typer.echo(f"{agent.id}\t{agent.name}")
+
+    _run(_list_agents())
+
+
+@app.command()
+def parse(
+    repo_path: Path = typer.Argument(..., help="Path to the local Git repository."),
+    branch: str = typer.Option("main", "--branch", "-b", help="Branch to parse."),
+    user_id: Optional[str] = typer.Option(
+        None,
+        "--user-id",
+        help="User id for the local runtime. Defaults to config default_user_id.",
+    ),
+    user_email: Optional[str] = typer.Option(
+        None,
+        "--user-email",
+        help="User email for the local runtime. Defaults to config default_user_email.",
+    ),
+):
+    """Register and parse a local repository, then print the project id."""
+    resolved_path = _ensure_repo_path(repo_path)
+
+    async def _parse():
+        async with PotpieRuntime.from_env() as runtime:
+            effective_user_id = user_id or runtime.config.default_user_id
+            effective_user_email = user_email or runtime.config.default_user_email
+            repo_name = _repo_name_from_path(resolved_path)
+
+            existing = await runtime.projects.get_by_repo(
+                repo_name=repo_name,
+                branch_name=branch,
+                user_id=effective_user_id,
+                repo_path=str(resolved_path),
+            )
+            if existing is None:
+                project_id = await runtime.projects.register(
+                    repo_name=repo_name,
+                    branch_name=branch,
+                    user_id=effective_user_id,
+                    repo_path=str(resolved_path),
+                )
+                typer.echo(f"Registered project: {project_id}")
+            else:
+                project_id = existing.id
+                typer.echo(f"Using existing project: {project_id}")
+
+            typer.echo("Parsing repository...")
+            result = await runtime.parsing.parse_project(
+                project_id,
+                user_id=effective_user_id,
+                user_email=effective_user_email,
+            )
+            if not result.success:
+                typer.echo(f"Parsing failed: {result.error_message}", err=True)
+                raise typer.Exit(1)
+
+            typer.echo(f"Ready: {project_id}")
+
+    _run(_parse())
+
+
+@app.command()
+def chat(
+    project_id: str = typer.Argument(
+        ...,
+        help="Project id returned by `potpie parse`.",
+    ),
+    agent: str = typer.Option(
+        "codebase_qna_agent",
+        "--agent",
+        "-a",
+        help="Agent id to chat with.",
+    ),
+    branch: str = typer.Option("main", "--branch", "-b", help="Repository branch."),
+    user_id: Optional[str] = typer.Option(
+        None,
+        "--user-id",
+        help="User id for the local runtime. Defaults to config default_user_id.",
+    ),
+):
+    """Open an interactive chat with a Potpie agent."""
+
+    async def _chat():
+        async with PotpieRuntime.from_env() as runtime:
+            project = await runtime.projects.get(project_id)
+            if project is None:
+                raise typer.BadParameter(f"Project not found: {project_id}")
+
+            effective_user_id = user_id or runtime.config.default_user_id
+            agent_handle = runtime.agents.get(agent)
+            history: list[str] = []
+
+            typer.echo("Enter a message. Use Ctrl-D or /exit to quit.")
+            while True:
+                try:
+                    query = typer.prompt("you")
+                except (EOFError, KeyboardInterrupt):
+                    typer.echo()
+                    break
+
+                if query.strip() in {"/exit", "/quit"}:
+                    break
+
+                ctx = ChatContext(
+                    project_id=project.id,
+                    project_name=project.repo_name,
+                    curr_agent_id=agent,
+                    history=history,
+                    query=query,
+                    project_status=(
+                        project.status.value
+                        if isinstance(project.status, ProjectStatus)
+                        else str(project.status)
+                    ),
+                    user_id=effective_user_id,
+                    repository=project.repo_name,
+                    branch=branch,
+                    local_mode=True,
+                )
+                response = await agent_handle.query(ctx)
+                typer.echo(response.response)
+                history.extend([f"user: {query}", f"assistant: {response.response}"])
+
+    _run(_chat())
+
+
+def main():
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/potpie/cli.py
+++ b/potpie/cli.py
@@ -99,7 +99,7 @@ def _matches_tracked_process(tracked_process: TrackedProcess) -> bool:
         return False
 
     expected = " ".join(tracked_process.command)
-    return expected in command
+    return command == expected or command.startswith(expected + " ")
 
 
 @app.command()

--- a/potpie/cli.py
+++ b/potpie/cli.py
@@ -140,17 +140,20 @@ def start(
 def stop():
     """Stop local Potpie services started by `potpie start`."""
     tracked_process = _read_tracked_process()
-    if tracked_process and _matches_tracked_process(tracked_process):
+    if tracked_process is None:
+        typer.echo("No tracked Potpie process is running.")
+    elif not _matches_tracked_process(tracked_process):
+        typer.echo("No tracked Potpie process is running.")
+    else:
         try:
             os.killpg(tracked_process.pid, signal.SIGTERM)
             typer.echo(f"Stopped Potpie process group for PID {tracked_process.pid}.")
         except ProcessLookupError:
             typer.echo("No tracked Potpie process is running.")
-    else:
-        typer.echo("No tracked Potpie process is running.")
+        except PermissionError:
+            typer.echo(f"Permission denied while stopping PID {tracked_process.pid}.")
 
-    if PID_FILE.exists():
-        PID_FILE.unlink()
+    PID_FILE.unlink(missing_ok=True)
 
     subprocess.run(["make", "infra-down"], check=False)
 
@@ -270,7 +273,7 @@ def chat(
             while True:
                 try:
                     query = typer.prompt("you")
-                except (EOFError, KeyboardInterrupt):
+                except typer.Abort:
                     typer.echo()
                     break
 

--- a/potpie/cli.py
+++ b/potpie/cli.py
@@ -7,6 +7,7 @@ import json
 import os
 import signal
 import subprocess
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -102,6 +103,25 @@ def _matches_tracked_process(tracked_process: TrackedProcess) -> bool:
     return command == expected or command.startswith(expected + " ")
 
 
+def _is_process_group_running(pid: int) -> bool:
+    try:
+        os.killpg(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _wait_for_process_group_exit(pid: int, timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _is_process_group_running(pid):
+            return True
+        time.sleep(0.1)
+    return not _is_process_group_running(pid)
+
+
 @app.command()
 def start(
     sandbox: Optional[str] = typer.Option(
@@ -142,19 +162,37 @@ def stop():
     tracked_process = _read_tracked_process()
     if tracked_process is None:
         typer.echo("No tracked Potpie process is running.")
+        PID_FILE.unlink(missing_ok=True)
+        subprocess.run(["make", "infra-down"], check=False)
+        return
+
     elif not _matches_tracked_process(tracked_process):
         typer.echo("No tracked Potpie process is running.")
+        PID_FILE.unlink(missing_ok=True)
+        subprocess.run(["make", "infra-down"], check=False)
+        return
+
     else:
         try:
             os.killpg(tracked_process.pid, signal.SIGTERM)
-            typer.echo(f"Stopped Potpie process group for PID {tracked_process.pid}.")
         except ProcessLookupError:
             typer.echo("No tracked Potpie process is running.")
         except PermissionError:
-            typer.echo(f"Permission denied while stopping PID {tracked_process.pid}.")
+            typer.echo(
+                f"Permission denied while stopping PID {tracked_process.pid}.",
+                err=True,
+            )
+            raise typer.Exit(1)
+        else:
+            if not _wait_for_process_group_exit(tracked_process.pid):
+                typer.echo(
+                    f"Timed out while stopping PID {tracked_process.pid}.",
+                    err=True,
+                )
+                raise typer.Exit(1)
+            typer.echo(f"Stopped Potpie process group for PID {tracked_process.pid}.")
 
     PID_FILE.unlink(missing_ok=True)
-
     subprocess.run(["make", "infra-down"], check=False)
 
 
@@ -250,7 +288,12 @@ def chat(
         "-a",
         help="Agent id to chat with.",
     ),
-    branch: str = typer.Option("main", "--branch", "-b", help="Repository branch."),
+    branch: Optional[str] = typer.Option(
+        None,
+        "--branch",
+        "-b",
+        help="Optional branch override. Defaults to the project's branch.",
+    ),
     user_id: Optional[str] = typer.Option(
         None,
         "--user-id",
@@ -264,6 +307,13 @@ def chat(
             project = await runtime.projects.get(project_id)
             if project is None:
                 raise typer.BadParameter(f"Project not found: {project_id}")
+
+            project_branch = project.branch_name or branch or "main"
+            if branch and project.branch_name and branch != project.branch_name:
+                raise typer.BadParameter(
+                    f"Branch {branch!r} does not match project branch "
+                    f"{project.branch_name!r}."
+                )
 
             effective_user_id = user_id or runtime.config.default_user_id
             agent_handle = runtime.agents.get(agent)
@@ -295,7 +345,7 @@ def chat(
                     ),
                     user_id=effective_user_id,
                     repository=project.repo_name,
-                    branch=branch,
+                    branch=project_branch,
                     local_mode=True,
                 )
                 response = await agent_handle.query(ctx)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ potpie-integrations = { path = "app/src/integrations", editable = true }
 potpie-sandbox = { path = "app/src/sandbox", editable = true }
 
 [project.scripts]
+potpie = "potpie.cli:main"
 potpie-seed = "seed.cli:main"
 
 [dependency-groups]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 
 from typer.testing import CliRunner
 
@@ -38,7 +39,12 @@ def test_start_writes_pid_and_log_path(monkeypatch):
     with runner.isolated_filesystem():
         result = runner.invoke(app, ["start", "--sandbox", "local"])
         pid_file = Path(".potpie/potpie.pid")
+        log_file = Path(".potpie/potpie.log")
 
         assert result.exit_code == 0
-        assert pid_file.read_text() == "12345\n"
+        assert json.loads(pid_file.read_text()) == {
+            "pid": 12345,
+            "command": ["make", "dev", "SANDBOX=local"],
+        }
+        assert log_file.exists()
         assert "Started Potpie with PID 12345." in result.output

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from potpie.cli import app
+
+
+runner = CliRunner()
+
+
+def test_status_reports_not_running_in_empty_workspace():
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0
+    assert "Potpie is not running." in result.output
+
+
+def test_parse_rejects_non_git_directory(tmp_path: Path):
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+
+    result = runner.invoke(app, ["parse", str(repo_path)])
+
+    assert result.exit_code != 0
+    assert "not a Git repository" in result.output
+
+
+def test_start_writes_pid_and_log_path(monkeypatch):
+    class FakePopen:
+        def __init__(self, command, **kwargs):
+            self.command = command
+            self.kwargs = kwargs
+            self.pid = 12345
+
+    monkeypatch.setattr("potpie.cli.subprocess.Popen", FakePopen)
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["start", "--sandbox", "local"])
+        pid_file = Path(".potpie/potpie.pid")
+
+        assert result.exit_code == 0
+        assert pid_file.read_text() == "12345\n"
+        assert "Started Potpie with PID 12345." in result.output


### PR DESCRIPTION
## Summary
- Add a `potpie` CLI entrypoint for local development workflows.
- Support starting/stopping local services, checking status, listing agents, parsing a local repository, and chatting with an agent.
- Add lightweight unit tests for CLI status, repository validation, and start command pid handling.

## Testing
- `python3 -m py_compile potpie/cli.py tests/unit/test_cli.py`

Note: full pytest was not run locally because `uv`/`pytest` were not available in the local environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local CLI: start/stop/status a Potpie background service, persist state and combined logs, list available runtime agents, validate and parse local Git repositories, and run interactive chat sessions against a project. Also exposes a top-level potpie command.

* **Tests**
  * Added unit tests for key CLI flows (status, parse validation, start behavior).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/potpie-ai/potpie/pull/776)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->