### PR TITLE
feat(ce): domain contracts — graph/ledger/service ports + lifecycle

### DIFF
--- a/app/src/context-engine/domain/agent_context_port.py
+++ b/app/src/context-engine/domain/agent_context_port.py
@@ -21,7 +21,6 @@ from typing import Any
 
 from domain.ontology import (
     PUBLIC_RECORD_TYPES,
-    STRUCTURAL_INCLUDES,
     advertised_include_families,
 )
 

--- a/app/src/context-engine/domain/agent_envelope.py
+++ b/app/src/context-engine/domain/agent_envelope.py
@@ -1,9 +1,11 @@
 """Canonical agent envelope (rebuild plan P8).
 
-The plan calls for one envelope shape across ``goal=answer|retrieve``
-and across MCP ``context_resolve`` / ``context_search``. This module
-defines that shape; the application layer's :class:`EnvelopeBuilder`
-produces it from ranked reader responses.
+The one read-result shape, returned by both ``context_resolve`` and
+``context_search`` across every surface (CLI / MCP / managed HTTP). It carries
+ranked evidence items + coverage; there is no server-side answer synthesis —
+the agent reasons over the evidence. This module defines that shape; the
+application layer's :class:`EnvelopeBuilder` produces it from ranked reader
+responses.
 
 The intent / include *vocabulary* lives in one place — ``domain.agent_context_port``
 (``CONTEXT_INTENTS`` + the reader-backed include tiers). This module used to

--- a/app/src/context-engine/domain/errors.py
+++ b/app/src/context-engine/domain/errors.py
@@ -45,3 +45,34 @@ class ReconciliationPlanValidationError(ContextEngineError):
 class ReconciliationApplyError(ContextEngineError):
     """Deterministic apply step failed after validation."""
 
+
+class CapabilityNotImplemented(ContextEngineError):
+    """A port/capability is wired into the skeleton but has no real
+    implementation yet.
+
+    The architectural skeleton wires *every* Protocol to at least a dummy
+    adapter, so no public surface dead-ends in a bare ``NotImplementedError``.
+    When an inbound adapter hits an unbuilt capability it catches this and
+    renders the structured not-implemented contract (CLI exit ``2``/``3``,
+    ``context_status`` ``not_implemented``, JSON ``code``/``message``/
+    ``recommended_next_action``) instead of a traceback.
+
+    ``capability`` is a dotted slot name (e.g. ``graph.inspection.path``) so
+    logs/telemetry can attribute the gap to a specific boundary.
+    """
+
+    def __init__(
+        self,
+        capability: str,
+        *,
+        detail: str | None = None,
+        recommended_next_action: str | None = None,
+    ) -> None:
+        self.capability = capability
+        self.detail = detail
+        self.recommended_next_action = recommended_next_action
+        message = f"Capability not implemented: {capability}"
+        if detail:
+            message = f"{message} — {detail}"
+        super().__init__(message)
+

--- a/app/src/context-engine/domain/graph_query.py
+++ b/app/src/context-engine/domain/graph_query.py
@@ -10,9 +10,11 @@ from pydantic import BaseModel, Field
 
 
 class ContextGraphGoal(StrEnum):
+    # Structural read hint only — never selects a different read path. The
+    # former ANSWER/INVESTIGATE members (server-side synthesis / agentic loop)
+    # were removed when the engine collapsed onto one evidence-envelope read
+    # contract; the agent synthesises answers from the returned evidence.
     RETRIEVE = "retrieve"
-    ANSWER = "answer"
-    INVESTIGATE = "investigate"
     NEIGHBORHOOD = "neighborhood"
     TIMELINE = "timeline"
     AGGREGATE = "aggregate"

--- a/app/src/context-engine/domain/lifecycle.py
+++ b/app/src/context-engine/domain/lifecycle.py
@@ -1,0 +1,172 @@
+"""Shared value objects for the component lifecycle / setup flow.
+
+``potpie setup`` is one orchestration (``SetupOrchestrator``) over bespoke
+per-component methods. These value objects are the currency between them: a
+``SetupPlan`` flows in, each step yields a ``StepResult``, and the run produces a
+``SetupReport``. See docs/context-graph/architecture.md "Component Lifecycle &
+Setup".
+
+The orchestrator splits **hard deps** (must succeed) from **soft steps**
+(best-effort): an unbuilt step raises ``CapabilityNotImplemented`` and is recorded
+as ``not_implemented`` rather than crashing setup, so component owners can land
+their step independently.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+# StepResult.state values.
+DONE = "done"
+SKIPPED = "skipped"
+NOT_IMPLEMENTED = "not_implemented"
+FAILED = "failed"
+PLANNED = "planned"
+
+_OK_STATES = frozenset({DONE, SKIPPED, PLANNED})
+
+
+@dataclass(frozen=True, slots=True)
+class SetupPlan:
+    """The first-run intent the orchestrator executes (built from CLI flags)."""
+
+    mode: str = "local"  # local setup; managed auth uses LoginPlan
+    host_mode: str = "daemon"  # daemon | in_process — flips daemon/installer hardness
+    backend: str = "embedded"  # embedded | postgres | neo4j | in_memory
+    repo: str | None = "."
+    pot: str = "default"
+    agent: str = "claude"
+    scan: bool = False
+    assume_yes: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class StepResult:
+    """Outcome of one setup step. ``hard`` steps gate ``SetupReport.ok``."""
+
+    step: str
+    state: str  # done | skipped | not_implemented | failed | planned
+    detail: str | None = None
+    hard: bool = True
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def ok(self) -> bool:
+        return self.state in _OK_STATES
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "step": self.step,
+            "state": self.state,
+            "detail": self.detail,
+            "hard": self.hard,
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SetupReport:
+    """The full result of a ``setup`` run: the plan + every step's result."""
+
+    plan: SetupPlan
+    steps: tuple[StepResult, ...]
+
+    @property
+    def ok(self) -> bool:
+        """True when every *hard* step succeeded (soft steps never gate ok)."""
+        return all(step.ok for step in self.steps if step.hard)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "plan": _plan_dict(self.plan),
+            "steps": [step.to_dict() for step in self.steps],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PlannedSetupStep:
+    """One step as it appears in a dry-run ``SetupPreview`` (unexecuted).
+
+    Carries the owner + hard/soft classification + skip reason so an operator
+    can read the plan — and a component owner can find their seam — before
+    anything runs. ``hard`` mirrors ``StepResult.hard``: hard steps gate the run.
+    """
+
+    step: str
+    hard: bool
+    owner: str
+    action: str
+    skip_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "step": self.step,
+            "hard": self.hard,
+            "owner": self.owner,
+            "action": self.action,
+            "skip_reason": self.skip_reason,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SetupPreview:
+    """The result of ``setup --dry-run``: the plan + the steps it *would* run.
+
+    Distinct from ``SetupReport`` — a preview never executes a step and never
+    carries ``StepResult``s. ``ok_to_run`` is False when a precondition would
+    block the run outright (today always True; reserved for the daemon owner).
+    """
+
+    plan: SetupPlan
+    steps: tuple[PlannedSetupStep, ...]
+    ok_to_run: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "dry_run": True,
+            "ok_to_run": self.ok_to_run,
+            "plan": _plan_dict(self.plan),
+            "steps": [step.to_dict() for step in self.steps],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class LoginPlan:
+    """The managed-backend login intent (separate lifecycle from local setup).
+
+    ``potpie login`` authenticates against ``backend_url`` (defaults to the
+    configured ``cloud.backend_url``) and binds managed pots into the same pot
+    surface. The managed-auth owner consumes this (see HU3).
+    """
+
+    backend_url: str | None = None
+    org: str | None = None
+
+
+def _plan_dict(plan: SetupPlan) -> dict[str, Any]:
+    return {
+        "mode": plan.mode,
+        "host_mode": plan.host_mode,
+        "backend": plan.backend,
+        "repo": plan.repo,
+        "pot": plan.pot,
+        "agent": plan.agent,
+        "scan": plan.scan,
+    }
+
+
+__all__ = [
+    "DONE",
+    "FAILED",
+    "NOT_IMPLEMENTED",
+    "PLANNED",
+    "SKIPPED",
+    "LoginPlan",
+    "PlannedSetupStep",
+    "SetupPlan",
+    "SetupPreview",
+    "SetupReport",
+    "StepResult",
+]

--- a/app/src/context-engine/domain/ports/agent_context.py
+++ b/app/src/context-engine/domain/ports/agent_context.py
@@ -1,0 +1,160 @@
+"""``AgentContextPort`` — the four-tool agent contract.
+
+This is the single public surface every inbound adapter (CLI, HTTP, MCP) binds
+to. There are exactly four tools and there will only ever be four:
+
+    context_resolve   resolve(ResolveRequest) -> AgentEnvelope
+    context_search    search(SearchRequest)   -> AgentEnvelope
+    context_record    record(RecordRequest)   -> RecordReceipt
+    context_status    status(StatusRequest)   -> StatusReport
+
+New use cases become new ``intent`` / ``include`` families, ``record_type``
+values, or skills — **never** new tools. ``AgentContextPort`` composes the
+three services: ``resolve``/``search``/``record`` delegate to ``GraphService``;
+``status`` composes ``GraphService`` data-plane status + ``PotManagementService``
+aggregate status + a ``SkillManager`` nudge.
+
+Request fields mirror the documented contract: ``pot_id``, ``intent``,
+``include``, ``scope``, ``mode`` (fast/balanced/verify/deep — retrieval depth),
+and ``source_policy``. The intent/include/record-type *vocabulary* stays in
+``domain.agent_context_port`` (one source of truth); these DTOs only carry it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Mapping, Protocol
+
+from domain.agent_envelope import AgentEnvelope
+
+# Retrieval depth. Replaces the old ``goal=ANSWER/INVESTIGATE`` surface: depth
+# is a dial on one read path, not a different read path.
+ResolveMode = str  # "fast" | "balanced" | "verify" | "deep"
+
+
+@dataclass(frozen=True, slots=True)
+class SkillNudge:
+    """Advisory skills block embedded in ``context_status``.
+
+    The only skill signal an agent ever sees: missing/outdated skills for its
+    harness plus the exact CLI command a human runs to close the gap.
+    Installation is never an agent action. Owned here (not in
+    ``skill_manager``) because it is part of the status contract — defining it
+    here keeps the ports layer acyclic.
+    """
+
+    agent: str
+    missing: tuple[str, ...] = ()
+    outdated: tuple[str, ...] = ()
+    install_command: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ResolveRequest:
+    """``context_resolve`` — bounded context wrap for a task."""
+
+    pot_id: str
+    task: str | None = None
+    intent: str | None = None
+    include: tuple[str, ...] = ()
+    exclude: tuple[str, ...] = ()
+    scope: Mapping[str, Any] = field(default_factory=dict)
+    mode: ResolveMode = "fast"
+    source_policy: str = "references_only"
+    max_items: int = 12
+    as_of: datetime | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class SearchRequest:
+    """``context_search`` — narrow follow-up lookup on a known phrase/entity."""
+
+    pot_id: str
+    query: str
+    include: tuple[str, ...] = ()
+    scope: Mapping[str, Any] = field(default_factory=dict)
+    mode: ResolveMode = "fast"
+    source_policy: str = "references_only"
+    max_items: int = 12
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class RecordRequest:
+    """``context_record`` — write a durable project learning."""
+
+    pot_id: str
+    record_type: str
+    summary: str
+    details: Mapping[str, Any] = field(default_factory=dict)
+    scope: Mapping[str, Any] = field(default_factory=dict)
+    source_refs: tuple[str, ...] = ()
+    idempotency_key: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class StatusRequest:
+    """``context_status`` — cheap pot readiness + next-action aggregate."""
+
+    pot_id: str
+    intent: str | None = None
+    harness: str | None = None  # agent harness, for the skill nudge
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class RecordReceipt:
+    """Outcome of ``context_record``."""
+
+    pot_id: str
+    record_type: str
+    accepted: bool
+    record_id: str | None = None
+    status: str = "recorded"  # recorded | duplicate | rejected | not_implemented
+    mutations_applied: int = 0
+    detail: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class StatusReport:
+    """Outcome of ``context_status`` — composed across the three services."""
+
+    pot_id: str
+    profile: str  # local | managed
+    daemon_up: bool
+    active_pot: str | None
+    backend_ready: bool
+    data_plane: Mapping[str, Any] = field(default_factory=dict)
+    pot_summary: Mapping[str, Any] = field(default_factory=dict)
+    skills: SkillNudge | None = None
+    recommended_next_action: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+class AgentContextPort(Protocol):
+    """The four-tool agent contract. The whole public agent surface."""
+
+    def resolve(self, request: ResolveRequest) -> AgentEnvelope: ...
+
+    def search(self, request: SearchRequest) -> AgentEnvelope: ...
+
+    def record(self, request: RecordRequest) -> RecordReceipt: ...
+
+    def status(self, request: StatusRequest) -> StatusReport: ...
+
+
+__all__ = [
+    "AgentContextPort",
+    "RecordReceipt",
+    "RecordRequest",
+    "ResolveMode",
+    "ResolveRequest",
+    "SearchRequest",
+    "SkillNudge",
+    "StatusReport",
+    "StatusRequest",
+]

--- a/app/src/context-engine/domain/ports/graph/__init__.py
+++ b/app/src/context-engine/domain/ports/graph/__init__.py
@@ -1,0 +1,48 @@
+"""The ``GraphBackend`` capability ports.
+
+One swappable backend = six narrow capability ports. ``mutation`` +
+``claim_query`` are the canonical source of truth; ``semantic`` ``inspection``
+``analytics`` ``snapshot`` are rebuildable projections. See ``backend.py``.
+"""
+
+from __future__ import annotations
+
+from domain.ports.graph.analytics import GraphAnalyticsPort, RepairReport
+from domain.ports.graph.backend import (
+    BackendCapabilities,
+    BackendReadiness,
+    GraphBackend,
+)
+from domain.ports.graph.claim_query import (
+    ClaimQueryFilter,
+    ClaimQueryPort,
+    ClaimRow,
+)
+from domain.ports.graph.inspection import (
+    GraphEdge,
+    GraphInspectionPort,
+    GraphNode,
+    GraphSlice,
+)
+from domain.ports.graph.mutation import GraphMutationPort
+from domain.ports.graph.semantic import SemanticSearchPort
+from domain.ports.graph.snapshot import GraphSnapshotPort, SnapshotManifest
+
+__all__ = [
+    "BackendCapabilities",
+    "BackendReadiness",
+    "ClaimQueryFilter",
+    "ClaimQueryPort",
+    "ClaimRow",
+    "GraphAnalyticsPort",
+    "GraphBackend",
+    "GraphEdge",
+    "GraphInspectionPort",
+    "GraphMutationPort",
+    "GraphNode",
+    "GraphSlice",
+    "GraphSnapshotPort",
+    "RepairReport",
+    "SemanticSearchPort",
+    "SnapshotManifest",
+]

--- a/app/src/context-engine/domain/ports/graph/analytics.py
+++ b/app/src/context-engine/domain/ports/graph/analytics.py
@@ -1,0 +1,44 @@
+"""``GraphAnalyticsPort`` — aggregate/quality projection of a ``GraphBackend``.
+
+Backs ``potpie graph status`` and ``graph repair``: entity/claim counts,
+freshness windows, quality signals, and rebuild/repair of derived indexes.
+A rebuildable projection — none of this is a source of truth.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol, Sequence
+
+
+@dataclass(frozen=True, slots=True)
+class RepairReport:
+    """Outcome of a ``repair`` run (e.g. semantic-index rebuild)."""
+
+    pot_id: str
+    targets: tuple[str, ...]
+    repaired: Mapping[str, int] = field(default_factory=dict)
+    detail: str | None = None
+
+
+class GraphAnalyticsPort(Protocol):
+    """Aggregates, freshness, quality, and repair over a pot's graph."""
+
+    def counts(self, pot_id: str) -> Mapping[str, int]:
+        """Entity/claim/predicate counts for the pot."""
+        ...
+
+    def freshness(self, pot_id: str) -> Mapping[str, Any]:
+        """Freshness windows (oldest/newest claim, per-source last write)."""
+        ...
+
+    def quality(self, pot_id: str) -> Mapping[str, Any]:
+        """Quality signals (open conflicts, orphan rate, status)."""
+        ...
+
+    def repair(self, pot_id: str, *, targets: Sequence[str] = ()) -> RepairReport:
+        """Rebuild derived indexes/projections. Empty ``targets`` repairs all."""
+        ...
+
+
+__all__ = ["GraphAnalyticsPort", "RepairReport"]

--- a/app/src/context-engine/domain/ports/graph/backend.py
+++ b/app/src/context-engine/domain/ports/graph/backend.py
@@ -1,0 +1,114 @@
+"""The ``GraphBackend`` capability bundle.
+
+A ``GraphBackend`` is the swappable storage substrate for one pot's graph.
+It is intentionally a *bundle of six narrow capability ports* rather than one
+fat interface, so a backend can implement the canonical claim store (the
+source of truth) while leaving rebuildable projections — semantic, inspection,
+analytics, snapshot — as ``CapabilityNotImplemented`` until built.
+
+    canonical (source of truth):  mutation + claim_query
+    rebuildable projections:      semantic + inspection + analytics + snapshot
+
+Profiles (``profile`` property) select the concrete backend:
+
+    in_memory   real, used for tests + conformance
+    neo4j       shape-first production target (delegates to existing Neo4j code)
+    embedded    OSS local default (TODO)
+    postgres    pgvector profile (TODO)
+    hosted      managed profile (TODO)
+
+Adding a backend means implementing these six ports behind a new profile —
+never widening the public agent contract. See ``adapters/outbound/graph/backends/``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from domain.lifecycle import SetupPlan, StepResult
+from domain.ports.claim_query import ClaimQueryPort
+from domain.ports.graph.analytics import GraphAnalyticsPort
+from domain.ports.graph.inspection import GraphInspectionPort
+from domain.ports.graph.mutation import BackendReadiness, GraphMutationPort
+from domain.ports.graph.semantic import SemanticSearchPort
+from domain.ports.graph.snapshot import GraphSnapshotPort
+
+
+@dataclass(frozen=True, slots=True)
+class BackendCapabilities:
+    """Static declaration of which capability ports a backend really
+    implements vs. raises ``CapabilityNotImplemented``.
+
+    The CLI ``backend status`` / ``backend doctor`` commands read this so a
+    user can see, per profile, what is real today without triggering errors.
+    """
+
+    profile: str
+    mutation: bool = False
+    claim_query: bool = False
+    semantic: bool = False
+    inspection: bool = False
+    analytics: bool = False
+    snapshot: bool = False
+
+    def implemented(self) -> tuple[str, ...]:
+        return tuple(
+            name
+            for name in (
+                "mutation",
+                "claim_query",
+                "semantic",
+                "inspection",
+                "analytics",
+                "snapshot",
+            )
+            if getattr(self, name)
+        )
+
+
+@runtime_checkable
+class GraphBackend(Protocol):
+    """Swappable graph capability bundle for one storage profile.
+
+    The bundle composes the six capability ports. Application services depend
+    on this — never on a concrete store — so swapping ``in_memory`` for
+    ``neo4j`` is a wiring change, not a service rewrite.
+    """
+
+    @property
+    def profile(self) -> str: ...
+
+    @property
+    def mutation(self) -> GraphMutationPort: ...
+
+    @property
+    def claim_query(self) -> ClaimQueryPort: ...
+
+    @property
+    def semantic(self) -> SemanticSearchPort: ...
+
+    @property
+    def inspection(self) -> GraphInspectionPort: ...
+
+    @property
+    def analytics(self) -> GraphAnalyticsPort: ...
+
+    @property
+    def snapshot(self) -> GraphSnapshotPort: ...
+
+    def capabilities(self) -> BackendCapabilities: ...
+
+    def provision(self, plan: SetupPlan) -> StepResult:
+        """Stand up this backend's own store, idempotently (the setup seam).
+
+        A backend self-provisions: ``embedded`` ensures its local file, a
+        ``postgres`` profile creates the DB + enables pgvector + runs DDL, a
+        ``neo4j`` profile pulls its container and creates indexes. Called by the
+        setup orchestrator as a hard step; raises ``CapabilityNotImplemented``
+        until a profile builds it.
+        """
+        ...
+
+
+__all__ = ["BackendCapabilities", "BackendReadiness", "GraphBackend"]

--- a/app/src/context-engine/domain/ports/graph/claim_query.py
+++ b/app/src/context-engine/domain/ports/graph/claim_query.py
@@ -1,0 +1,15 @@
+"""Re-export of the canonical :class:`ClaimQueryPort` under the GraphBackend
+capability namespace.
+
+``ClaimQueryPort`` is one of the six ``GraphBackend`` capabilities (and, with
+``GraphMutationPort``, the source of truth). It already lives at
+``domain.ports.claim_query`` with 100+ importers, so it is re-exported here
+rather than moved — new ``GraphBackend`` code can import it from the capability
+package while existing imports keep working.
+"""
+
+from __future__ import annotations
+
+from domain.ports.claim_query import ClaimQueryFilter, ClaimQueryPort, ClaimRow
+
+__all__ = ["ClaimQueryFilter", "ClaimQueryPort", "ClaimRow"]

--- a/app/src/context-engine/domain/ports/graph/inspection.py
+++ b/app/src/context-engine/domain/ports/graph/inspection.py
@@ -1,0 +1,72 @@
+"""``GraphInspectionPort`` — structural traversal projection of a ``GraphBackend``.
+
+Backs ``potpie graph inspect`` and the graph explorer: neighbourhoods, paths,
+label lookup, and bounded subgraph slices. A rebuildable projection over the
+canonical claim edges; not the agent read path (that is the readers over
+``ClaimQueryPort``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping, Protocol
+
+from domain.ports.claim_query import ClaimQueryFilter
+
+
+@dataclass(frozen=True, slots=True)
+class GraphNode:
+    """One entity in an inspection slice."""
+
+    key: str
+    labels: tuple[str, ...] = ()
+    properties: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class GraphEdge:
+    """One :RELATES_TO edge in an inspection slice."""
+
+    predicate: str
+    from_key: str
+    to_key: str
+    properties: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class GraphSlice:
+    """A bounded subgraph returned by inspection queries."""
+
+    pot_id: str
+    nodes: tuple[GraphNode, ...] = ()
+    edges: tuple[GraphEdge, ...] = ()
+    truncated: bool = False
+
+
+class GraphInspectionPort(Protocol):
+    """Structural traversal over the canonical graph."""
+
+    def neighborhood(
+        self, *, pot_id: str, entity_key: str, depth: int = 1
+    ) -> GraphSlice:
+        """Return the subgraph within ``depth`` hops of ``entity_key``."""
+        ...
+
+    def path(
+        self, *, pot_id: str, from_key: str, to_key: str, max_depth: int = 4
+    ) -> GraphSlice:
+        """Return a shortest path (if any) between two entities."""
+        ...
+
+    def labels(
+        self, *, pot_id: str, entity_keys: Iterable[str]
+    ) -> Mapping[str, tuple[str, ...]]:
+        """Bulk label lookup for entity keys."""
+        ...
+
+    def slice(self, *, pot_id: str, filter_: ClaimQueryFilter) -> GraphSlice:
+        """Return the subgraph matching a claim filter (explorer/export view)."""
+        ...
+
+
+__all__ = ["GraphEdge", "GraphInspectionPort", "GraphNode", "GraphSlice"]

--- a/app/src/context-engine/domain/ports/graph/mutation.py
+++ b/app/src/context-engine/domain/ports/graph/mutation.py
@@ -1,0 +1,87 @@
+"""``GraphMutationPort`` — the canonical write path of a ``GraphBackend``.
+
+Together with ``ClaimQueryPort`` this is the *source of truth*: every fact in
+the graph enters through ``apply`` and is read back through claim query. The
+other four capability ports are rebuildable projections off this store.
+
+Records (``context_record``) and reconciled source events both lower to a
+:class:`ReconciliationPlan` and land here — there is one write door.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol, Sequence
+
+from domain.graph_mutations import ProvenanceContext
+from domain.reconciliation import ReconciliationPlan, ReconciliationResult
+
+
+@dataclass(frozen=True, slots=True)
+class BackendReadiness:
+    """Backend health/readiness, rolled into ``context_status`` backend
+    readiness. Defined here (not in ``backend``) so capability ports can
+    reference it without importing the bundle."""
+
+    profile: str
+    ready: bool
+    detail: str | None = None
+    capability_ready: Mapping[str, bool] = field(default_factory=dict)
+
+
+class GraphMutationPort(Protocol):
+    """Apply typed mutation plans and lifecycle operations to the claim store."""
+
+    def apply(
+        self,
+        plan: ReconciliationPlan,
+        *,
+        expected_pot_id: str,
+        provenance_context: ProvenanceContext | None = None,
+    ) -> ReconciliationResult:
+        """Apply a constrained mutation plan (entity/edge upserts, deletes,
+        invalidations) against the canonical store for ``expected_pot_id``.
+
+        Sync entry, for non-async callers (CLI, tests). Backends whose store is
+        async (Neo4j) bridge with ``asyncio.run`` and therefore refuse to run
+        inside a running event loop — async callers must use :meth:`apply_async`.
+        """
+        ...
+
+    async def apply_async(
+        self,
+        plan: ReconciliationPlan,
+        *,
+        expected_pot_id: str,
+        provenance_context: ProvenanceContext | None = None,
+    ) -> ReconciliationResult:
+        """Async-native ``apply``. Preferred when called from inside an event
+        loop (FastAPI handlers, agent tools, Celery workers): backends whose
+        store is async (Neo4j) ``await`` their writer directly instead of
+        bridging through ``asyncio.run`` — which raises inside a running loop and
+        can cross-bind a connection pool to a dead loop. Sync backends just
+        return ``apply(...)``. Mirror of ``ContextGraphPort.apply_plan_async``."""
+        ...
+
+    def invalidate(
+        self,
+        *,
+        pot_id: str,
+        claim_keys: Sequence[str],
+        reason: str | None = None,
+    ) -> int:
+        """Soft-invalidate claims by key (stamp ``invalid_at``). Returns the
+        number of claims invalidated."""
+        ...
+
+    def reset_pot(self, pot_id: str) -> dict[str, Any]:
+        """Hard-reset all graph state for a pot. Returns a summary of what was
+        removed."""
+        ...
+
+    def readiness(self, pot_id: str) -> BackendReadiness:
+        """Cheap readiness probe for ``context_status`` / ``backend status``."""
+        ...
+
+
+__all__ = ["BackendReadiness", "GraphMutationPort"]

--- a/app/src/context-engine/domain/ports/graph/semantic.py
+++ b/app/src/context-engine/domain/ports/graph/semantic.py
@@ -1,0 +1,34 @@
+"""``SemanticSearchPort`` — vector retrieval projection of a ``GraphBackend``.
+
+A rebuildable projection: claims carry ``fact_embedding`` in the canonical
+store, and this port answers nearest-neighbour queries over them. The embedded
+``fact_query`` field on :class:`ClaimQueryFilter` is the inline path; this port
+is the explicit semantic surface used by ``context_search`` and readers that
+want similarity ordering independent of structural filters.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from domain.ports.claim_query import ClaimQueryFilter, ClaimRow
+
+
+class SemanticSearchPort(Protocol):
+    """Nearest-neighbour retrieval over claim embeddings."""
+
+    def search(
+        self,
+        *,
+        pot_id: str,
+        query: str,
+        k: int = 10,
+        filter_: ClaimQueryFilter | None = None,
+    ) -> list[ClaimRow]:
+        """Return up to ``k`` claims most similar to ``query``, optionally
+        narrowed by ``filter_``. Similarity is stamped onto
+        ``ClaimRow.properties['semantic_similarity']``."""
+        ...
+
+
+__all__ = ["SemanticSearchPort"]

--- a/app/src/context-engine/domain/ports/graph/snapshot.py
+++ b/app/src/context-engine/domain/ports/graph/snapshot.py
@@ -1,0 +1,40 @@
+"""``GraphSnapshotPort`` — portable export/import of a pot's graph.
+
+Backs ``potpie graph export/import`` and the ``cloud push/pull`` snapshot move
+between local and managed profiles. A snapshot is a self-describing dump of the
+canonical claim store for one pot; importing into a different backend profile
+rebuilds the projections.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotManifest:
+    """Metadata describing an exported/imported snapshot."""
+
+    pot_id: str
+    location: str  # file path or URI the snapshot was written to / read from
+    format_version: str = "1"
+    entity_count: int = 0
+    claim_count: int = 0
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+class GraphSnapshotPort(Protocol):
+    """Portable pot snapshot export/import."""
+
+    def export(self, *, pot_id: str, destination: str) -> SnapshotManifest:
+        """Write a portable snapshot of the pot's graph to ``destination``."""
+        ...
+
+    def import_(self, *, pot_id: str, source: str) -> SnapshotManifest:
+        """Load a snapshot from ``source`` into ``pot_id``, rebuilding
+        projections for this backend profile."""
+        ...
+
+
+__all__ = ["GraphSnapshotPort", "SnapshotManifest"]

--- a/app/src/context-engine/domain/ports/install.py
+++ b/app/src/context-engine/domain/ports/install.py
@@ -1,0 +1,37 @@
+"""``Installer`` — the packaging/OS lifecycle seam.
+
+Makes the ``potpie`` CLI available on PATH and registers the daemon as an OS
+service (systemd/launchd). Folded into ``potpie setup`` as a hard step that is
+**skipped when already present** (idempotent), so re-running setup is safe. This
+is the seam the installation-flow owner fills; it is an outbound adapter, not a
+service, because its work is environment-specific (pip/pipx/homebrew/deb).
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from domain.lifecycle import StepResult
+
+
+class Installer(Protocol):
+    """CLI-on-PATH + OS service-unit registration."""
+
+    def is_installed(self) -> bool:
+        """True when the CLI is reachable and the service unit is registered."""
+        ...
+
+    def install_cli(self) -> StepResult:
+        """Put ``potpie`` on PATH for the current platform."""
+        ...
+
+    def register_service(self) -> StepResult:
+        """Register the daemon as an OS service (systemd/launchd)."""
+        ...
+
+    def uninstall(self) -> StepResult:
+        """Reverse install_cli + register_service."""
+        ...
+
+
+__all__ = ["Installer"]

--- a/app/src/context-engine/domain/ports/ledger/__init__.py
+++ b/app/src/context-engine/domain/ports/ledger/__init__.py
@@ -1,0 +1,32 @@
+"""Event Ledger ports — the external source-event seam.
+
+The ledger is not graph storage. A graph pulls normalized events through
+``EventLedgerClientPort``, tracks position with ``LedgerCursorStorePort``, and
+turns events into claims through ``EventReconcilerPort`` (the parked
+LLM-vs-deterministic decision).
+"""
+
+from __future__ import annotations
+
+from domain.ports.ledger.client import (
+    EventLedgerClientPort,
+    LedgerCursor,
+    LedgerEvent,
+    LedgerHealth,
+    LedgerPage,
+    LedgerSource,
+)
+from domain.ports.ledger.cursor import LedgerCursorStorePort
+from domain.ports.ledger.reconciler import EventReconcilerPort, ReconcileResult
+
+__all__ = [
+    "EventLedgerClientPort",
+    "EventReconcilerPort",
+    "LedgerCursor",
+    "LedgerCursorStorePort",
+    "LedgerEvent",
+    "LedgerHealth",
+    "LedgerPage",
+    "LedgerSource",
+    "ReconcileResult",
+]

--- a/app/src/context-engine/domain/ports/ledger/client.py
+++ b/app/src/context-engine/domain/ports/ledger/client.py
@@ -1,0 +1,120 @@
+"""``EventLedgerClientPort`` — the pull/cursor seam to the Event Ledger.
+
+The Event Ledger is a *separate* managed-or-self-hosted source-event service.
+It owns provider credentials, webhooks, normalized event history, and cursors.
+A graph (local or managed) does not store source events — it *pulls* normalized
+events from the ledger through this port and reconciles them into claims.
+
+This port is deliberately the only thing the local daemon needs to consume a
+ledger; provider credentials never enter the local process. See
+``cursor.py`` (cursor storage) and ``reconciler.py`` (events → claims).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Mapping, Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class LedgerCursor:
+    """Opaque per-source position in the ledger event stream."""
+
+    source_id: str
+    token: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LedgerEvent:
+    """One normalized source event as the graph consumes it.
+
+    Already provider-normalized by the ledger — the graph never parses raw
+    GitHub/Linear/Slack payloads.
+    """
+
+    event_id: str
+    source_id: str
+    provider: str  # github | linear | slack | notion | ...
+    kind: str  # normalized event kind (e.g. pr_merge, issue_create)
+    payload: Mapping[str, Any] = field(default_factory=dict)
+    occurred_at: datetime | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LedgerSource:
+    """A source connector configured on the ledger for a pot."""
+
+    source_id: str
+    provider: str
+    display_name: str
+    connected: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class LedgerHealth:
+    """Ledger reachability/binding for ``ledger status`` and readiness."""
+
+    available: bool
+    binding: str = "none"  # none | managed | self_hosted
+    detail: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LedgerPage:
+    """One page of pulled events plus the advance cursor."""
+
+    events: tuple[LedgerEvent, ...] = ()
+    next_cursor: LedgerCursor | None = None
+    has_more: bool = False
+
+
+class EventLedgerClientPort(Protocol):
+    """Pull normalized source events from the Event Ledger."""
+
+    def fetch(
+        self,
+        *,
+        pot_id: str,
+        source_id: str,
+        cursor: LedgerCursor | None,
+        limit: int = 100,
+    ) -> LedgerPage:
+        """Fetch the next page of events for ``source_id`` after ``cursor``."""
+        ...
+
+    def query(
+        self,
+        *,
+        pot_id: str,
+        source_id: str | None = None,
+        kind: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        limit: int = 100,
+    ) -> LedgerPage:
+        """Inspect ledger event history WITHOUT touching the graph consumer cursor.
+
+        Distinct from ``fetch``: ``query`` is read-only history inspection
+        (``potpie ledger query``) — it never advances the per-(pot, source)
+        consumer cursor. ``fetch`` is the cursor-based pull that drives ``pull``.
+        """
+        ...
+
+    def sources(self, *, pot_id: str) -> list[LedgerSource]:
+        """List source connectors configured on the ledger for this pot."""
+        ...
+
+    def health(self) -> LedgerHealth:
+        """Ledger reachability + binding kind."""
+        ...
+
+
+__all__ = [
+    "EventLedgerClientPort",
+    "LedgerCursor",
+    "LedgerEvent",
+    "LedgerHealth",
+    "LedgerPage",
+    "LedgerSource",
+]

--- a/app/src/context-engine/domain/ports/ledger/cursor.py
+++ b/app/src/context-engine/domain/ports/ledger/cursor.py
@@ -1,0 +1,27 @@
+"""``LedgerCursorStorePort`` — durable per-source pull position.
+
+Cursors live with the *graph* (the consumer), not the ledger, so the same
+ledger can feed multiple graphs at independent positions and a graph can replay
+from a known point. Stored alongside pot state.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from domain.ports.ledger.client import LedgerCursor
+
+
+class LedgerCursorStorePort(Protocol):
+    """Persist and retrieve per-(pot, source) ledger cursors."""
+
+    def get(self, *, pot_id: str, source_id: str) -> LedgerCursor | None:
+        """Return the stored cursor for a source, or ``None`` if never pulled."""
+        ...
+
+    def set(self, *, pot_id: str, cursor: LedgerCursor) -> None:
+        """Persist the advance cursor after a successful pull/reconcile."""
+        ...
+
+
+__all__ = ["LedgerCursorStorePort"]

--- a/app/src/context-engine/domain/ports/ledger/reconciler.py
+++ b/app/src/context-engine/domain/ports/ledger/reconciler.py
@@ -1,0 +1,45 @@
+"""``EventReconcilerPort`` — normalized events → graph claims.
+
+This is the **parked decision seam**. How a batch of normalized ledger events
+becomes graph mutations — a deterministic extractor, an LLM reconciliation
+agent, or a hybrid — is an explicitly *undecided* low-level choice. The
+skeleton keeps it behind this port with a dummy implementation so the rest of
+the architecture (ledger pull → reconcile → GraphService.record/mutation) does
+not change when the decision is made.
+
+    TODO(decide): LLM-vs-deterministic reconciliation strategy.
+    The existing pydantic reconciliation agent and the deterministic
+    extractors are both candidate implementations of this port.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol, Sequence
+
+from domain.ports.ledger.client import LedgerEvent
+
+
+@dataclass(frozen=True, slots=True)
+class ReconcileResult:
+    """Outcome of reconciling one batch of events into a pot's graph."""
+
+    pot_id: str
+    events_in: int
+    claims_written: int = 0
+    skipped: int = 0
+    detail: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+class EventReconcilerPort(Protocol):
+    """Turn a batch of normalized events into graph mutations for a pot."""
+
+    def reconcile(
+        self, *, pot_id: str, events: Sequence[LedgerEvent]
+    ) -> ReconcileResult:
+        """Reconcile ``events`` into the pot's graph and report counts."""
+        ...
+
+
+__all__ = ["EventReconcilerPort", "ReconcileResult"]

--- a/app/src/context-engine/domain/ports/services/__init__.py
+++ b/app/src/context-engine/domain/ports/services/__init__.py
@@ -1,0 +1,52 @@
+"""The three service ports the host hosts.
+
+The same three service modules run inside either the local daemon or the
+managed API server:
+
+    GraphService            data plane   — resolve / search / record
+    PotManagementService    control plane — pots, active pot, sources, readiness
+    SkillManager            CLI-managed agent skill catalog + nudge
+
+``AgentContextPort`` (``domain.ports.agent_context``) composes them into the
+public four-tool surface.
+"""
+
+from __future__ import annotations
+
+from domain.ports.services.auth import AuthIdentity, AuthService
+from domain.ports.services.config import ConfigService
+from domain.ports.services.graph_service import DataPlaneStatus, GraphService
+from domain.ports.services.pot_management import (
+    PotAggregateStatus,
+    PotInfo,
+    PotManagementService,
+    SourceInfo,
+)
+from domain.ports.services.setup import SetupOrchestrator
+from domain.ports.services.skill_manager import (
+    AgentTargetPort,
+    SkillInfo,
+    SkillManager,
+    SkillNudge,
+    SkillOperationResult,
+    SkillStatus,
+)
+
+__all__ = [
+    "AgentTargetPort",
+    "AuthIdentity",
+    "AuthService",
+    "ConfigService",
+    "DataPlaneStatus",
+    "GraphService",
+    "PotAggregateStatus",
+    "PotInfo",
+    "PotManagementService",
+    "SetupOrchestrator",
+    "SkillInfo",
+    "SkillManager",
+    "SkillNudge",
+    "SkillOperationResult",
+    "SkillStatus",
+    "SourceInfo",
+]

--- a/app/src/context-engine/domain/ports/services/auth.py
+++ b/app/src/context-engine/domain/ports/services/auth.py
@@ -1,0 +1,38 @@
+"""``AuthService`` — the local auth/identity lifecycle seam.
+
+Local OSS works without auth; this seam exists so the auth owner can add local
+token/socket credentials (and the managed profile can bind ``potpie cloud
+login``) behind a stable interface. In setup it is a **soft** step: an unbuilt
+``init_local`` is reported ``not_implemented`` and never blocks first run.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from domain.lifecycle import StepResult
+
+
+@dataclass(frozen=True, slots=True)
+class AuthIdentity:
+    """Who the host thinks the caller is."""
+
+    subject: str
+    mode: str  # local | managed | none
+    detail: str | None = None
+
+
+class AuthService(Protocol):
+    """Local identity/credential provisioning."""
+
+    def init_local(self) -> StepResult:
+        """Provision local credentials (token/socket). Soft setup step."""
+        ...
+
+    def whoami(self) -> AuthIdentity: ...
+
+    def logout(self) -> None: ...
+
+
+__all__ = ["AuthIdentity", "AuthService"]

--- a/app/src/context-engine/domain/ports/services/config.py
+++ b/app/src/context-engine/domain/ports/services/config.py
@@ -1,0 +1,39 @@
+"""``ConfigService`` — the workspace/config lifecycle seam.
+
+Owns the local home directory (``~/.potpie`` or ``$CONTEXT_ENGINE_HOME``) and the
+config file written during ``potpie setup``. The first setup step; everything
+downstream resolves paths through here.
+
+    setup step 1 (hard): config.ensure_home(); config.write_defaults(plan)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping, Protocol
+
+from domain.lifecycle import SetupPlan
+
+
+class ConfigService(Protocol):
+    """Local config/workspace provisioning + get/set."""
+
+    def ensure_home(self) -> Path:
+        """Create the home directory tree if absent; return its path."""
+        ...
+
+    def write_defaults(self, plan: SetupPlan) -> Path:
+        """Write the default config file (profile, backend, paths) from the plan,
+        preserving any values a user already set. Returns the config path."""
+        ...
+
+    def get(self, key: str) -> str | None: ...
+
+    def set(self, key: str, value: str) -> None: ...
+
+    def probe(self) -> Mapping[str, Any]:
+        """Cheap state for ``doctor``/``status`` (home path, config presence)."""
+        ...
+
+
+__all__ = ["ConfigService"]

--- a/app/src/context-engine/domain/ports/services/graph_service.py
+++ b/app/src/context-engine/domain/ports/services/graph_service.py
@@ -1,0 +1,65 @@
+"""``GraphService`` — the data-plane service.
+
+The data plane behind three of the four tools: ``resolve``, ``search``, and
+``record``. It owns the readers, ranking, record lowering, and envelope
+assembly, and it talks to a ``GraphBackend`` (claim_query + mutation + semantic)
+— never to a store directly.
+
+``GraphService`` is *not* the agent contract. ``AgentContextPort`` is the public
+4-tool surface; ``GraphService`` is the data-plane half it composes (the other
+halves being ``PotManagementService`` and ``SkillManager``). The two share the
+same request DTOs but sit at different altitudes: ``GraphService.resolve`` does
+the read work; ``AgentContextPort.resolve`` is the public binding to it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol
+
+from domain.agent_envelope import AgentEnvelope
+from domain.ports.agent_context import (
+    RecordReceipt,
+    RecordRequest,
+    ResolveRequest,
+    SearchRequest,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DataPlaneStatus:
+    """Data-plane half of ``context_status``: backend readiness + coverage."""
+
+    pot_id: str
+    backend_profile: str
+    backend_ready: bool
+    reader_backed_includes: tuple[str, ...] = ()
+    counts: Mapping[str, int] = field(default_factory=dict)
+    freshness: Mapping[str, Any] = field(default_factory=dict)
+    quality: Mapping[str, Any] = field(default_factory=dict)
+    detail: str | None = None
+
+
+class GraphService(Protocol):
+    """Data plane for resolve/search/record over a ``GraphBackend``."""
+
+    def resolve(self, request: ResolveRequest) -> AgentEnvelope:
+        """Expand intent → includes, run readers over the backend, rank, and
+        assemble one ``AgentEnvelope``."""
+        ...
+
+    def search(self, request: SearchRequest) -> AgentEnvelope:
+        """Narrow lookup; same envelope shape as ``resolve``."""
+        ...
+
+    def record(self, request: RecordRequest) -> RecordReceipt:
+        """Lower a durable record into a mutation plan and apply it through the
+        backend's mutation port."""
+        ...
+
+    def data_plane_status(self, pot_id: str) -> DataPlaneStatus:
+        """Backend readiness + coverage for ``context_status``."""
+        ...
+
+
+__all__ = ["DataPlaneStatus", "GraphService"]

--- a/app/src/context-engine/domain/ports/services/pot_management.py
+++ b/app/src/context-engine/domain/ports/services/pot_management.py
@@ -1,0 +1,106 @@
+"""``PotManagementService`` — the control-plane service.
+
+The control plane for pots and sources: the active-pot pointer, pot lifecycle
+(create/use/rename/reset/archive), the source registry, and graph readiness
+rollup. It is the half of ``context_status`` that is *not* graph data.
+
+A **pot** is the workspace/tenant boundary — every query, source, record,
+claim, and graph operation is scoped to exactly one pot.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Mapping, Protocol
+
+from domain.lifecycle import StepResult
+
+
+@dataclass(frozen=True, slots=True)
+class PotInfo:
+    """One pot in the control plane."""
+
+    pot_id: str
+    name: str
+    active: bool = False
+    archived: bool = False
+    created_at: datetime | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SourceInfo:
+    """A source registered to a pot (repo, integration binding, …)."""
+
+    source_id: str
+    kind: str  # repo | github | linear | ...
+    name: str
+    last_sync_at: datetime | None = None
+    sync_mode: str | None = None
+    status: str = "unknown"  # ok | stale | error | unknown
+
+
+@dataclass(frozen=True, slots=True)
+class PotAggregateStatus:
+    """Control-plane half of ``context_status``."""
+
+    active_pot: PotInfo | None
+    pot_count: int = 0
+    sources: tuple[SourceInfo, ...] = ()
+    backend_ready: bool = False
+    detail: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+class PotManagementService(Protocol):
+    """Control plane for pots, the active pot, and the source registry."""
+
+    # --- lifecycle ----------------------------------------------------------
+    def init(self, *, mode: str, backend: str) -> StepResult:
+        """Provision the control-plane state store for this mode/backend and run
+        migrations to head (the setup seam). The flat-file POC self-creates; the
+        real local state DB (SQLite + migrations) runs schema setup here. Pot
+        creation itself is a separate step (``create_pot``)."""
+        ...
+
+    # --- pots ---------------------------------------------------------------
+    def list_pots(self) -> list[PotInfo]: ...
+
+    def active_pot(self) -> PotInfo | None: ...
+
+    def create_pot(self, *, name: str, repo: str | None = None, use: bool = False) -> PotInfo: ...
+
+    def use_pot(self, *, ref: str) -> PotInfo:
+        """Set the active pot by id-or-name."""
+        ...
+
+    def rename_pot(self, *, ref: str, new_name: str) -> PotInfo: ...
+
+    def reset_pot(self, *, ref: str, confirm: bool = False) -> PotInfo:
+        """Clear a pot's graph state (control-plane side of the reset)."""
+        ...
+
+    def archive_pot(self, *, ref: str) -> PotInfo: ...
+
+    # --- sources ------------------------------------------------------------
+    def add_source(self, *, pot_id: str, kind: str, location: str, name: str | None = None) -> SourceInfo: ...
+
+    def list_sources(self, *, pot_id: str) -> list[SourceInfo]: ...
+
+    def source_status(self, *, pot_id: str, source_id: str) -> SourceInfo: ...
+
+    def remove_source(self, *, pot_id: str, source_id: str) -> None: ...
+
+    # --- rollup -------------------------------------------------------------
+    def aggregate_status(self, *, pot_id: str | None = None) -> PotAggregateStatus:
+        """Control-plane status for ``context_status`` (active pot, sources,
+        readiness). ``None`` uses the active pot."""
+        ...
+
+
+__all__ = [
+    "PotAggregateStatus",
+    "PotInfo",
+    "PotManagementService",
+    "SourceInfo",
+]

--- a/app/src/context-engine/domain/ports/services/setup.py
+++ b/app/src/context-engine/domain/ports/services/setup.py
@@ -1,0 +1,40 @@
+"""``SetupOrchestrator`` — the one first-run flow.
+
+A single owner owns this sequence + its UX; each step it runs is a bespoke
+per-component method owned independently (config, installer, backend, pots,
+state store, migrator, daemon, auth, skills, ingest). The orchestrator is an
+*application* concern so the managed API server reuses the identical sequence —
+only the composition root swaps adapters.
+
+    potpie setup           -> SetupOrchestrator.run(plan)      (ensure each, in order)
+    potpie setup --dry-run -> SetupOrchestrator.preview(plan)  (describe; run nothing)
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from domain.lifecycle import SetupPlan, SetupPreview, SetupReport, StepResult
+
+
+class SetupOrchestrator(Protocol):
+    """Sequences the bespoke per-component lifecycle methods."""
+
+    def preview(self, plan: SetupPlan) -> SetupPreview:
+        """Dry-run: the ordered steps ``run`` would execute (owner, hard/soft,
+        skip reason), unexecuted. Carries no ``StepResult``s."""
+        ...
+
+    def plan(self, plan: SetupPlan) -> list[StepResult]:
+        """Deprecated alias for the ordered steps as ``PLANNED`` ``StepResult``s.
+
+        Retained during the ``preview`` migration; prefer :meth:`preview`.
+        """
+        ...
+
+    def run(self, plan: SetupPlan) -> SetupReport:
+        """Execute each step in dependency order; never crash on a soft gap."""
+        ...
+
+
+__all__ = ["SetupOrchestrator"]

--- a/app/src/context-engine/domain/ports/services/skill_manager.py
+++ b/app/src/context-engine/domain/ports/services/skill_manager.py
@@ -1,0 +1,118 @@
+"""``SkillManager`` service port.
+
+Skills are CLI-managed recipes that teach an agent harness how to use the
+``potpie`` CLI and the four context tools. They are **not** graph facts and
+**not** new agent tools. Agents only ever see an advisory ``skills`` block
+(``SkillNudge``) inside ``context_status`` listing missing/outdated skills and
+the exact install command — installation is a human/CLI action.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol
+
+# SkillNudge is the advisory block embedded in context_status; it is defined
+# in the agent contract module to keep the ports layer acyclic and re-exported
+# here so skill code can import it from its own service module.
+from domain.ports.agent_context import SkillNudge
+
+
+@dataclass(frozen=True, slots=True)
+class SkillInfo:
+    """One skill in the catalog or installed for an agent."""
+
+    id: str
+    title: str
+    version: str
+    description: str = ""
+    installed: bool = False
+    installed_version: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SkillStatus:
+    """Per-agent installed-vs-recommended drift for ``skills status``."""
+
+    agent: str
+    installed: tuple[SkillInfo, ...] = ()
+    missing: tuple[SkillInfo, ...] = ()
+    outdated: tuple[SkillInfo, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class SkillOperationResult:
+    """Outcome of an install/update/remove/add operation."""
+
+    agent: str
+    operation: str
+    changed: tuple[str, ...] = ()
+    detail: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+class AgentTargetPort(Protocol):
+    """Harness-specific install target (e.g. Claude ``.claude/`` bundle).
+
+    The extension seam for supporting a new agent harness: implement this port
+    and register it with the ``SkillManager``. The manager owns catalog/drift
+    logic; the target owns where/how files land for one harness.
+    """
+
+    @property
+    def agent(self) -> str: ...
+
+    def installed(self) -> Mapping[str, str]:
+        """Installed skill id -> version for this harness."""
+        ...
+
+    def install(self, *, skill_id: str, version: str, path: str | None = None) -> None: ...
+
+    def remove(self, *, skill_id: str) -> None: ...
+
+
+class SkillManager(Protocol):
+    """CLI-managed skill catalog and per-agent installation layer."""
+
+    def list(self) -> list[SkillInfo]:
+        """All catalog skills (with installed/version state when known)."""
+        ...
+
+    def install(
+        self, *, agent: str, skill_id: str | None = None, path: str | None = None
+    ) -> SkillOperationResult:
+        """Install one skill (or the full recommended set when ``skill_id`` is
+        ``None``) for an agent harness."""
+        ...
+
+    def update(
+        self, *, agent: str, skill_id: str | None = None, all_: bool = False
+    ) -> SkillOperationResult:
+        """Update an installed skill, or all of them when ``all_``."""
+        ...
+
+    def remove(self, *, agent: str, skill_id: str) -> SkillOperationResult:
+        """Remove an installed skill from an agent harness."""
+        ...
+
+    def status(self, *, agent: str) -> SkillStatus:
+        """Installed-vs-recommended drift for one agent."""
+        ...
+
+    def nudge(self, *, agent: str) -> SkillNudge:
+        """The advisory block ``context_status`` embeds for an agent."""
+        ...
+
+    def add(self, *, source: str) -> SkillOperationResult:
+        """Register a local-path or URL skill into the catalog."""
+        ...
+
+
+__all__ = [
+    "AgentTargetPort",
+    "SkillInfo",
+    "SkillManager",
+    "SkillNudge",
+    "SkillOperationResult",
+    "SkillStatus",
+]

--- a/app/src/context-engine/domain/ports/services/state_store.py
+++ b/app/src/context-engine/domain/ports/services/state_store.py
@@ -1,0 +1,38 @@
+"""Relational state-store + migration seams (setup step 4).
+
+The "Relational state store" component in the setup seam→owner map
+(architecture.md "Seam → owner map", row 4) is three independently-ownable
+methods: ``pot_service.init`` (owned by :class:`PotManagementService`),
+``state_store.provision`` (this :class:`StateStorePort`), and
+``migrator.migrate`` (this :class:`MigrationPort`).
+
+The flat-file local profile needs no relational store, so its adapters report
+``skipped``. The SQLite/Postgres owner fills ``provision``/``migrate`` behind
+these interfaces without touching the orchestrator, which depends only on the
+``-> StepResult`` signatures.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from domain.lifecycle import StepResult
+
+
+class StateStorePort(Protocol):
+    """Stand up the relational control-plane store, idempotently."""
+
+    def provision(self) -> StepResult:
+        """Create the state DB / schema. ``skipped`` when the profile is flat-file."""
+        ...
+
+
+class MigrationPort(Protocol):
+    """Run pending schema migrations against the relational state store."""
+
+    def migrate(self) -> StepResult:
+        """Apply outstanding migrations. ``skipped`` when there are none."""
+        ...
+
+
+__all__ = ["MigrationPort", "StateStorePort"]


### PR DESCRIPTION
> **Stacked PR 1/7** · merge bottom-up: **#822** → #823 → #824 → #825 → #826 → #827 → #828

## Context Engine skeleton cut-over — 1/7

This series breaks #821 ("feat: updated skeleton") — a 138-file strangler cut-over of the Context Engine onto a hexagonal (ports-and-adapters) architecture — into 7 dependency-ordered, file-disjoint **stacked** PRs. Review and merge bottom-up.

**This PR is the foundation: pure domain contracts.** It defines the ports (interfaces) and value objects that every later layer is written against. No behaviour, no wiring — only types and protocols. Fully additive, so it's safe to land first.

### What's here (27 files, +1,584)
- **Graph ports** — `domain/ports/graph/`: backend, mutation, semantic, analytics, inspection, snapshot, claim_query.
- **Ledger ports** — `domain/ports/ledger/`: client, cursor, reconciler.
- **Service ports** — `domain/ports/services/`: auth, config, graph_service, pot_management, setup, skill_manager, state_store.
- **Agent-context / install ports** — `domain/ports/agent_context.py`, `domain/ports/install.py`.
- **Value objects & errors** — `domain/lifecycle.py` (setup step states: `PLANNED`/`DONE`/`SKIPPED`/`NOT_IMPLEMENTED`), `domain/errors.py` (`CapabilityNotImplemented` — the structured not-implemented contract used across the engine), `domain/agent_envelope.py`, `domain/graph_query.py`, `domain/agent_context_port.py`.

### Why it's safe
Purely additive interface definitions. Later layers import these; this layer imports nothing new itself.

### Depends on
Base branch `feat/local-context-engine`. Root of the stack — no upstream PR.
