### PR TITLE
chore(context-engine): bind correlation IDs at job seam + quality pass on reconciliation agent (PR 2 of 3)

### DIFF
--- a/app/src/context-engine/adapters/outbound/reconciliation/pydantic_deep_agent.py
+++ b/app/src/context-engine/adapters/outbound/reconciliation/pydantic_deep_agent.py
@@ -359,9 +359,8 @@ class _ExecutionLogSink:
             )
         except Exception:  # noqa: BLE001 - liveness must not fail ingestion
             logger.warning(
-                "execution-log emit (%s) failed for batch %s",
-                record_type,
-                self._batch_id,
+                "execution-log emit failed",
+                record_type=record_type,
                 exc_info=True,
             )
 
@@ -384,8 +383,7 @@ class _ExecutionLogSink:
             )
         except Exception:  # noqa: BLE001
             logger.warning(
-                "execution-log part upsert failed for batch %s",
-                self._batch_id,
+                "execution-log part upsert failed",
                 exc_info=True,
             )
 
@@ -603,9 +601,7 @@ class _ExecutionLogCheckpointBridge:
         try:
             messages_json = json.loads(raw.decode("utf-8"))
         except Exception:
-            logger.exception(
-                "checkpoint serialize failed for batch %s", self._batch_id
-            )
+            logger.exception("checkpoint serialize failed")
             return
         if not isinstance(messages_json, list):
             return
@@ -772,7 +768,7 @@ class PydanticDeepReconciliationAgent:
                 self._run_batch_async(ctx, execution_log=execution_log)
             )
         except Exception as exc:
-            logger.exception("batch agent run crashed for batch %s", ctx.batch_id)
+            logger.exception("batch agent run crashed")
             return BatchAgentOutcome(
                 ok=False,
                 error=str(exc),
@@ -940,11 +936,7 @@ class PydanticDeepReconciliationAgent:
             )
         except (asyncio.TimeoutError, TimeoutError):
             await _run_cleanup_callbacks(state)
-            logger.error(
-                "agent.run() timed out after %.0fs for batch %s",
-                run_timeout,
-                ctx.batch_id,
-            )
+            logger.error("agent.run() timed out", timeout_s=run_timeout)
             return BatchAgentOutcome(
                 ok=False,
                 completed_event_ids=list(state.completed_event_ids),
@@ -959,7 +951,7 @@ class PydanticDeepReconciliationAgent:
             )
         except Exception as exc:
             await _run_cleanup_callbacks(state)
-            logger.exception("agent.run() raised for batch %s", ctx.batch_id)
+            logger.exception("agent.run() raised")
             return BatchAgentOutcome(
                 ok=False,
                 completed_event_ids=list(state.completed_event_ids),
@@ -996,11 +988,10 @@ class PydanticDeepReconciliationAgent:
         except Exception:
             pass
         logger.info(
-            "batch %s agent run finished: completed=%d finish_called=%s usage=%s",
-            ctx.batch_id,
-            len(state.completed_event_ids),
-            state.finish_called,
-            usage_payload,
+            "agent run finished",
+            completed_count=len(state.completed_event_ids),
+            finish_called=state.finish_called,
+            usage=usage_payload,
         )
         try:
             self._telemetry.record_cost(
@@ -1070,11 +1061,9 @@ class PydanticDeepReconciliationAgent:
                 dropped.append(name or "?")
         if dropped:
             logger.info(
-                "playbook tool allowlist blocked %s for batch %s "
-                "(allowed=%s)",
-                sorted(set(dropped)),
-                ctx.batch_id,
-                sorted(allowed),
+                "playbook tool allowlist blocked tools",
+                blocked=sorted(set(dropped)),
+                allowed=sorted(allowed),
             )
         return kept
 
@@ -1153,10 +1142,7 @@ class PydanticDeepReconciliationAgent:
                 if snapshot:
                     body["current_context_snapshot"] = snapshot
             except Exception:
-                logger.exception(
-                    "failed to build initial context snapshot for batch %s",
-                    ctx.batch_id,
-                )
+                logger.exception("failed to build initial context snapshot")
         # Data-fence: everything below is attacker-influenceable (webhook /
         # PR / issue / comment bodies in ``payload``, ``actor``, and any
         # snapshot text). It is DATA to analyze, never instructions. The
@@ -1204,7 +1190,7 @@ class PydanticDeepReconciliationAgent:
                 fn = _make_handler(desc.name)
                 built.append(Tool(fn, name=desc.name, description=desc.description))
             except Exception:
-                logger.exception("failed to build read tool %s", desc.name)
+                logger.exception("failed to build read tool", tool=desc.name)
         return built
 
     def _build_mutation_tools(self, state: _BatchRunState) -> list[Any]:
@@ -1240,11 +1226,9 @@ class PydanticDeepReconciliationAgent:
             _apply_calls["n"] += 1
             if _apply_calls["n"] > _apply_cap:
                 logger.error(
-                    "apply_graph_mutations cap (%d) exceeded for batch "
-                    "pot=%s — refusing further mutations (possible loop / "
-                    "prompt injection)",
-                    _apply_cap,
-                    state.pot_id,
+                    "apply_graph_mutations cap exceeded — refusing further "
+                    "mutations (possible loop / prompt injection)",
+                    cap=_apply_cap,
                 )
                 return {
                     "ok": False,
@@ -1284,7 +1268,7 @@ class PydanticDeepReconciliationAgent:
                     provenance_context=prov,
                 )
             except Exception as exc:
-                logger.exception("apply_plan failed for batch event %s", event_id)
+                logger.exception("apply_plan failed", event_id=event_id)
                 return {"ok": False, "error": f"apply_failed: {exc}"}
             ms = result.mutation_summary
             counts = {

--- a/app/src/context-engine/application/use_cases/context_graph_jobs.py
+++ b/app/src/context-engine/application/use_cases/context_graph_jobs.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import Session
 
 from application.use_cases.process_batch import process_batch
 from bootstrap.container import ContextEngineContainer
+from observability import log_context
 
 
 def handle_process_batch(
@@ -41,17 +42,21 @@ def handle_process_batch(
     batch = batches_repo.claim_batch_by_id(batch_id)
     if batch is None:
         return {"status": "skipped", "reason": "not_pending", "batch_id": batch_id}
-    outcome = process_batch(
-        batch=batch,
-        agent=container.reconciliation_agent,
-        batches=batches_repo,
-        reco_ledger=container.reconciliation_ledger(db),
-        checkpoints=container.agent_checkpoint_store(db),
-        pots=container.pots,
-        policy=container.policy(),
-        stream_publisher=container.event_stream_publisher,
-        execution_log=container.agent_execution_log(db),
-    )
+    # Bind batch_id / pot_id at the job boundary so every log emitted by
+    # process_batch and the reconciliation agent it drives carries them as
+    # structured fields. Single seam, no body changes downstream.
+    with log_context(batch_id=batch.id, pot_id=batch.pot_id):
+        outcome = process_batch(
+            batch=batch,
+            agent=container.reconciliation_agent,
+            batches=batches_repo,
+            reco_ledger=container.reconciliation_ledger(db),
+            checkpoints=container.agent_checkpoint_store(db),
+            pots=container.pots,
+            policy=container.policy(),
+            stream_publisher=container.event_stream_publisher,
+            execution_log=container.agent_execution_log(db),
+        )
     return {
         "status": "ok" if outcome.ok else "failed",
         "batch_id": outcome.batch_id,


### PR DESCRIPTION
Second of three PRs. Stacked on PR #813 (wire-up).

## Summary

Two-part change:

**Part 1 — correlation seam at the job boundary**

`application/use_cases/context_graph_jobs.py::handle_process_batch` wraps the `process_batch(...)` call in `with log_context(batch_id=batch.id, pot_id=batch.pot_id):`. Every log emitted by `process_batch` and the reconciliation agent it drives now carries those fields as structured metadata. **Single 3-line addition; zero callees changed.** The 17 log calls inside `process_batch.py` and most of the calls in `pydantic_deep_agent.py` benefit automatically.

**Part 2 — manual quality pass on the top-emitter file**

`adapters/outbound/reconciliation/pydantic_deep_agent.py` has 20 log sites — the biggest concentration in context-engine. Cleaned up:

- Dropped redundant `batch %s` / `for batch %s` / `pot=%s` interpolations now that `log_context` covers them.
- Converted message-baked values to structured kwargs where it improves queryability: `record_type`, `timeout_s`, `tool`, `completed_count`, `finish_called`, `usage`, `blocked`, `allowed`, `cap`, `event_id`.
- Left the bare-message exception / debug lines alone — they don't benefit from kwargs and the surgical rule says don't touch them.

**Net:** 11 of the 20 sites in `pydantic_deep_agent.py` converted, plus the one seam binding.

## Why not also do the other 4 top-emitter files manually

Originally PR 2 was scoped to do manual quality on the top 5 emitter files. Mid-PR I noticed that the remaining 4 (`episodic`, `hybrid_graph`, `github/agent_tools`, `process_batch` itself) are simpler patterns that fit cleanly into PR 3's mechanical AST sweep. Doing them by hand here and then re-sweeping with PR 3 would be duplicate work. Cleaner split: PR 2 = highest-judgment file by hand, PR 3 = everything else by AST. That keeps both PRs small and reviewable.

## What this PR does NOT do

- Doesn't touch the other 4 top-emitter files (handled by PR 3).
- Doesn't touch the 48 long-tail files (handled by PR 3).
- Doesn't change anything outside context-engine.

## Test plan

- [x] `uv run python -m compileall -q app/src/context-engine` clean.
- [x] `configure_observability()` still installs exactly one managed handler.
- [x] `with log_context(batch_id="b1", pot_id="p1"):` causes a downstream `logging.getLogger("demo").info(...)` to emit with `batch_id: b1, pot_id: p1` appended — confirmed end-to-end.
- [ ] Live runtime smoke — left to merger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)