### PR TITLE
feat(context-engine): wire observability package with logfire backend (PR 1 of 3)

### DIFF
--- a/app/src/context-engine/adapters/inbound/cli/main.py
+++ b/app/src/context-engine/adapters/inbound/cli/main.py
@@ -1717,6 +1717,9 @@ def ingest_cmd(
 
 
 def main() -> None:
+    from bootstrap.observability import configure_observability
+
+    configure_observability()
     app()
 
 

--- a/app/src/context-engine/adapters/inbound/http/app.py
+++ b/app/src/context-engine/adapters/inbound/http/app.py
@@ -9,6 +9,7 @@ from fastapi.responses import JSONResponse
 from adapters.inbound.http._hardening import install_hardening
 from adapters.inbound.http.api.router import api_router
 from adapters.inbound.http.webhooks.router import webhooks_router
+from bootstrap.observability import configure_observability
 
 try:
     __version__ = importlib.metadata.version("context-engine")
@@ -19,7 +20,18 @@ logger = logging.getLogger(__name__)
 
 
 def create_app() -> FastAPI:
+    configure_observability()
     app = FastAPI(title="context-engine", version=__version__)
+
+    # Attach the observability request-context middleware so every log
+    # inside a request automatically carries request_id / path / method
+    # (and user_id when auth populates request.state.user).
+    try:
+        from observability.integrations.fastapi import LoggingContextMiddleware
+
+        app.add_middleware(LoggingContextMiddleware)
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning("LoggingContextMiddleware not attached: %s", exc)
 
     @app.exception_handler(HTTPException)
     async def http_exception_handler(

--- a/app/src/context-engine/adapters/inbound/mcp/server.py
+++ b/app/src/context-engine/adapters/inbound/mcp/server.py
@@ -272,6 +272,9 @@ def _split_csv(value: str | None) -> list[str]:
 
 
 def main() -> None:
+    from bootstrap.observability import configure_observability
+
+    configure_observability()
     mcp.run()
 
 

--- a/app/src/context-engine/bootstrap/observability.py
+++ b/app/src/context-engine/bootstrap/observability.py
@@ -1,0 +1,80 @@
+"""Composition root for observability inside context-engine.
+
+context-engine is treated as an independent module — when its CLI / MCP /
+HTTP entry point boots, it owns observability setup itself. When the
+monolith hosts context-engine code, the monolith has already called
+`observability.configure(...)` and we skip (PID check) to avoid clobbering
+its sinks.
+
+Backend: logfire only. No Loki, no Sentry — that's a deliberate scope
+choice for this module.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def configure_observability() -> None:
+    """Initialise the observability package for the current process.
+
+    Idempotent and host-aware:
+    - If the monolith (or any other host) already called configure() in this
+      process, this is a no-op.
+    - If logfire is not installed or initialisation fails, we log a warning
+      and continue — context-engine never refuses to boot because tracing
+      isn't available.
+    """
+    try:
+        from observability import _state as _obs_state
+        from observability import configure
+        from observability.config import (
+            LogfireConfig,
+            ObservabilityConfig,
+            SentryConfig,
+        )
+    except ModuleNotFoundError:
+        # Observability is a hard dep, so this should never fire — but if a
+        # standalone install skipped the extras, don't crash the entry point.
+        logger.warning(
+            "observability package not importable; logs will use stdlib defaults"
+        )
+        return
+
+    if _obs_state.get("configured_pid") == os.getpid():
+        # The host (monolith / test harness) has already configured this
+        # process. Don't replace its sinks.
+        return
+
+    logfire_token = os.getenv("LOGFIRE_TOKEN") or None
+    # Production: logfire only. Dev / unconfigured: fall back to console so
+    # devs still see their own logs locally. (logfire sink returns no
+    # handler when the token is absent, which would leave root silent.)
+    sinks = ["logfire"] if logfire_token else ["console"]
+    cfg = ObservabilityConfig(
+        service_name=os.getenv("SERVICE_NAME", "context-engine"),
+        env=(os.getenv("ENV") or "development").lower().strip(),
+        level=os.getenv("LOG_LEVEL", "INFO").upper(),
+        redact=True,
+        sinks=sinks,
+        sentry=SentryConfig(enabled=False),
+        logfire=LogfireConfig(
+            enabled=bool(logfire_token),
+            token=logfire_token,
+            send_to_cloud=os.getenv("LOGFIRE_SEND_TO_CLOUD", "true").lower()
+            != "false",
+            project_name=os.getenv("LOGFIRE_PROJECT_NAME", "context-engine"),
+            # Defensive default for forked workers (Hatchet etc.). If/when a
+            # caller proves the OTel contextvar issue doesn't apply, flip
+            # this via env or override at the call site.
+            instrument_pydantic_ai=False,
+        ),
+    )
+
+    try:
+        configure(cfg)
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning("observability.configure failed: %s", exc)

--- a/app/src/context-engine/pyproject.toml
+++ b/app/src/context-engine/pyproject.toml
@@ -15,7 +15,13 @@ dependencies = [
     "typer>=0.15.0",
     "uvicorn[standard]>=0.32.0",
     "pydantic>=2.0",
+    "observability[logfire]",
 ]
+
+[tool.uv.sources]
+# Resolve the in-monorepo observability path-package by relative path so
+# context-engine works standalone (CLI / MCP / HTTP) as well as via root.
+observability = { path = "../observability", editable = true }
 
 [project.optional-dependencies]
 postgres = [

--- a/app/src/observability/observability/__init__.py
+++ b/app/src/observability/observability/__init__.py
@@ -1,0 +1,254 @@
+"""Observability package — FROZEN PUBLIC CONTRACT.
+
+Only the three functions below are the behavioral public API. The config and
+sink protocol are also re-exported as data/typing contracts.
+
+    get_logger(name)        -> StructuredLogger   (ambient; thin stdlib wrapper)
+    configure(config)       -> None               (idempotent composition root)
+    log_context(**fields)   -> context manager    (correlation-id propagation)
+
+Design: stdlib `logging` core, consumers stay ambient, backends (loguru /
+Sentry / logfire) plug in via the single `Sink` seam. No `app.*` imports
+anywhere in this package — it must remain liftable into any Python service.
+
+=========================== CONTRACT EDGE CASES ============================
+EC1  stdlib loggers reject arbitrary kwargs (only exc_info/stack_info/
+     stacklevel/extra). The codebase already uses loguru-style
+     `logger.info("msg", key=val)`. `get_logger` returns a `StructuredLogger`
+     that maps **fields -> record.obs_fields so structured sinks emit them as
+     fields, not f-string blobs.
+
+EC2  `configure()` is idempotent AND fork-aware. It removes its own previously
+     installed handlers (tag-based) before re-adding — never
+     `basicConfig(force=True)`. It records the configuring PID so a forked
+     Celery worker (Phase 3, worker_process_init) can safely re-configure.
+
+EC3  `log_context()` uses contextvars (async-safe). contextvars do NOT cross
+     thread-pool / process / Celery task boundaries automatically; integrations
+     must re-bind at each hop (Phase 3).
+
+EC4  Logs emitted before `configure()` would otherwise hit the default root
+     handler. A minimal safety handler (stderr, WARNING) is installed at
+     import and removed by `configure()`, so pre-configure logs are not lost.
+"""
+
+from __future__ import annotations
+
+import atexit
+import contextvars
+import logging
+import os
+import sys
+from contextlib import contextmanager
+
+from .config import ObservabilityConfig
+from .sink import Sink
+
+__all__ = ["get_logger", "configure", "log_context", "ObservabilityConfig", "Sink"]
+
+_TAG = "_observability_managed"
+HANDLER_TAG = "sink"
+SAFETY_TAG = "safety"
+
+_context_var: contextvars.ContextVar[dict] = contextvars.ContextVar(
+    "observability_context", default={}
+)
+_state: dict = {"configured_pid": None, "sinks": [], "config": None}
+
+_RESERVED = ("exc_info", "stack_info", "stacklevel")
+
+
+class StructuredLogger:
+    """Thin stdlib wrapper accepting loguru-style **fields (EC1).
+
+    `logger.info("msg", conversation_id=cid)` -> record.obs_fields, so sinks
+    emit it as a queryable field instead of interpolating into the message.
+    """
+
+    def __init__(
+        self,
+        logger: logging.Logger,
+        extra: dict | None = None,
+    ) -> None:
+        self._logger = logger
+        self._extra = extra or {}
+
+    def _prepare(self, kwargs: dict) -> dict:
+        passthru = {k: kwargs.pop(k) for k in _RESERVED if k in kwargs}
+        extra = kwargs.pop("extra", None) or {}
+        fields = {**self._extra, **extra, **kwargs}
+        passthru["extra"] = {"obs_fields": fields}
+        passthru["stacklevel"] = int(passthru.get("stacklevel", 1)) + 1
+        return passthru
+
+    def debug(self, message, *args, **kwargs) -> None:
+        self.log(logging.DEBUG, message, *args, **kwargs)
+
+    def info(self, message, *args, **kwargs) -> None:
+        self.log(logging.INFO, message, *args, **kwargs)
+
+    def warning(self, message, *args, **kwargs) -> None:
+        self.log(logging.WARNING, message, *args, **kwargs)
+
+    warn = warning
+
+    def error(self, message, *args, **kwargs) -> None:
+        self.log(logging.ERROR, message, *args, **kwargs)
+
+    def exception(self, message, *args, **kwargs) -> None:
+        kwargs.setdefault("exc_info", True)
+        self.error(message, *args, **kwargs)
+
+    def critical(self, message, *args, **kwargs) -> None:
+        self.log(logging.CRITICAL, message, *args, **kwargs)
+
+    fatal = critical
+
+    def log(self, log_level, message, *args, **kwargs) -> None:
+        self._logger.log(log_level, message, *args, **self._prepare(kwargs))
+
+    def isEnabledFor(self, level: int) -> bool:  # noqa: N802 - stdlib API name
+        return self._logger.isEnabledFor(level)
+
+    def getChild(self, suffix: str) -> "StructuredLogger":  # noqa: N802
+        return StructuredLogger(self._logger.getChild(suffix), self._extra)
+
+    def __getattr__(self, name: str):
+        return getattr(self._logger, name)
+
+
+class ContextFilter(logging.Filter):
+    """Inject log_context() correlation IDs (and ensure obs_fields exists) onto
+    every record — works for ambient stdlib loggers too, not just ours."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if not hasattr(record, "obs_fields"):
+            record.obs_fields = {}
+        record.obs_context = dict(_context_var.get())
+        return True
+
+
+def get_logger(name: str) -> StructuredLogger:
+    """Return an ambient structured logger. Thin wrapper over getLogger(name)."""
+    return StructuredLogger(logging.getLogger(name), {})
+
+
+@contextmanager
+def log_context(**fields):
+    """Bind correlation IDs to all logs in scope (async-safe, stackable; EC3)."""
+    current = _context_var.get()
+    token = _context_var.set({**current, **fields})
+    try:
+        yield
+    finally:
+        _context_var.reset(token)
+
+
+# --- internal helpers for cross-hop rebind (EC3) — used by integrations.* ---
+# Not part of the frozen public API; the Celery integration uses these to
+# bracket a task with prerun/postrun signals where a contextmanager doesn't fit.
+
+def _push_context(**fields) -> object:
+    cur = _context_var.get()
+    return _context_var.set({**cur, **fields})
+
+
+def _pop_context(token: object) -> None:
+    try:
+        _context_var.reset(token)  # type: ignore[arg-type]
+    except (ValueError, LookupError):
+        # Token from another context (e.g. task crashed before postrun) —
+        # swallow rather than mask the real error.
+        pass
+
+
+def _iter_managed(root: logging.Logger):
+    return [h for h in root.handlers if getattr(h, _TAG, None) is not None]
+
+
+def _install_safety_handler() -> None:
+    """EC4: minimal pre-configure handler so early logs are not dropped."""
+    root = logging.getLogger()
+    if any(getattr(h, _TAG, None) == SAFETY_TAG for h in root.handlers):
+        return
+    h = logging.StreamHandler(sys.stderr)
+    h.setLevel(logging.WARNING)
+    h.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
+    setattr(h, _TAG, SAFETY_TAG)
+    root.addHandler(h)
+
+
+def configure(config: "ObservabilityConfig | None" = None) -> None:
+    """Composition root: wire sinks + filters onto the root logger (EC2).
+
+    Idempotent and fork-aware: removes our previously installed/safety handlers
+    before re-adding, so repeat calls (tests, Celery worker re-init) never
+    duplicate handlers. Sentry/logfire backend init lands in Phase 3.
+    """
+    from .intercept import apply_library_levels
+    from .redaction import RedactionFilter
+    from .sink import registry
+
+    cfg = config or ObservabilityConfig()
+    root = logging.getLogger()
+
+    # Shutdown previously-active sinks (best-effort) before tearing down
+    # their handlers — gives batch backends (Sentry, logfire) a chance to
+    # flush. Never raise out of shutdown.
+    prev_sinks = list(_state.get("sinks") or ())
+    prev_cfg = _state.get("config") or cfg
+    for s in prev_sinks:
+        try:
+            getattr(s, "shutdown", lambda *_: None)(prev_cfg)
+        except Exception:
+            pass
+
+    for h in _iter_managed(root):
+        try:
+            h.close()
+        except Exception:
+            pass
+        root.removeHandler(h)
+
+    ctx_filter = ContextFilter()
+    red_filter = RedactionFilter() if cfg.redact else None
+    new_sinks: list = []
+
+    for name in cfg.sinks:
+        sink = registry.resolve(name)
+        sink.setup(cfg)
+        new_sinks.append(sink)
+        handler = sink.build_handler(cfg)
+        if handler is not None:
+            handler.addFilter(ctx_filter)  # inject context first
+            if red_filter is not None:
+                handler.addFilter(red_filter)  # then scrub message + context
+            # Respect sink-provided level (e.g. Sentry's event_level=ERROR);
+            # only default to cfg.level when the sink did not set one.
+            if handler.level == logging.NOTSET:
+                handler.setLevel(cfg.level)
+            setattr(handler, _TAG, HANDLER_TAG)
+            root.addHandler(handler)
+        sink.instrument(cfg)  # tracing-only sinks (logfire) still run this
+
+    root.setLevel(cfg.level)
+    apply_library_levels(cfg.library_levels)
+    _state["configured_pid"] = os.getpid()
+    _state["sinks"] = new_sinks
+    _state["config"] = cfg
+
+
+def _shutdown_all_sinks() -> None:
+    """atexit hook: flush every active sink so batched events (Sentry,
+    logfire) aren't lost on process exit. Never raise."""
+    sinks = list(_state.get("sinks") or ())
+    cfg = _state.get("config") or ObservabilityConfig()
+    for s in sinks:
+        try:
+            getattr(s, "shutdown", lambda *_: None)(cfg)
+        except Exception:
+            pass
+
+
+_install_safety_handler()
+atexit.register(_shutdown_all_sinks)

--- a/app/src/observability/observability/config.py
+++ b/app/src/observability/observability/config.py
@@ -1,0 +1,123 @@
+"""Observability configuration model (pure data — fully defined contract).
+
+Config is an explicit object passed into `configure()`. Env-loading is ONE
+optional adapter (`from_env`), so the package never assumes a host's env
+conventions. Env var names below are the ones the audit found in the current
+codebase, carried forward for migration parity.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+_TRUTHY = {"1", "true", "yes", "y"}
+_FALSY = {"0", "false", "no", "n"}
+
+
+def parse_bool(value: str | None, default: bool) -> bool:
+    if value is None:
+        return default
+    normalized = value.lower().strip()
+    if normalized in _TRUTHY:
+        return True
+    if normalized in _FALSY:
+        return False
+    return default
+
+
+@dataclass(slots=True)
+class SentryConfig:
+    """Sentry (error capture). GAP the audit found: today Sentry is prod-only,
+    web-only, no Celery, DSN often unset -> silent no-op. Contract fix:
+    `enabled` is derived (explicit flag AND dsn present); configure() emits ONE
+    visible 'sentry disabled: no DSN' log instead of silently doing nothing."""
+
+    enabled: bool = False
+    dsn: str | None = None
+    environment: str | None = None
+    traces_sample_rate: float = 0.25
+    # Audit flagged profiles_sample_rate=1.0 in prod as a cost smell.
+    profiles_sample_rate: float = 0.05
+    # EC: if a Sentry log-sink is registered, Sentry's own LoggingIntegration
+    # must be set event_level=None to avoid double-capture.
+    own_logging_integration: bool = True
+    # Which integrations to add. Audit-faithful: default_integrations=False +
+    # explicit list (preserves Strawberry-not-installed safety from the
+    # original setup_sentry).
+    with_fastapi: bool = False
+    with_celery: bool = False
+    # Sink handler emits events at this level and above.
+    event_level: str = "ERROR"
+
+
+@dataclass(slots=True)
+class LogfireConfig:
+    """logfire (tracing + optional log export). Carries the known Celery
+    escape hatch: instrument_pydantic_ai must be False in prefork workers
+    ('Token was created in a different Context' OTel contextvar bug)."""
+
+    enabled: bool = False
+    token: str | None = None
+    send_to_cloud: bool = True
+    project_name: str = "potpie"
+    instrument_litellm: bool = True
+    instrument_pydantic_ai: bool = True  # set False in Celery profile
+
+
+@dataclass(slots=True)
+class ObservabilityConfig:
+    """Top-level config. `sinks` are sink names resolved via the registry, or
+    pre-built Sink instances. Default per-library levels mirror the audit's
+    existing dial-down map (uvicorn/sqlalchemy/httpx/etc.)."""
+
+    service_name: str = "potpie"
+    env: str = "development"
+    level: str = "INFO"
+    redact: bool = True
+    show_stack_traces: bool = True
+    sinks: list[str] = field(default_factory=lambda: ["console"])
+    library_levels: dict[str, str] = field(default_factory=dict)
+    sentry: SentryConfig = field(default_factory=SentryConfig)
+    logfire: LogfireConfig = field(default_factory=LogfireConfig)
+
+    @classmethod
+    def from_env(cls) -> "ObservabilityConfig":
+        """Build from env vars: ENV, LOG_LEVEL, LOG_STACK_TRACES, SENTRY_DSN,
+        SENTRY_ENVIRONMENT, LOGFIRE_TOKEN, LOGFIRE_SEND_TO_CLOUD,
+        LOGFIRE_PROJECT_NAME, CELERY_WORKER.
+
+        Enablement is DERIVED, not silent: Sentry/logfire are only enabled when
+        their credential is actually present (the audit's silent-no-op fix).
+        """
+        import os
+
+        env = (os.getenv("ENV") or "development").lower().strip()
+        is_dev = env == "development"
+        sentry_dsn = os.getenv("SENTRY_DSN") or None
+        logfire_token = os.getenv("LOGFIRE_TOKEN") or None
+
+        return cls(
+            service_name=os.getenv("SERVICE_NAME", "potpie"),
+            env=env,
+            level=os.getenv("LOG_LEVEL", "INFO").upper(),
+            redact=True,
+            show_stack_traces=os.getenv("LOG_STACK_TRACES", "true").lower()
+            in ("true", "1", "yes"),
+            sinks=["console"] if is_dev else ["json_stdout"],
+            sentry=SentryConfig(
+                enabled=bool(sentry_dsn),
+                dsn=sentry_dsn,
+                environment=os.getenv("SENTRY_ENVIRONMENT", env),
+            ),
+            logfire=LogfireConfig(
+                enabled=bool(logfire_token),
+                token=logfire_token,
+                send_to_cloud=parse_bool(
+                    os.getenv("LOGFIRE_SEND_TO_CLOUD"),
+                    default=True,
+                ),
+                project_name=os.getenv("LOGFIRE_PROJECT_NAME", "potpie"),
+                # OTel prefork bug: never instrument pydantic-ai in a worker.
+                instrument_pydantic_ai=os.getenv("CELERY_WORKER") != "1",
+            ),
+        )

--- a/app/src/observability/observability/integrations/__init__.py
+++ b/app/src/observability/observability/integrations/__init__.py
@@ -1,0 +1,4 @@
+"""Optional framework integrations. Imported lazily — the core never depends
+on FastAPI/Starlette or Celery. Each integration re-binds correlation context
+at its boundary (EC3: contextvars don't cross thread/process/task hops).
+"""

--- a/app/src/observability/observability/integrations/celery.py
+++ b/app/src/observability/observability/integrations/celery.py
@@ -1,0 +1,75 @@
+"""Celery integration (extra: observability[celery]) — NEW; fixes audit gaps.
+
+The audit found: Celery workers never init Sentry; no Sentry CeleryIntegration;
+correlation IDs lost across the broker hop (EC3). This wires:
+
+ - worker_process_init -> configure(profiles.celery()). Backend init (Sentry/
+   logfire sockets) happens INSIDE the forked worker (EC2) — not at import,
+   which would leave pre-fork sockets dangling.
+ - task_prerun/task_postrun -> bracket each task with log_context bound to
+   task_id + task_name, plus best-effort scrape of well-known correlation
+   keys from kwargs (conversation_id/run_id/project_id/user_id). This re-binds
+   correlation across the broker hop where contextvars cannot survive (EC3).
+   Once callers migrate (Phase 4), they can layer their own log_context()
+   inside the task for richer fields.
+
+EDGE CASES:
+ - prefork is the standard pool; solo/threads/gevent also fork-or-not safely
+   because configure() is idempotent + PID-tracked.
+ - task_postrun fires even if the task raised — token cleanup is best-effort.
+ - kwargs may be missing/None on retries/chains; degrade silently.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_HINT = "celery integration requires celery — install observability[celery]"
+_KNOWN_CORRELATION_KEYS = (
+    "conversation_id",
+    "run_id",
+    "project_id",
+    "user_id",
+    "request_id",
+)
+
+
+def install_celery_observability(celery_app: Any = None, config: Any = None) -> None:
+    """Wire signals so workers initialise observability and propagate context.
+
+    celery_app is accepted (parity with similar libs) but not strictly needed;
+    Celery signals are global. config defaults to profiles.celery().
+    """
+    try:
+        from celery.signals import (
+            task_postrun,
+            task_prerun,
+            worker_process_init,
+        )
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(_HINT) from exc
+
+    from .. import _pop_context, _push_context, configure
+    from ..profiles import celery as celery_profile
+
+    cfg = config or celery_profile()
+    _pending: dict[Any, Any] = {}
+
+    @worker_process_init.connect
+    def _init_worker(**_kwargs):  # pragma: no cover — fires inside worker
+        configure(cfg)
+
+    @task_prerun.connect
+    def _on_prerun(task_id=None, task=None, args=None, kwargs=None, **_):  # noqa: D401
+        fields = {"task_id": task_id, "task_name": getattr(task, "name", None)}
+        if isinstance(kwargs, dict):
+            for key in _KNOWN_CORRELATION_KEYS:
+                if key in kwargs:
+                    fields[key] = kwargs[key]
+        _pending[task_id] = _push_context(**fields)
+
+    @task_postrun.connect
+    def _on_postrun(task_id=None, **_):
+        token = _pending.pop(task_id, None)
+        if token is not None:
+            _pop_context(token)

--- a/app/src/observability/observability/integrations/fastapi.py
+++ b/app/src/observability/observability/integrations/fastapi.py
@@ -1,0 +1,57 @@
+"""FastAPI/Starlette request-context middleware (extra: observability[fastapi]).
+
+Ports app/modules/utils/logging_middleware.py: binds request_id (X-Request-ID
+or generated), path, method, and user_id (if auth set request.state.user)
+into log_context for the request; echoes X-Request-ID on the response.
+
+starlette is imported lazily via module __getattr__ so importing the package
+never requires starlette; `from ...fastapi import LoggingContextMiddleware`
+still works and triggers the import only then.
+
+KNOWN LIMITATION (port-parity, EC3): with BaseHTTPMiddleware the context is
+bound in the dispatch task; for streaming/SSE responses the body is produced
+in a different task, so logs emitted *during* streaming may not carry the
+context. This matches the original implementation; a streaming-safe rebind is
+tracked for later, not changed in this port.
+"""
+
+from __future__ import annotations
+
+
+def _build_middleware():
+    import uuid
+
+    from starlette.middleware.base import BaseHTTPMiddleware
+
+    from .. import log_context
+
+    class LoggingContextMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            request_id = request.headers.get("X-Request-ID") or str(uuid.uuid4())
+            user_id = None
+            state_user = getattr(request.state, "user", None)
+            if isinstance(state_user, dict):
+                user_id = state_user.get("user_id")
+            elif state_user is not None:
+                user_id = getattr(state_user, "user_id", None)
+            ctx = {
+                "request_id": request_id,
+                "path": request.url.path,
+                "method": request.method,
+            }
+            if user_id:
+                ctx["user_id"] = user_id
+            with log_context(**ctx):
+                response = await call_next(request)
+                response.headers["X-Request-ID"] = request_id
+                return response
+
+    return LoggingContextMiddleware
+
+
+def __getattr__(name: str):
+    if name == "LoggingContextMiddleware":
+        cls = _build_middleware()
+        globals()[name] = cls
+        return cls
+    raise AttributeError(name)

--- a/app/src/observability/observability/intercept.py
+++ b/app/src/observability/observability/intercept.py
@@ -1,0 +1,49 @@
+"""Library-level control for ambient stdlib loggers.
+
+stdlib-core means we do NOT need a global stdlib->loguru bridge: third-party
+loggers (uvicorn, sqlalchemy, httpx, celery, ...) propagate to root, where
+configure() attached our managed handlers — so they flow through our sinks +
+redaction + context with zero caller changes.
+
+This module only dials per-library verbosity and stops libraries that attach
+their OWN handlers (uvicorn) from double-emitting, by clearing those handlers
+and forcing propagation.
+
+DEFAULT_LIBRARY_LEVELS is the verbatim map ported from
+app/modules/utils/logger.py.
+"""
+
+from __future__ import annotations
+
+import logging
+
+DEFAULT_LIBRARY_LEVELS: dict[str, str] = {
+    "uvicorn": "INFO",
+    "uvicorn.access": "WARNING",
+    "uvicorn.error": "INFO",
+    "fastapi": "INFO",
+    "sqlalchemy.engine": "WARNING",
+    "sqlalchemy.pool": "WARNING",
+    "sqlalchemy.orm": "WARNING",
+    "alembic": "INFO",
+    "celery": "INFO",
+    "kombu": "WARNING",
+    "httpx": "WARNING",
+    "urllib3": "WARNING",
+    "boto3": "WARNING",
+    "botocore": "WARNING",
+}
+
+
+def apply_library_levels(levels: dict[str, str] | None) -> None:
+    """Set levels and route the named libraries through root (our handlers).
+
+    Empty/None -> use DEFAULT_LIBRARY_LEVELS so callers get sane defaults.
+    Custom levels override/extend those defaults instead of replacing them.
+    """
+    mapping = {**DEFAULT_LIBRARY_LEVELS, **(levels or {})}
+    for name, level in mapping.items():
+        lib = logging.getLogger(name)
+        lib.setLevel(level)
+        lib.handlers = []          # don't let the library emit on its own
+        lib.propagate = True       # send to root -> our managed sinks

--- a/app/src/observability/observability/profiles.py
+++ b/app/src/observability/observability/profiles.py
@@ -1,0 +1,49 @@
+"""Per-runtime composition presets — the only place that knows the runtime.
+
+Each returns an ObservabilityConfig; pass it to configure().
+
+  monolith()    web app: from_env (console in dev / json_stdout otherwise;
+                 Sentry/logfire auto-enabled only when creds present).
+  standalone()  CLI / context-engine standalone: console + redaction, no
+                 Sentry/logfire. Fixes the audit gap where standalone had NO
+                 logging config and fell back to Python default (root=WARNING,
+                 no JSON, no redaction).
+  celery()      Phase 3 — needs Sentry CeleryIntegration + worker_process_init
+                 backend init + instrument_pydantic_ai=False.
+"""
+
+from __future__ import annotations
+
+import os
+
+from .config import LogfireConfig, ObservabilityConfig, SentryConfig
+
+
+def monolith() -> ObservabilityConfig:
+    cfg = ObservabilityConfig.from_env()
+    cfg.sentry.with_fastapi = True
+    return cfg
+
+
+def standalone() -> ObservabilityConfig:
+    return ObservabilityConfig(
+        env=(os.getenv("ENV") or "development").lower().strip(),
+        level=os.getenv("LOG_LEVEL", "INFO").upper(),
+        sinks=["console"],
+        redact=True,
+        sentry=SentryConfig(enabled=False),
+        logfire=LogfireConfig(enabled=False),
+    )
+
+
+def celery() -> ObservabilityConfig:
+    """Workers: JSONL out, Sentry with CeleryIntegration, logfire WITHOUT
+    pydantic-ai instrumentation (OTel prefork contextvar bug). Backend init
+    happens inside the worker process via integrations.celery (EC2).
+    """
+    cfg = ObservabilityConfig.from_env()
+    cfg.sinks = ["json_stdout"]
+    if cfg.sentry.enabled:
+        cfg.sentry.with_celery = True
+    cfg.logfire.instrument_pydantic_ai = False
+    return cfg

--- a/app/src/observability/observability/redaction.py
+++ b/app/src/observability/observability/redaction.py
@@ -1,0 +1,83 @@
+"""Sensitive-data redaction.
+
+Ported verbatim from app/modules/utils/logger.py SENSITIVE_PATTERNS /
+filter_sensitive_data (already app.*-free). Runs as a logging.Filter so it
+applies to every handler regardless of sink (stdlib-core requirement).
+
+KNOWN GAP (unchanged from the audit, deliberately not silently "fixed" here):
+patterns redact credentials/tokens but NOT emails or arbitrary user IDs. The
+email/PII decision is tracked separately (audit-remediation issue), not in
+this port — porting must not change behavior.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+REDACTION = r"\1=***REDACTED***"
+
+# (compiled pattern, replacement) — verbatim port.
+SENSITIVE_PATTERNS: list[tuple[re.Pattern, str]] = [
+    (re.compile(r'(password|passwd|pwd)=["\']?([^"\'\s&]+)', re.IGNORECASE),
+     REDACTION),
+    (re.compile(r'(token|access_token|refresh_token|id_token)=["\']?([^"\'\s&]+)',
+                re.IGNORECASE),
+     REDACTION),
+    (re.compile(r'(secret|client_secret|api_secret)=["\']?([^"\'\s&]+)',
+                re.IGNORECASE),
+     REDACTION),
+    (re.compile(r'(api[_-]?key|apikey)=["\']?([^"\'\s&]+)', re.IGNORECASE),
+     REDACTION),
+    (re.compile(r'(auth|authorization)=["\']?([^"\'\s&]+)', re.IGNORECASE),
+     REDACTION),
+    (re.compile(r"Bearer\s+([A-Za-z0-9\-._~+/]+=*)", re.IGNORECASE),
+     r"Bearer ***REDACTED***"),
+    (re.compile(r"Basic\s+([A-Za-z0-9+/]+=*)", re.IGNORECASE),
+     r"Basic ***REDACTED***"),
+    (re.compile(r"(redis|postgresql|mysql|mongodb)://([^:]+):([^@]+)@",
+                re.IGNORECASE),
+     r"\1://\2:***REDACTED***@"),
+    (re.compile(r"([?&]code=)([A-Za-z0-9\-._~]{20,100})([&\s]|$)", re.IGNORECASE),
+     r"\1***REDACTED***\3"),
+    (re.compile(r'("(?:password|token|secret|api_key)"\s*:\s*)"([^"]+)"',
+                re.IGNORECASE),
+     r'\1"***REDACTED***"'),
+    (re.compile(r"('(?:password|token|secret|api_key)'\s*:\s*)'([^']+)'",
+                re.IGNORECASE),
+     r"\1'***REDACTED***'"),
+]
+
+
+def redact(text: str) -> str:
+    """Scrub sensitive data from a string. Non-strings pass through unchanged."""
+    if not isinstance(text, str):
+        return text
+    out = text
+    for pattern, replacement in SENSITIVE_PATTERNS:
+        out = pattern.sub(replacement, out)
+    return out
+
+
+class RedactionFilter(logging.Filter):
+    """Scrubs the formatted message, string args, and structured fields.
+
+    Exception traceback text is scrubbed by the sink formatters (they own
+    exception rendering), mirroring the original sink-level behavior.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            msg = record.getMessage()
+        except Exception:
+            msg = str(record.msg)
+        record.msg = redact(msg)
+        record.args = None
+        for attr in ("obs_fields", "obs_context"):
+            data = getattr(record, attr, None)
+            if isinstance(data, dict):
+                setattr(record, attr, {
+                    k: (redact(v) if isinstance(v, str) else v)
+                    for k, v in data.items()
+                })
+        return True

--- a/app/src/observability/observability/sink.py
+++ b/app/src/observability/observability/sink.py
@@ -1,0 +1,74 @@
+"""The ONE abstraction seam: the `Sink` Protocol + a lazy registry.
+
+A Sink can receive logs and/or initialise a backend. Three methods so loguru,
+Sentry and logfire all fit one contract:
+
+  setup(config)          init the backend SDK (idempotent, fork-safe; EC2).
+  build_handler(config)  return a logging.Handler, or None for sinks that only
+                          init/instrument (e.g. tracing-only logfire).
+  instrument(config)     optional tracing hooks (logfire). No-op for log sinks.
+
+Built-ins are registered LAZILY: resolving a sink imports its module only
+then, so `import observability` never pulls loguru/sentry_sdk/logfire.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from typing import Callable, Protocol, runtime_checkable
+
+from .config import ObservabilityConfig
+
+
+@runtime_checkable
+class Sink(Protocol):
+    name: str
+
+    def setup(self, config: ObservabilityConfig) -> None: ...
+
+    def build_handler(
+        self, config: ObservabilityConfig
+    ) -> logging.Handler | None: ...
+
+    def instrument(self, config: ObservabilityConfig) -> None: ...
+
+    def shutdown(self, config: ObservabilityConfig) -> None:
+        """Flush + release resources. Called on reconfigure and at process
+        exit (atexit). Must be best-effort and never raise — backends may
+        already be torn down during interpreter shutdown."""
+        ...
+
+
+# name -> "module:ClassName" (relative to this package), imported on resolve.
+_BUILTIN: dict[str, str] = {
+    "console": ".sinks.console:ConsoleSink",
+    "json_stdout": ".sinks.json_stdout:JsonStdoutSink",
+    "loguru": ".sinks.loguru_sink:LoguruSink",
+    "sentry": ".sinks.sentry_sink:SentrySink",
+    "logfire": ".sinks.logfire_sink:LogfireSink",
+}
+
+
+class SinkRegistry:
+    def __init__(self) -> None:
+        self._factories: dict[str, Callable[[], Sink]] = {}
+
+    def register(self, name: str, factory: Callable[[], Sink]) -> None:
+        self._factories[name] = factory
+
+    def resolve(self, name: str) -> Sink:
+        if name in self._factories:
+            return self._factories[name]()
+        spec = _BUILTIN.get(name)
+        if spec is None:
+            raise KeyError(
+                f"Unknown sink {name!r}. Known: "
+                f"{sorted(set(self._factories) | set(_BUILTIN))}"
+            )
+        mod_path, cls_name = spec.split(":")
+        module = importlib.import_module(mod_path, __package__)
+        return getattr(module, cls_name)()
+
+
+registry = SinkRegistry()

--- a/app/src/observability/observability/sinks/__init__.py
+++ b/app/src/observability/observability/sinks/__init__.py
@@ -1,0 +1,5 @@
+"""Built-in sinks. Each conforms to observability.sink.Sink.
+
+Sinks are registered lazily (their optional deps may be absent) — importing
+this package must NOT import loguru/sentry_sdk/logfire. Resolution-time only.
+"""

--- a/app/src/observability/observability/sinks/console.py
+++ b/app/src/observability/observability/sinks/console.py
@@ -1,0 +1,76 @@
+"""Development sink: human-readable line. Ports logger.py dev sink/_filter.
+
+Format: `TS | LEVEL    | logger:func:line | message | k: v, ...`
+Context + structured fields are appended to the tail (mirrors the original
+dev `_filter` behavior). Minimal ANSI level color only when stdout is a TTY.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import traceback
+from datetime import datetime
+
+from ..config import ObservabilityConfig
+from ..redaction import redact
+
+_COLORS = {
+    "DEBUG": "\033[36m", "INFO": "\033[32m", "WARNING": "\033[33m",
+    "ERROR": "\033[31m", "CRITICAL": "\033[41m",
+}
+_RESET = "\033[0m"
+
+
+class TextFormatter(logging.Formatter):
+    def __init__(self, color: bool, redact_exc: bool) -> None:
+        super().__init__()
+        self._color = color
+        self._redact_exc = redact_exc
+
+    def format(self, record: logging.LogRecord) -> str:
+        ts = datetime.fromtimestamp(record.created).strftime("%Y-%m-%d %H:%M:%S")
+        level = record.levelname
+        if self._color and level in _COLORS:
+            level_s = f"{_COLORS[level]}{level:<8}{_RESET}"
+        else:
+            level_s = f"{level:<8}"
+        line = (
+            f"{ts} | {level_s} | "
+            f"{record.name}:{record.funcName}:{record.lineno} | "
+            f"{record.getMessage()}"
+        )
+        extras: dict = {}
+        for attr in ("obs_context", "obs_fields"):
+            data = getattr(record, attr, None)
+            if isinstance(data, dict):
+                extras.update(data)
+        if extras:
+            line += " | " + ", ".join(f"{k}: {v}" for k, v in extras.items())
+        if record.exc_info:
+            tb = "".join(traceback.format_exception(*record.exc_info))
+            line += "\n" + (redact(tb) if self._redact_exc else tb)
+        return line
+
+
+class ConsoleSink:
+    name = "console"
+
+    def setup(self, config: ObservabilityConfig) -> None:
+        return None
+
+    def build_handler(self, config: ObservabilityConfig) -> logging.Handler | None:
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(
+            TextFormatter(
+                color=sys.stdout.isatty(),
+                redact_exc=config.redact,
+            )
+        )
+        return handler
+
+    def instrument(self, config: ObservabilityConfig) -> None:
+        return None
+
+    def shutdown(self, config: ObservabilityConfig) -> None:
+        return None

--- a/app/src/observability/observability/sinks/json_stdout.py
+++ b/app/src/observability/observability/sinks/json_stdout.py
@@ -1,0 +1,74 @@
+"""Production sink: flat JSONL to stdout. Ports logger.py production_log_sink.
+
+Flattens obs_context + obs_fields to top level (the audit's 'structure lost'
+fix), serialises exception type/value/traceback, redacts exception text when
+config.redact is on (message/fields are already scrubbed by RedactionFilter).
+default=str so non-serialisable extras never crash logging.
+
+GAP (unchanged): stdout JSONL is inert without an aggregator — where it ships
+is a separate, untracked decision, not solved here.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import traceback
+from datetime import datetime, timezone
+
+from ..config import ObservabilityConfig
+from ..redaction import redact
+
+_STD = set(vars(logging.makeLogRecord({})))
+
+
+class JsonFormatter(logging.Formatter):
+    def __init__(self, redact_exc: bool) -> None:
+        super().__init__()
+        self._redact_exc = redact_exc
+
+    def format(self, record: logging.LogRecord) -> str:
+        data = {
+            "timestamp": datetime.fromtimestamp(
+                record.created, tz=timezone.utc
+            ).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "function": record.funcName,
+            "line": record.lineno,
+            "message": record.getMessage(),
+        }
+        for attr in ("obs_context", "obs_fields"):
+            extra = getattr(record, attr, None)
+            if isinstance(extra, dict):
+                for key, value in extra.items():
+                    target_key = f"extra_{key}" if key in data else key
+                    data[target_key] = value
+        if record.exc_info:
+            etype, eval_, _ = record.exc_info
+            tb = "".join(traceback.format_exception(*record.exc_info))
+            data["exception"] = {
+                "type": getattr(etype, "__name__", str(etype)),
+                "value": redact(str(eval_)) if self._redact_exc else str(eval_),
+                "traceback": redact(tb) if self._redact_exc else tb,
+            }
+        return json.dumps(data, default=str)
+
+
+class JsonStdoutSink:
+    name = "json_stdout"
+
+    def setup(self, config: ObservabilityConfig) -> None:
+        return None
+
+    def build_handler(self, config: ObservabilityConfig) -> logging.Handler | None:
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(JsonFormatter(redact_exc=config.redact))
+        return handler
+
+    def instrument(self, config: ObservabilityConfig) -> None:
+        return None
+
+    def shutdown(self, config: ObservabilityConfig) -> None:
+        return None

--- a/app/src/observability/observability/sinks/logfire_sink.py
+++ b/app/src/observability/observability/sinks/logfire_sink.py
@@ -1,0 +1,86 @@
+"""logfire log sink (extra: observability[logfire]) — NEW.
+
+logfire does double duty: tracing (tracing.configure_tracing) AND structured
+log export (this sink). Both share a single logfire.configure() call —
+setup() here delegates to tracing.configure_tracing so logfire is configured
+ONCE per process (EC2).
+
+Edge cases:
+ - Import logfire lazily.
+ - No token / disabled -> setup() returns; build_handler returns None.
+   tracing.configure_tracing already emits the one visible 'local-only' notice.
+ - instrument() is no-op here: instrument_litellm/pydantic_ai already happen
+   inside configure_tracing, so they aren't repeated.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from ..config import ObservabilityConfig
+from ..tracing import configure_tracing
+
+_HINT = "logfire sink requires logfire — install observability[logfire]"
+
+
+class LogfireSink:
+    name = "logfire"
+
+    def setup(self, config: ObservabilityConfig) -> None:
+        if not config.logfire.enabled and not config.logfire.token:
+            return
+        try:
+            import logfire  # noqa: F401
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(_HINT) from exc
+        configure_tracing(config)
+
+    def build_handler(
+        self, config: ObservabilityConfig
+    ) -> logging.Handler | None:
+        if not config.logfire.enabled and not config.logfire.token:
+            return None
+        try:
+            import logfire
+        except ModuleNotFoundError:
+            return None
+        Handler = getattr(logfire, "LogfireLoggingHandler", None)
+        if Handler is None:  # pragma: no cover — older logfire fallback
+            class _MinimalHandler(logging.Handler):
+                def emit(self, record: logging.LogRecord) -> None:
+                    try:
+                        import logfire as lf
+                        fields: dict = {}
+                        for attr in ("obs_context", "obs_fields"):
+                            data = getattr(record, attr, None)
+                            if isinstance(data, dict):
+                                fields.update(data)
+                        lf.log(
+                            record.levelname.lower(),
+                            record.getMessage(),
+                            **fields,
+                        )
+                    except Exception:
+                        self.handleError(record)
+
+            return _MinimalHandler()
+        return Handler()
+
+    def instrument(self, config: ObservabilityConfig) -> None:
+        return None
+
+    def shutdown(self, config: ObservabilityConfig) -> None:
+        # logfire batches spans/logs; flush before the process / sink dies.
+        # API surface varies across versions; try the common spellings.
+        try:
+            import logfire
+        except Exception:
+            return
+        for name in ("force_flush", "shutdown"):
+            fn = getattr(logfire, name, None)
+            if callable(fn):
+                try:
+                    fn()
+                    return
+                except Exception:
+                    continue

--- a/app/src/observability/observability/sinks/loguru_sink.py
+++ b/app/src/observability/observability/sinks/loguru_sink.py
@@ -1,0 +1,68 @@
+"""loguru as an OPTIONAL sink (extra: observability[loguru]).
+
+Filename is loguru_sink.py, NOT loguru.py — a module named loguru.py would
+shadow the real `loguru` package (same reason the package is 'observability',
+not 'logging').
+
+loguru is imported lazily inside methods: importing this package never
+requires loguru. If a host configures the 'loguru' sink without loguru
+installed, resolution fails with a clear, actionable error (not at import).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from ..config import ObservabilityConfig
+
+_HINT = "loguru sink requires loguru — install observability[loguru]"
+
+
+class _LoguruHandler(logging.Handler):
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            from loguru import logger as L
+
+            try:
+                level = L.level(record.levelname).name
+            except ValueError:
+                level = record.levelno
+            fields: dict = {}
+            for attr in ("obs_context", "obs_fields"):
+                data = getattr(record, attr, None)
+                if isinstance(data, dict):
+                    fields.update(data)
+            L.bind(**fields).opt(depth=6, exception=record.exc_info).log(
+                level, record.getMessage()
+            )
+        except Exception:
+            self.handleError(record)
+
+
+class LoguruSink:
+    name = "loguru"
+
+    def setup(self, config: ObservabilityConfig) -> None:
+        try:
+            import loguru  # noqa: F401
+        except ModuleNotFoundError as exc:  # pragma: no cover
+            raise ModuleNotFoundError(_HINT) from exc
+
+    def build_handler(self, config: ObservabilityConfig) -> logging.Handler | None:
+        return _LoguruHandler()
+
+    def instrument(self, config: ObservabilityConfig) -> None:
+        return None
+
+    def shutdown(self, config: ObservabilityConfig) -> None:
+        try:
+            from loguru import logger as L
+            # complete() awaits enqueued async sinks; safe no-op if none.
+            complete = getattr(L, "complete", None)
+            if complete is not None:
+                try:
+                    complete()
+                except Exception:
+                    pass
+        except Exception:
+            pass

--- a/app/src/observability/observability/sinks/sentry_sink.py
+++ b/app/src/observability/observability/sinks/sentry_sink.py
@@ -1,0 +1,146 @@
+"""Sentry sink (extra: observability[sentry]) — NEW; fixes the audit's core gap.
+
+Today (pre-package) Sentry is web-only, prod-only, DSN-often-unset, and there
+is NO loguru->Sentry bridge so logger.error/exception calls never reach
+Sentry. This sink closes that:
+
+ - setup(): sentry_sdk.init with the config; idempotent per-process. Network
+   init is acceptable here because integrations/celery.py calls configure()
+   INSIDE worker_process_init (EC2) — never at module import for workers.
+   default_integrations=False + explicit list (preserves the audit's
+   Strawberry-not-installed safety from the original setup_sentry).
+ - build_handler(): handler at config.sentry.event_level (default ERROR)
+   that calls capture_exception/capture_message, attaching obs_context +
+   obs_fields as scope tags / extras.
+ - own_logging_integration=True (default): include LoggingIntegration with
+   event_level=None so THIS sink owns the log -> event path (no double
+   capture).
+ - Disabled-state contract: enabled=False or no DSN -> setup() emits ONE
+   visible warning and build_handler returns None (no silent no-op).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from ..config import ObservabilityConfig
+
+_HINT = "sentry sink requires sentry-sdk — install observability[sentry]"
+_LEVEL_TO_SENTRY = {
+    "DEBUG": "debug",
+    "INFO": "info",
+    "WARNING": "warning",
+    "ERROR": "error",
+    "CRITICAL": "fatal",
+}
+_logger = logging.getLogger(__name__)
+_state = {"initialised_pid": None}
+_disabled_notices: set[tuple[int, str]] = set()
+
+
+class _SentryHandler(logging.Handler):
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            import sentry_sdk
+
+            fields: dict = {}
+            for attr in ("obs_context", "obs_fields"):
+                data = getattr(record, attr, None)
+                if isinstance(data, dict):
+                    fields.update(data)
+            # new_scope is the sentry-sdk 2.x preferred API (push_scope deprecated).
+            with sentry_sdk.new_scope() as scope:
+                for k, v in fields.items():
+                    try:
+                        scope.set_tag(str(k), str(v))
+                    except Exception:
+                        pass
+                scope.set_extra("logger", record.name)
+                scope.set_extra("function", record.funcName)
+                scope.set_extra("line", record.lineno)
+                if record.exc_info:
+                    sentry_sdk.capture_exception(record.exc_info)
+                else:
+                    level = _LEVEL_TO_SENTRY.get(record.levelname, "info")
+                    sentry_sdk.capture_message(record.getMessage(), level=level)
+        except Exception:
+            self.handleError(record)
+
+
+class SentrySink:
+    name = "sentry"
+
+    def setup(self, config: ObservabilityConfig) -> None:
+        sc = config.sentry
+        if not sc.enabled or not sc.dsn:
+            reason = "enabled=False" if not sc.enabled else "no SENTRY_DSN"
+            notice_key = (os.getpid(), reason)
+            if notice_key not in _disabled_notices:
+                _logger.warning("sentry disabled: %s", reason)
+                _disabled_notices.add(notice_key)
+            return
+        try:
+            import sentry_sdk
+            from sentry_sdk.integrations.logging import LoggingIntegration
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(_HINT) from exc
+
+        if _state["initialised_pid"] == os.getpid():
+            return  # idempotent within a process
+
+        integrations: list = []
+        if sc.own_logging_integration:
+            # event_level=None disables Sentry's auto log->event capture;
+            # our _SentryHandler owns that path.
+            integrations.append(LoggingIntegration(event_level=None))
+        if sc.with_fastapi:
+            try:
+                from sentry_sdk.integrations.fastapi import FastApiIntegration
+                integrations.append(FastApiIntegration())
+            except Exception as exc:
+                _logger.debug("FastApiIntegration skipped: %s", exc)
+        if sc.with_celery:
+            try:
+                from sentry_sdk.integrations.celery import CeleryIntegration
+                integrations.append(CeleryIntegration())
+            except Exception as exc:
+                _logger.debug("CeleryIntegration skipped: %s", exc)
+
+        try:
+            sentry_sdk.init(
+                dsn=sc.dsn,
+                environment=sc.environment,
+                traces_sample_rate=sc.traces_sample_rate,
+                profiles_sample_rate=sc.profiles_sample_rate,
+                default_integrations=False,
+                integrations=integrations,
+            )
+            _state["initialised_pid"] = os.getpid()
+        except Exception as exc:
+            _logger.warning("sentry_sdk.init failed: %s", exc)
+
+    def build_handler(
+        self, config: ObservabilityConfig
+    ) -> logging.Handler | None:
+        sc = config.sentry
+        if not sc.enabled or not sc.dsn:
+            return None
+        handler = _SentryHandler()
+        handler.setLevel(sc.event_level)
+        return handler
+
+    def instrument(self, config: ObservabilityConfig) -> None:
+        return None
+
+    def shutdown(self, config: ObservabilityConfig) -> None:
+        # Flush pending events on reconfigure / process exit. Bounded timeout
+        # so a slow Sentry endpoint can't hang shutdown.
+        try:
+            import sentry_sdk
+            try:
+                sentry_sdk.flush(timeout=2.0)
+            except Exception:
+                pass
+        except Exception:
+            pass

--- a/app/src/observability/observability/tracing.py
+++ b/app/src/observability/observability/tracing.py
@@ -1,0 +1,68 @@
+"""logfire tracing/instrumentation — subsumes the current logfire_tracer.py.
+
+CONTRACT: one place owns logfire init + instrumentation. Used by both web and
+Celery composition roots and shared with sinks/logfire_sink.py (so we never
+configure logfire twice — EC2).
+
+EDGE CASES:
+ - Celery prefork: callers must pass instrument_pydantic_ai=False (handled by
+   profiles.celery()) to avoid OTel 'Token was created in a different
+   Context' on async-generator tool execution.
+ - No token -> send_to_cloud forced False; local-only is still safe. We emit a
+   single visible 'logfire local-only: no token' notice on the package logger
+   instead of the audit's silent no-op.
+ - logfire library missing -> return False (sink will skip).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from .config import ObservabilityConfig
+
+_logger = logging.getLogger(__name__)
+_state = {"initialised": False, "pid": None}
+
+
+def configure_tracing(cfg: ObservabilityConfig) -> bool:
+    """Initialise logfire once per process. Returns True if initialised."""
+    pid = os.getpid()
+    if _state["initialised"] and _state["pid"] == pid:
+        return True
+    try:
+        import logfire
+    except ModuleNotFoundError:
+        _logger.warning("logfire not installed; tracing disabled")
+        return False
+
+    lf = cfg.logfire
+    send = bool(lf.token) and lf.send_to_cloud
+    if not lf.token:
+        _logger.info("logfire local-only: no LOGFIRE_TOKEN set")
+
+    try:
+        logfire.configure(
+            token=lf.token if send else None,
+            send_to_logfire=send,
+            environment=cfg.env,
+            service_name=cfg.service_name,
+        )
+    except Exception as exc:  # logfire init failures must NOT crash the app
+        _logger.warning("logfire.configure failed: %s", exc)
+        return False
+
+    if lf.instrument_litellm:
+        try:
+            logfire.instrument_litellm()
+        except Exception as exc:
+            _logger.debug("instrument_litellm skipped: %s", exc)
+    if lf.instrument_pydantic_ai:
+        try:
+            logfire.instrument_pydantic_ai()
+        except Exception as exc:
+            _logger.debug("instrument_pydantic_ai skipped: %s", exc)
+
+    _state["initialised"] = True
+    _state["pid"] = pid
+    return True

--- a/app/src/observability/pyproject.toml
+++ b/app/src/observability/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "observability"
+version = "0.1.0"
+description = "Liftable observability layer: structured logging + Sentry + logfire behind one contract. app.*-free."
+requires-python = ">=3.10"
+# Core is stdlib-only on purpose: max portability, survives a codebase rewrite.
+dependencies = []
+
+[project.optional-dependencies]
+loguru = ["loguru>=0.7.3"]
+sentry = ["sentry-sdk>=2.43.0,<3.0"]
+logfire = ["logfire>=4.32.1,<5.0"]
+fastapi = ["starlette>=1.0.0,<2.0"]
+celery = ["celery>=5.6.3,<6.0"]
+dev = ["pytest>=9.0.3,<10.0"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["observability"]

--- a/uv.lock
+++ b/uv.lock
@@ -822,6 +822,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "mcp" },
+    { name = "observability", extra = ["logfire"] },
     { name = "pydantic" },
     { name = "rich" },
     { name = "typer" },
@@ -850,6 +851,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "neo4j", marker = "extra == 'all'", specifier = ">=5.28.0" },
     { name = "neo4j", marker = "extra == 'graph'", specifier = ">=5.28.0" },
+    { name = "observability", extras = ["logfire"], editable = "app/src/observability" },
     { name = "openai", marker = "extra == 'benchmarks'", specifier = ">=1.50.0" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'all'", specifier = ">=3.2" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.2" },
@@ -2760,7 +2762,7 @@ wheels = [
 
 [[package]]
 name = "logfire"
-version = "4.32.0"
+version = "4.34.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "executing" },
@@ -2772,9 +2774,9 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/64/f927d4f9de1f1371047b9016adba1ec2e08258301708d548d41f86f27772/logfire-4.32.0.tar.gz", hash = "sha256:f1dc9d756a4b28f0483645244aaf3ea8535b8e2ae5a1068442a968ca0c746304", size = 1088575, upload-time = "2026-04-10T19:36:54.172Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/a6/6cbd7064d7ab120fbdd72ca1a218b3fa3343a5f1f0733fcfa34d43333aaf/logfire-4.34.0.tar.gz", hash = "sha256:d88bb04f26a5ae0064d36eeb0fca5413599f0e2d068d629bcab25993ff405e25", size = 1144711, upload-time = "2026-05-26T18:09:51.81Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/33/81b13e1f2044b5fe0112068a2494526db9cfdf784030a2ea57688279360a/logfire-4.32.0-py3-none-any.whl", hash = "sha256:d9cff51c3c093c4161ece87a65e6ac6e2d862258b62494c30d93d713e9858758", size = 312412, upload-time = "2026-04-10T19:36:50.97Z" },
+    { url = "https://files.pythonhosted.org/packages/de/04/a386debccf1e91575dda55fa07b96f8309fc544833d7eec24b69869278f9/logfire-4.34.0-py3-none-any.whl", hash = "sha256:b9d9fc71aec184b28c29a9a9e280c954a3ea52c399f1d7b95ce82bff6b177364", size = 344385, upload-time = "2026-05-26T18:09:48.436Z" },
 ]
 
 [package.optional-dependencies]
@@ -3553,6 +3555,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
     { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
 ]
+
+[[package]]
+name = "observability"
+version = "0.1.0"
+source = { editable = "app/src/observability" }
+
+[package.optional-dependencies]
+logfire = [
+    { name = "logfire" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "celery", marker = "extra == 'celery'", specifier = ">=5.6.3,<6.0" },
+    { name = "logfire", marker = "extra == 'logfire'", specifier = ">=4.32.1,<5.0" },
+    { name = "loguru", marker = "extra == 'loguru'", specifier = ">=0.7.3" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3,<10.0" },
+    { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = ">=2.43.0,<3.0" },
+    { name = "starlette", marker = "extra == 'fastapi'", specifier = ">=1.0.0,<2.0" },
+]
+provides-extras = ["loguru", "sentry", "logfire", "fastapi", "celery", "dev"]
 
 [[package]]
 name = "obstore"


### PR DESCRIPTION
First of three PRs that bring observability to context-engine and clean up its log content. This one is the **plumbing**: bring the package onto staging and hook it into the three entry points. **Zero changes** to existing `logger.*` call sites.

## What this PR adds

- Brings the **observability package** onto staging at `app/src/observability/`. It lives on the open observability PR stack against `main` and hasn't merged here yet; same files as `origin/feat/observability-cutover`. (Once those PRs merge to main and main rolls into staging, this addition will be a no-op merge — same source, same path.)
- `app/src/context-engine/pyproject.toml`: declares `"observability[logfire]"` as a dependency and adds a relative `[tool.uv.sources]` entry so context-engine resolves the package even when installed standalone (CLI / MCP / HTTP), not just via the root workspace.
- `app/src/context-engine/bootstrap/observability.py` (new): a tiny composition root.
  - Builds a **logfire-only** `ObservabilityConfig`.
  - PID-scoped skip so the monolith doesn't get clobbered when it imports context-engine code.
  - Falls back to a **console sink** in dev / when `LOGFIRE_TOKEN` is absent so logs aren't silent.
  - Never raises — failures are warned via stdlib and the entry point continues.
- Each entry point invokes `configure_observability()` at startup:
  - `adapters/inbound/http/app.py` — top of `create_app()`. Also attaches the observability `LoggingContextMiddleware` so HTTP requests carry `request_id` / `path` / `user_id` automatically.
  - `adapters/inbound/cli/main.py` — top of `main()`.
  - `adapters/inbound/mcp/server.py` — top of `main()`.

## What this PR does NOT do

- **Zero changes to the 204 existing `logger.*` call sites in context-engine.** They already use ambient `logging.getLogger(__name__)` and flow through `configure()`'s root handlers automatically.
- No Sentry, no Loki — deliberate scope choice. logfire is the only backend for context-engine.
- The follow-up PRs handle:
  - **PR 2** — `log_context()` at correlation seams (batch, reconciliation, MCP) and manual quality pass on top emitter files.
  - **PR 3** — long-tail `%`-style → kwargs conversion, level downgrades, removing low-value logs.

## Why context-engine looked so clean already

A quick audit before this PR:

| Pattern | Monolith | context-engine |
|---|---|---|
| Total log calls | ~3,000 | **204** |
| f-string log calls | 748 | **0** |
| %-style lazy formatting | 29 | **104** |
| log-and-raise | 325 | **1** |
| DEBUG-prefix at INFO | 14+ | **0** |
| PII/secrets in INFO/WARN | 18+ | **0** |

So this initiative's content cleanup is a smaller surface than the monolith's — concentrated in field-level queryability and correlation thread-through.

## Test plan

- [x] `uv lock` resolves `observability v0.1.0` cleanly (also bumps logfire to 4.34).
- [x] `app/src/context-engine/` compiles end-to-end.
- [x] All three entry points (`http/app`, `cli/main`, `mcp/server`) import without error.
- [x] `configure_observability()` installs exactly one managed sink handler on root.
- [x] Calling `configure_observability()` twice is a no-op (PID-scoped idempotency).
- [x] No-token path falls back to console; real log lines flow.
- [x] With a fake `LOGFIRE_TOKEN`, logfire is initialised; SDK warns about the invalid token but the process keeps running (resilient).
- [ ] Live runtime smoke: boot the HTTP app + the MCP server + the CLI against a real Logfire project. Left to whoever validates this against a real backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)