### PR TITLE
feat: validate repo_name format in get_branch_list and check_public_repo

### DIFF
--- a/app/modules/code_provider/github/github_service.py
+++ b/app/modules/code_provider/github/github_service.py
@@ -43,6 +43,7 @@ from app.modules.code_provider.github.github_provider import GitHubProvider
 from app.modules.code_provider.provider_factory import CodeProviderFactory
 from app.modules.projects.projects_model import Project
 from app.modules.projects.projects_service import ProjectService
+from app.modules.code_provider.github.repo_name_validator import validate_repo_name
 from app.modules.users.user_model import User
 
 try:
@@ -1190,6 +1191,7 @@ class GithubService:
         return {"repositories": combined_repos}
 
     async def get_branch_list(self, repo_name: str):
+        validate_repo_name(repo_name)
         try:
             # Check if repo_name is a path to a local repository
             if os.path.exists(repo_name) and os.path.isdir(repo_name):
@@ -1558,6 +1560,7 @@ class GithubService:
         return "\n".join(_format_node(structure))
 
     async def check_public_repo(self, repo_name: str) -> bool:
+        validate_repo_name(repo_name)
         try:
             github = self.get_public_github_instance()
             github.get_repo(repo_name)

--- a/app/modules/code_provider/github/repo_name_validator.py
+++ b/app/modules/code_provider/github/repo_name_validator.py
@@ -1,0 +1,46 @@
+import re
+
+def validate_repo_name(repo_name: str) -> None:
+    """
+    Validate that repo_name follows GitHub's owner/repo naming convention.
+    
+    Format: owner/repo where:
+    - owner: alphanumeric characters, hyphens, underscores (1-39 chars)
+    - repo: alphanumeric characters, hyphens, underscores, dots (1-100 chars)
+    
+    Raises ValueError if format is invalid.
+    """
+    if not repo_name or not isinstance(repo_name, str):
+        raise ValueError(
+            "Repository name must be a non-empty string in the format 'owner/repo'. "
+            "Example: 'octocat/Hello-World'"
+        )
+    
+    # GitHub naming rules: owner/repo
+    # owner: [a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])? up to 39 chars
+    # repo: [a-zA-Z0-9_.-]+ up to 100 chars
+    pattern = r'^[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?/[a-zA-Z0-9._\-]+$'
+    
+    if not re.match(pattern, repo_name):
+        raise ValueError(
+            f"Invalid repository name format: '{repo_name}'. "
+            "Expected format: 'owner/repo' where owner and repo contain only "
+            "alphanumeric characters, hyphens, underscores, and (for repo) dots. "
+            "Example: 'octocat/Hello-World'"
+        )
+    
+    # Check length constraints
+    owner, repo = repo_name.split("/", 1)
+    if len(owner) > 39:
+        raise ValueError(
+            f"Owner name '{owner}' exceeds GitHub's 39-character limit."
+        )
+    if len(repo) > 100:
+        raise ValueError(
+            f"Repository name '{repo}' exceeds GitHub's 100-character limit."
+        )
+    if repo_name.endswith(".git"):
+        raise ValueError(
+            f"Repository name should not include '.git' suffix: '{repo_name}'. "
+            f"Use '{repo_name[:-4]}' instead."
+        )


### PR DESCRIPTION
## Summary
Closes #354

Adds `validate_repo_name()` that enforces GitHub's `owner/repo` naming convention before making API calls.

### Changes
- **New file**: `app/modules/code_provider/github/repo_name_validator.py` — standalone validation function
- **Modified**: `app/modules/code_provider/github/github_service.py` — calls validation in `get_branch_list()` and `check_public_repo()`

### Validation rules
- Must be non-empty string in `owner/repo` format
- Owner: 1-39 chars, alphanumeric with hyphens/underscores (not starting/ending with hyphen)
- Repo: 1-100 chars, alphanumeric with hyphens/underscores/dots
- Rejects `.git` suffix
- Raises `ValueError` with descriptive message for each failure case

### Test plan
- Valid names: `octocat/Hello-World`, `user/repo_name`, `org/project.v2`
- Invalid names: empty string, missing `/`, `-invalid/owner`, `owner/.git`, `owner/repo.git`, name exceeding length limits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved validation of repository name formatting to enforce proper structure and constraints, reducing errors when accessing repositories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/potpie-ai/potpie/pull/781?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->