### PR TITLE
Added remote mcp support and added one more MCP tool to ingest events

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -56,6 +56,7 @@ from app.modules.context_graph.context_engine_http import (
     potpie_context_engine_router,
     potpie_context_pot_v1_router,
 )
+from app.modules.context_graph.mcp_mount import get_embedded_mcp_asgi_app
 from app.modules.users.user_service import UserService
 from app.modules.utils.firebase_setup import FirebaseSetup
 from app.modules.utils.logger import configure_logging, setup_logger
@@ -83,7 +84,10 @@ class MainApp:
         async def lifespan(_app: FastAPI):
             _app.state.main_app = self
             await self.startup_event()
-            yield
+            from adapters.inbound.mcp.http_server import mcp_http_lifespan
+
+            async with mcp_http_lifespan():
+                yield
             await self.shutdown_event()
 
         self.app = FastAPI(lifespan=lifespan)
@@ -218,6 +222,7 @@ class MainApp:
             prefix="/api/v1/context",
             tags=["Context Graph API"],
         )
+        self.app.mount("/mcp", get_embedded_mcp_asgi_app())
 
     def add_health_check(self):
         @self.app.get("/health", tags=["Health"])

--- a/app/modules/context_graph/context_engine_http.py
+++ b/app/modules/context_graph/context_engine_http.py
@@ -3,19 +3,70 @@
 from __future__ import annotations
 
 import logging
+import os
+from typing import Any
 
-from fastapi import Depends
+from fastapi import Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from adapters.inbound.http.api.v1.context.router import create_context_router
 from app.core.database import get_db
-from app.modules.auth.api_key_deps import get_api_key_user
+from app.modules.auth.api_key_deps import get_api_key_user, is_development_mode
+from app.modules.auth.api_key_service import APIKeyService
 from app.modules.auth.auth_service import AuthService
 from app.modules.context_graph.context_pot_routes import make_pot_router
 from app.modules.context_graph.wiring import build_container_for_user_session
+from app.modules.users.user_service import AsyncUserService
 from bootstrap.container import ContextEngineContainer
 
 logger = logging.getLogger(__name__)
+
+
+async def resolve_user_from_api_key(
+    api_key: str,
+    db: Session,
+    *,
+    async_db: AsyncSession | None = None,
+    x_user_id: str | None = None,
+) -> dict[str, Any] | None:
+    """Validate X-API-Key and return user dict (same rules as get_api_key_user)."""
+    key = (api_key or "").strip()
+    if not key:
+        return None
+
+    admin_secret = (os.environ.get("INTERNAL_ADMIN_SECRET") or "").strip()
+    if admin_secret and key == admin_secret:
+        uid = (x_user_id or "").strip() or os.getenv("defaultUsername", "").strip()
+        if not uid:
+            return None
+        if async_db is None:
+            raise ValueError("async_db required for admin secret API key validation")
+        user_svc = AsyncUserService(async_db)
+        user = await user_svc.get_user_by_uid(uid)
+        if not user and is_development_mode():
+            user = await user_svc.get_user_by_email("defaultuser@potpie.ai")
+        if not user:
+            return None
+        return {"user_id": user.uid, "email": user.email, "auth_type": "api_key"}
+
+    return await APIKeyService.validate_api_key(key, db)
+
+
+async def build_container_from_api_key(
+    api_key: str,
+    db: Session,
+    *,
+    async_db: AsyncSession | None = None,
+    x_user_id: str | None = None,
+) -> ContextEngineContainer:
+    """Build a user-scoped context engine container from an API key (embedded MCP / scripts)."""
+    user = await resolve_user_from_api_key(
+        api_key, db, async_db=async_db, x_user_id=x_user_id
+    )
+    if not user:
+        raise HTTPException(status_code=401, detail="Invalid API key")
+    return build_container_for_user_session(db, user["user_id"])
 
 
 def get_context_engine_container(

--- a/app/modules/context_graph/mcp_mount.py
+++ b/app/modules/context_graph/mcp_mount.py
@@ -1,0 +1,59 @@
+"""Wire embedded HTTP MCP into the Potpie app (session factory + ASGI app)."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from adapters.inbound.mcp.http_server import default_mcp_client_name
+from adapters.inbound.mcp.session import McpSession, register_mcp_session_factory
+from app.core.database import AsyncSessionLocal, SessionLocal
+from app.modules.context_graph.context_engine_http import resolve_user_from_api_key
+from app.modules.context_graph.wiring import build_container_for_user_session
+from domain.actor import Actor
+
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def _mcp_session_from_api_key(api_key: str) -> AsyncIterator[McpSession]:
+    db = SessionLocal()
+    try:
+        async with AsyncSessionLocal() as async_db:
+            user = await resolve_user_from_api_key(
+                api_key, db, async_db=async_db
+            )
+            if user is None:
+                raise ValueError("Invalid API key")
+            container = build_container_for_user_session(db, user["user_id"])
+            client_name = None
+            try:
+                from adapters.inbound.mcp.auth_context import get_mcp_client_name
+
+                client_name = get_mcp_client_name()
+            except Exception:
+                client_name = None
+            actor = Actor(
+                user_id=str(user["user_id"]),
+                surface="mcp",
+                client_name=client_name or default_mcp_client_name(),
+                auth_method="api_key",
+            )
+            yield container, db, user, actor
+    finally:
+        db.close()
+
+
+def init_embedded_mcp() -> None:
+    """Register the MCP session factory (idempotent)."""
+    register_mcp_session_factory(_mcp_session_from_api_key)
+    logger.info("Potpie embedded HTTP MCP session factory registered")
+
+
+def get_embedded_mcp_asgi_app():
+    """Return the Streamable HTTP MCP ASGI app (call init_embedded_mcp first)."""
+    from adapters.inbound.mcp.http_server import build_embedded_mcp_asgi_app
+
+    init_embedded_mcp()
+    return build_embedded_mcp_asgi_app()

--- a/app/src/context-engine/adapters/inbound/cli/README.md
+++ b/app/src/context-engine/adapters/inbound/cli/README.md
@@ -39,7 +39,7 @@ potpie -v search "query here"
 
 Install the packaged agent bundle into the current repository. This writes a top-level `AGENTS.md` plus the repo-local `.agents/skills/potpie-*` files used by Codex-style agent workflows.
 
-The bundle includes a dedicated `potpie-agent-context` skill for MCP workflows. That skill keeps the public agent surface to `context_resolve`, `context_search`, `context_record`, and `context_status`, and encodes feature, debugging, review, operations, docs, and onboarding workflows as `context_resolve` parameter recipes.
+The bundle includes a dedicated `potpie-agent-context` skill for MCP workflows. That skill keeps the public agent surface to `context_resolve`, `context_search`, `context_record`, `context_status`, and `context_ingest`, and encodes feature, debugging, review, operations, docs, and onboarding workflows as `context_resolve` parameter recipes.
 
 | Command | Description |
 |---------|-------------|
@@ -253,18 +253,56 @@ uv run potpie event list --status done -n 10
 
 - Full service and env tables: repository root `app/src/context-engine/README.md`.
 - CLI targets **`/api/v2/context/`** with **`X-API-Key`**. **`/api/v1/context/`** remains for Firebase-authenticated clients.
-- MCP entrypoint: `potpie-mcp` (stdio server).
+- MCP entrypoints:
+  - **`potpie-mcp`** — local stdio server (CLI / editor spawn); calls **`/api/v2/context`** over HTTP. May require env **`CONTEXT_ENGINE_MCP_ALLOWED_POTS`** for the stdio allowlist.
+  - **`GET/POST /mcp`** on the Potpie FastAPI app — embedded Streamable HTTP MCP (same deploy as API). Pot access uses the same policy as **`/api/v2/context`** (no **`CONTEXT_ENGINE_MCP_ALLOWED_POTS`** required).
+
+### MCP setup (Cursor and other HTTP clients)
+
+1. **Run Potpie** with the context graph stack (API on port **8001** by default, Postgres, Neo4j, Redis/Celery for async ingest).
+2. **API key** — must be issued for **that** environment (local UI → API keys, or dev **`INTERNAL_ADMIN_SECRET`** in server `.env` used as `X-API-Key`). Staging keys do not work against localhost.
+3. **Client config** (project `.cursor/mcp.json` or global MCP settings):
+
+```json
+{
+  "mcpServers": {
+    "potpie": {
+      "url": "http://localhost:8001/mcp",
+      "headers": {
+        "X-API-Key": "your-key-for-this-environment",
+        "X-Potpie-Client-Name": "cursor"
+      }
+    }
+  }
+}
+```
+
+4. **`pot_id`** — not stored in MCP JSON. List or create pots via the API, then pass **`pot_id`** on every tool call (or put the UUID in project rules):
+
+```bash
+curl -sS "http://localhost:8001/api/v2/context/pots" -H "X-API-Key: YOUR_KEY"
+curl -sS -X POST "http://localhost:8001/api/v2/context/pots" \
+  -H "X-API-Key: YOUR_KEY" -H "Content-Type: application/json" \
+  -d '{"name": "my-pot", "slug": "my-pot"}'
+```
+
+5. **Smoke test** — `GET /health`, then MCP `initialize` against `POST http://localhost:8001/mcp/` with the same headers (expect `serverInfo.name` **`potpie`**).
+
+Recommended agent flow: **`context_status`** → **`context_ingest`** (optional raw episodes) → **`context_resolve`** → **`context_search`** (follow-ups) → **`context_record`** (durable memory).
 
 ### MCP agent context port
 
-MCP exposes the minimal context port:
+Embedded HTTP MCP exposes five tools:
 
 | Tool | Use |
 |------|-----|
-| `context_resolve` | Primary bounded context wrap for a task. |
-| `context_status` | Cheap pot/scope readiness, freshness gaps, and recommended recipe. |
-| `context_search` | Narrow follow-up lookup after `context_resolve`. |
-| `context_record` | Durable learnings: decisions, fixes, preferences, workflows, feature notes, doc refs, and incident summaries. |
+| `context_status` | Cheap pot/scope readiness, freshness gaps, and recommended `context_resolve` recipe. Call before broad work. |
+| `context_resolve` | Primary bounded context wrap for a task (hybrid graph query + envelope). |
+| `context_search` | Narrow semantic follow-up lookup after `context_resolve`. |
+| `context_record` | Structured durable learnings: decisions, fixes, preferences, workflows, feature notes, doc refs, incident summaries. |
+| `context_ingest` | Raw episodic ingest (release notes, meeting notes, CI text) into the graph. Default **async** (`sync=false`, queued); use **`sync=true`** for inline apply. Supports **`idempotency_key`**; duplicate submissions return **`ok: true`**, **`status: duplicate`**. |
+
+**`context_ingest` parameters:** `pot_id`, `name`, `episode_body`, `source_description` (required); optional `reference_time` (ISO 8601, default UTC now), `idempotency_key`, `sync` (default `false`).
 
 Use `context_resolve` recipes instead of adding separate tools per context type:
 

--- a/app/src/context-engine/adapters/inbound/mcp/auth_context.py
+++ b/app/src/context-engine/adapters/inbound/mcp/auth_context.py
@@ -1,0 +1,66 @@
+"""Request-scoped API key for embedded Streamable HTTP MCP (set by ASGI middleware)."""
+
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.types import ASGIApp
+
+_api_key_var: ContextVar[str | None] = ContextVar("potpie_mcp_api_key", default=None)
+_client_name_var: ContextVar[str | None] = ContextVar("potpie_mcp_client_name", default=None)
+
+
+def set_mcp_request_context(
+    *,
+    api_key: str | None,
+    client_name: str | None,
+) -> tuple[Token, Token]:
+    return (
+        _api_key_var.set(api_key),
+        _client_name_var.set(client_name),
+    )
+
+
+def reset_mcp_request_context(tokens: tuple[Token, Token]) -> None:
+    _api_key_var.reset(tokens[0])
+    _client_name_var.reset(tokens[1])
+
+
+def get_mcp_api_key() -> str:
+    key = (_api_key_var.get() or "").strip()
+    if not key:
+        raise ValueError(
+            "X-API-Key header is required for Potpie MCP. "
+            "Create a key in Potpie Key management and add it to your MCP client headers."
+        )
+    return key
+
+
+def get_mcp_client_name() -> str | None:
+    name = (_client_name_var.get() or "").strip()
+    return name or None
+
+
+class PotpieMcpApiKeyMiddleware(BaseHTTPMiddleware):
+    """Capture X-API-Key (and optional client name) for MCP tool handlers."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next):
+        api_key = request.headers.get("x-api-key") or request.headers.get("X-API-Key")
+        client_name = (
+            request.headers.get("x-potpie-client-name")
+            or request.headers.get("X-Potpie-Client-Name")
+            or request.headers.get("mcp-client-name")
+        )
+        tokens = set_mcp_request_context(
+            api_key=api_key.strip() if api_key else None,
+            client_name=client_name.strip() if client_name else None,
+        )
+        try:
+            return await call_next(request)
+        finally:
+            reset_mcp_request_context(tokens)

--- a/app/src/context-engine/adapters/inbound/mcp/http_server.py
+++ b/app/src/context-engine/adapters/inbound/mcp/http_server.py
@@ -1,0 +1,271 @@
+"""Embedded Streamable HTTP MCP on the Potpie FastAPI app (X-API-Key auth)."""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from mcp.server.fastmcp import FastMCP
+
+from adapters.inbound.mcp.auth_context import get_mcp_api_key
+from adapters.inbound.mcp.session import mcp_request_session
+from adapters.inbound.mcp.tool_impl import (
+    run_context_ingest,
+    run_context_record,
+    run_context_resolve,
+    run_context_search,
+    run_context_status,
+)
+
+logger = logging.getLogger(__name__)
+
+# streamable_http_path="/" so FastAPI mount at /mcp yields https://host/mcp (not /mcp/mcp).
+mcp_http = FastMCP(
+    "potpie",
+    streamable_http_path="/",
+    instructions=(
+        "Potpie context graph MCP. All tools require pot_id for a pot you can access "
+        "with your API key. Prefer context_resolve for task context; use context_status "
+        "before broad work; context_search for narrow follow-ups; context_record for "
+        "durable learnings; context_ingest for raw episodic episodes."
+    ),
+)
+
+
+def _auth_error(exc: Exception) -> dict:
+    return {"ok": False, "error": "auth_error", "detail": str(exc)}
+
+
+@mcp_http.tool()
+async def context_search(
+    pot_id: str,
+    query: str,
+    limit: int = 8,
+    node_labels: str | None = None,
+    repo_name: str | None = None,
+    source_description: str | None = None,
+    include_invalidated: bool = False,
+    as_of: str | None = None,
+) -> dict:
+    """Narrow follow-up memory search. Prefer context_resolve first for task context wraps."""
+    try:
+        api_key = get_mcp_api_key()
+    except ValueError as exc:
+        return _auth_error(exc)
+    async with mcp_request_session(api_key) as (container, _db, _user, actor):
+        return await run_context_search(
+            container=container,
+            actor=actor,
+            pot_id=pot_id,
+            query=query,
+            limit=limit,
+            node_labels=node_labels,
+            repo_name=repo_name,
+            source_description=source_description,
+            include_invalidated=include_invalidated,
+            as_of=as_of,
+        )
+
+
+@mcp_http.tool()
+async def context_resolve(
+    pot_id: str,
+    query: str,
+    consumer_hint: str | None = None,
+    intent: str | None = None,
+    repo_name: str | None = None,
+    branch: str | None = None,
+    file_path: str | None = None,
+    function_name: str | None = None,
+    symbol: str | None = None,
+    pr_number: int | None = None,
+    services: str | None = None,
+    features: str | None = None,
+    environment: str | None = None,
+    ticket_ids: str | None = None,
+    user: str | None = None,
+    source_refs: str | None = None,
+    include: str | None = None,
+    exclude: str | None = None,
+    mode: str = "fast",
+    source_policy: str = "references_only",
+    max_items: int = 12,
+    max_tokens: int | None = None,
+    timeout_ms: int = 4000,
+    freshness: str = "prefer_fresh",
+    as_of: str | None = None,
+) -> dict:
+    """Primary agent context tool: resolve a bounded task context wrap with evidence, freshness, and fallbacks."""
+    try:
+        api_key = get_mcp_api_key()
+    except ValueError as exc:
+        return _auth_error(exc)
+    async with mcp_request_session(api_key) as (container, _db, _user, actor):
+        return await run_context_resolve(
+            container=container,
+            actor=actor,
+            pot_id=pot_id,
+            query=query,
+            consumer_hint=consumer_hint,
+            intent=intent,
+            repo_name=repo_name,
+            branch=branch,
+            file_path=file_path,
+            function_name=function_name,
+            symbol=symbol,
+            pr_number=pr_number,
+            services=services,
+            features=features,
+            environment=environment,
+            ticket_ids=ticket_ids,
+            user=user,
+            source_refs=source_refs,
+            include=include,
+            exclude=exclude,
+            mode=mode,
+            source_policy=source_policy,
+            max_items=max_items,
+            max_tokens=max_tokens,
+            timeout_ms=timeout_ms,
+            freshness=freshness,
+            as_of=as_of,
+        )
+
+
+@mcp_http.tool()
+async def context_ingest(
+    pot_id: str,
+    name: str,
+    episode_body: str,
+    source_description: str,
+    reference_time: str | None = None,
+    idempotency_key: str | None = None,
+    sync: bool = False,
+) -> dict:
+    """Ingest a raw episodic episode into the context graph for a pot.
+    Async by default (queued); pass sync=True for inline apply.
+    Idempotency key deduplicates re-submissions."""
+    try:
+        api_key = get_mcp_api_key()
+    except ValueError as exc:
+        return _auth_error(exc)
+    async with mcp_request_session(api_key) as (container, db, _user, actor):
+        return await asyncio.to_thread(
+            functools.partial(
+                run_context_ingest,
+                container=container,
+                db=db,
+                actor=actor,
+                pot_id=pot_id,
+                name=name,
+                episode_body=episode_body,
+                source_description=source_description,
+                reference_time=reference_time,
+                idempotency_key=idempotency_key,
+                sync=sync,
+            )
+        )
+
+
+@mcp_http.tool()
+async def context_record(
+    pot_id: str,
+    record_type: str,
+    summary: str,
+    repo_name: str | None = None,
+    source_refs: str | None = None,
+    confidence: float = 0.7,
+    visibility: str = "project",
+    idempotency_key: str | None = None,
+    details: str | None = None,
+    sync: bool = False,
+) -> dict:
+    """Record durable project memory: decisions, fixes, preferences, workflows, feature notes, or incidents."""
+    try:
+        api_key = get_mcp_api_key()
+    except ValueError as exc:
+        return _auth_error(exc)
+    async with mcp_request_session(api_key) as (container, db, _user, actor):
+        return await asyncio.to_thread(
+            functools.partial(
+                run_context_record,
+                container=container,
+                db=db,
+                actor=actor,
+                pot_id=pot_id,
+                record_type=record_type,
+                summary=summary,
+                repo_name=repo_name,
+                source_refs=source_refs,
+                confidence=confidence,
+                visibility=visibility,
+                idempotency_key=idempotency_key,
+                details=details,
+                sync=sync,
+            )
+        )
+
+
+@mcp_http.tool()
+async def context_status(
+    pot_id: str,
+    repo_name: str | None = None,
+    source_refs: str | None = None,
+    intent: str | None = None,
+) -> dict:
+    """Return cheap pot readiness plus the recommended context_resolve recipe for an intent."""
+    try:
+        api_key = get_mcp_api_key()
+    except ValueError as exc:
+        return _auth_error(exc)
+    async with mcp_request_session(api_key) as (container, db, _user, actor):
+        return await asyncio.to_thread(
+            functools.partial(
+                run_context_status,
+                container=container,
+                db=db,
+                actor=actor,
+                pot_id=pot_id,
+                repo_name=repo_name,
+                source_refs=source_refs,
+                intent=intent,
+            )
+        )
+
+
+_embedded_mcp_asgi_app = None
+
+
+@asynccontextmanager
+async def mcp_http_lifespan() -> AsyncIterator[None]:
+    """Run Streamable HTTP MCP session manager (required when mounted on FastAPI)."""
+    async with mcp_http._session_manager.run():
+        yield
+
+
+def build_embedded_mcp_asgi_app():
+    """ASGI app for ``app.mount('/mcp', ...)`` with API-key middleware."""
+    global _embedded_mcp_asgi_app
+    if _embedded_mcp_asgi_app is not None:
+        return _embedded_mcp_asgi_app
+    from adapters.inbound.mcp.auth_context import PotpieMcpApiKeyMiddleware
+
+    inner = mcp_http.streamable_http_app()
+    _embedded_mcp_asgi_app = PotpieMcpApiKeyMiddleware(inner)
+    return _embedded_mcp_asgi_app
+
+
+def default_mcp_client_name() -> str:
+    for var in (
+        "POTPIE_CLIENT_NAME",
+        "MCP_CLIENT_NAME",
+        "CONTEXT_ENGINE_CLIENT_NAME",
+    ):
+        v = os.getenv(var)
+        if v and v.strip():
+            return v.strip()
+    return "mcp-unknown"

--- a/app/src/context-engine/adapters/inbound/mcp/policy.py
+++ b/app/src/context-engine/adapters/inbound/mcp/policy.py
@@ -1,0 +1,44 @@
+"""Policy checks for MCP tools (mirrors HTTP router _enforce)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from bootstrap.container import ContextEngineContainer
+from domain.ports.policy import REASON_UNKNOWN_POT
+
+UNKNOWN_POT_DETAIL = (
+    "Unknown pot_id for this user (create with POST /api/v2/context/pots "
+    "and attach at least one repository)."
+)
+
+
+def policy_error_response(
+    container: ContextEngineContainer,
+    *,
+    actor: Any,
+    resource: str,
+    action: str,
+    pot_id: str,
+) -> dict[str, Any] | None:
+    """Return an error dict when denied; None when allowed."""
+    decision = container.policy().authorize(
+        actor=actor,
+        resource=resource,
+        action=action,
+        context={"pot_id": pot_id},
+    )
+    if decision.allowed:
+        return None
+    detail = (
+        UNKNOWN_POT_DETAIL
+        if decision.reason == REASON_UNKNOWN_POT
+        else decision.detail or decision.reason
+    )
+    return {
+        "ok": False,
+        "error": "policy_denied",
+        "reason": decision.reason,
+        "status_code": decision.status_code,
+        "detail": detail,
+    }

--- a/app/src/context-engine/adapters/inbound/mcp/session.py
+++ b/app/src/context-engine/adapters/inbound/mcp/session.py
@@ -1,0 +1,37 @@
+"""Host-injected session factory for embedded HTTP MCP."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable
+from contextlib import asynccontextmanager
+from typing import Any
+
+from bootstrap.container import ContextEngineContainer
+from domain.actor import Actor
+from sqlalchemy.orm import Session
+
+McpSession = tuple[ContextEngineContainer, Session, dict[str, Any], Actor]
+
+SessionFactory = Callable[[str], AsyncIterator[McpSession]]
+
+_factory: SessionFactory | None = None
+
+
+def register_mcp_session_factory(factory: SessionFactory) -> None:
+    global _factory
+    _factory = factory
+
+
+def mcp_session_factory_registered() -> bool:
+    return _factory is not None
+
+
+@asynccontextmanager
+async def mcp_request_session(api_key: str) -> AsyncIterator[McpSession]:
+    if _factory is None:
+        raise RuntimeError(
+            "Potpie MCP session factory is not registered. "
+            "Mount MCP from app.main after importing app.modules.context_graph.mcp_mount."
+        )
+    async with _factory(api_key) as session:
+        yield session

--- a/app/src/context-engine/adapters/inbound/mcp/tool_impl.py
+++ b/app/src/context-engine/adapters/inbound/mcp/tool_impl.py
@@ -1,0 +1,580 @@
+"""In-process MCP tool implementations (shared by HTTP and future transports)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from application.use_cases.record_durable_context import (
+    DurableContextPayload,
+    record_durable_context,
+)
+from application.use_cases.report_status import report_status
+from application.use_cases.submit_raw_episode import (
+    RawEpisodeSubmissionResult,
+    submit_raw_episode,
+)
+from bootstrap.container import ContextEngineContainer
+from domain.actor import Actor
+from domain.graph_query import (
+    ContextGraphBudget,
+    ContextGraphGoal,
+    ContextGraphQuery,
+    ContextGraphScope,
+    ContextGraphStrategy,
+)
+from domain.ports.policy import (
+    ACTION_POT_INGEST_EPISODE,
+    ACTION_POT_READ,
+    ACTION_POT_RECORD,
+    RESOURCE_POT,
+)
+from sqlalchemy.orm import Session
+
+from adapters.inbound.mcp.policy import UNKNOWN_POT_DETAIL, policy_error_response
+
+
+def _parse_as_of_iso(value: str | None) -> datetime | None:
+    if not value or not value.strip():
+        return None
+    s = value.strip()
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    return datetime.fromisoformat(s)
+
+
+def _split_csv(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _scope_from_mcp(
+    *,
+    repo_name: str | None = None,
+    branch: str | None = None,
+    file_path: str | None = None,
+    function_name: str | None = None,
+    symbol: str | None = None,
+    pr_number: int | None = None,
+    services: str | None = None,
+    features: str | None = None,
+    environment: str | None = None,
+    ticket_ids: str | None = None,
+    user: str | None = None,
+    source_refs: str | None = None,
+) -> dict[str, Any]:
+    scope = {
+        "repo_name": repo_name,
+        "branch": branch,
+        "file_path": file_path,
+        "function_name": function_name,
+        "symbol": symbol,
+        "pr_number": pr_number,
+        "services": _split_csv(services),
+        "features": _split_csv(features),
+        "environment": environment,
+        "ticket_ids": _split_csv(ticket_ids),
+        "user": user,
+        "source_refs": _split_csv(source_refs),
+    }
+    return {k: v for k, v in scope.items() if v not in (None, [], "")}
+
+
+def _context_graph_jsonable(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        try:
+            return str(isoformat())
+        except Exception:
+            pass
+    if isinstance(value, dict):
+        return {str(k): _context_graph_jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_context_graph_jsonable(v) for v in value]
+    return str(value)
+
+
+async def run_context_search(
+    *,
+    container: ContextEngineContainer,
+    actor: Actor,
+    pot_id: str,
+    query: str,
+    limit: int = 8,
+    node_labels: str | None = None,
+    repo_name: str | None = None,
+    source_description: str | None = None,
+    include_invalidated: bool = False,
+    as_of: str | None = None,
+) -> dict[str, Any]:
+    denied = policy_error_response(
+        container,
+        actor=actor,
+        resource=RESOURCE_POT,
+        action=ACTION_POT_READ,
+        pot_id=pot_id,
+    )
+    if denied:
+        return denied
+
+    as_of_dt = None
+    if as_of:
+        try:
+            as_of_dt = _parse_as_of_iso(as_of)
+        except ValueError as exc:
+            return {"ok": False, "error": "invalid_as_of", "detail": str(exc)}
+
+    labels = None
+    if node_labels:
+        labels = [x.strip() for x in node_labels.split(",") if x.strip()]
+
+    if container.context_graph is None:
+        return {
+            "ok": False,
+            "error": "api_error",
+            "status_code": 503,
+            "detail": "Unified context graph query port is not configured.",
+        }
+
+    body = ContextGraphQuery(
+        pot_id=pot_id,
+        query=query,
+        goal=ContextGraphGoal.RETRIEVE,
+        strategy=ContextGraphStrategy.SEMANTIC,
+        limit=limit,
+        node_labels=labels or [],
+        scope=ContextGraphScope(repo_name=repo_name) if repo_name else ContextGraphScope(),
+        source_descriptions=[source_description] if source_description else [],
+        include_invalidated=include_invalidated,
+        as_of=as_of_dt,
+    )
+    try:
+        result = await container.context_graph.query_async(body)
+        dumped = result.model_dump()
+        rows = dumped.get("result") if isinstance(dumped, dict) else []
+        rows = rows if isinstance(rows, list) else []
+        return {
+            "ok": True,
+            "answer": {"summary": f"Found {len(rows)} context search result(s)."},
+            "evidence": rows,
+            "source_refs": [],
+            "coverage": {
+                "status": "complete" if rows else "empty",
+                "available": ["semantic_search"] if rows else [],
+                "missing": [] if rows else ["semantic_search"],
+                "missing_reasons": {} if rows else {"semantic_search": "empty_result"},
+            },
+            "freshness": {
+                "status": "unknown",
+                "last_graph_update": None,
+                "last_source_verification": None,
+                "stale_refs": [],
+                "needs_verification_refs": [],
+            },
+            "fallbacks": [],
+            "recommended_next_actions": [],
+        }
+    except Exception as exc:
+        return {"ok": False, "error": "api_error", "detail": str(exc)}
+
+
+async def run_context_resolve(
+    *,
+    container: ContextEngineContainer,
+    actor: Actor,
+    pot_id: str,
+    query: str,
+    consumer_hint: str | None = None,
+    intent: str | None = None,
+    repo_name: str | None = None,
+    branch: str | None = None,
+    file_path: str | None = None,
+    function_name: str | None = None,
+    symbol: str | None = None,
+    pr_number: int | None = None,
+    services: str | None = None,
+    features: str | None = None,
+    environment: str | None = None,
+    ticket_ids: str | None = None,
+    user: str | None = None,
+    source_refs: str | None = None,
+    include: str | None = None,
+    exclude: str | None = None,
+    mode: str = "fast",
+    source_policy: str = "references_only",
+    max_items: int = 12,
+    max_tokens: int | None = None,
+    timeout_ms: int = 4000,
+    freshness: str = "prefer_fresh",
+    as_of: str | None = None,
+) -> dict[str, Any]:
+    denied = policy_error_response(
+        container,
+        actor=actor,
+        resource=RESOURCE_POT,
+        action=ACTION_POT_READ,
+        pot_id=pot_id,
+    )
+    if denied:
+        return denied
+
+    as_of_dt = None
+    if as_of:
+        try:
+            as_of_dt = _parse_as_of_iso(as_of)
+        except ValueError as exc:
+            return {"ok": False, "error": "invalid_as_of", "detail": str(exc)}
+
+    if container.context_graph is None:
+        return {
+            "ok": False,
+            "error": "api_error",
+            "status_code": 503,
+            "detail": "Unified context graph query port is not configured.",
+        }
+
+    scope_dict = _scope_from_mcp(
+        repo_name=repo_name,
+        branch=branch,
+        file_path=file_path,
+        function_name=function_name,
+        symbol=symbol,
+        pr_number=pr_number,
+        services=services,
+        features=features,
+        environment=environment,
+        ticket_ids=ticket_ids,
+        user=user,
+        source_refs=source_refs,
+    )
+    body = ContextGraphQuery(
+        pot_id=pot_id,
+        query=query,
+        consumer_hint=consumer_hint,
+        intent=intent,
+        scope=ContextGraphScope(**scope_dict) if scope_dict else ContextGraphScope(),
+        include=_split_csv(include),
+        exclude=_split_csv(exclude),
+        goal=ContextGraphGoal.ANSWER,
+        strategy=ContextGraphStrategy.HYBRID if mode == "balanced" else ContextGraphStrategy.AUTO,
+        source_policy=source_policy,
+        as_of=as_of_dt,
+        budget=ContextGraphBudget(
+            max_items=max_items,
+            max_tokens=max_tokens,
+            timeout_ms=timeout_ms,
+            freshness=freshness,
+        ),
+    )
+    try:
+        result = await container.context_graph.query_async(body)
+        dumped = _context_graph_jsonable(result.model_dump())
+        inner = dumped.get("result") if isinstance(dumped, dict) else None
+        return inner if isinstance(inner, dict) else dumped
+    except Exception as exc:
+        return {"ok": False, "error": "api_error", "detail": str(exc)}
+
+
+def run_context_record(
+    *,
+    container: ContextEngineContainer,
+    db: Session,
+    actor: Actor,
+    pot_id: str,
+    record_type: str,
+    summary: str,
+    repo_name: str | None = None,
+    source_refs: str | None = None,
+    confidence: float = 0.7,
+    visibility: str = "project",
+    idempotency_key: str | None = None,
+    details: str | None = None,
+    sync: bool = False,
+) -> dict[str, Any]:
+    denied = policy_error_response(
+        container,
+        actor=actor,
+        resource=RESOURCE_POT,
+        action=ACTION_POT_RECORD,
+        pot_id=pot_id,
+    )
+    if denied:
+        return denied
+
+    scope = {"repo_name": repo_name} if repo_name else {}
+    try:
+        receipt, record_type_out, source_id = record_durable_context(
+            container.ingestion_submission(db),
+            pot_id=pot_id,
+            record=DurableContextPayload(
+                record_type=record_type,
+                summary=summary,
+                details={"text": details} if details else {},
+                source_refs=tuple(_split_csv(source_refs)),
+                confidence=confidence,
+                visibility=visibility,
+            ),
+            scope={**scope, "source_refs": _split_csv(source_refs)},
+            actor=actor,
+            idempotency_key=idempotency_key,
+            occurred_at=None,
+            sync=sync,
+        )
+        db.commit()
+    except ValueError as exc:
+        db.rollback()
+        err = str(exc)
+        if err == "unknown_pot_id":
+            return {
+                "ok": False,
+                "error": "api_error",
+                "status_code": 404,
+                "detail": UNKNOWN_POT_DETAIL,
+            }
+        if err in {"context_graph_disabled", "async_requires_database"}:
+            return {"ok": False, "error": "api_error", "status_code": 503, "detail": err}
+        return {"ok": False, "error": "api_error", "status_code": 400, "detail": err}
+    except Exception as exc:
+        db.rollback()
+        return {"ok": False, "error": "api_error", "detail": str(exc)}
+
+    return {
+        "ok": receipt.error is None,
+        "status": "duplicate" if receipt.duplicate else receipt.status,
+        "event_id": receipt.event_id,
+        "job_id": receipt.job_id,
+        "record_type": record_type_out,
+        "source_id": source_id,
+        "fallbacks": [
+            {
+                "code": "record_queued",
+                "message": "The context record was accepted and queued for reconciliation.",
+                "impact": "It may not appear in graph reads until the worker applies it.",
+            }
+        ]
+        if receipt.status == "queued" and not receipt.duplicate
+        else [],
+        "error": receipt.error,
+    }
+
+
+def _map_raw_episode_submission_result(
+    result: RawEpisodeSubmissionResult,
+) -> dict[str, Any]:
+    """Map submit_raw_episode outcome to the MCP ingest envelope."""
+    downgrades = list(result.downgrades or [])
+    if result.status == "duplicate":
+        return {
+            "ok": True,
+            "status": "duplicate",
+            "event_id": result.event_id,
+            "job_id": result.job_id,
+            "episode_uuid": result.episode_uuid,
+            "detail": "Already ingested.",
+            "duplicate_reason": result.duplicate_reason,
+            "downgrades": downgrades,
+            "fallbacks": [],
+        }
+    if result.status == "reconciliation_rejected":
+        return {
+            "ok": False,
+            "error": "reconciliation_rejected",
+            "status": result.status,
+            "event_id": result.event_id,
+            "job_id": result.job_id,
+            "errors": list(result.reconciliation_errors or []),
+            "downgrades": downgrades,
+            "fallbacks": [],
+        }
+    if result.status == "queued" and result.ok:
+        return {
+            "ok": True,
+            "status": "queued",
+            "event_id": result.event_id,
+            "job_id": result.job_id,
+            "episode_uuid": result.episode_uuid,
+            "downgrades": downgrades,
+            "fallbacks": [
+                {
+                    "code": "ingest_queued",
+                    "message": "The episode was accepted and queued for ingestion.",
+                    "impact": "It may not appear in context_resolve or context_search until the worker applies it.",
+                }
+            ],
+        }
+    if result.status == "applied" and result.ok:
+        return {
+            "ok": True,
+            "status": "applied",
+            "event_id": result.event_id,
+            "job_id": result.job_id,
+            "episode_uuid": result.episode_uuid,
+            "downgrades": downgrades,
+            "fallbacks": [],
+        }
+    err = result.error or "ingest_failed"
+    if err == "unknown_pot_id":
+        return {
+            "ok": False,
+            "error": "unknown_pot_id",
+            "status_code": 404,
+            "detail": UNKNOWN_POT_DETAIL,
+        }
+    if err == "async_requires_database":
+        return {
+            "ok": False,
+            "error": "async_requires_database",
+            "status_code": 503,
+            "detail": "Pass sync=True or configure Postgres for async ingest.",
+        }
+    if err == "context_graph_disabled":
+        return {
+            "ok": False,
+            "error": "context_graph_disabled",
+            "status_code": 503,
+            "detail": (
+                "Context graph is disabled (unset CONTEXT_GRAPH_ENABLED or set to true)."
+            ),
+        }
+    if err == "context_graph_unavailable":
+        return {
+            "ok": False,
+            "error": "context_graph_unavailable",
+            "status_code": 503,
+            "detail": "Unified context graph query port is not configured.",
+        }
+    if err == "graphiti_returned_no_uuid":
+        return {
+            "ok": False,
+            "error": "graphiti_returned_no_uuid",
+            "status_code": 502,
+            "detail": "Graph write completed without an episode UUID.",
+        }
+    return {
+        "ok": False,
+        "error": "api_error",
+        "status": result.status,
+        "event_id": result.event_id,
+        "job_id": result.job_id,
+        "detail": err,
+        "downgrades": downgrades,
+        "fallbacks": [],
+    }
+
+
+def run_context_ingest(
+    *,
+    container: ContextEngineContainer,
+    db: Session,
+    actor: Actor,
+    pot_id: str,
+    name: str,
+    episode_body: str,
+    source_description: str,
+    reference_time: str | None = None,
+    idempotency_key: str | None = None,
+    sync: bool = False,
+) -> dict[str, Any]:
+    denied = policy_error_response(
+        container,
+        actor=actor,
+        resource=RESOURCE_POT,
+        action=ACTION_POT_INGEST_EPISODE,
+        pot_id=pot_id,
+    )
+    if denied:
+        return denied
+
+    if not name.strip():
+        return {
+            "ok": False,
+            "error": "validation_error",
+            "detail": "name must not be empty",
+        }
+    if not episode_body.strip():
+        return {
+            "ok": False,
+            "error": "validation_error",
+            "detail": "episode_body must not be empty",
+        }
+
+    ref_dt: datetime
+    if reference_time is not None and reference_time.strip():
+        try:
+            parsed = _parse_as_of_iso(reference_time)
+        except ValueError as exc:
+            return {
+                "ok": False,
+                "error": "invalid_reference_time",
+                "detail": str(exc),
+            }
+        ref_dt = parsed if parsed is not None else datetime.now(timezone.utc)
+    else:
+        ref_dt = datetime.now(timezone.utc)
+
+    try:
+        result = submit_raw_episode(
+            container=container,
+            db=db,
+            pot_id=pot_id,
+            name=name.strip(),
+            episode_body=episode_body,
+            source_description=source_description,
+            reference_time=ref_dt,
+            idempotency_key=idempotency_key,
+            sync=sync,
+            source_channel=actor.surface,
+            actor=actor,
+        )
+        if result.ok:
+            db.commit()
+        else:
+            db.rollback()
+    except Exception as exc:
+        db.rollback()
+        return {"ok": False, "error": "api_error", "detail": str(exc)}
+
+    return _map_raw_episode_submission_result(result)
+
+
+def run_context_status(
+    *,
+    container: ContextEngineContainer,
+    db: Session | None,
+    actor: Actor,
+    pot_id: str,
+    repo_name: str | None = None,
+    source_refs: str | None = None,
+    intent: str | None = None,
+) -> dict[str, Any]:
+    denied = policy_error_response(
+        container,
+        actor=actor,
+        resource=RESOURCE_POT,
+        action=ACTION_POT_READ,
+        pot_id=pot_id,
+    )
+    if denied:
+        return denied
+
+    scope = _scope_from_mcp(repo_name=repo_name, source_refs=source_refs)
+    report = report_status(
+        container,
+        pot_id=pot_id,
+        scope=scope,
+        intent=intent,
+        db=db,
+    )
+    if report.unknown_pot:
+        return {
+            "ok": False,
+            "error": "api_error",
+            "status_code": 404,
+            "detail": UNKNOWN_POT_DETAIL,
+        }
+    return report.payload

--- a/app/src/context-engine/domain/agent_context_port.py
+++ b/app/src/context-engine/domain/agent_context_port.py
@@ -395,6 +395,13 @@ def context_port_manifest() -> dict[str, Any]:
                 "role": "cheap_status",
                 "description": "Check pot readiness, source coverage, freshness gaps, and recommended next context action.",
             },
+            "context_ingest": {
+                "role": "write",
+                "description": (
+                    "Ingest a raw episodic episode into the graph for a pot. "
+                    "Async by default; use sync for inline apply."
+                ),
+            },
         },
         "recipes": CONTEXT_RESOLVE_RECIPES,
         "rules": [
@@ -405,6 +412,7 @@ def context_port_manifest() -> dict[str, Any]:
             "If quality.status is watch or degraded, verify relevant facts against source truth before high-impact work.",
             "Use context_search only for specific follow-up lookup when the needed entity or phrase is already known.",
             "Use context_record when a durable decision, fix, workflow, preference, feature note, document reference, or incident summary should become reusable project memory.",
+            "Use context_ingest for raw episodic text (release notes, meeting notes, CI summaries) that should enter the graph as episodes.",
         ],
     }
 

--- a/app/src/context-engine/tests/unit/test_agent_surface_contract.py
+++ b/app/src/context-engine/tests/unit/test_agent_surface_contract.py
@@ -5,12 +5,12 @@ re-introduce per-context-family public tools or drift the recipe shape.
 
 Covers:
 
-- MCP exposes exactly four tools: ``context_resolve``, ``context_search``,
-  ``context_record``, ``context_status``.
+- MCP exposes exactly five tools: ``context_resolve``, ``context_search``,
+  ``context_record``, ``context_status``, ``context_ingest``.
 - Every CONTEXT_RESOLVE_RECIPES entry is a valid ``context_resolve`` recipe
   (no one-off tool per intent), with an ``include`` list, a supported
   ``mode``, and a supported ``source_policy``.
-- ``context_port_manifest`` advertises exactly those four tools and its
+- ``context_port_manifest`` advertises exactly those five tools and its
   ``recipes`` payload stays consistent with ``CONTEXT_RESOLVE_RECIPES``.
 - ``context_recipe_for_intent`` falls back to a generic ``context_resolve``
   shape for unknown intents (no hidden escape hatch to another tool).
@@ -22,7 +22,7 @@ import asyncio
 
 import pytest
 
-from adapters.inbound.mcp.server import mcp
+from adapters.inbound.mcp.http_server import mcp_http
 from domain.agent_context_port import (
     CONTEXT_INCLUDE_VALUES,
     CONTEXT_RESOLVE_RECIPES,
@@ -33,13 +33,19 @@ from domain.agent_context_port import (
 pytestmark = pytest.mark.unit
 
 
-EXPECTED_TOOLS = {"context_resolve", "context_search", "context_record", "context_status"}
+EXPECTED_TOOLS = {
+    "context_resolve",
+    "context_search",
+    "context_record",
+    "context_status",
+    "context_ingest",
+}
 VALID_MODES = {"fast", "balanced", "deep"}
 VALID_SOURCE_POLICIES = {"references_only", "summary", "verify", "snippets"}
 
 
-def test_mcp_exposes_exactly_the_four_agent_tools() -> None:
-    tools = asyncio.run(mcp.list_tools())
+def test_mcp_exposes_exactly_the_agent_tools() -> None:
+    tools = asyncio.run(mcp_http.list_tools())
     names = {t.name for t in tools}
     assert names == EXPECTED_TOOLS, (
         f"MCP tool surface drift: expected {EXPECTED_TOOLS}, got {names}"

--- a/app/src/context-engine/tests/unit/test_mcp_context_ingest.py
+++ b/app/src/context-engine/tests/unit/test_mcp_context_ingest.py
@@ -1,0 +1,101 @@
+"""Unit tests for MCP context_ingest tool implementation."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from adapters.inbound.mcp.tool_impl import run_context_ingest
+from application.use_cases.submit_raw_episode import RawEpisodeSubmissionResult
+from domain.actor import Actor
+
+pytestmark = pytest.mark.unit
+
+
+def test_run_context_ingest_rejects_empty_episode_body() -> None:
+    container = MagicMock()
+    db = MagicMock()
+    actor = Actor(user_id="u1", surface="mcp", client_name="test", auth_method="api_key")
+    with patch(
+        "adapters.inbound.mcp.tool_impl.policy_error_response", return_value=None
+    ):
+        out = run_context_ingest(
+            container=container,
+            db=db,
+            actor=actor,
+            pot_id="pot-1",
+            name="episode",
+            episode_body="   ",
+            source_description="mcp",
+        )
+    assert out["ok"] is False
+    assert out["error"] == "validation_error"
+    db.commit.assert_not_called()
+
+
+def test_run_context_ingest_maps_duplicate_as_ok() -> None:
+    container = MagicMock()
+    db = MagicMock()
+    actor = Actor(user_id="u1", surface="mcp", client_name="test", auth_method="api_key")
+    result = RawEpisodeSubmissionResult(
+        ok=False,
+        status="duplicate",
+        event_id="ev-1",
+        duplicate_reason="idempotency",
+    )
+    with (
+        patch(
+            "adapters.inbound.mcp.tool_impl.policy_error_response", return_value=None
+        ),
+        patch(
+            "adapters.inbound.mcp.tool_impl.submit_raw_episode", return_value=result
+        ),
+    ):
+        out = run_context_ingest(
+            container=container,
+            db=db,
+            actor=actor,
+            pot_id="pot-1",
+            name="episode",
+            episode_body="body",
+            source_description="mcp",
+            idempotency_key="key-1",
+        )
+    assert out["ok"] is True
+    assert out["status"] == "duplicate"
+    assert out["event_id"] == "ev-1"
+    db.rollback.assert_called_once()
+
+
+def test_run_context_ingest_maps_queued_with_fallback() -> None:
+    container = MagicMock()
+    db = MagicMock()
+    actor = Actor(user_id="u1", surface="mcp", client_name="test", auth_method="api_key")
+    result = RawEpisodeSubmissionResult(
+        ok=True,
+        status="queued",
+        event_id="ev-2",
+        job_id="job-2",
+    )
+    with (
+        patch(
+            "adapters.inbound.mcp.tool_impl.policy_error_response", return_value=None
+        ),
+        patch(
+            "adapters.inbound.mcp.tool_impl.submit_raw_episode", return_value=result
+        ),
+    ):
+        out = run_context_ingest(
+            container=container,
+            db=db,
+            actor=actor,
+            pot_id="pot-1",
+            name="episode",
+            episode_body="body",
+            source_description="mcp",
+        )
+    assert out["ok"] is True
+    assert out["status"] == "queued"
+    assert out["fallbacks"]
+    db.commit.assert_called_once()

--- a/app/src/context-engine/tests/unit/test_mcp_policy.py
+++ b/app/src/context-engine/tests/unit/test_mcp_policy.py
@@ -1,0 +1,59 @@
+"""Unit tests for embedded MCP policy helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from adapters.inbound.mcp.policy import policy_error_response
+from domain.actor import Actor
+from domain.ports.policy import (
+    ACTION_POT_READ,
+    REASON_UNKNOWN_POT,
+    RESOURCE_POT,
+    PolicyDecision,
+)
+
+
+def test_policy_error_response_none_when_allowed() -> None:
+    container = MagicMock()
+    container.policy.return_value.authorize.return_value = PolicyDecision(
+        allowed=True,
+        reason="ok",
+        detail="",
+        status_code=200,
+        metadata={},
+    )
+    actor = Actor(user_id="u1", surface="mcp", auth_method="api_key")
+    assert (
+        policy_error_response(
+            container,
+            actor=actor,
+            resource=RESOURCE_POT,
+            action=ACTION_POT_READ,
+            pot_id="pot-1",
+        )
+        is None
+    )
+
+
+def test_policy_error_response_unknown_pot() -> None:
+    container = MagicMock()
+    container.policy.return_value.authorize.return_value = PolicyDecision(
+        allowed=False,
+        reason=REASON_UNKNOWN_POT,
+        detail="",
+        status_code=404,
+        metadata={},
+    )
+    actor = Actor(user_id="u1", surface="mcp", auth_method="api_key")
+    out = policy_error_response(
+        container,
+        actor=actor,
+        resource=RESOURCE_POT,
+        action=ACTION_POT_READ,
+        pot_id="bad-pot",
+    )
+    assert out is not None
+    assert out["error"] == "policy_denied"
+    assert out["reason"] == REASON_UNKNOWN_POT
+    assert "Unknown pot_id" in out["detail"]


### PR DESCRIPTION
**Summary**
Adds embedded Streamable HTTP MCP on the Potpie FastAPI app at /mcp, so Cursor and other HTTP MCP clients can use the context graph in-process (same deploy and API-key auth as /api/v2/context) without spawning potpie-mcp. Introduces a fifth agent tool, context_ingest, for raw episodic ingest via the existing submit_raw_episode use case, and documents setup and the full five-tool surface in the CLI README and MCP server instructions.

**What changed**
Embedded HTTP MCP
Mount /mcp on the main Potpie app 1 with FastAPI lifespan wiring for FastMCP’s session manager (fixes “task group not initialized” on mount-only setups).
Session factory in [potpie/app/modules/context_graph/mcp_mount.py](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/potpie/app/modules/context_graph/mcp_mount.py): X-API-Key → user resolution → user-scoped ContextEngineContainer + Actor (surface=mcp).
Shared API-key resolution in [potpie/app/modules/context_graph/context_engine_http.py](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/potpie/app/modules/context_graph/context_engine_http.py) (resolve_user_from_api_key, build_container_from_api_key).
Streamable HTTP server in [potpie/app/src/context-engine/adapters/inbound/mcp/http_server.py](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/potpie/app/src/context-engine/adapters/inbound/mcp/http_server.py) with API-key middleware 2.

**Tests**
[tests/unit/test_mcp_context_ingest.py](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/potpie/app/src/context-engine/tests/unit/test_mcp_context_ingest.py) — validation, duplicate, queued mapping.
[tests/unit/test_agent_surface_contract.py](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/potpie/app/src/context-engine/tests/unit/test_agent_surface_contract.py) — expects five tools on mcp_http.