### PR TITLE
disabling fast MCP auto localhost only DNS rebinding

### DIFF
--- a/app/src/context-engine/adapters/inbound/mcp/http_server.py
+++ b/app/src/context-engine/adapters/inbound/mcp/http_server.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 mcp_http = FastMCP(
     "potpie",
     streamable_http_path="/",
+    host="0.0.0.0",
     instructions=(
         "Potpie context graph MCP. All tools require pot_id for a pot you can access "
         "with your API key. Prefer context_resolve for task context; use context_status "

--- a/app/src/context-engine/adapters/inbound/mcp/http_server.py
+++ b/app/src/context-engine/adapters/inbound/mcp/http_server.py
@@ -28,6 +28,7 @@ mcp_http = FastMCP(
     "potpie",
     streamable_http_path="/",
     host="0.0.0.0",
+    stateless_http=True,
     instructions=(
         "Potpie context graph MCP. All tools require pot_id for a pot you can access "
         "with your API key. Prefer context_resolve for task context; use context_status "


### PR DESCRIPTION
**FastMCP DNS rebinding protection bug on staging.**
In FastMCP.__init__:
if transport_security is None and host in ("127.0.0.1", "localhost", "::1"):
    transport_security = TransportSecuritySettings(
        enable_dns_rebinding_protection=True,
        allowed_hosts=["127.0.0.1:*", "localhost:*", "[::1]:*"],  # <-- only localhost!

FastMCP defaults to host="127.0.0.1", so it auto-enables a security guard that only allows localhost in the Host header. 
The fix is one line: pass host="0.0.0.0" to the FastMCP constructor. This skips the auto-localhost guard.