### PR TITLE
add DebugAgent and debug_tools coverage

### DIFF
--- a/app/celery/celery_app.py
+++ b/app/celery/celery_app.py
@@ -18,6 +18,7 @@ if platform.system() == "Darwin":
         # Already set, which is fine
         pass
 
+from pathlib import Path
 from urllib.parse import urlparse, urlunparse
 
 from dotenv import load_dotenv
@@ -30,8 +31,13 @@ from app.modules.utils.logger import configure_logging, setup_logger
 from celery import Celery
 from celery.signals import worker_process_init, worker_process_shutdown
 
-# Load environment variables from a .env file if present
-load_dotenv()
+# Load .env from repo root so worker env is correct even when cwd is not the project directory
+# (e.g. IDE-launched Celery). Falls back to default dotenv search if file is missing.
+_repo_dotenv = Path(__file__).resolve().parents[2] / ".env"
+if _repo_dotenv.is_file():
+    load_dotenv(_repo_dotenv)
+else:
+    load_dotenv()
 
 # Configure logging
 configure_logging()

--- a/app/modules/conversations/conversation/conversation_controller.py
+++ b/app/modules/conversations/conversation/conversation_controller.py
@@ -120,11 +120,20 @@ class ConversationController:
             raise HTTPException(status_code=500, detail=str(e))
 
     async def post_message(
-        self, conversation_id: str, message: MessageRequest, stream: bool = True
+        self,
+        conversation_id: str,
+        message: MessageRequest,
+        stream: bool = True,
+        local_mode: bool = False,
     ) -> AsyncGenerator[ChatMessageResponse, None]:
         try:
             async for chunk in self.service.store_message(
-                conversation_id, message, MessageType.HUMAN, self.user_id, stream
+                conversation_id,
+                message,
+                MessageType.HUMAN,
+                self.user_id,
+                stream,
+                local_mode=local_mode,
             ):
                 yield chunk
         except ConversationNotFoundError as e:

--- a/app/modules/conversations/conversations_router.py
+++ b/app/modules/conversations/conversations_router.py
@@ -295,9 +295,10 @@ class ConversationAPI:
             controller = ConversationController(db, async_db, user_id, user_email)
 
             if not stream:
-                # Non-streaming behavior unchanged
+                # Non-streaming: must pass local_mode (VS Code extension User-Agent)
+                # so debugger/terminal tools are available to the agent.
                 message_stream = controller.post_message(
-                    conversation_id, message, stream
+                    conversation_id, message, stream, local_mode=local_mode
                 )
                 async for chunk in message_stream:
                     return chunk

--- a/app/modules/intelligence/agents/chat_agents/multi_agent/execution_flows.py
+++ b/app/modules/intelligence/agents/chat_agents/multi_agent/execution_flows.py
@@ -57,6 +57,9 @@ def init_managers(
     from app.modules.intelligence.tools.sandbox.context import (
         set_run_context as _set_sandbox_run_context,
     )
+    from app.modules.intelligence.tools.code_changes_manager.lifecycle import (
+        _init_code_changes_manager,
+    )
 
     _reset_todo_manager()
     _set_sandbox_run_context(
@@ -66,6 +69,16 @@ def init_managers(
         local_mode=local_mode,
     )
     _reset_requirement_manager()
+    # debug_* / tunnel helpers read user_id from code_changes_manager ContextVars.
+    _init_code_changes_manager(
+        conversation_id=conversation_id,
+        agent_id=agent_id,
+        user_id=user_id,
+        tunnel_url=tunnel_url,
+        local_mode=local_mode,
+        repository=repository,
+        branch=branch,
+    )
     logger.info(
         f"🔄 Initialized managers for agent run (conversation_id={conversation_id}, agent_id={agent_id}, user_id={user_id}, tunnel_url={tunnel_url})"
     )

--- a/app/modules/intelligence/agents/chat_agents/pydantic_agent.py
+++ b/app/modules/intelligence/agents/chat_agents/pydantic_agent.py
@@ -96,6 +96,33 @@ def handle_exception(tool_func):
     return wrapper
 
 
+def _sync_pydantic_rag_tool_runtime_context(ctx: ChatContext) -> None:
+    """Set ContextVars used by tunnel/debug tools via get_context_vars()."""
+    from app.modules.intelligence.tools.sandbox.context import (
+        set_run_context as _set_sandbox_run_context,
+    )
+    from app.modules.intelligence.tools.code_changes_manager.lifecycle import (
+        _init_code_changes_manager,
+    )
+
+    lm = bool(getattr(ctx, "local_mode", False))
+    _set_sandbox_run_context(
+        user_id=ctx.user_id,
+        conversation_id=ctx.conversation_id,
+        branch=getattr(ctx, "branch", None),
+        local_mode=lm,
+    )
+    _init_code_changes_manager(
+        conversation_id=ctx.conversation_id,
+        agent_id=ctx.curr_agent_id,
+        user_id=ctx.user_id,
+        tunnel_url=getattr(ctx, "tunnel_url", None),
+        local_mode=lm,
+        repository=getattr(ctx, "repository", None),
+        branch=getattr(ctx, "branch", None),
+    )
+
+
 class PydanticRagAgent(ChatAgent):
     def __init__(
         self,
@@ -609,16 +636,7 @@ CURRENT CONTEXT AND AGENT TASK OVERVIEW:
             f"Running pydantic-ai agent {'with multimodal support' if (ctx.has_images() or ctx.has_documents()) else ''}"
         )
 
-        from app.modules.intelligence.tools.sandbox.context import (
-            set_run_context as _set_sandbox_run_context,
-        )
-
-        _set_sandbox_run_context(
-            user_id=ctx.user_id,
-            conversation_id=ctx.conversation_id,
-            branch=getattr(ctx, "branch", None),
-            local_mode=ctx.local_mode if hasattr(ctx, "local_mode") else False,
-        )
+        _sync_pydantic_rag_tool_runtime_context(ctx)
 
         # Check if we have media and if the model supports vision/multimodal input
         has_multimodal_content = ctx.has_images() or ctx.has_documents()
@@ -717,6 +735,8 @@ CURRENT CONTEXT AND AGENT TASK OVERVIEW:
         logger.info(
             f"[PydanticRagAgent.run_stream] has_images={has_images}, has_documents={has_documents}, is_vision_model={is_vision}, model={self.llm_provider.chat_config.model}"
         )
+
+        _sync_pydantic_rag_tool_runtime_context(ctx)
 
         # Check if we have media and if the model supports vision
         if has_multimodal_content and is_vision:

--- a/app/modules/intelligence/agents/chat_agents/system_agents/debug_agent.py
+++ b/app/modules/intelligence/agents/chat_agents/system_agents/debug_agent.py
@@ -32,7 +32,13 @@ class DebugAgent(ChatAgent):
         self.llm_provider = llm_provider
         self.prompt_provider = prompt_provider
 
-    def _build_agent(self, ctx: Optional[ChatContext] = None) -> ChatAgent:
+    def _build_agent(
+        self, ctx: Optional[ChatContext] = None, local_mode: bool = False
+    ) -> ChatAgent:
+        task_prompt = debug_task_prompt
+        if local_mode:
+            task_prompt = debug_task_prompt + debug_tools_prompt_section
+
         agent_config = AgentConfig(
             role="Debugging and Code Analysis Specialist",
             goal="Provide comprehensive debugging solutions and code analysis by identifying root causes, tracing code flows, and delivering precise fixes. For general queries, maintain a conversational approach while grounding responses in code context.",
@@ -48,7 +54,7 @@ class DebugAgent(ChatAgent):
                 """,
             tasks=[
                 TaskConfig(
-                    description=debug_task_prompt,
+                    description=task_prompt,
                     expected_output="Markdown formatted chat response to user's query grounded in provided code context and tool results. For debugging tasks, includes root cause analysis, fix location rationale, and implementation details.",
                 )
             ],
@@ -91,6 +97,35 @@ class DebugAgent(ChatAgent):
             ],
             exclude_embedding_tools=exclude_embedding_tools,
         )
+
+        if local_mode:
+            debug_tool_names = [
+                "debug_start",
+                "debug_stop",
+                "debug_set_breakpoints",
+                "debug_snapshot",
+                "debug_step_into",
+                "debug_step_out",
+                "debug_step_over",
+                "debug_continue",
+                "debug_select_frame",
+                "debug_list_sessions",
+                "execute_terminal_command",
+                "search_text",
+                "search_files",
+            ]
+            extra = self.tools_provider.get_tools(
+                debug_tool_names,
+                exclude_embedding_tools=exclude_embedding_tools,
+            )
+            got = {getattr(t, "name", None) for t in extra}
+            missing = [n for n in debug_tool_names if n not in got]
+            if missing:
+                logger.warning(
+                    "DebugAgent local_mode: requested tools missing from ToolService — {}",
+                    missing,
+                )
+            tools.extend(extra)
 
         supports_pydantic = self.llm_provider.supports_pydantic("chat")
         should_use_multi = MultiAgentConfig.should_use_multi_agent("debugging_agent")
@@ -148,14 +183,67 @@ class DebugAgent(ChatAgent):
 
     async def run(self, ctx: ChatContext) -> ChatAgentResponse:
         ctx = await self._enriched_context(ctx)
-        return await self._build_agent(ctx).run(ctx)
+        local_mode = bool(getattr(ctx, "local_mode", False))
+        return await self._build_agent(ctx, local_mode=local_mode).run(ctx)
 
     async def run_stream(
         self, ctx: ChatContext
     ) -> AsyncGenerator[ChatAgentResponse, None]:
         ctx = await self._enriched_context(ctx)
-        async for chunk in self._build_agent(ctx).run_stream(ctx):
+        local_mode = bool(getattr(ctx, "local_mode", False))
+        async for chunk in self._build_agent(ctx, local_mode=local_mode).run_stream(
+            ctx
+        ):
             yield chunk
+
+
+
+debug_tools_prompt_section = """
+---
+
+## DEBUGGER TOOLS (available in VS Code local mode)
+
+You have access to a full interactive debugger through the VS Code extension. These tools
+let you inspect RUNTIME state — variable values, call stacks, and expression evaluation —
+which is often essential for bugs that cannot be found by reading code alone.
+
+### When to Use the Debugger
+
+Use the debugger when:
+- The bug involves incorrect runtime values (wrong calculation, unexpected None, type mismatch)
+- Static analysis of code is insufficient to determine the root cause
+- You need to verify your hypothesis about variable state at a specific point
+- The code path is complex with multiple branches and you need to confirm which path executes
+
+Do NOT use the debugger when:
+- The bug is clearly a syntax or structural issue visible in the code
+- You already have enough context from static analysis tools
+
+### Debugger Workflow
+
+1. **Reproduce first**: Use `execute_terminal_command` to run the program normally and see the buggy output
+2. **Set strategic breakpoints**: Use `debug_set_breakpoints` at locations where you suspect the bug manifests
+3. **Start debug session**: Use `debug_start` to launch the program under the debugger
+4. **Capture state**: Use `debug_snapshot` (with wait=True) to run to the first breakpoint and capture
+   the call stack, local variables, and any expressions you want to evaluate
+5. **Analyze**: Compare actual variable values to expected values
+6. **Navigate**: Use `debug_step_over`, `debug_step_into`, `debug_step_out` to trace execution line-by-line
+7. **Inspect frames**: Use `debug_select_frame` to look at variables in caller functions
+8. **Continue**: Use `debug_continue` to run to the next breakpoint
+9. **Clean up**: Always call `debug_stop` when done
+
+### Key Principles
+
+- `debug_snapshot` is your primary inspection tool — it bundles stack trace + locals + expression
+  evaluation into one call
+- After every step (step_into, step_over, step_out), you automatically get a snapshot back
+- Set breakpoints BEFORE starting the debug session
+- Use the `expressions` parameter of `debug_snapshot` to evaluate arbitrary expressions in the
+  current scope (e.g., `len(items)`, `user.email`, `type(result)`)
+- Always clean up: call `debug_stop` when your investigation is complete
+- If the program finishes without hitting a breakpoint, `debug_snapshot` will time out —
+  reconsider your breakpoint placement
+"""
 
 
 debug_task_prompt = """

--- a/app/modules/intelligence/agents/chat_agents/system_agents/debug_agent.py
+++ b/app/modules/intelligence/agents/chat_agents/system_agents/debug_agent.py
@@ -35,9 +35,7 @@ class DebugAgent(ChatAgent):
     def _build_agent(
         self, ctx: Optional[ChatContext] = None, local_mode: bool = False
     ) -> ChatAgent:
-        task_prompt = debug_task_prompt
-        if local_mode:
-            task_prompt = debug_task_prompt + debug_tools_prompt_section
+        task_prompt = debug_local_task_prompt if local_mode else debug_task_prompt
 
         agent_config = AgentConfig(
             role="Debugging and Code Analysis Specialist",
@@ -113,6 +111,14 @@ class DebugAgent(ChatAgent):
                 "execute_terminal_command",
                 "search_text",
                 "search_files",
+                "parse_debug_signal",
+                "build_debug_context",
+                "find_related_tests",
+                "add_watch",
+                "remove_watch",
+                "list_watches",
+                "debug_list_launch_configs",
+                "debug_list_adapters",
             ]
             extra = self.tools_provider.get_tools(
                 debug_tool_names,
@@ -198,51 +204,265 @@ class DebugAgent(ChatAgent):
 
 
 
-debug_tools_prompt_section = """
+debug_local_task_prompt = """
+# VS Code Debug Agent — Hypothesis-Driven Workflow
+
+You are running in **local mode** with access to the VS Code interactive debugger.
+Your job is to take a pasted log, stack trace, failed test, or symptom description,
+form concrete hypotheses, validate each one with the debugger, and deliver a minimal
+evidence-backed fix.
+
 ---
 
-## DEBUGGER TOOLS (available in VS Code local mode)
+## CONVERSATIONAL FOLLOW-UP
 
-You have access to a full interactive debugger through the VS Code extension. These tools
-let you inspect RUNTIME state — variable values, call stacks, and expression evaluation —
-which is often essential for bugs that cannot be found by reading code alone.
+If the user is asking a follow-up question about a finding you already explained in this
+conversation, answer conversationally using available code navigation tools
+(`get_code_from_probable_node_name`, `ask_knowledge_graph_queries`, `fetch_file`, etc.).
+Do not restart the full debugging workflow.
 
-### When to Use the Debugger
+---
 
-Use the debugger when:
-- The bug involves incorrect runtime values (wrong calculation, unexpected None, type mismatch)
-- Static analysis of code is insufficient to determine the root cause
-- You need to verify your hypothesis about variable state at a specific point
-- The code path is complex with multiple branches and you need to confirm which path executes
+## DEBUGGING WORKFLOW
 
-Do NOT use the debugger when:
-- The bug is clearly a syntax or structural issue visible in the code
-- You already have enough context from static analysis tools
+If the user pastes a log, stack trace, failed test output, or describes a broken behavior,
+follow every step below **in order**. Do not skip steps.
 
-### Debugger Workflow
+---
 
-1. **Reproduce first**: Use `execute_terminal_command` to run the program normally and see the buggy output
-2. **Set strategic breakpoints**: Use `debug_set_breakpoints` at locations where you suspect the bug manifests
-3. **Start debug session**: Use `debug_start` to launch the program under the debugger
-4. **Capture state**: Use `debug_snapshot` (with wait=True) to run to the first breakpoint and capture
-   the call stack, local variables, and any expressions you want to evaluate
-5. **Analyze**: Compare actual variable values to expected values
-6. **Navigate**: Use `debug_step_over`, `debug_step_into`, `debug_step_out` to trace execution line-by-line
-7. **Inspect frames**: Use `debug_select_frame` to look at variables in caller functions
-8. **Continue**: Use `debug_continue` to run to the next breakpoint
-9. **Clean up**: Always call `debug_stop` when done
+### Step 0 — Parse the Signal
 
-### Key Principles
+Call `parse_debug_signal` with the full user input text.
 
-- `debug_snapshot` is your primary inspection tool — it bundles stack trace + locals + expression
-  evaluation into one call
-- After every step (step_into, step_over, step_out), you automatically get a snapshot back
-- Set breakpoints BEFORE starting the debug session
-- Use the `expressions` parameter of `debug_snapshot` to evaluate arbitrary expressions in the
-  current scope (e.g., `len(items)`, `user.email`, `type(result)`)
-- Always clean up: call `debug_stop` when your investigation is complete
+This extracts:
+- `signal_type`: `pasted_log | stack_trace | failed_test | natural_language`
+- `stack_frames[]`: `{file, line, symbol}` from Python / Node / Go / Java traces
+- `error_signature`: top-level error class or code
+- `request_id`, `correlation_id`, `trace_id` if present
+- For failed tests: `expected`, `actual`, `test_path`
+
+If the signal is `natural_language` only (no frames extracted), note that and proceed
+with code navigation in Step 1.
+
+---
+
+### Step 1 — Build Debug Context
+
+Call `build_debug_context` with the parsed signal from Step 0.
+
+It returns:
+- `source_locations[]` — candidate files with `reason` and `confidence` (`high/medium/low`)
+- `related_tests[]` — test files that cover the suspect code
+- `recent_changes[]` — git log + diff for suspect files over the last 7 days
+- `launch_configs[]` — available VS Code launch.json configurations
+- `debug_capabilities` — which debug adapters (python/node/go) are available
+
+Use this context to decide which launch config to use and which adapter to start.
+
+---
+
+### Step 2 — Reproduce the Failure
+
+Run the failing command or test via `execute_terminal_command` and capture the baseline output.
+
+- Record the **exact** exit code, stdout tail, and error message. This is your baseline.
+- If you cannot reproduce the failure: tell the user immediately and ask for the reproduction
+  command. Do **not** proceed to hypothesis generation until you have a confirmed reproduction.
+
+---
+
+### Step 3 — Generate Ranked Hypotheses
+
+Emit **2–4 ranked hypotheses** in the schema below. This is mandatory output. Every
+hypothesis must be a complete, falsifiable claim about root cause — not a vague description.
+
+Use the following exact markdown format:
+
+```
+### Hypothesis 1: <short falsifiable claim>
+Status: proposed
+Evidence:
+- <static evidence from code/git/test context>
+Validation plan:
+- Breakpoints: <file:line> (<why this location>)
+- Watches: <expression>, <expression>
+- Conditional breakpoint: <file:line> when <condition> (if narrowing by request id / value)
+- Re-run: <command>
+```
+
+Allowed `Status` values: `proposed | debugging | needs_evidence | supported | rejected | fix_proposed | validated`
+
+Rank hypotheses by likelihood. Lead with the one most directly indicated by the stack frames
+and static code evidence. Include the weakest hypothesis last so the user sees the full
+possibility space.
+
+---
+
+### Step 4 — Validate Top Hypothesis with the Debugger
+
+**Exact tool call order (do not deviate):**
+
+1. `debug_start` — launch with the selected launch config (choose `python`/`node`/`go` per `debug_capabilities`)
+2. `debug_set_breakpoints` — set all breakpoints from the hypothesis Validation plan.
+   Use the `condition` field when the hypothesis is about a specific request id or value.
+3. `add_watch` — register all watch expressions from the hypothesis Validation plan.
+   These are automatically injected into every snapshot from this point on.
+4. Re-run via `execute_terminal_command` (the same command from Step 2) OR
+   let the already-launched debug session reach the breakpoints naturally.
+5. `debug_snapshot(wait=True)` — run to the first breakpoint, capture stack + locals +
+   watch expression results.
+
+**Why this order matters**: `configurationDone` is deferred until the first
+`debug_snapshot(wait=True)` call. Setting breakpoints before that call ensures they are
+registered before the program starts running.
+
+After each snapshot:
+- Append an **Evidence bullet** to the active hypothesis block:
+  ```
+  Evidence:
+  - Breakpoint hit at paymentAdapter.ts:42 — observed error.constructor.name == 'PaymentTimeoutError'
+  ```
+- Update `Status: debugging`
+- Decide: supported / rejected / needs_evidence (see Step 5 / 6)
+
+Use `debug_step_over`, `debug_step_into`, `debug_step_out` to trace line-by-line when a
+single snapshot is not enough. Each step automatically returns a fresh snapshot with your
+persistent watch expressions included.
+
+Use `debug_select_frame` to inspect caller variables when the bug may originate upstream.
+
+---
+
+### Step 5 — Rejection Loop
+
+If debugger evidence **contradicts** the hypothesis:
+
+1. Update `Status: rejected` and write the contradicting evidence bullet.
+2. Call `debug_continue` or let execution finish, then start validating the next hypothesis
+   (go back to Step 4 for Hypothesis N+1).
+3. If all hypotheses are rejected, call `debug_stop`, then revisit Step 3 with new
+   hypotheses informed by what the debugger revealed.
+
+---
+
+### Step 6 — Needs-Evidence Branch
+
+If the debugger **cannot confirm or deny** a hypothesis (e.g., the breakpoint is never hit,
+config values look correct, or the failure only occurs with a specific payload):
+
+1. Update `Status: needs_evidence`
+2. Propose one or both of:
+
+   **Option A — Conditional breakpoint:**
+   ```
+   Suggested: add conditional breakpoint at chargeCard.ts:42 when request_id == "req_456"
+   Reason: only the failing request triggers the timeout path
+   ```
+
+   **Option B — Temporary log diff:**
+   ```diff
+   + logger.debug("payment retry config", { timeoutMs, retryCount, provider: provider.name });
+   ```
+   Show this as a diff. Do **not** auto-apply it — ask the user to approve insertion,
+   then offer to remove or convert to permanent logging after rerun.
+
+3. Once additional evidence is gathered (conditional breakpoint hits, or log output observed),
+   return to Step 4 and update hypothesis status accordingly.
+
+---
+
+### Step 7 — Propose Minimal Fix
+
+Once a hypothesis is `supported`:
+
+1. Update `Status: fix_proposed`
+2. Emit a minimal fix tied **directly to the debugger evidence**:
+   ```
+   Proposed fix: In src/checkout/createOrder.ts, map PaymentTimeoutError to a controlled
+   payment failure response.
+   Why: debugger showed chargeCard throws PaymentTimeoutError at line 42 (captured in snapshot).
+        createOrder error handler at line 88 does not catch this type — it escapes as a 500.
+   ```
+3. Show a diff:
+   ```diff
+    try {
+      const paymentResult = await chargeCard(order.payment);
+      return createSuccessResponse(paymentResult);
+    } catch (error) {
+   +  if (error instanceof PaymentTimeoutError) {
+   +    return createPaymentFailureResponse("payment_timeout");
+   +  }
+      throw error;
+    }
+   ```
+
+**Important**: Keep the fix minimal and evidence-backed. Do not generalise into a full
+refactor or "fix all similar patterns" unless the debugger explicitly revealed multiple
+broken paths. Flag broader concerns as a separate follow-up note.
+
+---
+
+### Step 8 — Validate the Fix and Clean Up
+
+1. Rerun the exact command from Step 2 (`execute_terminal_command`).
+2. Write a before/after block in markdown:
+   ```
+   Before fix:
+   - exit code: 1
+   - output tail: "PaymentTimeoutError: timeout after 30s"
+
+   After fix:
+   - exit code: 0
+   - output tail: "checkout returned: {status: 'payment_timeout'}"
+   ```
+3. Update the hypothesis to `Status: validated`
+4. Call `debug_stop` to clean up the debug session.
+5. Emit a brief **Evidence Trail Summary**:
+   - Signal → Hypothesis → Debugger evidence → Fix → Validation result
+
+---
+
+## Debugger Tool Reference
+
+### Tool call order
+```
+debug_start → debug_set_breakpoints → [add_watch] → execute_terminal_command → debug_snapshot(wait=True)
+```
+Then navigate with `debug_step_over / into / out`, inspect callers with `debug_select_frame`,
+continue to next breakpoint with `debug_continue`.
+
+Always end with `debug_stop`.
+
+### Key principles
+
+- `debug_snapshot` is your primary inspection tool — call it explicitly or receive it
+  automatically after every step.
+- Set breakpoints **before** calling `debug_snapshot(wait=True)` for the first time.
+- Use `condition` in `debug_set_breakpoints` to narrow to a specific request id or value.
+- Persistent watches registered with `add_watch` are auto-included in every snapshot.
+  Use `list_watches` to see the current watch list. Remove stale watches with `remove_watch`.
 - If the program finishes without hitting a breakpoint, `debug_snapshot` will time out —
-  reconsider your breakpoint placement
+  reconsider breakpoint placement and recheck the reproduction command.
+
+### Code navigation (available alongside debugger tools)
+
+Use these freely at any step:
+- `ask_knowledge_graph_queries` — find where a class/function lives
+- `get_code_from_probable_node_name` — fetch a specific symbol
+- `fetch_file` / `fetch_files_batch` — read full files or line ranges
+- `get_node_neighbours_from_node_id` — find callers/callees
+- `sandbox_git` — `git log`, `git diff`, `git blame` for change correlation
+- `sandbox_search` (`rg`) — text search across codebase
+
+---
+
+## Response Formatting
+
+- Use markdown throughout.
+- Format file paths without project root prefix: `src/payments/paymentAdapter.ts`, not absolute.
+- Always show the hypothesis block with its current `Status` when updating it.
+- Code diffs must use ` ```diff ` blocks.
+- Keep prose tight — evidence bullets over paragraphs.
 """
 
 

--- a/app/modules/intelligence/agents/chat_agents/tool_helpers.py
+++ b/app/modules/intelligence/agents/chat_agents/tool_helpers.py
@@ -182,6 +182,32 @@ def get_tool_run_message(tool_name: str, args: Dict[str, Any] | None = None):
                     mode_text = f" ({mode} mode)" if mode == "async" else ""
                     return f"run: {display_cmd}{mode_text}"
             return "running command"
+        case "debug_start":
+            return "Starting debug session"
+        case "debug_stop":
+            return "Stopping debug session"
+        case "debug_set_breakpoints":
+            fp = args.get("file") if args else None
+            return f"Setting breakpoints in {fp}" if fp else "Setting breakpoints"
+        case "debug_snapshot":
+            return "Capturing debug snapshot"
+        case "debug_step_into":
+            return "Stepping into function"
+        case "debug_step_out":
+            return "Stepping out"
+        case "debug_step_over":
+            return "Stepping over line"
+        case "debug_continue":
+            return "Continuing debug session"
+        case "debug_select_frame":
+            idx = args.get("frame_index") if args else None
+            return (
+                f"Inspecting stack frame #{idx}"
+                if idx is not None
+                else "Inspecting stack frame"
+            )
+        case "debug_list_sessions":
+            return "Listing debug sessions"
         case "read_todos":
             return "Reading todo list"
         case "write_todos":
@@ -857,6 +883,22 @@ def get_tool_response_message(
                 )
                 return f"Terminal command executed successfully: {display_cmd}{mode_text}{result_suffix}"
             return "Terminal command executed successfully"
+        case (
+            "debug_start"
+            | "debug_stop"
+            | "debug_set_breakpoints"
+            | "debug_snapshot"
+            | "debug_step_into"
+            | "debug_step_out"
+            | "debug_step_over"
+            | "debug_continue"
+            | "debug_select_frame"
+            | "debug_list_sessions"
+        ):
+            if isinstance(result, str):
+                preview = result[:200] + ("..." if len(result) > 200 else "")
+                return f"Debug tool finished ({preview})"
+            return "Debug tool finished"
         case "add_todo":
             content = args.get("content") if args else None
             if content:

--- a/app/modules/intelligence/agents/chat_agents/tool_helpers.py
+++ b/app/modules/intelligence/agents/chat_agents/tool_helpers.py
@@ -208,6 +208,30 @@ def get_tool_run_message(tool_name: str, args: Dict[str, Any] | None = None):
             )
         case "debug_list_sessions":
             return "Listing debug sessions"
+        case "debug_list_launch_configs":
+            return "Listing launch configurations"
+        case "debug_list_adapters":
+            return "Detecting debug adapters"
+        case "parse_debug_signal":
+            return "Parsing debug signal"
+        case "build_debug_context":
+            return "Building debug context"
+        case "find_related_tests":
+            fp = args.get("file_path") if args else None
+            sym = args.get("symbol") if args else None
+            if fp:
+                return f"Finding tests for {fp}"
+            if sym:
+                return f"Finding tests for {sym}"
+            return "Finding related tests"
+        case "add_watch":
+            expr = args.get("expression") if args else None
+            return f"Adding watch: {expr}" if expr else "Adding watch expression"
+        case "remove_watch":
+            expr = args.get("expression") if args else None
+            return f"Removing watch: {expr}" if expr else "Removing watch expression"
+        case "list_watches":
+            return "Listing active watches"
         case "read_todos":
             return "Reading todo list"
         case "write_todos":
@@ -894,6 +918,14 @@ def get_tool_response_message(
             | "debug_continue"
             | "debug_select_frame"
             | "debug_list_sessions"
+            | "debug_list_launch_configs"
+            | "debug_list_adapters"
+            | "parse_debug_signal"
+            | "build_debug_context"
+            | "find_related_tests"
+            | "add_watch"
+            | "remove_watch"
+            | "list_watches"
         ):
             if isinstance(result, str):
                 preview = result[:200] + ("..." if len(result) > 200 else "")

--- a/app/modules/intelligence/tools/debug_tools/__init__.py
+++ b/app/modules/intelligence/tools/debug_tools/__init__.py
@@ -4,7 +4,11 @@ from typing import List
 
 from langchain_core.tools import StructuredTool
 
+from .add_watch_tool import create_add_watch_tool
+from .build_debug_context_tool import create_build_debug_context_tool
 from .debug_continue_tool import create_debug_continue_tool
+from .debug_list_adapters_tool import create_debug_list_adapters_tool
+from .debug_list_launch_configs_tool import create_debug_list_launch_configs_tool
 from .debug_list_sessions_tool import create_debug_list_sessions_tool
 from .debug_select_frame_tool import create_debug_select_frame_tool
 from .debug_set_breakpoints_tool import create_debug_set_breakpoints_tool
@@ -14,11 +18,16 @@ from .debug_step_into_tool import create_debug_step_into_tool
 from .debug_step_out_tool import create_debug_step_out_tool
 from .debug_step_over_tool import create_debug_step_over_tool
 from .debug_stop_tool import create_debug_stop_tool
+from .find_related_tests_tool import create_find_related_tests_tool
+from .list_watches_tool import create_list_watches_tool
+from .parse_debug_signal_tool import create_parse_debug_signal_tool
+from .remove_watch_tool import create_remove_watch_tool
 
 
 def create_debug_tools() -> List[StructuredTool]:
     """Return all debugger StructuredTools for ToolService registration."""
     return [
+        # DAP / extension tunnel tools
         create_debug_start_tool(),
         create_debug_stop_tool(),
         create_debug_set_breakpoints_tool(),
@@ -29,6 +38,15 @@ def create_debug_tools() -> List[StructuredTool]:
         create_debug_continue_tool(),
         create_debug_select_frame_tool(),
         create_debug_list_sessions_tool(),
+        create_debug_list_launch_configs_tool(),
+        create_debug_list_adapters_tool(),
+        # Backend-only debug workflow tools
+        create_parse_debug_signal_tool(),
+        create_build_debug_context_tool(),
+        create_find_related_tests_tool(),
+        create_add_watch_tool(),
+        create_remove_watch_tool(),
+        create_list_watches_tool(),
     ]
 
 

--- a/app/modules/intelligence/tools/debug_tools/__init__.py
+++ b/app/modules/intelligence/tools/debug_tools/__init__.py
@@ -1,0 +1,35 @@
+"""Debugger tools routed through the VS Code extension tunnel (local mode)."""
+
+from typing import List
+
+from langchain_core.tools import StructuredTool
+
+from .debug_continue_tool import create_debug_continue_tool
+from .debug_list_sessions_tool import create_debug_list_sessions_tool
+from .debug_select_frame_tool import create_debug_select_frame_tool
+from .debug_set_breakpoints_tool import create_debug_set_breakpoints_tool
+from .debug_snapshot_tool import create_debug_snapshot_tool
+from .debug_start_tool import create_debug_start_tool
+from .debug_step_into_tool import create_debug_step_into_tool
+from .debug_step_out_tool import create_debug_step_out_tool
+from .debug_step_over_tool import create_debug_step_over_tool
+from .debug_stop_tool import create_debug_stop_tool
+
+
+def create_debug_tools() -> List[StructuredTool]:
+    """Return all debugger StructuredTools for ToolService registration."""
+    return [
+        create_debug_start_tool(),
+        create_debug_stop_tool(),
+        create_debug_set_breakpoints_tool(),
+        create_debug_snapshot_tool(),
+        create_debug_step_into_tool(),
+        create_debug_step_out_tool(),
+        create_debug_step_over_tool(),
+        create_debug_continue_tool(),
+        create_debug_select_frame_tool(),
+        create_debug_list_sessions_tool(),
+    ]
+
+
+__all__ = ["create_debug_tools"]

--- a/app/modules/intelligence/tools/debug_tools/add_watch_tool.py
+++ b/app/modules/intelligence/tools/debug_tools/add_watch_tool.py
@@ -1,0 +1,32 @@
+"""Add a persistent watch expression for the current debug session."""
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from app.modules.intelligence.tools.local_search_tools.tunnel_utils import get_context_vars
+from .watch_store import add_watch
+
+
+class AddWatchInput(BaseModel):
+    expression: str = Field(
+        description="Expression to evaluate in every subsequent snapshot (e.g. 'len(items)', 'user.email', 'error.constructor.name')"
+    )
+
+
+def add_watch_tool(input_data: AddWatchInput) -> str:
+    user_id, conversation_id = get_context_vars()
+    watches = add_watch(user_id, conversation_id, input_data.expression)
+    return f"Watch added. Active watches ({len(watches)}):\n" + "\n".join(f"  - {w}" for w in watches)
+
+
+def create_add_watch_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=add_watch_tool,
+        name="add_watch",
+        description=(
+            "Register a persistent watch expression for this debug session. "
+            "The expression will be automatically evaluated in every debug_snapshot, "
+            "debug_step_*, and debug_select_frame call."
+        ),
+        args_schema=AddWatchInput,
+    )

--- a/app/modules/intelligence/tools/debug_tools/build_debug_context_tool.py
+++ b/app/modules/intelligence/tools/debug_tools/build_debug_context_tool.py
@@ -1,0 +1,238 @@
+"""Build a structured debug context packet from a parsed debug signal.
+
+Orchestrates several existing tools (code lookup, git, related tests, launch configs,
+adapters) and returns a consolidated markdown packet for the agent.
+
+Each sub-tool failure is caught and noted gracefully — the packet is always returned
+even if individual sections are empty.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from app.modules.utils.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Input schema
+# ---------------------------------------------------------------------------
+
+class BuildDebugContextInput(BaseModel):
+    stack_frames: Optional[List[Dict[str, Any]]] = Field(
+        default=None,
+        description="Extracted stack frames from parse_debug_signal: list of {file, line, symbol}",
+    )
+    error_signature: Optional[str] = Field(
+        default=None,
+        description="Top-level error class or code (e.g. 'PaymentTimeoutError')",
+    )
+    signal_type: Optional[str] = Field(
+        default=None,
+        description="signal_type from parse_debug_signal (pasted_log / stack_trace / failed_test / natural_language)",
+    )
+    test_path: Optional[str] = Field(
+        default=None,
+        description="Failing test file path from parse_debug_signal (for failed_test signals)",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _safe_call(label: str, fn, *args, **kwargs) -> Optional[str]:
+    try:
+        result = fn(*args, **kwargs)
+        return result if isinstance(result, str) else str(result)
+    except Exception as e:
+        logger.debug(f"build_debug_context: [{label}] failed: {e}")
+        return None
+
+
+def _section(title: str, body: Optional[str]) -> str:
+    if not body or not body.strip():
+        return f"### {title}\n_Not available._\n"
+    return f"### {title}\n{body.strip()}\n"
+
+
+# ---------------------------------------------------------------------------
+# Sub-tool wrappers
+# ---------------------------------------------------------------------------
+
+def _fetch_source_locations(frames: List[Dict[str, Any]]) -> str:
+    """Fetch code snippets for each stack frame and produce a source-locations list."""
+    if not frames:
+        return ""
+    try:
+        from app.modules.intelligence.tools.code_tools.get_code_from_probable_node_name_tool import (
+            GetCodeFromProbableNodeNameInput,
+            get_code_from_probable_node_name_tool,
+        )
+    except ImportError:
+        return ""
+
+    lines = []
+    for frame in frames[:6]:  # limit to top 6 frames
+        sym = frame.get("symbol") or ""
+        file_ = frame.get("file") or ""
+        line_ = frame.get("line") or "?"
+        confidence = "high" if sym and sym != "?" else "medium"
+        lines.append(f"- **{file_}:{line_}** in `{sym}` — confidence: {confidence}")
+
+        if sym and sym not in ("?", "<module>", "<anonymous>"):
+            result = _safe_call(
+                f"node_name/{sym}",
+                lambda s=sym: get_code_from_probable_node_name_tool(
+                    GetCodeFromProbableNodeNameInput(node_name=s)
+                ),
+            )
+            if result and len(result) < 3000:
+                lines.append(f"  ```\n  {result[:1500]}\n  ```")
+
+    return "\n".join(lines)
+
+
+def _fetch_related_tests(frames: List[Dict[str, Any]], test_path: Optional[str]) -> str:
+    """Find related tests for the top stack frame."""
+    if test_path:
+        return f"- `{test_path}` (from signal)"
+
+    if not frames:
+        return ""
+
+    try:
+        from app.modules.intelligence.tools.debug_tools.find_related_tests_tool import (
+            FindRelatedTestsInput,
+            find_related_tests,
+        )
+
+        top = frames[0]
+        result = _safe_call(
+            "find_related_tests",
+            find_related_tests,
+            FindRelatedTestsInput(
+                file_path=top.get("file"),
+                symbol=top.get("symbol") if top.get("symbol") != "?" else None,
+            ),
+        )
+        return result or ""
+    except Exception:
+        return ""
+
+
+def _fetch_recent_git_changes(frames: List[Dict[str, Any]]) -> str:
+    """Run git log + diff around suspect files."""
+    if not frames:
+        return ""
+    try:
+        from app.modules.intelligence.tools.sandbox.tool_functions import sandbox_git_fn
+
+        suspect_files = [f["file"] for f in frames[:3] if f.get("file")]
+
+        log_result = _safe_call(
+            "git_log",
+            sandbox_git_fn,
+            command="log",
+        )
+
+        diff_result = None
+        if suspect_files:
+            diff_result = _safe_call(
+                "git_diff",
+                sandbox_git_fn,
+                command="diff",
+                paths=suspect_files,
+            )
+
+        parts = []
+        if log_result:
+            parts.append(f"**Recent commits:**\n{log_result[:1500]}")
+        if diff_result:
+            parts.append(f"**Diff for suspect files:**\n{diff_result[:2000]}")
+        return "\n\n".join(parts)
+    except Exception as e:
+        logger.debug(f"build_debug_context: git section failed: {e}")
+        return ""
+
+
+def _fetch_launch_configs() -> str:
+    """List available VS Code launch.json configurations."""
+    try:
+        from app.modules.intelligence.tools.debug_tools.debug_list_launch_configs_tool import (
+            DebugListLaunchConfigsInput,
+            debug_list_launch_configs_tool,
+        )
+
+        result = _safe_call(
+            "launch_configs",
+            debug_list_launch_configs_tool,
+            DebugListLaunchConfigsInput(),
+        )
+        return result or "_debug_list_launch_configs not yet available — read .vscode/launch.json manually._"
+    except Exception:
+        return "_debug_list_launch_configs not yet available — read .vscode/launch.json manually._"
+
+
+def _fetch_adapters() -> str:
+    """List available debug adapters."""
+    try:
+        from app.modules.intelligence.tools.debug_tools.debug_list_adapters_tool import (
+            DebugListAdaptersInput,
+            debug_list_adapters_tool,
+        )
+
+        result = _safe_call(
+            "adapters",
+            debug_list_adapters_tool,
+            DebugListAdaptersInput(),
+        )
+        return result or "_debug_list_adapters not yet available._"
+    except Exception:
+        return "_debug_list_adapters not yet available._"
+
+
+# ---------------------------------------------------------------------------
+# Main tool function
+# ---------------------------------------------------------------------------
+
+def build_debug_context(input_data: BuildDebugContextInput) -> str:
+    frames = input_data.stack_frames or []
+    error_sig = input_data.error_signature or ""
+    signal_type = input_data.signal_type or "unknown"
+    test_path = input_data.test_path
+
+    sections: List[str] = [
+        f"## Debug Context Packet\n\n"
+        f"**signal_type**: {signal_type}  \n"
+        f"**error_signature**: {error_sig or '_none detected_'}  \n"
+        f"**stack_frames_count**: {len(frames)}\n",
+    ]
+
+    sections.append(_section("Source Locations", _fetch_source_locations(frames)))
+    sections.append(_section("Related Tests", _fetch_related_tests(frames, test_path)))
+    sections.append(_section("Recent Git Changes", _fetch_recent_git_changes(frames)))
+    sections.append(_section("Launch Configurations", _fetch_launch_configs()))
+    sections.append(_section("Debug Capabilities (Adapters)", _fetch_adapters()))
+
+    return "\n".join(sections)
+
+
+def create_build_debug_context_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=build_debug_context,
+        name="build_debug_context",
+        description=(
+            "Build a structured debug context packet from a parsed signal. "
+            "Fetches source code for stack frames (with confidence ratings), "
+            "related tests, recent git changes around suspect files, available "
+            "VS Code launch configs, and debug adapter capabilities. "
+            "Pass stack_frames and error_signature from parse_debug_signal output."
+        ),
+        args_schema=BuildDebugContextInput,
+    )

--- a/app/modules/intelligence/tools/debug_tools/debug_continue_tool.py
+++ b/app/modules/intelligence/tools/debug_tools/debug_continue_tool.py
@@ -1,0 +1,31 @@
+"""Continue execution until next breakpoint."""
+
+from typing import Optional
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
+    get_context_vars,
+)
+
+from .debug_tunnel_utils import route_debug_command
+
+
+class DebugContinueInput(BaseModel):
+    session_id: Optional[str] = Field(default=None, description="Debug session ID")
+
+
+def debug_continue_tool(input_data: DebugContinueInput) -> str:
+    user_id, conversation_id = get_context_vars()
+    payload = input_data.model_dump(exclude_none=True)
+    return route_debug_command("debug_continue", payload, user_id, conversation_id)
+
+
+def create_debug_continue_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=debug_continue_tool,
+        name="debug_continue",
+        description="Resume execution (does not wait for next pause); call debug_snapshot(wait=true) later.",
+        args_schema=DebugContinueInput,
+    )

--- a/app/modules/intelligence/tools/debug_tools/debug_list_adapters_tool.py
+++ b/app/modules/intelligence/tools/debug_tools/debug_list_adapters_tool.py
@@ -1,0 +1,34 @@
+"""List available debug adapters in the VS Code workspace.
+
+Routes to the VS Code extension via the debug tunnel.
+Extension endpoint: POST /api/debug/adapters
+"""
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, ConfigDict
+
+from app.modules.intelligence.tools.local_search_tools.tunnel_utils import get_context_vars
+from .debug_tunnel_utils import route_debug_command
+
+
+class DebugListAdaptersInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+def debug_list_adapters_tool(_input_data: DebugListAdaptersInput) -> str:
+    user_id, conversation_id = get_context_vars()
+    result = route_debug_command("debug_list_adapters", {}, user_id, conversation_id)
+    return result
+
+
+def create_debug_list_adapters_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=debug_list_adapters_tool,
+        name="debug_list_adapters",
+        description=(
+            "List available debug adapters installed in VS Code (python/debugpy, node, go/delve). "
+            "Returns language, availability flag, and extension id for each adapter. "
+            "Use the result to pick the correct adapter type for debug_start."
+        ),
+        args_schema=DebugListAdaptersInput,
+    )

--- a/app/modules/intelligence/tools/debug_tools/debug_list_launch_configs_tool.py
+++ b/app/modules/intelligence/tools/debug_tools/debug_list_launch_configs_tool.py
@@ -1,0 +1,34 @@
+"""List available VS Code launch.json debug configurations.
+
+Routes to the VS Code extension via the debug tunnel.
+Extension endpoint: POST /api/debug/launch-configs
+"""
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, ConfigDict
+
+from app.modules.intelligence.tools.local_search_tools.tunnel_utils import get_context_vars
+from .debug_tunnel_utils import route_debug_command
+
+
+class DebugListLaunchConfigsInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+def debug_list_launch_configs_tool(_input_data: DebugListLaunchConfigsInput) -> str:
+    user_id, conversation_id = get_context_vars()
+    result = route_debug_command("debug_list_launch_configs", {}, user_id, conversation_id)
+    return result
+
+
+def create_debug_list_launch_configs_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=debug_list_launch_configs_tool,
+        name="debug_list_launch_configs",
+        description=(
+            "List all VS Code launch.json debug configurations available in the workspace. "
+            "Returns config names, types (python/node/go), and entry points. "
+            "Use this to choose the right config before calling debug_start."
+        ),
+        args_schema=DebugListLaunchConfigsInput,
+    )

--- a/app/modules/intelligence/tools/debug_tools/debug_list_sessions_tool.py
+++ b/app/modules/intelligence/tools/debug_tools/debug_list_sessions_tool.py
@@ -1,0 +1,28 @@
+"""List active debugger sessions handled by the extension."""
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, ConfigDict
+
+from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
+    get_context_vars,
+)
+
+from .debug_tunnel_utils import route_debug_command
+
+
+class DebugListSessionsInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+def debug_list_sessions_tool(_input_data: DebugListSessionsInput) -> str:
+    user_id, conversation_id = get_context_vars()
+    return route_debug_command("debug_list_sessions", {}, user_id, conversation_id)
+
+
+def create_debug_list_sessions_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=debug_list_sessions_tool,
+        name="debug_list_sessions",
+        description="List debug sessions for this workspace (read-only).",
+        args_schema=DebugListSessionsInput,
+    )

--- a/app/modules/intelligence/tools/debug_tools/debug_select_frame_tool.py
+++ b/app/modules/intelligence/tools/debug_tools/debug_select_frame_tool.py
@@ -1,6 +1,6 @@
 """Select a stack frame index for inspection (locals scoped to that frame)."""
 
-from typing import Optional
+from typing import List, Optional
 
 from langchain_core.tools import StructuredTool
 from pydantic import BaseModel, Field
@@ -10,16 +10,24 @@ from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
 )
 
 from .debug_tunnel_utils import route_debug_command
+from .watch_store import merge_into_expressions
 
 
 class DebugSelectFrameInput(BaseModel):
     frame_index: int = Field(ge=0, description="0-based index into the call stack (0 = top)")
     session_id: Optional[str] = Field(default=None, description="Debug session ID")
+    expressions: Optional[List[str]] = Field(
+        default=None,
+        description="Extra expressions to evaluate in the selected frame. Persistent watches are merged in automatically.",
+    )
 
 
 def debug_select_frame_tool(input_data: DebugSelectFrameInput) -> str:
     user_id, conversation_id = get_context_vars()
     payload = input_data.model_dump(exclude_none=True)
+    merged = merge_into_expressions(user_id, conversation_id, payload.get("expressions"))
+    if merged:
+        payload["expressions"] = merged
     return route_debug_command(
         "debug_select_frame", payload, user_id, conversation_id
     )

--- a/app/modules/intelligence/tools/debug_tools/debug_select_frame_tool.py
+++ b/app/modules/intelligence/tools/debug_tools/debug_select_frame_tool.py
@@ -1,0 +1,34 @@
+"""Select a stack frame index for inspection (locals scoped to that frame)."""
+
+from typing import Optional
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
+    get_context_vars,
+)
+
+from .debug_tunnel_utils import route_debug_command
+
+
+class DebugSelectFrameInput(BaseModel):
+    frame_index: int = Field(ge=0, description="0-based index into the call stack (0 = top)")
+    session_id: Optional[str] = Field(default=None, description="Debug session ID")
+
+
+def debug_select_frame_tool(input_data: DebugSelectFrameInput) -> str:
+    user_id, conversation_id = get_context_vars()
+    payload = input_data.model_dump(exclude_none=True)
+    return route_debug_command(
+        "debug_select_frame", payload, user_id, conversation_id
+    )
+
+
+def create_debug_select_frame_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=debug_select_frame_tool,
+        name="debug_select_frame",
+        description="Inspect locals and expressions for a specific stack frame.",
+        args_schema=DebugSelectFrameInput,
+    )

--- a/app/modules/intelligence/tools/debug_tools/debug_set_breakpoints_tool.py
+++ b/app/modules/intelligence/tools/debug_tools/debug_set_breakpoints_tool.py
@@ -1,0 +1,38 @@
+"""Set breakpoints in a source file (workspace-relative path)."""
+
+from typing import List, Optional
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
+    get_context_vars,
+)
+
+from .debug_tunnel_utils import route_debug_command
+
+
+class DebugSetBreakpointsInput(BaseModel):
+    file: str = Field(description="Source file path relative to workspace root")
+    lines: List[int] = Field(description="1-based lines where breakpoints should be set")
+    condition: Optional[str] = Field(default=None, description="Optional breakpoint condition expression")
+
+
+def debug_set_breakpoints_tool(input_data: DebugSetBreakpointsInput) -> str:
+    user_id, conversation_id = get_context_vars()
+    payload = input_data.model_dump(exclude_none=True)
+    return route_debug_command(
+        "debug_set_breakpoints", payload, user_id, conversation_id
+    )
+
+
+def create_debug_set_breakpoints_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=debug_set_breakpoints_tool,
+        name="debug_set_breakpoints",
+        description=(
+            "Set breakpoints before starting execution. Prefer calling after debug_start "
+            "and before the first debug_snapshot(wait=True)."
+        ),
+        args_schema=DebugSetBreakpointsInput,
+    )

--- a/app/modules/intelligence/tools/debug_tools/debug_snapshot_tool.py
+++ b/app/modules/intelligence/tools/debug_tools/debug_snapshot_tool.py
@@ -10,12 +10,13 @@ from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
 )
 
 from .debug_tunnel_utils import route_debug_command
+from .watch_store import merge_into_expressions
 
 
 class DebugSnapshotInput(BaseModel):
     expressions: Optional[List[str]] = Field(
         default=None,
-        description="Expressions to evaluate in the current frame (e.g. len(items), user.email)",
+        description="Expressions to evaluate in the current frame (e.g. len(items), user.email). Persistent watches registered via add_watch are merged in automatically.",
     )
     wait: bool = Field(
         default=True,
@@ -31,6 +32,9 @@ class DebugSnapshotInput(BaseModel):
 def debug_snapshot_tool(input_data: DebugSnapshotInput) -> str:
     user_id, conversation_id = get_context_vars()
     payload = input_data.model_dump(exclude_none=True)
+    merged = merge_into_expressions(user_id, conversation_id, payload.get("expressions"))
+    if merged:
+        payload["expressions"] = merged
     return route_debug_command("debug_snapshot", payload, user_id, conversation_id)
 
 

--- a/app/modules/intelligence/tools/debug_tools/debug_snapshot_tool.py
+++ b/app/modules/intelligence/tools/debug_tools/debug_snapshot_tool.py
@@ -1,0 +1,47 @@
+"""Capture stack, locals, and optional watch expressions."""
+
+from typing import List, Optional
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
+    get_context_vars,
+)
+
+from .debug_tunnel_utils import route_debug_command
+
+
+class DebugSnapshotInput(BaseModel):
+    expressions: Optional[List[str]] = Field(
+        default=None,
+        description="Expressions to evaluate in the current frame (e.g. len(items), user.email)",
+    )
+    wait: bool = Field(
+        default=True,
+        description="If true, wait until paused at a breakpoint or completion timeout",
+    )
+    timeout: float = Field(
+        default=30.0,
+        description="Seconds to wait when wait=true before failing",
+    )
+    session_id: Optional[str] = Field(default=None, description="Debug session ID")
+
+
+def debug_snapshot_tool(input_data: DebugSnapshotInput) -> str:
+    user_id, conversation_id = get_context_vars()
+    payload = input_data.model_dump(exclude_none=True)
+    return route_debug_command("debug_snapshot", payload, user_id, conversation_id)
+
+
+def create_debug_snapshot_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=debug_snapshot_tool,
+        name="debug_snapshot",
+        description=(
+            "Primary inspection tool: returns paused location, call stack, locals, "
+            "and expression evaluations. With wait=true, resumes configuration "
+            "when needed so the program runs to breakpoints."
+        ),
+        args_schema=DebugSnapshotInput,
+    )

--- a/app/modules/intelligence/tools/debug_tools/debug_start_tool.py
+++ b/app/modules/intelligence/tools/debug_tools/debug_start_tool.py
@@ -1,0 +1,39 @@
+"""Launch or attach a debug session via the VS Code extension."""
+
+from typing import Any, Dict, Optional
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
+    get_context_vars,
+)
+
+from .debug_tunnel_utils import route_debug_command
+
+
+class DebugStartInput(BaseModel):
+    program: str = Field(description="Entry script path relative to workspace root (e.g. src/app.py)")
+    language: str = Field(default="python", description="Language/runtime (initial support: python)")
+    mode: str = Field(default="launch", description="'launch' or 'attach'")
+    port: Optional[int] = Field(default=None, description="Port when mode is attach")
+    args: Dict[str, Any] = Field(default_factory=dict, description="Extra launch arguments for the adapter")
+
+
+def debug_start_tool(input_data: DebugStartInput) -> str:
+    user_id, conversation_id = get_context_vars()
+    payload = input_data.model_dump(exclude_none=True)
+    return route_debug_command("debug_start", payload, user_id, conversation_id)
+
+
+def create_debug_start_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=debug_start_tool,
+        name="debug_start",
+        description=(
+            "Start a debugger session under the VS Code extension (local mode). "
+            "Sets up an adapter session; use debug_set_breakpoints before debug_snapshot(wait=True) "
+            "so breakpoints apply before execution begins."
+        ),
+        args_schema=DebugStartInput,
+    )

--- a/app/modules/intelligence/tools/debug_tools/debug_step_into_tool.py
+++ b/app/modules/intelligence/tools/debug_tools/debug_step_into_tool.py
@@ -1,6 +1,6 @@
 """Step execution (step into)."""
 
-from typing import Optional
+from typing import List, Optional
 
 from langchain_core.tools import StructuredTool
 from pydantic import BaseModel, Field
@@ -10,15 +10,23 @@ from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
 )
 
 from .debug_tunnel_utils import route_debug_command
+from .watch_store import merge_into_expressions
 
 
 class DebugStepInput(BaseModel):
     session_id: Optional[str] = Field(default=None, description="Debug session ID")
+    expressions: Optional[List[str]] = Field(
+        default=None,
+        description="Extra expressions to evaluate in the post-step snapshot. Persistent watches are merged in automatically.",
+    )
 
 
 def debug_step_into_tool(input_data: DebugStepInput) -> str:
     user_id, conversation_id = get_context_vars()
     payload = input_data.model_dump(exclude_none=True)
+    merged = merge_into_expressions(user_id, conversation_id, payload.get("expressions"))
+    if merged:
+        payload["expressions"] = merged
     return route_debug_command("debug_step_into", payload, user_id, conversation_id)
 
 

--- a/app/modules/intelligence/tools/debug_tools/debug_step_into_tool.py
+++ b/app/modules/intelligence/tools/debug_tools/debug_step_into_tool.py
@@ -1,0 +1,31 @@
+"""Step execution (step into)."""
+
+from typing import Optional
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
+    get_context_vars,
+)
+
+from .debug_tunnel_utils import route_debug_command
+
+
+class DebugStepInput(BaseModel):
+    session_id: Optional[str] = Field(default=None, description="Debug session ID")
+
+
+def debug_step_into_tool(input_data: DebugStepInput) -> str:
+    user_id, conversation_id = get_context_vars()
+    payload = input_data.model_dump(exclude_none=True)
+    return route_debug_command("debug_step_into", payload, user_id, conversation_id)
+
+
+def create_debug_step_into_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=debug_step_into_tool,
+        name="debug_step_into",
+        description="Step debugger execution; returns a fresh snapshot after the step completes.",
+        args_schema=DebugStepInput,
+    )

--- a/app/modules/intelligence/tools/debug_tools/debug_step_out_tool.py
+++ b/app/modules/intelligence/tools/debug_tools/debug_step_out_tool.py
@@ -1,6 +1,6 @@
 """Step execution (step out)."""
 
-from typing import Optional
+from typing import List, Optional
 
 from langchain_core.tools import StructuredTool
 from pydantic import BaseModel, Field
@@ -10,15 +10,23 @@ from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
 )
 
 from .debug_tunnel_utils import route_debug_command
+from .watch_store import merge_into_expressions
 
 
 class DebugStepInput(BaseModel):
     session_id: Optional[str] = Field(default=None, description="Debug session ID")
+    expressions: Optional[List[str]] = Field(
+        default=None,
+        description="Extra expressions to evaluate in the post-step snapshot. Persistent watches are merged in automatically.",
+    )
 
 
 def debug_step_out_tool(input_data: DebugStepInput) -> str:
     user_id, conversation_id = get_context_vars()
     payload = input_data.model_dump(exclude_none=True)
+    merged = merge_into_expressions(user_id, conversation_id, payload.get("expressions"))
+    if merged:
+        payload["expressions"] = merged
     return route_debug_command("debug_step_out", payload, user_id, conversation_id)
 
 

--- a/app/modules/intelligence/tools/debug_tools/debug_step_out_tool.py
+++ b/app/modules/intelligence/tools/debug_tools/debug_step_out_tool.py
@@ -1,0 +1,31 @@
+"""Step execution (step out)."""
+
+from typing import Optional
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
+    get_context_vars,
+)
+
+from .debug_tunnel_utils import route_debug_command
+
+
+class DebugStepInput(BaseModel):
+    session_id: Optional[str] = Field(default=None, description="Debug session ID")
+
+
+def debug_step_out_tool(input_data: DebugStepInput) -> str:
+    user_id, conversation_id = get_context_vars()
+    payload = input_data.model_dump(exclude_none=True)
+    return route_debug_command("debug_step_out", payload, user_id, conversation_id)
+
+
+def create_debug_step_out_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=debug_step_out_tool,
+        name="debug_step_out",
+        description="Step debugger execution; returns a fresh snapshot after the step completes.",
+        args_schema=DebugStepInput,
+    )

--- a/app/modules/intelligence/tools/debug_tools/debug_step_over_tool.py
+++ b/app/modules/intelligence/tools/debug_tools/debug_step_over_tool.py
@@ -1,6 +1,6 @@
 """Step execution (step over)."""
 
-from typing import Optional
+from typing import List, Optional
 
 from langchain_core.tools import StructuredTool
 from pydantic import BaseModel, Field
@@ -10,15 +10,23 @@ from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
 )
 
 from .debug_tunnel_utils import route_debug_command
+from .watch_store import merge_into_expressions
 
 
 class DebugStepInput(BaseModel):
     session_id: Optional[str] = Field(default=None, description="Debug session ID")
+    expressions: Optional[List[str]] = Field(
+        default=None,
+        description="Extra expressions to evaluate in the post-step snapshot. Persistent watches are merged in automatically.",
+    )
 
 
 def debug_step_over_tool(input_data: DebugStepInput) -> str:
     user_id, conversation_id = get_context_vars()
     payload = input_data.model_dump(exclude_none=True)
+    merged = merge_into_expressions(user_id, conversation_id, payload.get("expressions"))
+    if merged:
+        payload["expressions"] = merged
     return route_debug_command("debug_step_over", payload, user_id, conversation_id)
 
 

--- a/app/modules/intelligence/tools/debug_tools/debug_step_over_tool.py
+++ b/app/modules/intelligence/tools/debug_tools/debug_step_over_tool.py
@@ -1,0 +1,31 @@
+"""Step execution (step over)."""
+
+from typing import Optional
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
+    get_context_vars,
+)
+
+from .debug_tunnel_utils import route_debug_command
+
+
+class DebugStepInput(BaseModel):
+    session_id: Optional[str] = Field(default=None, description="Debug session ID")
+
+
+def debug_step_over_tool(input_data: DebugStepInput) -> str:
+    user_id, conversation_id = get_context_vars()
+    payload = input_data.model_dump(exclude_none=True)
+    return route_debug_command("debug_step_over", payload, user_id, conversation_id)
+
+
+def create_debug_step_over_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=debug_step_over_tool,
+        name="debug_step_over",
+        description="Step debugger execution; returns a fresh snapshot after the step completes.",
+        args_schema=DebugStepInput,
+    )

--- a/app/modules/intelligence/tools/debug_tools/debug_stop_tool.py
+++ b/app/modules/intelligence/tools/debug_tools/debug_stop_tool.py
@@ -1,0 +1,31 @@
+"""Stop an active debug session."""
+
+from typing import Optional
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
+    get_context_vars,
+)
+
+from .debug_tunnel_utils import route_debug_command
+
+
+class DebugStopInput(BaseModel):
+    session_id: Optional[str] = Field(default=None, description="Session ID from debug_start; omit if single session")
+
+
+def debug_stop_tool(input_data: DebugStopInput) -> str:
+    user_id, conversation_id = get_context_vars()
+    payload = input_data.model_dump(exclude_none=True)
+    return route_debug_command("debug_stop", payload, user_id, conversation_id)
+
+
+def create_debug_stop_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=debug_stop_tool,
+        name="debug_stop",
+        description="Terminate the debug session and disconnect from the adapter.",
+        args_schema=DebugStopInput,
+    )

--- a/app/modules/intelligence/tools/debug_tools/debug_tunnel_utils.py
+++ b/app/modules/intelligence/tools/debug_tools/debug_tunnel_utils.py
@@ -32,6 +32,8 @@ DEBUG_ENDPOINTS: Dict[str, str] = {
     "debug_continue": "/api/debug/continue",
     "debug_select_frame": "/api/debug/select-frame",
     "debug_list_sessions": "/api/debug/sessions",
+    "debug_list_launch_configs": "/api/debug/launch-configs",
+    "debug_list_adapters": "/api/debug/adapters",
 }
 
 _DEBUG_OPERATION_TIMEOUT_SECS: Dict[str, float] = {
@@ -45,6 +47,8 @@ _DEBUG_OPERATION_TIMEOUT_SECS: Dict[str, float] = {
     "debug_continue": 10.0,
     "debug_set_breakpoints": 30.0,
     "debug_select_frame": 30.0,
+    "debug_list_launch_configs": 5.0,
+    "debug_list_adapters": 5.0,
 }
 
 _SNAPSHOT_LIKE_OPS = frozenset(
@@ -89,6 +93,12 @@ def format_debug_result(operation: str, result: Any) -> str:
 
     if operation == "debug_list_sessions":
         return _format_sessions_result(result)
+
+    if operation == "debug_list_launch_configs":
+        return _format_launch_configs_result(result)
+
+    if operation == "debug_list_adapters":
+        return _format_adapters_result(result)
 
     if operation in _SNAPSHOT_LIKE_OPS:
         return _format_snapshot_result(result)
@@ -216,6 +226,38 @@ def _format_sessions_result(result: Dict[str, Any]) -> str:
         lines.append(f"{sid:<12} {prog:<24} {lang:<10} {st}")
     if len(sessions) > 30:
         lines.append(f"... and {len(sessions) - 30} more")
+    return "\n".join(lines)
+
+
+def _format_launch_configs_result(result: Dict[str, Any]) -> str:
+    configs = result.get("configs") or []
+    if not configs:
+        return "No launch configurations found. Check .vscode/launch.json in the workspace."
+    lines = ["Available launch configurations:"]
+    for cfg in configs:
+        if not isinstance(cfg, dict):
+            continue
+        name = cfg.get("name") or "Unnamed"
+        typ = cfg.get("type") or "?"
+        req = cfg.get("request") or "launch"
+        prog = cfg.get("program") or cfg.get("module") or ""
+        lines.append(f"  - **{name}** ({typ} / {req})" + (f" → `{prog}`" if prog else ""))
+    return "\n".join(lines)
+
+
+def _format_adapters_result(result: Dict[str, Any]) -> str:
+    adapters = result.get("adapters") or []
+    if not adapters:
+        return "No debug adapters detected."
+    lines = ["Available debug adapters:"]
+    for a in adapters:
+        if not isinstance(a, dict):
+            continue
+        lang = a.get("language") or "?"
+        available = a.get("available", False)
+        ext_id = a.get("extension_id") or ""
+        status = "available" if available else "not installed"
+        lines.append(f"  - **{lang}**: {status}" + (f" ({ext_id})" if ext_id else ""))
     return "\n".join(lines)
 
 

--- a/app/modules/intelligence/tools/debug_tools/debug_tunnel_utils.py
+++ b/app/modules/intelligence/tools/debug_tools/debug_tunnel_utils.py
@@ -1,0 +1,377 @@
+"""
+Route high-level debug operations to the VS Code extension LocalServer via tunnel.
+
+Socket.IO responses look like ``{success, result?, error?}``.
+Direct HTTP to the LocalServer (when the backend resolves a local tunnel URL)
+uses the same JSON shape.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Optional
+
+import httpx
+
+from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
+    SOCKET_TUNNEL_PREFIX,
+    _execute_via_socket_full_response,
+)
+from app.modules.utils.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+DEBUG_ENDPOINTS: Dict[str, str] = {
+    "debug_start": "/api/debug/start",
+    "debug_stop": "/api/debug/stop",
+    "debug_set_breakpoints": "/api/debug/breakpoints",
+    "debug_snapshot": "/api/debug/snapshot",
+    "debug_step_into": "/api/debug/step-into",
+    "debug_step_out": "/api/debug/step-out",
+    "debug_step_over": "/api/debug/step-over",
+    "debug_continue": "/api/debug/continue",
+    "debug_select_frame": "/api/debug/select-frame",
+    "debug_list_sessions": "/api/debug/sessions",
+}
+
+_DEBUG_OPERATION_TIMEOUT_SECS: Dict[str, float] = {
+    "debug_start": 120.0,
+    "debug_snapshot": 120.0,
+    "debug_step_into": 30.0,
+    "debug_step_out": 30.0,
+    "debug_step_over": 30.0,
+    "debug_stop": 15.0,
+    "debug_list_sessions": 15.0,
+    "debug_continue": 10.0,
+    "debug_set_breakpoints": 30.0,
+    "debug_select_frame": 30.0,
+}
+
+_SNAPSHOT_LIKE_OPS = frozenset(
+    {
+        "debug_snapshot",
+        "debug_step_into",
+        "debug_step_out",
+        "debug_step_over",
+        "debug_select_frame",
+    }
+)
+
+
+def _short_path(path: Optional[str]) -> str:
+    if not path:
+        return "?"
+    base = os.path.basename(path.rstrip("/"))
+    return base or path
+
+
+def _normalize_extension_payload(body: Any) -> Dict[str, Any]:
+    """Accept either bare ``{success,...}`` or legacy nested shapes."""
+    if not isinstance(body, dict):
+        return {"success": False, "error": "Invalid JSON response from extension"}
+    if "success" in body:
+        return body
+    inner = body.get("body") if isinstance(body.get("body"), dict) else None
+    if inner and "success" in inner:
+        return inner
+    return {"success": False, "error": str(body.get("error", "Unknown extension response"))}
+
+
+def format_debug_result(operation: str, result: Any) -> str:
+    """Turn extension ``result`` JSON into concise text for the LLM."""
+    if result is None:
+        return "✅ Debug operation completed (no result payload)."
+    if not isinstance(result, dict):
+        return str(result)
+
+    if operation == "debug_set_breakpoints":
+        return _format_breakpoints_result(result)
+
+    if operation == "debug_list_sessions":
+        return _format_sessions_result(result)
+
+    if operation in _SNAPSHOT_LIKE_OPS:
+        return _format_snapshot_result(result)
+
+    lines = []
+    if "session_id" in result:
+        lines.append(f"session_id: {result['session_id']}")
+    if "program" in result:
+        lines.append(f"program: {result['program']}")
+    if "language" in result:
+        lines.append(f"language: {result['language']}")
+    if "status" in result:
+        lines.append(f"status: {result['status']}")
+    if "stopped" in result:
+        lines.append(f"stopped: {result['stopped']}")
+    if not lines:
+        text = "\n".join(f"{k}: {v}" for k, v in sorted(result.items()))
+        return text[:8000]
+    return "\n".join(lines)
+
+
+def _format_snapshot_result(result: Dict[str, Any]) -> str:
+    paused = result.get("paused_at") or {}
+    fn = paused.get("function") or "?"
+    line = paused.get("line")
+    file_short = _short_path(paused.get("file"))
+    head = (
+        f"Paused at {file_short}:{line} in {fn}()"
+        if line is not None
+        else f"Paused at {file_short} in {fn}()"
+    )
+
+    out = [head, ""]
+
+    stack = result.get("call_stack") or []
+    if stack:
+        out.append("Call Stack:")
+        for i, frame in enumerate(stack[:25]):
+            fp = _short_path(frame.get("file"))
+            nm = frame.get("function") or "?"
+            ln = frame.get("line")
+            fid = frame.get("frame_id", "")
+            suffix = f":{ln}" if ln is not None else ""
+            out.append(f"  #{i}  {nm}()  {fp}{suffix}  (frame_id={fid})")
+        if len(stack) > 25:
+            out.append(f"  ... {len(stack) - 25} more frame(s)")
+        out.append("")
+
+    locals_ = result.get("locals") or {}
+    if locals_:
+        out.append("Local Variables:")
+        for k, v in list(locals_.items())[:80]:
+            vs = str(v)
+            if len(vs) > 500:
+                vs = vs[:497] + "..."
+            out.append(f"  {k} = {vs}")
+        if len(locals_) > 80:
+            out.append(f"  ... {len(locals_) - 80} more variable(s)")
+        out.append("")
+
+    exprs = result.get("expression_results") or []
+    if exprs:
+        out.append("Expression Results:")
+        for item in exprs:
+            if not isinstance(item, dict):
+                continue
+            ex = item.get("expression", "?")
+            if item.get("error"):
+                out.append(f"  {ex} → error: {item['error']}")
+            else:
+                out.append(f"  {ex} = {item.get('result')}")
+        out.append("")
+
+    if result.get("session_id"):
+        out.append(f"session_id: {result['session_id']}")
+    if result.get("status"):
+        out.append(f"status: {result['status']}")
+
+    return "\n".join(out).strip()
+
+
+def _format_breakpoints_result(result: Dict[str, Any]) -> str:
+    file_path = result.get("file") or "?"
+    short = _short_path(file_path)
+    bps = result.get("breakpoints") or []
+    lines = [f"Breakpoints in {short}:"]
+    for bp in bps:
+        if not isinstance(bp, dict):
+            continue
+        line_no = bp.get("line")
+        verified = bp.get("verified", False)
+        actual = bp.get("actual_line")
+        msg = bp.get("message") or ""
+        if verified:
+            if actual is not None and actual != line_no:
+                lines.append(
+                    f"  Line {line_no}: verified (adjusted to line {actual})"
+                    + (f" — {msg}" if msg else "")
+                )
+            else:
+                lines.append(f"  Line {line_no}: verified" + (f" — {msg}" if msg else ""))
+        else:
+            lines.append(f"  Line {line_no}: not verified" + (f" — {msg}" if msg else ""))
+    if len(lines) == 1:
+        lines.append("  (no breakpoint details returned)")
+    return "\n".join(lines)
+
+
+def _format_sessions_result(result: Dict[str, Any]) -> str:
+    sessions = result.get("sessions") or []
+    if not sessions:
+        return "Active debug sessions:\n  (none)"
+    lines = [
+        "Active debug sessions:",
+        f"{'ID':<12} {'Program':<24} {'Lang':<10} Status",
+        "-" * 60,
+    ]
+    for s in sessions[:30]:
+        if not isinstance(s, dict):
+            continue
+        sid = str(s.get("session_id", ""))[:12]
+        prog = _short_path(s.get("program"))[:24]
+        lang = str(s.get("language", ""))[:10]
+        st = str(s.get("status", ""))
+        lines.append(f"{sid:<12} {prog:<24} {lang:<10} {st}")
+    if len(sessions) > 30:
+        lines.append(f"... and {len(sessions) - 30} more")
+    return "\n".join(lines)
+
+
+def _try_http_local_debug(
+    endpoint: str,
+    request_data: Dict[str, Any],
+    timeout: float,
+) -> Optional[Dict[str, Any]]:
+    force_tunnel = os.getenv("FORCE_TUNNEL", "").lower() in ["true", "1", "yes"]
+    base_url = os.getenv("BASE_URL", "").lower()
+    environment = os.getenv("ENVIRONMENT", "").lower()
+    is_backend_local = (
+        "localhost" in base_url
+        or "127.0.0.1" in base_url
+        or environment in ["local", "dev", "development"]
+        or not base_url
+    )
+    if not is_backend_local or force_tunnel:
+        return None
+
+    from app.modules.tunnel.tunnel_service import _get_local_tunnel_server_url
+
+    direct_base = _get_local_tunnel_server_url()
+    if not direct_base:
+        local_port_env = os.getenv("LOCAL_SERVER_PORT")
+        direct_port = int(local_port_env) if local_port_env else 3001
+        direct_base = f"http://localhost:{direct_port}"
+
+    url = f"{direct_base.rstrip('/')}{endpoint}"
+    try:
+        with httpx.Client(timeout=2.0) as health_client:
+            health = health_client.get(f"{direct_base.rstrip('/')}/health")
+            if health.status_code != 200:
+                return None
+        with httpx.Client(timeout=timeout) as client:
+            resp = client.post(
+                url,
+                json=request_data,
+                headers={"Content-Type": "application/json"},
+            )
+        if resp.status_code != 200:
+            logger.warning(
+                "[debug_tunnel] HTTP %s %s — %s",
+                resp.status_code,
+                url,
+                resp.text[:300],
+            )
+            return None
+        return resp.json()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[debug_tunnel] direct HTTP unavailable: %s", exc)
+        return None
+
+
+def route_debug_command(
+    operation: str,
+    data: Dict[str, Any],
+    user_id: Optional[str],
+    conversation_id: Optional[str],
+) -> str:
+    """Execute a debug RPC via tunnel (socket preferred; optional direct HTTP when backend is local)."""
+    endpoint = DEBUG_ENDPOINTS.get(operation)
+    if not endpoint:
+        return f"❌ Unknown debug operation: {operation}"
+
+    if not user_id:
+        return (
+            "❌ Debug tools require an authenticated user context and VS Code extension tunnel.\n\n"
+            "Ensure you are running in local mode with the Potpie extension connected."
+        )
+
+    timeout = _DEBUG_OPERATION_TIMEOUT_SECS.get(operation, 60.0)
+    request_data = {**data, "conversation_id": conversation_id}
+
+    from app.modules.intelligence.tools.code_changes_manager import (
+        _get_tunnel_url,
+        _get_repository,
+        _get_branch,
+    )
+    from app.modules.tunnel.tunnel_service import get_tunnel_service
+
+    context_tunnel_url = _get_tunnel_url()
+    repository = _get_repository()
+    branch = _get_branch()
+    tunnel_service = get_tunnel_service()
+    tunnel_url = tunnel_service.get_tunnel_url(
+        user_id,
+        conversation_id,
+        tunnel_url=context_tunnel_url,
+        repository=repository,
+        branch=branch,
+    )
+
+    if not tunnel_url:
+        return (
+            "❌ No VS Code extension tunnel available for this workspace.\n\n"
+            "**Fix:** Connect the Potpie extension (workspace registered), ensure repository context "
+            "is present for this conversation, then retry."
+        )
+
+    raw: Optional[Dict[str, Any]] = None
+
+    http_body = _try_http_local_debug(endpoint, request_data, timeout)
+    if isinstance(http_body, dict):
+        raw = _normalize_extension_payload(http_body)
+
+    if raw is None and tunnel_url.startswith(SOCKET_TUNNEL_PREFIX):
+        logger.info("[debug_tunnel] routing %s via Socket.IO → %s", operation, endpoint)
+        sock = _execute_via_socket_full_response(
+            user_id=user_id,
+            conversation_id=conversation_id,
+            endpoint=endpoint,
+            payload=request_data,
+            tunnel_url=tunnel_url,
+            repository=repository,
+            branch=branch,
+            timeout=timeout,
+        )
+        raw = _normalize_extension_payload(sock) if sock else None
+
+    if raw is None and tunnel_url and not tunnel_url.startswith(SOCKET_TUNNEL_PREFIX):
+        base = tunnel_url.rstrip("/")
+        url = f"{base}{endpoint}"
+        try:
+            logger.info("[debug_tunnel] routing %s via HTTP tunnel → %s", operation, url)
+            with httpx.Client(timeout=timeout) as client:
+                resp = client.post(
+                    url,
+                    json=request_data,
+                    headers={"Content-Type": "application/json"},
+                )
+            if resp.status_code == 200:
+                raw = _normalize_extension_payload(resp.json())
+            else:
+                logger.warning(
+                    "[debug_tunnel] HTTP tunnel %s failed: %s %s",
+                    url,
+                    resp.status_code,
+                    resp.text[:300],
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[debug_tunnel] HTTP tunnel error %s: %s", url, exc)
+
+    if raw is None:
+        return (
+            f"❌ Debug request failed or timed out ({operation}).\n\n"
+            "Check that the VS Code extension is connected and implements "
+            f"`POST {endpoint}`."
+        )
+
+    if raw.get("success") and "result" in raw:
+        try:
+            return format_debug_result(operation, raw["result"])
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("format_debug_result failed: %s", exc)
+            return f"✅ Success but formatting failed: {raw['result']!r}"
+
+    err = raw.get("error") or raw.get("message") or "Unknown error"
+    return f"❌ Debug operation failed ({operation}): {err}"

--- a/app/modules/intelligence/tools/debug_tools/find_related_tests_tool.py
+++ b/app/modules/intelligence/tools/debug_tools/find_related_tests_tool.py
@@ -1,0 +1,149 @@
+"""Find test files related to a given source file or symbol.
+
+Strategy (in order, stops at first useful result):
+1. Knowledge-graph query for callers of the symbol that live in test files.
+2. ripgrep via sandbox_search for import of the file's basename.
+3. Path-mirror heuristic: src/foo/bar.ts → tests/foo/bar.test.ts, etc.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import List, Optional
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from app.modules.utils.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+_TEST_DIR_CANDIDATES = ["tests", "test", "__tests__", "spec", "e2e"]
+_TEST_EXT_MAP = {
+    ".py": [".test.py", "_test.py"],
+    ".ts": [".test.ts", ".spec.ts"],
+    ".js": [".test.js", ".spec.js"],
+    ".go": ["_test.go"],
+    ".java": ["Test.java"],
+    ".rb": ["_spec.rb"],
+}
+
+
+def _basename_without_ext(file_path: str) -> str:
+    base = os.path.basename(file_path)
+    name, _ = os.path.splitext(base)
+    return name
+
+
+def _path_mirror_candidates(file_path: str) -> List[str]:
+    """Generate mirror test path candidates for a source file."""
+    name, ext = os.path.splitext(os.path.basename(file_path))
+    suffixes = _TEST_EXT_MAP.get(ext, [f".test{ext}", f".spec{ext}", f"_test{ext}"])
+    parts = re.split(r"[/\\]", file_path)
+
+    candidates = []
+    for test_dir in _TEST_DIR_CANDIDATES:
+        # Replace first path component that looks like src/lib/app with test_dir
+        for i, part in enumerate(parts):
+            if part in ("src", "lib", "app", "source", "main"):
+                mirror_parts = parts[:i] + [test_dir] + parts[i + 1 :]
+                base_path = "/".join(mirror_parts[:-1])
+                for suffix in suffixes:
+                    candidates.append(f"{base_path}/{name}{suffix}")
+                break
+        # Also try flat: <test_dir>/<filename><suffix>
+        for suffix in suffixes:
+            candidates.append(f"{test_dir}/{name}{suffix}")
+
+    return candidates
+
+
+def find_related_tests(input_data: "FindRelatedTestsInput") -> str:
+    file_path = input_data.file_path or ""
+    symbol = input_data.symbol or ""
+
+    results: List[str] = []
+    methods_used: List[str] = []
+
+    # --- Strategy 1: knowledge graph ---
+    if symbol:
+        try:
+            from app.modules.intelligence.tools.code_tools.ask_knowledge_graph_queries_tool import (
+                AskKnowledgeGraphQueriesInput,
+                ask_knowledge_graph_queries_tool,
+            )
+
+            query = f"Which test files or test functions call or import '{symbol}'?"
+            kg_result = ask_knowledge_graph_queries_tool(
+                AskKnowledgeGraphQueriesInput(query=query)
+            )
+            if kg_result and "test" in kg_result.lower():
+                results.append(f"**Knowledge graph results for `{symbol}`:**\n{kg_result}")
+                methods_used.append("knowledge_graph")
+        except Exception as e:
+            logger.debug(f"find_related_tests: KG strategy failed: {e}")
+
+    # --- Strategy 2: ripgrep via sandbox_search ---
+    if file_path:
+        basename = _basename_without_ext(file_path)
+        try:
+            from app.modules.intelligence.tools.local_search_tools.search_text_tool import (
+                SearchTextInput,
+                search_text_tool,
+            )
+
+            rg_result = search_text_tool(
+                SearchTextInput(
+                    query=basename,
+                    file_pattern="**/*{test,spec}*",
+                    case_sensitive=False,
+                    use_regex=False,
+                    max_results=20,
+                )
+            )
+            if rg_result and "❌" not in rg_result:
+                results.append(f"**ripgrep search for `{basename}` in test files:**\n{rg_result}")
+                methods_used.append("ripgrep")
+        except Exception as e:
+            logger.debug(f"find_related_tests: ripgrep strategy failed: {e}")
+
+    # --- Strategy 3: path-mirror heuristic ---
+    if file_path:
+        candidates = _path_mirror_candidates(file_path)
+        mirror_hits = candidates[:8]  # surface top candidates to the agent
+        results.append(
+            "**Path-mirror candidates** (check if these exist):\n"
+            + "\n".join(f"  - `{c}`" for c in mirror_hits)
+        )
+        methods_used.append("path_mirror")
+
+    if not results:
+        return f"No related tests found for file=`{file_path}` symbol=`{symbol}`. Try searching manually with `sandbox_search`."
+
+    header = f"Related tests for {'`' + file_path + '`' if file_path else ''}{' / `' + symbol + '`' if symbol else ''} (strategies: {', '.join(methods_used)}):\n"
+    return header + "\n\n".join(results)
+
+
+class FindRelatedTestsInput(BaseModel):
+    file_path: Optional[str] = Field(
+        default=None,
+        description="Source file path (e.g. src/checkout/createOrder.ts). Used for ripgrep and path-mirror strategies.",
+    )
+    symbol: Optional[str] = Field(
+        default=None,
+        description="Function or class name (e.g. createOrder). Used for knowledge-graph strategy.",
+    )
+
+
+def create_find_related_tests_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=find_related_tests,
+        name="find_related_tests",
+        description=(
+            "Find test files related to a source file or symbol using three strategies: "
+            "knowledge-graph callers, ripgrep import search, and path-mirror heuristics. "
+            "Provide file_path, symbol, or both."
+        ),
+        args_schema=FindRelatedTestsInput,
+    )

--- a/app/modules/intelligence/tools/debug_tools/list_watches_tool.py
+++ b/app/modules/intelligence/tools/debug_tools/list_watches_tool.py
@@ -1,0 +1,28 @@
+"""List all persistent watch expressions for the current debug session."""
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, ConfigDict
+
+from app.modules.intelligence.tools.local_search_tools.tunnel_utils import get_context_vars
+from .watch_store import list_watches
+
+
+class ListWatchesInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+def list_watches_tool(_input_data: ListWatchesInput) -> str:
+    user_id, conversation_id = get_context_vars()
+    watches = list_watches(user_id, conversation_id)
+    if not watches:
+        return "No active watches. Use `add_watch` to register expressions."
+    return f"Active watches ({len(watches)}):\n" + "\n".join(f"  - {w}" for w in watches)
+
+
+def create_list_watches_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=list_watches_tool,
+        name="list_watches",
+        description="List all persistent watch expressions registered for this debug session.",
+        args_schema=ListWatchesInput,
+    )

--- a/app/modules/intelligence/tools/debug_tools/parse_debug_signal_tool.py
+++ b/app/modules/intelligence/tools/debug_tools/parse_debug_signal_tool.py
@@ -1,0 +1,210 @@
+"""Parse a pasted log, stack trace, or failed test into a structured debug signal.
+
+Pure-regex extraction — no LLM call. Deterministic and unit-testable.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# Regex bank
+# ---------------------------------------------------------------------------
+
+_PYTHON_FRAME = re.compile(
+    r'File\s+"([^"]+)",\s+line\s+(\d+),\s+in\s+(\S+)'
+)
+_NODE_FRAME = re.compile(
+    r"at\s+(?:(?P<sym>[^\s(]+)\s+)?\((?P<file>[^:)]+):(?P<line>\d+):\d+\)"
+)
+_NODE_FRAME_NOPARENS = re.compile(
+    r"at\s+(?P<sym>[^\s(]+)\s+(?P<file>[^\s:]+):(?P<line>\d+):\d+"
+)
+_GO_FRAME = re.compile(
+    r"(?P<file>[^\s]+\.go):(?P<line>\d+)\s+\+0x"
+)
+_JAVA_FRAME = re.compile(
+    r"at\s+[\w$.]+\((?P<file>[\w$]+\.java):(?P<line>\d+)\)"
+)
+_GENERIC_PATH_LINE = re.compile(
+    r"(?P<file>(?:[\w./\\-]+/)?[\w-]+\.(?:py|ts|js|go|java|rb|rs|cs|cpp|c|h|php|swift))"
+    r":(?P<line>\d+)"
+)
+
+_ERROR_CLASS_PYTHON = re.compile(r"^(\w+(?:\.\w+)*Error|\w+Exception|\w+Error):\s", re.M)
+_ERROR_CLASS_NODE = re.compile(r"^(\w+Error|Error):\s", re.M)
+_ERROR_CODE = re.compile(r"\b([A-Z][A-Z0-9_]{2,}(?:_ERROR|_TIMEOUT|_FAILURE|_EXCEPTION))\b")
+
+_REQUEST_ID = re.compile(r"(?:request_id|req_id|requestId)\s*[=:]\s*([^\s,]+)", re.I)
+_CORRELATION_ID = re.compile(r"(?:correlation_id|correlationId|x-correlation-id)\s*[=:]\s*([^\s,]+)", re.I)
+_TRACE_ID = re.compile(r"(?:trace_id|traceId|x-trace-id)\s*[=:]\s*([^\s,]+)", re.I)
+
+_JEST_EXPECTED = re.compile(r"Expected(?:\s+value)?:\s+(.+?)(?=\n\s*Received|\Z)", re.S)
+_JEST_RECEIVED = re.compile(r"Received(?:\s+value)?:\s+(.+?)(?=\n\n|\Z)", re.S)
+_PYTEST_EXPECTED = re.compile(r"\+\s*(.+)", re.M)
+_PYTEST_RECEIVED = re.compile(r"-\s*(.+)", re.M)
+_FAIL_LINE = re.compile(r"(?:FAIL|FAILED|✕|✗)\s+([^\n]+)")
+_TEST_PATH = re.compile(r"(?:FAIL|FAILED)\s+([\w./\\-]+(?:test|spec)[\w./\\-]*)", re.I)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _dedupe_frames(frames: List[Dict]) -> List[Dict]:
+    seen: set = set()
+    out = []
+    for f in frames:
+        key = (f["file"], f["line"])
+        if key not in seen:
+            seen.add(key)
+            out.append(f)
+    return out
+
+
+def _parse_frames(text: str) -> List[Dict]:
+    frames: List[Dict] = []
+
+    for m in _PYTHON_FRAME.finditer(text):
+        frames.append({"file": m.group(1), "line": int(m.group(2)), "symbol": m.group(3)})
+
+    for m in _NODE_FRAME.finditer(text):
+        sym = m.group("sym") or "?"
+        frames.append({"file": m.group("file"), "line": int(m.group("line")), "symbol": sym})
+
+    for m in _NODE_FRAME_NOPARENS.finditer(text):
+        frames.append({"file": m.group("file"), "line": int(m.group("line")), "symbol": m.group("sym")})
+
+    for m in _GO_FRAME.finditer(text):
+        frames.append({"file": m.group("file"), "line": int(m.group("line")), "symbol": "?"})
+
+    for m in _JAVA_FRAME.finditer(text):
+        frames.append({"file": m.group("file"), "line": int(m.group("line")), "symbol": "?"})
+
+    if not frames:
+        for m in _GENERIC_PATH_LINE.finditer(text):
+            frames.append({"file": m.group("file"), "line": int(m.group("line")), "symbol": "?"})
+
+    return _dedupe_frames(frames)
+
+
+def _detect_signal_type(text: str, frames: List[Dict]) -> str:
+    lower = text.lower()
+    if re.search(r"(FAIL|FAILED|✕|✗|Expected:|Received:|\bfailed\b.*test|\btest.*failed\b)", text):
+        return "failed_test"
+    if frames:
+        if any(kw in lower for kw in ("traceback", "stack trace", "at ", "file \"")):
+            return "stack_trace"
+        return "pasted_log"
+    return "natural_language"
+
+
+def _extract_error_signature(text: str) -> Optional[str]:
+    m = _ERROR_CLASS_PYTHON.search(text) or _ERROR_CLASS_NODE.search(text)
+    if m:
+        return m.group(1)
+    m = _ERROR_CODE.search(text)
+    if m:
+        return m.group(1)
+    return None
+
+
+def _extract_test_info(text: str) -> Dict[str, Optional[str]]:
+    expected = received = test_path = None
+
+    m = _TEST_PATH.search(text)
+    if m:
+        test_path = m.group(1).strip()
+
+    m = _JEST_EXPECTED.search(text)
+    if m:
+        expected = m.group(1).strip()[:200]
+    m = _JEST_RECEIVED.search(text)
+    if m:
+        received = m.group(1).strip()[:200]
+
+    return {"expected": expected, "actual": received, "test_path": test_path}
+
+
+def _format_output(data: Dict[str, Any]) -> str:
+    lines = [f"**signal_type**: {data['signal_type']}"]
+
+    if data.get("error_signature"):
+        lines.append(f"**error_signature**: {data['error_signature']}")
+
+    if data.get("request_id"):
+        lines.append(f"**request_id**: {data['request_id']}")
+    if data.get("correlation_id"):
+        lines.append(f"**correlation_id**: {data['correlation_id']}")
+    if data.get("trace_id"):
+        lines.append(f"**trace_id**: {data['trace_id']}")
+
+    frames = data.get("stack_frames", [])
+    if frames:
+        lines.append(f"\n**stack_frames** ({len(frames)} extracted):")
+        for f in frames:
+            sym = f.get("symbol") or "?"
+            lines.append(f"  - {f['file']}:{f['line']}  in `{sym}`")
+    else:
+        lines.append("\n**stack_frames**: none extracted")
+
+    ti = data.get("test_info", {})
+    if ti.get("test_path"):
+        lines.append(f"\n**test_path**: {ti['test_path']}")
+    if ti.get("expected"):
+        lines.append(f"**expected**: {ti['expected']}")
+    if ti.get("actual"):
+        lines.append(f"**actual**: {ti['actual']}")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Tool
+# ---------------------------------------------------------------------------
+
+class ParseDebugSignalInput(BaseModel):
+    text: str = Field(description="Raw pasted log, stack trace, failed test output, or symptom description")
+
+
+def parse_debug_signal(input_data: ParseDebugSignalInput) -> str:
+    text = input_data.text
+
+    frames = _parse_frames(text)
+    signal_type = _detect_signal_type(text, frames)
+    error_sig = _extract_error_signature(text)
+    test_info = _extract_test_info(text) if signal_type == "failed_test" else {}
+
+    req_m = _REQUEST_ID.search(text)
+    corr_m = _CORRELATION_ID.search(text)
+    trace_m = _TRACE_ID.search(text)
+
+    data: Dict[str, Any] = {
+        "signal_type": signal_type,
+        "stack_frames": frames,
+        "error_signature": error_sig,
+        "request_id": req_m.group(1) if req_m else None,
+        "correlation_id": corr_m.group(1) if corr_m else None,
+        "trace_id": trace_m.group(1) if trace_m else None,
+        "test_info": test_info,
+    }
+
+    return _format_output(data)
+
+
+def create_parse_debug_signal_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=parse_debug_signal,
+        name="parse_debug_signal",
+        description=(
+            "Parse a pasted log, stack trace, failed test output, or symptom description "
+            "into a structured signal: signal_type, stack_frames (file/line/symbol), "
+            "error_signature, request/correlation/trace ids, and test expected/actual."
+        ),
+        args_schema=ParseDebugSignalInput,
+    )

--- a/app/modules/intelligence/tools/debug_tools/remove_watch_tool.py
+++ b/app/modules/intelligence/tools/debug_tools/remove_watch_tool.py
@@ -1,0 +1,28 @@
+"""Remove a persistent watch expression for the current debug session."""
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from app.modules.intelligence.tools.local_search_tools.tunnel_utils import get_context_vars
+from .watch_store import remove_watch
+
+
+class RemoveWatchInput(BaseModel):
+    expression: str = Field(description="Watch expression to remove")
+
+
+def remove_watch_tool(input_data: RemoveWatchInput) -> str:
+    user_id, conversation_id = get_context_vars()
+    watches = remove_watch(user_id, conversation_id, input_data.expression)
+    if watches:
+        return f"Watch removed. Remaining watches ({len(watches)}):\n" + "\n".join(f"  - {w}" for w in watches)
+    return "Watch removed. No active watches."
+
+
+def create_remove_watch_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=remove_watch_tool,
+        name="remove_watch",
+        description="Remove a persistent watch expression from this debug session.",
+        args_schema=RemoveWatchInput,
+    )

--- a/app/modules/intelligence/tools/debug_tools/watch_store.py
+++ b/app/modules/intelligence/tools/debug_tools/watch_store.py
@@ -1,0 +1,60 @@
+"""In-memory persistent watch expression store.
+
+Keyed by (user_id, conversation_id) so each debug session has its own watch list.
+TTL is implicit — the process lifetime covers the chat session.
+"""
+
+from __future__ import annotations
+
+from threading import Lock
+from typing import Dict, List, Optional, Tuple
+
+_store: Dict[Tuple[Optional[str], Optional[str]], List[str]] = {}
+_lock = Lock()
+
+
+def _key(user_id: Optional[str], conversation_id: Optional[str]) -> Tuple:
+    return (user_id, conversation_id)
+
+
+def add_watch(user_id: Optional[str], conversation_id: Optional[str], expression: str) -> List[str]:
+    k = _key(user_id, conversation_id)
+    with _lock:
+        watches = _store.setdefault(k, [])
+        if expression not in watches:
+            watches.append(expression)
+        return list(watches)
+
+
+def remove_watch(user_id: Optional[str], conversation_id: Optional[str], expression: str) -> List[str]:
+    k = _key(user_id, conversation_id)
+    with _lock:
+        watches = _store.get(k, [])
+        _store[k] = [w for w in watches if w != expression]
+        return list(_store[k])
+
+
+def list_watches(user_id: Optional[str], conversation_id: Optional[str]) -> List[str]:
+    k = _key(user_id, conversation_id)
+    with _lock:
+        return list(_store.get(k, []))
+
+
+def clear_watches(user_id: Optional[str], conversation_id: Optional[str]) -> None:
+    k = _key(user_id, conversation_id)
+    with _lock:
+        _store.pop(k, None)
+
+
+def merge_into_expressions(
+    user_id: Optional[str],
+    conversation_id: Optional[str],
+    expressions: Optional[List[str]],
+) -> List[str]:
+    """Return the union of persistent watches and the caller-supplied expressions, deduped."""
+    watches = list_watches(user_id, conversation_id)
+    combined = list(watches)
+    for expr in expressions or []:
+        if expr not in combined:
+            combined.append(expr)
+    return combined

--- a/app/modules/intelligence/tools/local_search_tools/tunnel_utils.py
+++ b/app/modules/intelligence/tools/local_search_tools/tunnel_utils.py
@@ -114,6 +114,69 @@ def _execute_via_socket(
     return None
 
 
+def _execute_via_socket_full_response(
+    user_id: str,
+    conversation_id: Optional[str],
+    endpoint: str,
+    payload: Dict[str, Any],
+    tunnel_url: Optional[str] = None,
+    repository: Optional[str] = None,
+    branch: Optional[str] = None,
+    timeout: float = 120.0,
+) -> Optional[Dict[str, Any]]:
+    """Socket.IO tool call returning the full ``{success, result?, error?}`` dict.
+
+    Used by debug tools so failures can surface ``error`` to the agent (unlike
+    :func:`_execute_via_socket`, which drops failed responses).
+    """
+    from app.modules.tunnel.tunnel_service import (
+        get_tunnel_service,
+        TunnelConnectionError,
+    )
+
+    last_error: Optional[str] = None
+    for attempt in range(1, _SOCKET_MAX_RETRIES + 2):
+        try:
+            out = get_tunnel_service().execute_tool_call_with_fallback(
+                user_id=user_id,
+                conversation_id=conversation_id,
+                endpoint=endpoint,
+                payload=payload,
+                tunnel_url=tunnel_url,
+                repository=repository,
+                branch=branch,
+                timeout=timeout,
+            )
+            if isinstance(out, dict) and "success" in out:
+                return out
+            return None
+        except TunnelConnectionError as exc:
+            last_error = exc.last_error or str(exc)
+            if last_error == "timeout":
+                logger.warning(
+                    "[_execute_via_socket_full_response] Attempt %d failed (timeout) — not retrying",
+                    attempt,
+                )
+                return None
+            if attempt <= _SOCKET_MAX_RETRIES:
+                delay = _SOCKET_RETRY_DELAY_SECS * attempt
+                logger.warning(
+                    "[_execute_via_socket_full_response] Attempt %d/%d failed (%s) — retrying in %.1fs",
+                    attempt,
+                    _SOCKET_MAX_RETRIES + 1,
+                    last_error,
+                    delay,
+                )
+                time.sleep(delay)
+            else:
+                logger.warning(
+                    "[_execute_via_socket_full_response] All %d attempts failed (last: %s)",
+                    _SOCKET_MAX_RETRIES + 1,
+                    last_error,
+                )
+    return None
+
+
 def _curl_equivalent_terminal_execute(
     url: str, request_data: Dict[str, Any], timeout_sec: float
 ) -> str:

--- a/app/modules/intelligence/tools/registry/definitions.py
+++ b/app/modules/intelligence/tools/registry/definitions.py
@@ -255,7 +255,83 @@ TOOL_DEFINITIONS: Dict[str, dict] = {
         "short_description": "Post a top-level or inline comment on a PR via the sandbox.",
         "aliases": ["github_add_pr_comments_sandbox"],
     },
+    # Debugger (VS Code extension / LocalServer; local_mode_only)
+    "debug_start": {
+        "tier": "low",
+        "category": "debug",
+        "short_description": "Launch or attach a debug session.",
+        "local_mode_only": True,
+    },
+    "debug_stop": {
+        "tier": "low",
+        "category": "debug",
+        "short_description": "Stop a debug session.",
+        "local_mode_only": True,
+    },
+    "debug_set_breakpoints": {
+        "tier": "low",
+        "category": "debug",
+        "short_description": "Set breakpoints in a source file.",
+        "local_mode_only": True,
+    },
+    "debug_snapshot": {
+        "tier": "low",
+        "category": "debug",
+        "short_description": "Capture call stack, locals, and expression values.",
+        "local_mode_only": True,
+    },
+    "debug_step_into": {
+        "tier": "low",
+        "category": "debug",
+        "short_description": "Step into function call.",
+        "local_mode_only": True,
+    },
+    "debug_step_out": {
+        "tier": "low",
+        "category": "debug",
+        "short_description": "Step out to caller.",
+        "local_mode_only": True,
+    },
+    "debug_step_over": {
+        "tier": "low",
+        "category": "debug",
+        "short_description": "Step over current line.",
+        "local_mode_only": True,
+    },
+    "debug_continue": {
+        "tier": "low",
+        "category": "debug",
+        "short_description": "Resume execution to next breakpoint.",
+        "local_mode_only": True,
+    },
+    "debug_select_frame": {
+        "tier": "low",
+        "category": "debug",
+        "short_description": "Select a stack frame for inspection.",
+        "local_mode_only": True,
+    },
+    "debug_list_sessions": {
+        "tier": "low",
+        "category": "debug",
+        "short_description": "List active debug sessions.",
+        "read_only": True,
+        "idempotent": True,
+        "local_mode_only": True,
+    },
 }
+
+DEBUG_TOOLS: List[str] = [
+    "debug_start",
+    "debug_stop",
+    "debug_set_breakpoints",
+    "debug_snapshot",
+    "debug_step_into",
+    "debug_step_out",
+    "debug_step_over",
+    "debug_continue",
+    "debug_select_frame",
+    "debug_list_sessions",
+]
 
 # --- Allow-lists ---
 

--- a/app/modules/intelligence/tools/registry/definitions.py
+++ b/app/modules/intelligence/tools/registry/definitions.py
@@ -318,9 +318,65 @@ TOOL_DEFINITIONS: Dict[str, dict] = {
         "idempotent": True,
         "local_mode_only": True,
     },
+    "debug_list_launch_configs": {
+        "tier": "low",
+        "category": "debug",
+        "short_description": "List VS Code launch.json debug configurations.",
+        "read_only": True,
+        "idempotent": True,
+        "local_mode_only": True,
+    },
+    "debug_list_adapters": {
+        "tier": "low",
+        "category": "debug",
+        "short_description": "List available debug adapters (python/node/go).",
+        "read_only": True,
+        "idempotent": True,
+        "local_mode_only": True,
+    },
+    # Hypothesis workflow tools — no extension dependency
+    "parse_debug_signal": {
+        "tier": "low",
+        "category": "debug",
+        "short_description": "Parse pasted log/stack trace into a structured signal.",
+        "read_only": True,
+        "idempotent": True,
+    },
+    "build_debug_context": {
+        "tier": "medium",
+        "category": "debug",
+        "short_description": "Build a debug context packet from a parsed signal.",
+        "read_only": True,
+        "idempotent": True,
+    },
+    "find_related_tests": {
+        "tier": "medium",
+        "category": "debug",
+        "short_description": "Find test files related to a source file or symbol.",
+        "read_only": True,
+        "idempotent": True,
+    },
+    "add_watch": {
+        "tier": "low",
+        "category": "debug",
+        "short_description": "Register a persistent watch expression for this debug session.",
+    },
+    "remove_watch": {
+        "tier": "low",
+        "category": "debug",
+        "short_description": "Remove a persistent watch expression from this debug session.",
+    },
+    "list_watches": {
+        "tier": "low",
+        "category": "debug",
+        "short_description": "List all active watch expressions for this debug session.",
+        "read_only": True,
+        "idempotent": True,
+    },
 }
 
 DEBUG_TOOLS: List[str] = [
+    # DAP / extension tunnel
     "debug_start",
     "debug_stop",
     "debug_set_breakpoints",
@@ -331,6 +387,15 @@ DEBUG_TOOLS: List[str] = [
     "debug_continue",
     "debug_select_frame",
     "debug_list_sessions",
+    "debug_list_launch_configs",
+    "debug_list_adapters",
+    # Hypothesis workflow (backend-only)
+    "parse_debug_signal",
+    "build_debug_context",
+    "find_related_tests",
+    "add_watch",
+    "remove_watch",
+    "list_watches",
 ]
 
 # --- Allow-lists ---

--- a/app/modules/intelligence/tools/registry/population.py
+++ b/app/modules/intelligence/tools/registry/population.py
@@ -51,6 +51,7 @@ def _derive_phase4_annotations(name: str, category: ToolCategory) -> Dict[str, b
     if category == "terminal":
         out["destructive"] = True
         out["requires_confirmation"] = True
+    # debug: annotations come from TOOL_DEFINITIONS (avoid treating as terminal/search).
     return out
 
 

--- a/app/modules/intelligence/tools/registry/schema.py
+++ b/app/modules/intelligence/tools/registry/schema.py
@@ -25,6 +25,7 @@ ToolCategory = Literal[
     "file_fetch",
     "analysis",
     "sandbox",
+    "debug",
     "other",
 ]
 

--- a/app/modules/intelligence/tools/tool_service.py
+++ b/app/modules/intelligence/tools/tool_service.py
@@ -95,6 +95,10 @@ from langchain_core.tools import StructuredTool
 from .todo_management_tool import create_todo_management_tools
 from .requirement_verification_tool import create_requirement_verification_tools
 from .sandbox.tools import create_sandbox_tools
+from .debug_tools import create_debug_tools
+from .code_changes_manager.tools import create_code_changes_management_tools
+from .local_search_tools.search_text_tool import SearchTextInput, search_text_tool
+from .local_search_tools.search_files_tool import SearchFilesInput, search_files_tool
 
 
 logger = setup_logger(__name__)
@@ -256,6 +260,32 @@ class ToolService:
         requirement_tools = create_requirement_verification_tools()
         for tool in requirement_tools:
             tools[tool.name] = tool
+
+        # Local VS Code tunnel: terminal sessions + debugger + minimal search surfaces
+        for tool in create_code_changes_management_tools():
+            tools[tool.name] = tool
+
+        for tool in create_debug_tools():
+            tools[tool.name] = tool
+
+        tools["search_text"] = StructuredTool.from_function(
+            func=search_text_tool,
+            name="search_text",
+            description=(
+                "Search for text patterns across the workspace via the VS Code extension tunnel "
+                "(LocalServer). Requires local mode / extension connected."
+            ),
+            args_schema=SearchTextInput,
+        )
+        tools["search_files"] = StructuredTool.from_function(
+            func=search_files_tool,
+            name="search_files",
+            description=(
+                "Find files by glob pattern via the VS Code extension tunnel (LocalServer). "
+                "Requires local mode / extension connected."
+            ),
+            args_schema=SearchFilesInput,
+        )
 
         if self.webpage_extractor_tool:
             tools["webpage_extractor"] = self.webpage_extractor_tool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dependencies = [
     "resend>=2.19.0",
     "scikit-learn>=1.7.2",
     "sentence-transformers>=5.1.2",
+    "torch>=2.12.0",
     "sentry-sdk[fastapi]>=2.43.0",
     "sqlalchemy>=2.0.44",
     "tiktoken>=0.12.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -971,8 +971,10 @@ tokenizers==0.22.2
     #   transformers
 toml==0.10.2
     # via daytona
-torch==2.10.0
-    # via sentence-transformers
+torch==2.12.0
+    # via
+    #   potpie (pyproject.toml)
+    #   sentence-transformers
 tornado==6.5.5
     # via
     #   potpie (pyproject.toml)

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 set -e
 
+# Export every variable assigned while sourcing .env so gunicorn/celery children inherit them
+# (lines like KEY=value without `export` are otherwise not passed to subprocesses).
+set -a
+# shellcheck source=/dev/null
 source .env
+set +a
 
 # Set up Google ADC-style Service Account Credentials when available.
 # Firebase startup uses firebase_service_account.json/txt separately; this file is

--- a/tests/unit/intelligence/agents/chat_agents/system_agents/test_debug_agent_integration.py
+++ b/tests/unit/intelligence/agents/chat_agents/system_agents/test_debug_agent_integration.py
@@ -1,0 +1,187 @@
+"""Mock integration: DebugAgent wires debugger tools only in local_mode."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.intelligence.agents.chat_agent import ChatContext
+from app.modules.intelligence.agents.chat_agents.system_agents.debug_agent import (
+    DebugAgent,
+)
+from app.modules.intelligence.tools.debug_tools.debug_tunnel_utils import (
+    route_debug_command,
+)
+
+
+def _capture_get_tools():  # type: ignore[no-untyped-def]
+    captured = []
+
+    def get_tools_capture(names, exclude_embedding_tools=False):
+        captured.append((list(names), exclude_embedding_tools))
+        return [SimpleNamespace(name=n) for n in names]
+
+    return captured, get_tools_capture
+
+
+def test_debug_agent_build_non_local_skips_debug_tools() -> None:
+    captured, get_tools_capture = _capture_get_tools()
+    mock_tools = MagicMock()
+    mock_tools.get_tools = get_tools_capture
+
+    llm = MagicMock()
+    llm.supports_pydantic.return_value = True
+    prompts = MagicMock()
+
+    ctx = ChatContext(
+        project_id="p1",
+        project_name="Pn",
+        curr_agent_id="debugging_agent",
+        history=[],
+        query="why",
+        project_status=None,
+    )
+
+    with patch(
+        "app.modules.intelligence.agents.chat_agents.system_agents.debug_agent.MultiAgentConfig.should_use_multi_agent",
+        return_value=False,
+    ):
+        agent = DebugAgent(llm, mock_tools, prompts)
+        agent._build_agent(ctx, local_mode=False)
+
+    assert len(captured) == 1
+    assert "debug_start" not in captured[0][0]
+
+
+def test_debug_agent_build_local_extends_tools_with_debug_bundle() -> None:
+    captured, get_tools_capture = _capture_get_tools()
+    mock_tools = MagicMock()
+    mock_tools.get_tools = get_tools_capture
+
+    llm = MagicMock()
+    llm.supports_pydantic.return_value = True
+    prompts = MagicMock()
+
+    ctx = ChatContext(
+        project_id="p1",
+        project_name="Pn",
+        curr_agent_id="debugging_agent",
+        history=[],
+        query="trace bug",
+        project_status=None,
+    )
+
+    with patch(
+        "app.modules.intelligence.agents.chat_agents.system_agents.debug_agent.MultiAgentConfig.should_use_multi_agent",
+        return_value=False,
+    ):
+        agent = DebugAgent(llm, mock_tools, prompts)
+        agent._build_agent(ctx, local_mode=True)
+
+    assert len(captured) == 2
+    extra_names = captured[1][0]
+    expected = [
+        "debug_start",
+        "debug_stop",
+        "debug_set_breakpoints",
+        "debug_snapshot",
+        "debug_step_into",
+        "debug_step_out",
+        "debug_step_over",
+        "debug_continue",
+        "debug_select_frame",
+        "debug_list_sessions",
+        "execute_terminal_command",
+        "search_text",
+        "search_files",
+    ]
+    assert extra_names == expected
+
+
+def test_mock_debug_session_flow_via_route_layer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Chained Socket.IO payloads: start → breakpoints → snapshot."""
+    monkeypatch.setenv("FORCE_TUNNEL", "true")
+
+    mock_ts = MagicMock()
+    mock_ts.get_tunnel_url.return_value = "socket://workspace-1"
+
+    payloads = iter(
+        [
+            {"success": True, "result": {"session_id": "sid-1", "status": "initialized"}},
+            {
+                "success": True,
+                "result": {
+                    "file": "app.py",
+                    "breakpoints": [{"line": 10, "verified": True}],
+                },
+            },
+            {
+                "success": True,
+                "result": {
+                    "paused_at": {"file": "app.py", "line": 10, "function": "f"},
+                    "call_stack": [
+                        {"file": "app.py", "line": 10, "function": "f", "frame_id": 1},
+                    ],
+                    "locals": {"x": "1"},
+                    "expression_results": [],
+                    "session_id": "sid-1",
+                    "status": "paused",
+                },
+            },
+        ]
+    )
+
+    def next_sock_payload(*args, **kwargs):  # type: ignore[no-untyped-def]
+        try:
+            return next(payloads)
+        except StopIteration as exc:
+            raise AssertionError("unexpected extra socket call") from exc
+
+    with (
+        patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_tunnel_url",
+            return_value=None,
+        ),
+        patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_repository",
+            return_value="repo",
+        ),
+        patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_branch",
+            return_value="main",
+        ),
+        patch(
+            "app.modules.tunnel.tunnel_service.get_tunnel_service",
+            return_value=mock_ts,
+        ),
+        patch(
+            "app.modules.intelligence.tools.debug_tools.debug_tunnel_utils._try_http_local_debug",
+            return_value=None,
+        ),
+        patch(
+            "app.modules.intelligence.tools.debug_tools.debug_tunnel_utils._execute_via_socket_full_response",
+            side_effect=next_sock_payload,
+        ),
+    ):
+        s1 = route_debug_command(
+            "debug_start",
+            {"program": "app.py"},
+            "u1",
+            "c1",
+        )
+        s2 = route_debug_command(
+            "debug_set_breakpoints",
+            {"file": "app.py", "lines": [10]},
+            "u1",
+            "c1",
+        )
+        s3 = route_debug_command("debug_snapshot", {"wait": True}, "u1", "c1")
+
+    assert "sid-1" in s1
+    assert "Breakpoints" in s2 or "verified" in s2.lower()
+    assert "Paused at" in s3
+    assert "x = 1" in s3

--- a/tests/unit/intelligence/tools/debug_tools/test_debug_structured_tools.py
+++ b/tests/unit/intelligence/tools/debug_tools/test_debug_structured_tools.py
@@ -1,0 +1,186 @@
+"""Per-tool StructuredTool tests — each forwards to route_debug_command with correct operation/payload."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.intelligence.tools.debug_tools import create_debug_tools
+from app.modules.intelligence.tools.registry.definitions import DEBUG_TOOLS
+
+
+@pytest.fixture
+def tools_by_name():
+    mapping = {}
+    for t in create_debug_tools():
+        mapping[t.name] = t
+    return mapping
+
+
+def _run_debug_tool(tool: Any, raw: Dict[str, Any]) -> str:
+    """Execute the tool's sync body with a validated Pydantic input (matches agent binding)."""
+    if tool.args_schema is None:
+        raise AssertionError(f"{tool.name} missing args_schema")
+    model = tool.args_schema.model_validate(raw)
+    return tool.func(model)
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "module", "invoke_arg", "expected_payload"),
+    [
+        (
+            "debug_start",
+            "app.modules.intelligence.tools.debug_tools.debug_start_tool",
+            {"program": "src/app.py"},
+            {
+                "program": "src/app.py",
+                "language": "python",
+                "mode": "launch",
+                "args": {},
+            },
+        ),
+        (
+            "debug_stop",
+            "app.modules.intelligence.tools.debug_tools.debug_stop_tool",
+            {},
+            {},
+        ),
+        (
+            "debug_set_breakpoints",
+            "app.modules.intelligence.tools.debug_tools.debug_set_breakpoints_tool",
+            {"file": "src/a.py", "lines": [10, 20]},
+            {"file": "src/a.py", "lines": [10, 20]},
+        ),
+        (
+            "debug_snapshot",
+            "app.modules.intelligence.tools.debug_tools.debug_snapshot_tool",
+            {},
+            {"wait": True, "timeout": 30.0},
+        ),
+        (
+            "debug_step_into",
+            "app.modules.intelligence.tools.debug_tools.debug_step_into_tool",
+            {},
+            {},
+        ),
+        (
+            "debug_step_out",
+            "app.modules.intelligence.tools.debug_tools.debug_step_out_tool",
+            {},
+            {},
+        ),
+        (
+            "debug_step_over",
+            "app.modules.intelligence.tools.debug_tools.debug_step_over_tool",
+            {},
+            {},
+        ),
+        (
+            "debug_continue",
+            "app.modules.intelligence.tools.debug_tools.debug_continue_tool",
+            {},
+            {},
+        ),
+        (
+            "debug_select_frame",
+            "app.modules.intelligence.tools.debug_tools.debug_select_frame_tool",
+            {"frame_index": 2},
+            {"frame_index": 2},
+        ),
+        (
+            "debug_list_sessions",
+            "app.modules.intelligence.tools.debug_tools.debug_list_sessions_tool",
+            {},
+            {},
+        ),
+    ],
+)
+def test_structured_tool_invokes_route_debug_command(
+    tools_by_name: Dict[str, Any],
+    tool_name: str,
+    module: str,
+    invoke_arg: Dict[str, Any],
+    expected_payload: Dict[str, Any],
+) -> None:
+    tool = tools_by_name[tool_name]
+    with patch(f"{module}.route_debug_command", return_value="ok") as mock_route:
+        with patch(f"{module}.get_context_vars", return_value=("user-1", "conv-1")):
+            result = _run_debug_tool(tool, invoke_arg)
+    assert result == "ok"
+    mock_route.assert_called_once()
+    args, kw = mock_route.call_args
+    assert kw == {}
+    op, data, user_id, conv_id = args
+    assert op == tool_name
+    assert data == expected_payload
+    assert user_id == "user-1"
+    assert conv_id == "conv-1"
+
+
+@pytest.mark.parametrize("tool_name", DEBUG_TOOLS)
+def test_tool_tunnel_unauthorized_user_returns_message(
+    tools_by_name: Dict[str, Any], tool_name: str
+) -> None:
+    """When user_id from context is None, extension route is unreachable — clear error."""
+    tool = tools_by_name[tool_name]
+    invoke_arg = _minimal_invoke_args(tool_name)
+    module = _tool_module(tool_name)
+
+    # Real route_debug_command; no authenticated user_id from context vars
+    with patch(f"{module}.get_context_vars", return_value=(None, None)):
+        out = _run_debug_tool(tool, invoke_arg)
+    assert "authenticated user" in out.lower() or "❌" in out
+
+
+@pytest.mark.parametrize("tool_name", DEBUG_TOOLS)
+def test_tool_tunnel_missing_returns_message(
+    tools_by_name: Dict[str, Any], tool_name: str
+) -> None:
+    """With user_id present but tunnel URL unavailable, tools surface tunnel error."""
+    mock_ts = MagicMock()
+    mock_ts.get_tunnel_url.return_value = None
+    invoke_arg = _minimal_invoke_args(tool_name)
+    module = _tool_module(tool_name)
+
+    with (
+        patch(f"{module}.get_context_vars", return_value=("user-1", "conv-1")),
+        patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_tunnel_url",
+            return_value=None,
+        ),
+        patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_repository",
+            return_value=None,
+        ),
+        patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_branch",
+            return_value=None,
+        ),
+        patch(
+            "app.modules.tunnel.tunnel_service.get_tunnel_service",
+            return_value=mock_ts,
+        ),
+        patch(
+            "app.modules.intelligence.tools.debug_tools.debug_tunnel_utils._try_http_local_debug",
+            return_value=None,
+        ),
+    ):
+        out = _run_debug_tool(tools_by_name[tool_name], invoke_arg)
+
+    assert "tunnel" in out.lower()
+
+
+def _tool_module(tool_name: str) -> str:
+    return f"app.modules.intelligence.tools.debug_tools.{tool_name}_tool"
+
+
+def _minimal_invoke_args(tool_name: str) -> Dict[str, Any]:
+    if tool_name == "debug_start":
+        return {"program": "x.py"}
+    if tool_name == "debug_set_breakpoints":
+        return {"file": "x.py", "lines": [1]}
+    if tool_name == "debug_select_frame":
+        return {"frame_index": 0}
+    return {}

--- a/tests/unit/intelligence/tools/debug_tools/test_debug_tunnel_utils.py
+++ b/tests/unit/intelligence/tools/debug_tools/test_debug_tunnel_utils.py
@@ -1,0 +1,259 @@
+"""Tests for debug tunnel formatting and routing."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.intelligence.tools.debug_tools.debug_tunnel_utils import (
+    format_debug_result,
+    route_debug_command,
+)
+
+
+class TestFormatDebugResult:
+    def test_none_result(self) -> None:
+        assert "completed" in format_debug_result("debug_continue", None)
+
+    def test_snapshot_like_with_stack_and_locals(self) -> None:
+        text = format_debug_result(
+            "debug_snapshot",
+            {
+                "paused_at": {"file": "/proj/foo.py", "line": 10, "function": "bar"},
+                "call_stack": [
+                    {"file": "/proj/foo.py", "line": 10, "function": "bar", "frame_id": "f1"},
+                ],
+                "locals": {"x": 1},
+                "session_id": "s1",
+                "status": "stopped",
+            },
+        )
+        assert "Paused at foo.py:10 in bar()" in text
+        assert "Call Stack:" in text
+        assert "bar()" in text
+        assert "Local Variables:" in text
+        assert "x = 1" in text
+        assert "session_id: s1" in text
+
+    def test_breakpoints_format(self) -> None:
+        text = format_debug_result(
+            "debug_set_breakpoints",
+            {
+                "file": "/proj/app.py",
+                "breakpoints": [
+                    {"line": 5, "verified": True},
+                    {"line": 20, "verified": False, "message": "no code"},
+                ],
+            },
+        )
+        assert "Breakpoints in app.py:" in text
+        assert "Line 5: verified" in text
+        assert "Line 20: not verified" in text
+
+    def test_sessions_empty_and_nonempty(self) -> None:
+        empty = format_debug_result("debug_list_sessions", {"sessions": []})
+        assert "(none)" in empty
+
+        full = format_debug_result(
+            "debug_list_sessions",
+            {
+                "sessions": [
+                    {
+                        "session_id": "abc123",
+                        "program": "/proj/main.py",
+                        "language": "python",
+                        "status": "running",
+                    },
+                ],
+            },
+        )
+        assert "Active debug sessions:" in full
+        assert "main.py" in full
+
+    def test_generic_truncates_large_dict(self) -> None:
+        big = {f"k{i}": i for i in range(500)}
+        text = format_debug_result("debug_start", big)
+        assert len(text) <= 8000
+
+
+class TestRouteDebugCommand:
+    def test_unknown_operation(self) -> None:
+        out = route_debug_command("debug_nope", {}, "u1", "c1")
+        assert "Unknown debug operation" in out
+
+    def test_requires_user_id(self) -> None:
+        out = route_debug_command("debug_continue", {}, None, "c1")
+        assert "authenticated user" in out.lower()
+
+    @pytest.mark.parametrize(
+        ("operation", "minimal_payload"),
+        [
+            ("debug_start", {"program": "m.py"}),
+            ("debug_stop", {}),
+            ("debug_set_breakpoints", {"file": "m.py", "lines": [1]}),
+            ("debug_snapshot", {}),
+            ("debug_step_into", {}),
+            ("debug_step_out", {}),
+            ("debug_step_over", {}),
+            ("debug_continue", {}),
+            ("debug_select_frame", {"frame_index": 0}),
+            ("debug_list_sessions", {}),
+        ],
+    )
+    def test_no_tunnel_url_every_operation(
+        self, operation: str, minimal_payload: dict
+    ) -> None:
+        mock_ts = MagicMock()
+        mock_ts.get_tunnel_url.return_value = None
+        with (
+            patch(
+                "app.modules.intelligence.tools.code_changes_manager._get_tunnel_url",
+                return_value=None,
+            ),
+            patch(
+                "app.modules.intelligence.tools.code_changes_manager._get_repository",
+                return_value=None,
+            ),
+            patch(
+                "app.modules.intelligence.tools.code_changes_manager._get_branch",
+                return_value=None,
+            ),
+            patch(
+                "app.modules.tunnel.tunnel_service.get_tunnel_service",
+                return_value=mock_ts,
+            ),
+            patch(
+                "app.modules.intelligence.tools.debug_tools.debug_tunnel_utils._try_http_local_debug",
+                return_value=None,
+            ),
+        ):
+            out = route_debug_command(
+                operation, minimal_payload, "user-1", "conv-1"
+            )
+        assert "tunnel" in out.lower()
+
+    def test_socket_success_formats_result(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FORCE_TUNNEL", "true")
+        mock_ts = MagicMock()
+        mock_ts.get_tunnel_url.return_value = "socket://workspace-1"
+
+        sock_payload = {
+            "success": True,
+            "result": {"session_id": "sid", "status": "started"},
+        }
+
+        with (
+            patch(
+                "app.modules.intelligence.tools.code_changes_manager._get_tunnel_url",
+                return_value=None,
+            ),
+            patch(
+                "app.modules.intelligence.tools.code_changes_manager._get_repository",
+                return_value="repo",
+            ),
+            patch(
+                "app.modules.intelligence.tools.code_changes_manager._get_branch",
+                return_value="main",
+            ),
+            patch(
+                "app.modules.tunnel.tunnel_service.get_tunnel_service",
+                return_value=mock_ts,
+            ),
+            patch(
+                "app.modules.intelligence.tools.debug_tools.debug_tunnel_utils._try_http_local_debug",
+                return_value=None,
+            ),
+            patch(
+                "app.modules.intelligence.tools.debug_tools.debug_tunnel_utils._execute_via_socket_full_response",
+                return_value=sock_payload,
+            ),
+        ):
+            out = route_debug_command("debug_start", {"program": "main.py"}, "u1", "c1")
+
+        assert "session_id: sid" in out
+        assert "status: started" in out
+
+    def test_socket_extension_error_message(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FORCE_TUNNEL", "true")
+        mock_ts = MagicMock()
+        mock_ts.get_tunnel_url.return_value = "socket://workspace-1"
+
+        with (
+            patch(
+                "app.modules.intelligence.tools.code_changes_manager._get_tunnel_url",
+                return_value=None,
+            ),
+            patch(
+                "app.modules.intelligence.tools.code_changes_manager._get_repository",
+                return_value=None,
+            ),
+            patch(
+                "app.modules.intelligence.tools.code_changes_manager._get_branch",
+                return_value=None,
+            ),
+            patch(
+                "app.modules.tunnel.tunnel_service.get_tunnel_service",
+                return_value=mock_ts,
+            ),
+            patch(
+                "app.modules.intelligence.tools.debug_tools.debug_tunnel_utils._try_http_local_debug",
+                return_value=None,
+            ),
+            patch(
+                "app.modules.intelligence.tools.debug_tools.debug_tunnel_utils._execute_via_socket_full_response",
+                return_value={"success": False, "error": "no active session"},
+            ),
+        ):
+            out = route_debug_command("debug_continue", {}, "u1", "c1")
+
+        assert "failed" in out.lower()
+        assert "no active session" in out
+
+    def test_legacy_http_tunnel_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FORCE_TUNNEL", "true")
+        mock_ts = MagicMock()
+        mock_ts.get_tunnel_url.return_value = "http://127.0.0.1:7777/tool"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "success": True,
+            "result": {"sessions": []},
+        }
+        mock_client_instance = MagicMock()
+        mock_client_instance.post.return_value = mock_response
+
+        mock_http_class = MagicMock()
+        mock_http_class.return_value.__enter__.return_value = mock_client_instance
+
+        with (
+            patch(
+                "app.modules.intelligence.tools.code_changes_manager._get_tunnel_url",
+                return_value=None,
+            ),
+            patch(
+                "app.modules.intelligence.tools.code_changes_manager._get_repository",
+                return_value=None,
+            ),
+            patch(
+                "app.modules.intelligence.tools.code_changes_manager._get_branch",
+                return_value=None,
+            ),
+            patch(
+                "app.modules.tunnel.tunnel_service.get_tunnel_service",
+                return_value=mock_ts,
+            ),
+            patch(
+                "app.modules.intelligence.tools.debug_tools.debug_tunnel_utils._try_http_local_debug",
+                return_value=None,
+            ),
+            patch(
+                "app.modules.intelligence.tools.debug_tools.debug_tunnel_utils.httpx.Client",
+                mock_http_class,
+            ),
+        ):
+            out = route_debug_command("debug_list_sessions", {}, "u1", "c1")
+
+        assert "(none)" in out or "sessions" in out.lower()
+        mock_client_instance.post.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -1040,9 +1040,6 @@ wheels = [
 ]
 
 [package.optional-dependencies]
-cublas = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-]
 cudart = [
     { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
@@ -3441,14 +3438,14 @@ wheels = [
 
 [[package]]
 name = "nvidia-cudnn-cu13"
-version = "9.19.0.56"
+version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nvidia-cublas" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/22/0b4b932655d17a6da1b92fa92ab12844b053bb2ac2475e179ba6f043da1e/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:d20e1734305e9d68889a96e3f35094d733ff1f83932ebe462753973e53a572bf", size = 366066321, upload-time = "2026-02-03T20:44:52.837Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
 ]
 
 [[package]]
@@ -3509,20 +3506,20 @@ wheels = [
 
 [[package]]
 name = "nvidia-cusparselt-cu13"
-version = "0.8.0"
+version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/10/8dcd1175260706a2fc92a16a52e306b71d4c1ea0b0cc4a9484183399818a/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:400c6ed1cf6780fc6efedd64ec9f1345871767e6a1a0a552a1ea0578117ea77c", size = 220791277, upload-time = "2025-08-13T19:22:40.982Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/53/43b0d71f4e702fa9733f8b4571fdca50a8813f1e450b656c239beff12315/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:25e30a8a7323935d4ad0340b95a0b69926eee755767e8e0b1cf8dd85b197d3fd", size = 169884119, upload-time = "2025-08-13T19:23:41.967Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
 ]
 
 [[package]]
 name = "nvidia-nccl-cu13"
-version = "2.28.9"
+version = "2.29.7"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/55/1920646a2e43ffd4fc958536b276197ed740e9e0c54105b4bb3521591fc7/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:01c873ba1626b54caa12272ed228dc5b2781545e0ae8ba3f432a8ef1c6d78643", size = 196561677, upload-time = "2025-11-18T05:49:03.45Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/b4/878fefaad5b2bcc6fcf8d474a25e3e3774bc5133e4b58adff4d0bca238bc/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:e4553a30f34195f3fa1da02a6da3d6337d28f2003943aa0a3d247bbc25fefc42", size = 196493177, upload-time = "2025-11-18T05:49:17.677Z" },
+    { url = "https://files.pythonhosted.org/packages/72/0d/daf50d44177ee0cbc7ff0a0c91eb5ff676c82be42f9a970bc7597f440c3a/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:674a12383e3c38a1bcccae7d4f3633b37852230b6047883cb2f4c2d1b36d9bf5", size = 206014712, upload-time = "2026-03-03T05:34:20.843Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f4/58e4e91b6919367c7aafb8e36fce9aad1a3047e536bf7e2fd560927d3a4c/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:edd81538446786ec3b73972543e53bb43bcaf0bfc8ef76cb679fcc390ffe136d", size = 205976000, upload-time = "2026-03-03T05:36:24.472Z" },
 ]
 
 [[package]]
@@ -4215,6 +4212,7 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "tiktoken" },
     { name = "tldextract" },
+    { name = "torch" },
     { name = "tornado" },
     { name = "tqdm" },
     { name = "transformers" },
@@ -4316,6 +4314,7 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0.44" },
     { name = "tiktoken", specifier = ">=0.12.0" },
     { name = "tldextract", specifier = ">=5.3.1" },
+    { name = "torch", specifier = ">=2.12.0" },
     { name = "tornado", specifier = ">=6.5.5" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "transformers", specifier = ">=4.57.1" },
@@ -6316,16 +6315,17 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.11.0"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
     { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
     { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
     { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
@@ -6336,26 +6336,26 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/f2/c1690994afe461aae2d0cac62251e6802a703dec0a6c549c02ecd0de92a9/torch-2.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2c0d7fcfbc0c4e8bb5ebc3907cbc0c6a0da1b8f82b1fc6e14e914fa0b9baf74e", size = 80526521, upload-time = "2026-03-23T18:12:06.86Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/f0/98ae802fa8c09d3149b0c8690741f3f5753c90e779bd28c9613257295945/torch-2.11.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:4cf8687f4aec3900f748d553483ef40e0ac38411c3c48d0a86a438f6d7a99b18", size = 419723025, upload-time = "2026-03-23T18:11:43.774Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/1e/18a9b10b4bd34f12d4e561c52b0ae7158707b8193c6cfc0aad2b48167090/torch-2.11.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:1b32ceda909818a03b112006709b02be1877240c31750a8d9c6b7bf5f2d8a6e5", size = 530589207, upload-time = "2026-03-23T18:11:23.756Z" },
-    { url = "https://files.pythonhosted.org/packages/35/40/2d532e8c0e23705be9d1debce5bc37b68d59a39bda7584c26fe9668076fe/torch-2.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:b3c712ae6fb8e7a949051a953fc412fe0a6940337336c3b6f905e905dac5157f", size = 114518313, upload-time = "2026-03-23T18:11:58.281Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/0d/98b410492609e34a155fa8b121b55c7dca229f39636851c3a9ec20edea21/torch-2.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7b6a60d48062809f58595509c524b88e6ddec3ebe25833d6462eeab81e5f2ce4", size = 80529712, upload-time = "2026-03-23T18:12:02.608Z" },
-    { url = "https://files.pythonhosted.org/packages/84/03/acea680005f098f79fd70c1d9d5ccc0cb4296ec2af539a0450108232fc0c/torch-2.11.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:d91aac77f24082809d2c5a93f52a5f085032740a1ebc9252a7b052ef5a4fddc6", size = 419718178, upload-time = "2026-03-23T18:10:46.675Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/8b/d7be22fbec9ffee6cff31a39f8750d4b3a65d349a286cf4aec74c2375662/torch-2.11.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:7aa2f9bbc6d4595ba72138026b2074be1233186150e9292865e04b7a63b8c67a", size = 530604548, upload-time = "2026-03-23T18:10:03.569Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/bd/9912d30b68845256aabbb4a40aeefeef3c3b20db5211ccda653544ada4b6/torch-2.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:73e24aaf8f36ab90d95cd1761208b2eb70841c2a9ca1a3f9061b39fc5331b708", size = 114519675, upload-time = "2026-03-23T18:11:52.995Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/8b/69e3008d78e5cee2b30183340cc425081b78afc5eff3d080daab0adda9aa/torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b5866312ee6e52ea625cd211dcb97d6a2cdc1131a5f15cc0d87eec948f6dd34", size = 80606338, upload-time = "2026-03-23T18:11:34.781Z" },
-    { url = "https://files.pythonhosted.org/packages/13/16/42e5915ebe4868caa6bac83a8ed59db57f12e9a61b7d749d584776ed53d5/torch-2.11.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f99924682ef0aa6a4ab3b1b76f40dc6e273fca09f367d15a524266db100a723f", size = 419731115, upload-time = "2026-03-23T18:11:06.944Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/c9/82638ef24d7877510f83baf821f5619a61b45568ce21c0a87a91576510aa/torch-2.11.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0f68f4ac6d95d12e896c3b7a912b5871619542ec54d3649cf48cc1edd4dd2756", size = 530712279, upload-time = "2026-03-23T18:10:31.481Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/ff/6756f1c7ee302f6d202120e0f4f05b432b839908f9071157302cedfc5232/torch-2.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:fbf39280699d1b869f55eac536deceaa1b60bd6788ba74f399cc67e60a5fab10", size = 114556047, upload-time = "2026-03-23T18:10:55.931Z" },
-    { url = "https://files.pythonhosted.org/packages/87/89/5ea6722763acee56b045435fb84258db7375c48165ec8be7880ab2b281c5/torch-2.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1e6debd97ccd3205bbb37eb806a9d8219e1139d15419982c09e23ef7d4369d18", size = 80606801, upload-time = "2026-03-23T18:10:18.649Z" },
-    { url = "https://files.pythonhosted.org/packages/32/d1/8ed2173589cbfe744ed54e5a73efc107c0085ba5777ee93a5f4c1ab90553/torch-2.11.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:63a68fa59de8f87acc7e85a5478bb2dddbb3392b7593ec3e78827c793c4b73fd", size = 419732382, upload-time = "2026-03-23T18:08:30.835Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/e1/b73f7c575a4b8f87a5928f50a1e35416b5e27295d8be9397d5293e7e8d4c/torch-2.11.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:cc89b9b173d9adfab59fd227f0ab5e5516d9a52b658ae41d64e59d2e55a418db", size = 530711509, upload-time = "2026-03-23T18:08:47.213Z" },
-    { url = "https://files.pythonhosted.org/packages/66/82/3e3fcdd388fbe54e29fd3f991f36846ff4ac90b0d0181e9c8f7236565f82/torch-2.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:4dda3b3f52d121063a731ddb835f010dc137b920d7fec2778e52f60d8e4bf0cd", size = 114555842, upload-time = "2026-03-23T18:09:52.111Z" },
-    { url = "https://files.pythonhosted.org/packages/db/38/8ac78069621b8c2b4979c2f96dc8409ef5e9c4189f6aac629189a78677ca/torch-2.11.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8b394322f49af4362d4f80e424bcaca7efcd049619af03a4cf4501520bdf0fb4", size = 80959574, upload-time = "2026-03-23T18:10:14.214Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/6c/56bfb37073e7136e6dd86bfc6af7339946dd684e0ecf2155ac0eee687ae1/torch-2.11.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:2658f34ce7e2dabf4ec73b45e2ca68aedad7a5be87ea756ad656eaf32bf1e1ea", size = 419732324, upload-time = "2026-03-23T18:09:36.604Z" },
-    { url = "https://files.pythonhosted.org/packages/07/f4/1b666b6d61d3394cca306ea543ed03a64aad0a201b6cd159f1d41010aeb1/torch-2.11.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:98bb213c3084cfe176302949bdc360074b18a9da7ab59ef2edc9d9f742504778", size = 530596026, upload-time = "2026-03-23T18:09:20.842Z" },
-    { url = "https://files.pythonhosted.org/packages/48/6b/30d1459fa7e4b67e9e3fe1685ca1d8bb4ce7c62ef436c3a615963c6c866c/torch-2.11.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a97b94bbf62992949b4730c6cd2cc9aee7b335921ee8dc207d930f2ed09ae2db", size = 114793702, upload-time = "2026-03-23T18:09:47.304Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b7/53fe0436586716ab7aecff41e26b9302d57c85ded481fd83a2cd741e6b4e/torch-2.12.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:1834bd984f8a2f4f16bdfbeecca9146184b220aa46276bf5756735b5dae12812", size = 87981887, upload-time = "2026-05-13T14:55:53.234Z" },
+    { url = "https://files.pythonhosted.org/packages/34/60/d930eac44c30de06ed16f6d1ba4e785e1632532b50d8f0bf9bf699a4d0c7/torch-2.12.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:d4d029801cb7b6df858804a2a21b00cc2aa0bf0ee5d2ab18d343c9e9e5681f35", size = 426355000, upload-time = "2026-05-13T14:54:31.944Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0c/c76b6a087820bab55705b94dfc074e520de9ae91f5ef90da2ecbf2a3ef12/torch-2.12.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:d47e7dee68ac4cd7a068b26bcd6b989935427709fae1c8f7bd0019978f829e15", size = 532144998, upload-time = "2026-05-13T14:56:05.523Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/64/8a0d036e166a6aa85ee09bef072f3655d1ba5d5486a68d1b03b6813c01b3/torch-2.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:cf9839790285dd472e7a16aafcb4a4e6bf58ec1b494045044b0eefb0eb4bd1f2", size = 122949877, upload-time = "2026-05-13T14:55:46.841Z" },
+    { url = "https://files.pythonhosted.org/packages/18/62/131124fb95df03811b8260d1d43dcc5ee85ea1a344b964613d7efe77fb08/torch-2.12.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:10802fd383bbfed646212e765a72c37d2185205d4f26eb197a254e8ac7ddcb25", size = 87990344, upload-time = "2026-05-13T14:55:42.154Z" },
+    { url = "https://files.pythonhosted.org/packages/12/9c/dda0dbd547dc549839824135f223792fd0e725f28ed0715dda366b7acaa2/torch-2.12.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:c12592630aef72feaf18bd3f197ef587bbfa21131b31c38b23ab2e55fce92e36", size = 426362932, upload-time = "2026-05-13T14:54:15.295Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/d2/a7dd5a3f9bdaa7842124e8e2359202b317c48d47d2fc5816fafdf2049adb/torch-2.12.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:415c1b8d0412f67551c8e89a2daca0fb3e56694af0281ba155eaa9da481f58b4", size = 532170085, upload-time = "2026-05-13T14:55:20.788Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1b/a61ce2004f9ab0ea8964a6e6168133a127795667639e2ff4f8f2bdb16a65/torch-2.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:dd37188ea325042cb1f6cafa56822b11ada2520c04791a52629b0af25bdfbfd9", size = 122953128, upload-time = "2026-05-13T14:54:52.744Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/bb/285d643f254731294c9b595a007eac39db4600a98682d7bca688f42ca164/torch-2.12.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:b41339df93d491435e790ff8bcbae1c0ce777175889bfd1281d119862793e6a2", size = 88010197, upload-time = "2026-05-13T14:55:35.414Z" },
+    { url = "https://files.pythonhosted.org/packages/79/81/76debf1db1343bd929bbb5d74c89fb437c2ed88eb144712557e7bd3eea45/torch-2.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:8fbef9f108a863e7722a73740998967e3b074742a834fc5be3a535a2befa7057", size = 426376751, upload-time = "2026-05-13T14:55:03.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f0/80026028b603c4650ff270fc3785bdef4bd6738765a9cc5a0f5a637d65a2/torch-2.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4b4f64c2c2b11f7510d93dd6412b87025ff6eddd6bb61c3b5a3d892ea20c4756", size = 532261691, upload-time = "2026-05-13T14:52:54.453Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c2/64b06cbb7830fb3cd9be13e1158b31a3f36b68e6a209105ee3c9d9480be0/torch-2.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:8b958caff4a14d3a3b0b2dfc6a378f64dda9728a9dad28c08a0db9ce4dafb549", size = 122988114, upload-time = "2026-05-13T14:54:42.153Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ca/01896c80ba921676aa45886b2c5b8d774912de2a1f719de48169c6f755cd/torch-2.12.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:90dd587a5f61bfe1307148b581e2084fc5bc4a06e2b90a20e9a36b81087ff16b", size = 88009511, upload-time = "2026-05-13T14:54:47.411Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/04/52bdaf4787eab6ac7d7f5851dff934e4def0bc8ead9c8fd2b69b3e529699/torch-2.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:864392c73b7654f4d2b3ae712f607937d0dbb1101c4555fbb41848106b297f39", size = 426383231, upload-time = "2026-05-13T14:53:32.129Z" },
+    { url = "https://files.pythonhosted.org/packages/49/8a/94bdecd13f5aaa90d45920b89789d9fe7c6f4af8c3cdd7ce01fcb59908fc/torch-2.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5d6b560dfa7d56291c07d615c3bb73e8d9943d9b6d87f76cd0d9d570c4797fa6", size = 532269288, upload-time = "2026-05-13T14:53:49.423Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2f/bdbaaa267de519ef1b73054bf590d8c93c37a266c9a4e24a01bd38b6918f/torch-2.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:3fee918902090ade827643e758e98363278815de583c75d111fdd665ebffde9f", size = 122987706, upload-time = "2026-05-13T14:54:00.335Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ad/e95e822f3538171e22640a7fbe839a1fdb666600bf6487025de2ff03b11a/torch-2.12.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:10ee1448a9f304d3b987eb4656f664ba6e4d7b410ca7a5a7c642199777a2cf88", size = 88319556, upload-time = "2026-05-13T14:54:05.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/07/055d06d985b445d67422d25b033c11cf55bbb81785d4c4e68e28bca5820e/torch-2.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:af68dbf403439cae9ceaeaaf92f8352b460787dcd27b92aa05c40dd4a19c0f1e", size = 426397656, upload-time = "2026-05-13T14:52:38.84Z" },
+    { url = "https://files.pythonhosted.org/packages/43/94/b0b4fdc3014122e0a7302fb90086d352aa48f2576f0b252561ebb38c01a8/torch-2.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:a6a2eebb237d3b1d9ad3b378e86d9b9e0782afdea8b1e0eba6a13646b9b49c07", size = 532183124, upload-time = "2026-05-13T14:53:16.178Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/c8/052405e6ad05d3237bfe5a4df78f917773956f8e17813a2d44c059068b74/torch-2.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2140e373e9a51a3e22ef62e8d14366d0b470d18f0adf19fdc757368077133a34", size = 123232462, upload-time = "2026-05-13T14:52:27.26Z" },
 ]
 
 [[package]]
@@ -6460,19 +6460,19 @@ wheels = [
 
 [[package]]
 name = "triton"
-version = "3.6.0"
+version = "3.7.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/ba/b1b04f4b291a3205d95ebd24465de0e5bf010a2df27a4e58a9b5f039d8f2/triton-3.6.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c723cfb12f6842a0ae94ac307dba7e7a44741d720a40cf0e270ed4a4e3be781", size = 175972180, upload-time = "2026-01-20T16:15:53.664Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/f7/f1c9d3424ab199ac53c2da567b859bcddbb9c9e7154805119f8bd95ec36f/triton-3.6.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a6550fae429e0667e397e5de64b332d1e5695b73650ee75a6146e2e902770bea", size = 188105201, upload-time = "2026-01-20T16:00:29.272Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/2c/96f92f3c60387e14cc45aed49487f3486f89ea27106c1b1376913c62abe4/triton-3.6.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49df5ef37379c0c2b5c0012286f80174fcf0e073e5ade1ca9a86c36814553651", size = 176081190, upload-time = "2026-01-20T16:16:00.523Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/12/b05ba554d2c623bffa59922b94b0775673de251f468a9609bc9e45de95e9/triton-3.6.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8e323d608e3a9bfcc2d9efcc90ceefb764a82b99dea12a86d643c72539ad5d3", size = 188214640, upload-time = "2026-01-20T16:00:35.869Z" },
-    { url = "https://files.pythonhosted.org/packages/17/5d/08201db32823bdf77a0e2b9039540080b2e5c23a20706ddba942924ebcd6/triton-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:374f52c11a711fd062b4bfbb201fd9ac0a5febd28a96fb41b4a0f51dde3157f4", size = 176128243, upload-time = "2026-01-20T16:16:07.857Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/a8/cdf8b3e4c98132f965f88c2313a4b493266832ad47fb52f23d14d4f86bb5/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca", size = 188266850, upload-time = "2026-01-20T16:00:43.041Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/12/34d71b350e89a204c2c7777a9bba0dcf2f19a5bfdd70b57c4dbc5ffd7154/triton-3.6.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448e02fe6dc898e9e5aa89cf0ee5c371e99df5aa5e8ad976a80b93334f3494fd", size = 176133521, upload-time = "2026-01-20T16:16:13.321Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/4e/41b0c8033b503fd3cfcd12392cdd256945026a91ff02452bef40ec34bee7/triton-3.6.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1722e172d34e32abc3eb7711d0025bb69d7959ebea84e3b7f7a341cd7ed694d6", size = 176276087, upload-time = "2026-01-20T16:16:18.989Z" },
-    { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/97/dcd1f2a0f8336691bff74abc59b2ed9c69a0c0f8f65cd77109c49e05f068/triton-3.7.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223ac302091491436c248a34ee1e6c47a1026486579103c906ffd805be50cb89", size = 188367104, upload-time = "2026-05-07T19:04:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c0/c2ac4fd2d8809b7579d4a820a0f9e5de62a9bc8a757ed4b3abf4f7ee964a/triton-3.7.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c631b65668d4951213b948a413c0564184305b77bb45cc9d686d3e1ecc4701a3", size = 201313191, upload-time = "2026-05-07T18:45:58.444Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c1/5d842314bb6c78442cc60437928781701c6050b8d479bc2a1aed691d37ca/triton-3.7.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a9e71fc392675fac364e0ecf4ef3f76f85b7f5433a16f4c3c5fe5f05a52c85fe", size = 188480277, upload-time = "2026-05-07T19:05:03.231Z" },
+    { url = "https://files.pythonhosted.org/packages/13/31/8315ea5f8dd18e60970b3022e3a8b93fd37e0b784fbbef86e10c8e6e5ca1/triton-3.7.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22bacffce443f54593dd20f05294d5a40622e0ea9ab632816f87154504356221", size = 201415942, upload-time = "2026-05-07T18:46:06.479Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/13/ec05adfcd87311d532ba61e3af143e8be59fcd26675884c4682841406a20/triton-3.7.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4bf49b00a7a377a68a6da603a876e797614e6455a80e9021669c476a953ad9a", size = 188505104, upload-time = "2026-05-07T19:05:09.843Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7b/468a576e35beef1426e0828e28e9ba9e65f5474d496f16ee126c15646324/triton-3.7.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f111161d49bf903c0eaedde3962353a3d841c08a836839b7cc1025b8426efcf", size = 201457567, upload-time = "2026-05-07T18:46:13.505Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e1/a59a583de59b8f62c495d67c80ee3ea97d09e91ac80c4c6e76456ed8d8ac/triton-3.7.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abdf6beaa89b1bcfb9a43cd990536ce66091a997841a4814b260b7bee4c88c3c", size = 188503209, upload-time = "2026-05-07T19:05:17.935Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b1/b7507bb9815d403927c8dd51d4158ed2e11751a92dbc118a044f247b6848/triton-3.7.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a35d7afe3f3f058e7ec49fcce09794049e0ffc5c59019ac25ec3413741b8c4e7", size = 201453566, upload-time = "2026-05-07T18:46:20.427Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/8f/0bea7a6a0c989315c9135a1d7fb37e41905cfb3a17cbc1f10044ebd4cc3a/triton-3.7.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc1d61c172d257db80ddf42595131fb196ad2e9bdd751e90fe2ef13531734e8b", size = 188612899, upload-time = "2026-05-07T19:05:24.955Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/02/d96f57828d0912aec733b9bc7e0e7dbfd2c6f079a8fa433ac25cb93d1a30/triton-3.7.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70fb9bbdc9f400afc54bbf6eb2670af28829a6ae3996863317964783141daf56", size = 201553816, upload-time = "2026-05-07T18:46:27.49Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Summary** 
This change delivers the VS Code–tunnel–backed debug agent work end to end on the backend: 10 high-level debugger tools, registry and ToolService wiring, DebugAgent local_mode behavior and workflow prompt, UI progress strings, and automated tests that cover routing, per-tool behavior, and mock integration with the agent.

**What’s included**

  **Debugger tool package :**

  • 10 StructuredTool modules: debug_start, debug_stop, debug_set_breakpoints, debug_snapshot, debug_step_into, debug_step_out, debug_step_over, debug_continue, debug_select_frame, debug_list_sessions.
  • debug_tunnel_utils.py: maps each operation to LocalServer /api/debug/* paths, applies operation-specific timeouts, normalizes { success, result?, error? }, and routes over socket tunnel or legacy HTTP tunnel (and optional local-server HTTP shortcut where the
    environment resolves a reachable LocalServer without going through tunnel metadata).
  • create_debug_tools() in __init__.py exposes a single registration surface for ToolService.

  **Registry & tooling:**

  • ToolCategory extended with "debug".
  • TOOL_DEFINITIONS: entries for all 10 tools with local_mode_only: true (and read_only / idempotent on debug_list_sessions).
  • DEBUG_TOOLS constant lists the canonical tool names.
  • tool_service.py registers tools from create_debug_tools() alongside existing tunnel-backed helpers.

  **Debug agent:**

  • DebugAgent._build_agent(..., local_mode=...) appends debug_tools_prompt_section when local_mode is true.
  • When local_mode, get_tools(...) is called again for debugger tools plus execute_terminal_command, search_text, search_files; missing names are logged.
  • run / run_stream derive local_mode from ChatContext.

  **Product / UX copy:**

  • tool_helpers.py: get_tool_run_message() branches for every debug tool name for streaming/progress UX.

  **Registry population:**

  • population.py: debug is handled so annotations come from TOOL_DEFINITIONS (no accidental derivation as terminal/search).

 **Tests:**

  • test_debug_tunnel_utils.py: formatting + route_debug_command with mocks (no tunnel parameterized for all operations, socket success/errors, legacy HTTP tunnel).
  • test_debug_structured_tools.py: per-tool assertions that payloads and route_debug_command invocation match expectations; tunnel-unavailable and missing-user behaviors for all 10 tools.
  • test_debug_agent_integration.py: mock integration checks that local_mode changes the get_tools call shape and documents a start → breakpoints → snapshot sequence at the routing layer under socket stubs.

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive local debugging: start/stop, breakpoints, step (into/out/over/continue), snapshots, frame selection, session listing, watch management, and related helper tools.
  * Local-mode propagation so debugging tools and VS Code tunnel features are available for local runs.
  * Structured debug & search tools exposed for use in local-mode environments.

* **Infrastructure**
  * Worker .env loading improved to prefer repo-root .env; startup script now exports .env vars.
  * Tool registry extended with a debug category.

* **Tests**
  * New unit tests covering debug tools, tunneling, and agent integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/potpie-ai/potpie/pull/778)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->