### PR TITLE
github device flow integration

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -199,6 +199,8 @@ LOGFIRE_PROJECT_NAME=potpie-ai
 # Environment for traces (e.g. development, staging, production). Also set via ENV.
 # LOGFIRE_ENVIRONMENT=development
 # GitHub Authentication Configuration
+# CLI device flow OAuth app client ID
+POTPIE_GITHUB_CLIENT_ID=
 # GH_TOKEN_LIST: Personal Access Tokens for GitHub.com (comma-separated for token pool)
 # GITHUB_APP_ID + GITHUB_PRIVATE_KEY: GitHub App credentials (recommended for production)
 # CODE_PROVIDER_TOKEN: Token for self-hosted Git servers (GitBucket, GitLab, etc.)

--- a/app/src/context-engine/adapters/inbound/cli/auth/github.py
+++ b/app/src/context-engine/adapters/inbound/cli/auth/github.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+from adapters.inbound.cli.auth.models import (
+    AccessToken,
+    DeviceCode,
+    GitHubAccount,
+    ProviderCredentials,
+)
+
+GITHUB_CLIENT_ID = "Ov23lijYk3917lvotBPx"
+GITHUB_SCOPES = ("repo", "read:org", "read:user", "user:email")
+GITHUB_DEVICE_CODE_URL = "https://github.com/login/device/code"
+GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token"
+GITHUB_USER_URL = "https://api.github.com/user"
+GITHUB_USER_EMAILS_URL = "https://api.github.com/user/emails"
+GITHUB_USER_REPOS_URL = "https://api.github.com/user/repos"
+GITHUB_PROVIDER = "github"
+GITHUB_PROVIDER_HOST = "github.com"
+GITHUB_VERIFICATION_URI = "https://github.com/login/device"
+
+
+class GitHubDeviceFlowError(Exception):
+    """Expected GitHub auth flow failure."""
+
+
+def _parse_scopes(raw: Any) -> list[str]:
+    if isinstance(raw, str):
+        return [part.strip() for part in raw.replace(",", " ").split() if part.strip()]
+    if isinstance(raw, list):
+        out: list[str] = []
+        for item in raw:
+            if isinstance(item, str) and item.strip():
+                out.append(item.strip())
+        return out
+    return []
+
+
+def _json_or_error(response: httpx.Response) -> dict[str, Any]:
+    try:
+        data = response.json()
+    except Exception as exc:
+        raise GitHubDeviceFlowError("GitHub returned a non-JSON response.") from exc
+    if not isinstance(data, dict):
+        raise GitHubDeviceFlowError("GitHub returned an unexpected response body.")
+    return data
+
+
+def _json_list_or_error(response: httpx.Response) -> list[Any]:
+    try:
+        data = response.json()
+    except Exception as exc:
+        raise GitHubDeviceFlowError("GitHub returned a non-JSON response.") from exc
+    if not isinstance(data, list):
+        raise GitHubDeviceFlowError("GitHub returned an unexpected response body.")
+    return data
+
+
+def request_device_code(
+    *,
+    client_id: str = GITHUB_CLIENT_ID,
+    scopes: tuple[str, ...] = GITHUB_SCOPES,
+    client: httpx.Client | None = None,
+) -> DeviceCode:
+    owns_client = client is None
+    if owns_client:
+        client = httpx.Client(timeout=30.0)
+    try:
+        response = client.post(
+            GITHUB_DEVICE_CODE_URL,
+            headers={"Accept": "application/json"},
+            data={"client_id": client_id, "scope": " ".join(scopes)},
+        )
+    finally:
+        if owns_client:
+            client.close()
+    data = _json_or_error(response)
+    if response.status_code >= 400:
+        raise GitHubDeviceFlowError(
+            str(
+                data.get("error_description")
+                or data.get("error")
+                or "GitHub device-code request failed."
+            )
+        )
+    return DeviceCode(
+        device_code=str(data["device_code"]),
+        user_code=str(data["user_code"]),
+        verification_uri=str(data.get("verification_uri") or GITHUB_VERIFICATION_URI),
+        expires_in=int(data["expires_in"]),
+        interval=max(int(data.get("interval") or 5), 1),
+    )
+
+
+def poll_for_access_token(
+    device_code: DeviceCode,
+    *,
+    client_id: str = GITHUB_CLIENT_ID,
+    client: httpx.Client | None = None,
+    sleep_fn: Any = time.sleep,
+) -> AccessToken:
+    owns_client = client is None
+    if owns_client:
+        client = httpx.Client(timeout=30.0)
+    interval = device_code.interval
+    try:
+        sleep_fn(interval)
+        while True:
+            response = client.post(
+                GITHUB_TOKEN_URL,
+                headers={"Accept": "application/json"},
+                data={
+                    "client_id": client_id,
+                    "device_code": device_code.device_code,
+                    "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                },
+            )
+            data = _json_or_error(response)
+            error = str(data.get("error") or "").strip()
+            if response.status_code < 400 and data.get("access_token"):
+                return AccessToken(
+                    access_token=str(data["access_token"]),
+                    token_type=str(data.get("token_type") or "bearer"),
+                    scopes=_parse_scopes(data.get("scope") or data.get("scopes")),
+                )
+            if error == "authorization_pending":
+                sleep_fn(interval)
+                continue
+            if error == "slow_down":
+                interval += 5
+                sleep_fn(interval)
+                continue
+            if error == "expired_token":
+                raise GitHubDeviceFlowError(
+                    "GitHub device code expired before authorization completed."
+                )
+            if error == "access_denied":
+                raise GitHubDeviceFlowError("GitHub authorization was denied.")
+            detail = str(
+                data.get("error_description") or error or "GitHub token exchange failed."
+            )
+            raise GitHubDeviceFlowError(detail)
+    finally:
+        if owns_client:
+            client.close()
+
+
+def verify_account(
+    access_token: str,
+    *,
+    client: httpx.Client | None = None,
+) -> GitHubAccount:
+    owns_client = client is None
+    if owns_client:
+        client = httpx.Client(timeout=30.0)
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {access_token}",
+    }
+    try:
+        response = client.get(
+            GITHUB_USER_URL,
+            headers=headers,
+        )
+        data = _json_or_error(response)
+        if response.status_code >= 400:
+            raise GitHubDeviceFlowError(
+                str(data.get("message") or "GitHub account verification failed.")
+            )
+        login = str(data.get("login") or "").strip()
+        account_id = data.get("id")
+        if not login or not isinstance(account_id, int):
+            raise GitHubDeviceFlowError(
+                "GitHub account verification returned incomplete account data."
+            )
+        email = str(data["email"]) if data.get("email") is not None else None
+        if email is None:
+            emails_response = client.get(GITHUB_USER_EMAILS_URL, headers=headers)
+            if emails_response.status_code >= 400:
+                emails_data = _json_or_error(emails_response)
+                raise GitHubDeviceFlowError(
+                    str(emails_data.get("message") or "GitHub email lookup failed.")
+                )
+            for item in _json_list_or_error(emails_response):
+                if (
+                    isinstance(item, dict)
+                    and item.get("primary") is True
+                    and item.get("verified") is True
+                    and item.get("email") is not None
+                ):
+                    email = str(item["email"])
+                    break
+        return GitHubAccount(
+            login=login,
+            id=account_id,
+            name=str(data["name"]) if data.get("name") is not None else None,
+            email=email,
+        )
+    finally:
+        if owns_client:
+            client.close()
+
+
+def _has_next_page(response: httpx.Response) -> bool:
+    link = response.headers.get("Link", "")
+    return 'rel="next"' in link
+
+
+def list_user_owned_repositories(
+    access_token: str,
+    *,
+    client: httpx.Client | None = None,
+) -> list[dict[str, Any]]:
+    owns_client = client is None
+    if owns_client:
+        client = httpx.Client(timeout=30.0)
+    repos: list[dict[str, Any]] = []
+    page = 1
+    try:
+        while True:
+            response = client.get(
+                GITHUB_USER_REPOS_URL,
+                headers={
+                    "Accept": "application/vnd.github+json",
+                    "Authorization": f"Bearer {access_token}",
+                },
+                params={
+                    "affiliation": "owner",
+                    "per_page": 100,
+                    "page": page,
+                    "sort": "updated",
+                    "direction": "desc",
+                },
+            )
+            if response.status_code >= 400:
+                data = _json_or_error(response)
+                raise GitHubDeviceFlowError(
+                    str(data.get("message") or "GitHub repository listing failed.")
+                )
+            data = _json_list_or_error(response)
+            for item in data:
+                if isinstance(item, dict):
+                    repos.append(
+                        {
+                            "id": item.get("id"),
+                            "name": item.get("name"),
+                            "full_name": item.get("full_name"),
+                            "private": bool(item.get("private")),
+                            "html_url": item.get("html_url"),
+                            "default_branch": item.get("default_branch"),
+                            "updated_at": item.get("updated_at"),
+                        }
+                    )
+            if not _has_next_page(response):
+                return repos
+            page += 1
+    finally:
+        if owns_client:
+            client.close()
+
+
+def build_provider_credentials(
+    token: AccessToken,
+    account: GitHubAccount,
+    *,
+    now: datetime | None = None,
+    verification_uri: str = GITHUB_VERIFICATION_URI,
+) -> ProviderCredentials:
+    stamp = (now or datetime.now(timezone.utc)).isoformat()
+    scopes = token.scopes or list(GITHUB_SCOPES)
+    return ProviderCredentials(
+        provider=GITHUB_PROVIDER,
+        provider_host=GITHUB_PROVIDER_HOST,
+        access_token=token.access_token,
+        token_type=token.token_type,
+        scopes=scopes,
+        account={
+            "login": account.login,
+            "id": account.id,
+            "name": account.name,
+            "email": account.email,
+        },
+        created_at=stamp,
+        updated_at=stamp,
+        expires_at=None,
+        metadata={
+            "auth_flow": "device",
+            "verification_uri": verification_uri,
+        },
+        token_storage="keychain",
+    )

--- a/app/src/context-engine/adapters/inbound/cli/auth/github.py
+++ b/app/src/context-engine/adapters/inbound/cli/auth/github.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import time
 from datetime import datetime, timezone
 from typing import Any
@@ -13,7 +14,7 @@ from adapters.inbound.cli.auth.models import (
     ProviderCredentials,
 )
 
-GITHUB_CLIENT_ID = "Ov23lijYk3917lvotBPx"
+GITHUB_CLIENT_ID = os.getenv("POTPIE_GITHUB_CLIENT_ID", "Ov23lijYk3917lvotBPx")
 GITHUB_SCOPES = ("repo", "read:org", "read:user", "user:email")
 GITHUB_DEVICE_CODE_URL = "https://github.com/login/device/code"
 GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token"
@@ -108,9 +109,14 @@ def poll_for_access_token(
     if owns_client:
         client = httpx.Client(timeout=30.0)
     interval = device_code.interval
+    deadline = time.monotonic() + max(device_code.expires_in, 1)
     try:
         sleep_fn(interval)
         while True:
+            if time.monotonic() >= deadline:
+                raise GitHubDeviceFlowError(
+                    "GitHub device code expired before authorization completed."
+                )
             response = client.post(
                 GITHUB_TOKEN_URL,
                 headers={"Accept": "application/json"},

--- a/app/src/context-engine/adapters/inbound/cli/auth/github_commands.py
+++ b/app/src/context-engine/adapters/inbound/cli/auth/github_commands.py
@@ -1,0 +1,183 @@
+"""GitHub CLI authentication commands (device flow)."""
+
+from __future__ import annotations
+
+import webbrowser
+
+import typer
+
+from adapters.inbound.cli.auth.github import (
+    GitHubDeviceFlowError,
+    build_provider_credentials,
+    list_user_owned_repositories,
+    poll_for_access_token,
+    request_device_code,
+    verify_account,
+)
+from adapters.inbound.cli.auth_commands import register_provider_app
+from adapters.inbound.cli.credentials_store import (
+    CredentialStoreError,
+    ProviderCredentialError,
+    clear_provider_credentials,
+    credentials_path,
+    get_provider_credentials,
+    write_provider_credentials,
+)
+from adapters.inbound.cli.output import emit_error, print_json_blob, print_plain_line
+
+github_app = typer.Typer(help="GitHub authentication.")
+github_test_app = typer.Typer(help="GitHub test helpers.")
+git_app = typer.Typer(
+    help="Deprecated: use `potpie auth github` instead.",
+    hidden=True,
+)
+git_test_app = typer.Typer(help="Git provider test helpers.", hidden=True)
+
+
+def _flags() -> tuple[bool, bool]:
+    from adapters.inbound.cli.main import _flags as main_flags
+
+    return main_flags()
+
+
+def github_login_impl() -> None:
+    """Authenticate the CLI with GitHub using device flow."""
+    j, v = _flags()
+    account = None
+    payload = None
+    try:
+        device_code = request_device_code()
+        if not j:
+            webbrowser.open(device_code.verification_uri)
+            print_plain_line(
+                f"Enter code {device_code.user_code} at {device_code.verification_uri}",
+                as_json=False,
+            )
+            print_plain_line("Waiting for authorization…", as_json=False)
+        token = poll_for_access_token(device_code)
+        account = verify_account(token.access_token)
+        payload = build_provider_credentials(
+            token, account, verification_uri=device_code.verification_uri
+        )
+        write_provider_credentials("github", payload.as_dict())
+    except GitHubDeviceFlowError as exc:
+        emit_error("GitHub login failed", str(exc), verbose=v)
+        raise typer.Exit(code=1) from exc
+    except (ProviderCredentialError, CredentialStoreError) as exc:
+        emit_error("GitHub login failed", str(exc), verbose=v)
+        raise typer.Exit(code=1) from exc
+
+    if j:
+        print_json_blob(
+            {
+                "ok": True,
+                "provider": "github",
+                "account": payload.account if payload else {},
+                "path": str(credentials_path()),
+            },
+            as_json=True,
+        )
+        return
+
+    assert account is not None and payload is not None
+    stored = get_provider_credentials("github")
+    login = str(stored.get("account", {}).get("login") or account.login)
+    email = str(stored.get("account", {}).get("email") or account.email or "")
+    print_plain_line(
+        f"Logged in to GitHub as {login}" + (f" ({email})" if email else ""),
+        as_json=False,
+    )
+
+
+def github_logout_impl() -> None:
+    """Remove GitHub credentials from keychain and config."""
+    j, v = _flags()
+    try:
+        clear_provider_credentials("github")
+    except (ProviderCredentialError, CredentialStoreError, ValueError) as exc:
+        emit_error("GitHub logout failed", str(exc), verbose=v)
+        raise typer.Exit(code=1) from exc
+
+    if j:
+        print_json_blob({"ok": True, "provider": "github"}, as_json=True)
+        return
+    print_plain_line("Logged out of GitHub.", as_json=False)
+
+
+@github_app.command("login")
+def github_login_cmd() -> None:
+    """Authenticate with GitHub using device flow."""
+    github_login_impl()
+
+
+@github_app.command("logout")
+def github_logout_cmd() -> None:
+    """Remove stored GitHub credentials."""
+    github_logout_impl()
+
+
+@git_app.command("login", hidden=True)
+def git_login_cmd() -> None:
+    """Deprecated alias for `potpie auth github login`."""
+    github_login_impl()
+
+
+@git_app.command("logout", hidden=True)
+def git_logout_cmd() -> None:
+    """Deprecated alias for `potpie auth github logout`."""
+    github_logout_impl()
+
+
+@github_test_app.command("repos")
+@git_test_app.command("repos")
+def github_test_repos_cmd() -> None:
+    """List GitHub repositories owned by the authenticated user."""
+    j, v = _flags()
+    try:
+        credentials = get_provider_credentials("github")
+    except (ProviderCredentialError, CredentialStoreError) as exc:
+        emit_error(
+            "GitHub credentials not found",
+            str(exc),
+            verbose=v,
+        )
+        raise typer.Exit(code=1) from exc
+    token = str(credentials.get("access_token") or "").strip()
+    if not token:
+        emit_error(
+            "GitHub credentials not found",
+            "GitHub token not found in system keychain. Run: potpie auth github login",
+            verbose=v,
+        )
+        raise typer.Exit(code=1)
+    try:
+        repos = list_user_owned_repositories(token)
+    except GitHubDeviceFlowError as exc:
+        emit_error("GitHub repository listing failed", str(exc), verbose=v)
+        raise typer.Exit(code=1) from exc
+
+    if j:
+        print_json_blob(
+            {"ok": True, "provider": "github", "count": len(repos), "repos": repos},
+            as_json=True,
+        )
+        return
+
+    for repo in repos:
+        visibility = "private" if repo.get("private") else "public"
+        print_plain_line(
+            f"{repo.get('full_name')}\t{visibility}\t{repo.get('default_branch') or ''}",
+            as_json=False,
+        )
+
+
+def register_github_commands(root_app: typer.Typer) -> None:
+    """Wire GitHub auth and test commands into the root CLI."""
+    register_provider_app("github", github_app)
+    github_root = typer.Typer(
+        help="GitHub CLI helpers (use `potpie auth github` to sign in).",
+    )
+    github_root.add_typer(github_test_app, name="test")
+    root_app.add_typer(github_root, name="github")
+    git_app.add_typer(git_test_app, name="test")
+    root_app.add_typer(git_app, name="git")

--- a/app/src/context-engine/adapters/inbound/cli/auth/models.py
+++ b/app/src/context-engine/adapters/inbound/cli/auth/models.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class DeviceCode:
+    device_code: str
+    user_code: str
+    verification_uri: str
+    expires_in: int
+    interval: int
+
+
+@dataclass(frozen=True)
+class AccessToken:
+    access_token: str
+    token_type: str
+    scopes: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class GitHubAccount:
+    login: str
+    id: int
+    name: str | None
+    email: str | None
+
+
+@dataclass(frozen=True)
+class ProviderCredentials:
+    provider: str
+    provider_host: str
+    access_token: str
+    token_type: str
+    scopes: list[str]
+    account: dict[str, Any]
+    created_at: str
+    updated_at: str
+    expires_at: str | None
+    metadata: dict[str, Any]
+    token_storage: str = "keychain"
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "provider_host": self.provider_host,
+            "access_token": self.access_token,
+            "token_type": self.token_type,
+            "scopes": list(self.scopes),
+            "account": dict(self.account),
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "expires_at": self.expires_at,
+            "metadata": dict(self.metadata),
+            "token_storage": self.token_storage,
+        }

--- a/app/src/context-engine/adapters/inbound/cli/credentials_store.py
+++ b/app/src/context-engine/adapters/inbound/cli/credentials_store.py
@@ -16,10 +16,15 @@ _CREDENTIALS_FILENAME = "credentials.json"
 _CONFIG_DIR_NAME = "potpie"
 _LEGACY_CONFIG_DIR_NAME = "context-engine"
 _KEYRING_SERVICE = "potpie"
+_GITHUB_TOKEN_SECRET = "github_token"
 
 
 class CredentialStoreError(Exception):
     """Credential metadata or secure secret storage failure."""
+
+
+# Alias used by GitHub CLI auth (matches integration branch naming).
+ProviderCredentialError = CredentialStoreError
 
 
 def config_dir() -> Path:
@@ -333,3 +338,48 @@ def resolve_cli_pot_ref(ref: str) -> tuple[str | None, str]:
         f"Unknown pot {s!r}. Run `potpie pot create <slug>` (server pot + alias), "
         f"or `potpie pot pots` for slugs/ids, then `pot use` / `pot alias`."
     )
+
+
+def write_provider_credentials(provider: str, payload: dict[str, Any]) -> None:
+    """Persist provider credentials (GitHub only on this branch)."""
+    key = _norm_integration_key(provider)
+    if key != "github":
+        raise ValueError(f"Unsupported provider {provider!r}; expected 'github'.")
+    stored_payload = dict(payload)
+    access_token = str(stored_payload.pop("access_token", "") or "").strip()
+    if not access_token:
+        raise ProviderCredentialError("GitHub access token is required.")
+    store_secure_secret(
+        _GITHUB_TOKEN_SECRET,
+        access_token,
+        label="GitHub token",
+    )
+    stored_payload["token_storage"] = "keychain"
+    write_integration_metadata(key, stored_payload)
+
+
+def get_provider_credentials(provider: str) -> dict[str, Any]:
+    """Return provider metadata merged with secrets from keychain."""
+    key = _norm_integration_key(provider)
+    if key != "github":
+        return {}
+    metadata = get_integration_metadata(key)
+    if not metadata:
+        return {}
+    result = dict(metadata)
+    token = load_secure_secret(_GITHUB_TOKEN_SECRET, label="GitHub token")
+    if not token:
+        raise ProviderCredentialError(
+            "GitHub token not found in system keychain. Run: potpie auth github login"
+        )
+    result["access_token"] = token
+    return result
+
+
+def clear_provider_credentials(provider: str) -> None:
+    """Remove provider secrets from keychain and drop integration metadata."""
+    key = _norm_integration_key(provider)
+    if key != "github":
+        raise ValueError(f"Unsupported provider {provider!r}; expected 'github'.")
+    delete_secure_secret(_GITHUB_TOKEN_SECRET, label="GitHub token")
+    clear_integration_metadata(key)

--- a/app/src/context-engine/adapters/inbound/cli/main.py
+++ b/app/src/context-engine/adapters/inbound/cli/main.py
@@ -24,6 +24,7 @@ from adapters.inbound.cli.credentials_store import (
     write_credentials,
 )
 from adapters.inbound.cli.agent_installer import AGENT_TYPES, install_agent_bundle
+from adapters.inbound.cli.auth.github_commands import register_github_commands
 from adapters.inbound.cli.auth_commands import auth_app
 from adapters.inbound.cli.env_bootstrap import load_cli_env
 from adapters.inbound.cli.git_project import (
@@ -812,6 +813,7 @@ def pot_hard_reset(
 
 
 app.add_typer(pot_app, name="pot")
+register_github_commands(app)
 app.add_typer(auth_app, name="auth")
 
 

--- a/app/src/context-engine/adapters/inbound/cli/output.py
+++ b/app/src/context-engine/adapters/inbound/cli/output.py
@@ -39,7 +39,13 @@ def configure_cli_logging(verbose: bool) -> None:
     )
     noisy = verbose or env_verbose
     level = logging.DEBUG if noisy else logging.ERROR
-    for name in ("neo4j", "neo4j.io", "neo4j.notifications"):
+    for name in (
+        "neo4j",
+        "neo4j.io",
+        "neo4j.notifications",
+        "httpx",
+        "httpcore",
+    ):
         logging.getLogger(name).setLevel(level)
 
 

--- a/app/src/context-engine/tests/unit/test_cli_output.py
+++ b/app/src/context-engine/tests/unit/test_cli_output.py
@@ -20,6 +20,7 @@ def test_configure_cli_logging_no_crash() -> None:
     configure_cli_logging(verbose=True)
     assert logging.getLogger("neo4j").level == logging.DEBUG
     assert logging.getLogger("httpx").level == logging.DEBUG
+    assert logging.getLogger("httpcore").level == logging.DEBUG
 
 
 def test_print_doctor_json_mode(capsys) -> None:

--- a/app/src/context-engine/tests/unit/test_cli_output.py
+++ b/app/src/context-engine/tests/unit/test_cli_output.py
@@ -15,8 +15,11 @@ from adapters.inbound.cli.output import (
 def test_configure_cli_logging_no_crash() -> None:
     configure_cli_logging(verbose=False)
     assert logging.getLogger("neo4j").level == logging.ERROR
+    assert logging.getLogger("httpx").level == logging.ERROR
+    assert logging.getLogger("httpcore").level == logging.ERROR
     configure_cli_logging(verbose=True)
     assert logging.getLogger("neo4j").level == logging.DEBUG
+    assert logging.getLogger("httpx").level == logging.DEBUG
 
 
 def test_print_doctor_json_mode(capsys) -> None:

--- a/app/src/context-engine/tests/unit/test_credentials_store.py
+++ b/app/src/context-engine/tests/unit/test_credentials_store.py
@@ -217,3 +217,137 @@ def test_resolve_cli_pot_ref_uuid_normalizes() -> None:
     got, err = cs.resolve_cli_pot_ref(s)
     assert err == ""
     assert got == "550e8400-e29b-41d4-a716-446655440000"
+
+
+@pytest.fixture
+def fake_keyring(monkeypatch: pytest.MonkeyPatch) -> dict[tuple[str, str], str]:
+    store: dict[tuple[str, str], str] = {}
+
+    def _set_password(service: str, username: str, password: str) -> None:
+        store[(service, username)] = password
+
+    def _get_password(service: str, username: str) -> str | None:
+        return store.get((service, username))
+
+    def _delete_password(service: str, username: str) -> None:
+        store.pop((service, username), None)
+
+    monkeypatch.setattr(cs.keyring, "set_password", _set_password)
+    monkeypatch.setattr(cs.keyring, "get_password", _get_password)
+    monkeypatch.setattr(cs.keyring, "delete_password", _delete_password)
+    return store
+
+
+def test_write_provider_credentials_preserves_existing_fields(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, fake_keyring: dict[tuple[str, str], str]
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    cs.write_credentials(api_key="secret-token", api_base_url="http://localhost:9999")
+    cs.set_active_pot_id("11111111-1111-1111-1111-111111111111")
+    cs.register_pot_alias("demo", "22222222-2222-2222-2222-222222222222")
+
+    cs.write_provider_credentials(
+        "github",
+        {
+            "provider": "github",
+            "provider_host": "github.com",
+            "access_token": "plaintext-token",
+            "token_type": "bearer",
+            "scopes": ["repo", "read:org", "read:user"],
+            "account": {"login": "octocat", "id": 1, "name": None, "email": None},
+            "created_at": "2026-05-29T00:00:00+00:00",
+            "updated_at": "2026-05-29T00:00:00+00:00",
+            "expires_at": None,
+            "metadata": {"auth_flow": "device"},
+        },
+    )
+
+    path = cs.credentials_path()
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["api_key"] == "secret-token"
+    assert data["api_base_url"] == "http://localhost:9999"
+    assert data["active_pot_id"] == "11111111-1111-1111-1111-111111111111"
+    assert data["pot_aliases"] == {"demo": "22222222-2222-2222-2222-222222222222"}
+    assert "access_token" not in data["integrations"]["github"]
+    assert data["integrations"]["github"]["token_storage"] == "keychain"
+    assert fake_keyring[("potpie", "github_token")] == "plaintext-token"
+    assert cs.get_provider_credentials("github")["access_token"] == "plaintext-token"
+
+
+def test_get_provider_credentials_reads_from_keychain(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, fake_keyring: dict[tuple[str, str], str]
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    cs.write_provider_credentials(
+        "github",
+        {
+            "provider": "github",
+            "provider_host": "github.com",
+            "access_token": "plaintext-token",
+            "token_type": "bearer",
+            "scopes": ["repo"],
+            "account": {"login": "octocat", "id": 1, "name": None, "email": None},
+            "created_at": "2026-05-29T00:00:00+00:00",
+            "updated_at": "2026-05-29T00:00:00+00:00",
+            "expires_at": None,
+            "metadata": {"auth_flow": "device"},
+        },
+    )
+
+    fake_keyring[("potpie", "github_token")] = "from-keychain"
+
+    assert cs.get_provider_credentials("github")["access_token"] == "from-keychain"
+
+
+def test_get_provider_credentials_raises_when_keychain_token_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    cs.write_integration_metadata(
+        "github",
+        {
+            "provider": "github",
+            "provider_host": "github.com",
+            "token_storage": "keychain",
+            "account": {"login": "octocat", "id": 1},
+        },
+    )
+    monkeypatch.setattr(cs.keyring, "get_password", lambda _service, _username: None)
+
+    with pytest.raises(cs.ProviderCredentialError) as exc:
+        cs.get_provider_credentials("github")
+
+    assert str(exc.value) == (
+        "GitHub token not found in system keychain. Run: potpie auth github login"
+    )
+
+
+def test_write_provider_credentials_raises_on_keychain_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+
+    def _fail(_service: str, _username: str, _password: str) -> None:
+        raise KeyringError("backend unavailable")
+
+    monkeypatch.setattr(cs.keyring, "set_password", _fail)
+
+    with pytest.raises(cs.ProviderCredentialError) as exc:
+        cs.write_provider_credentials(
+            "github",
+            {
+                "provider": "github",
+                "provider_host": "github.com",
+                "access_token": "plaintext-token",
+                "token_type": "bearer",
+                "scopes": ["repo"],
+                "account": {"login": "octocat", "id": 1, "name": None, "email": None},
+                "created_at": "2026-05-29T00:00:00+00:00",
+                "updated_at": "2026-05-29T00:00:00+00:00",
+                "expires_at": None,
+                "metadata": {"auth_flow": "device"},
+            },
+        )
+
+    assert "Failed to store GitHub token in system keychain" in str(exc.value)

--- a/app/src/context-engine/tests/unit/test_github_cli_auth.py
+++ b/app/src/context-engine/tests/unit/test_github_cli_auth.py
@@ -1,0 +1,429 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from adapters.inbound.cli import main as cli_main
+from adapters.inbound.cli.auth import github as gh_auth
+from adapters.inbound.cli.auth import github_commands as gh_cmds
+from adapters.inbound.cli import credentials_store as cs
+
+pytestmark = pytest.mark.unit
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def fake_keyring(monkeypatch: pytest.MonkeyPatch) -> dict[tuple[str, str], str]:
+    store: dict[tuple[str, str], str] = {}
+
+    def _set_password(service: str, username: str, password: str) -> None:
+        store[(service, username)] = password
+
+    def _get_password(service: str, username: str) -> str | None:
+        return store.get((service, username))
+
+    def _delete_password(service: str, username: str) -> None:
+        store.pop((service, username), None)
+
+    monkeypatch.setattr(cs.keyring, "set_password", _set_password)
+    monkeypatch.setattr(cs.keyring, "get_password", _get_password)
+    monkeypatch.setattr(cs.keyring, "delete_password", _delete_password)
+    return store
+
+
+class FakeClient:
+    def __init__(self, responses: list[httpx.Response]) -> None:
+        self._responses = responses
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    def post(self, url: str, **kwargs: Any) -> httpx.Response:
+        self.calls.append(("POST", url, kwargs))
+        return self._responses.pop(0)
+
+    def get(self, url: str, **kwargs: Any) -> httpx.Response:
+        self.calls.append(("GET", url, kwargs))
+        return self._responses.pop(0)
+
+    def close(self) -> None:
+        return
+
+
+def test_request_device_code_sends_expected_payload() -> None:
+    client = FakeClient(
+        [
+            httpx.Response(
+                200,
+                json={
+                    "device_code": "dev-code",
+                    "user_code": "ABCD-EFGH",
+                    "verification_uri": "https://github.com/login/device",
+                    "expires_in": 900,
+                    "interval": 5,
+                },
+            )
+        ]
+    )
+
+    result = gh_auth.request_device_code(client=client)
+
+    assert result.device_code == "dev-code"
+    method, url, kwargs = client.calls[0]
+    assert method == "POST"
+    assert url == gh_auth.GITHUB_DEVICE_CODE_URL
+    assert kwargs["headers"]["Accept"] == "application/json"
+    assert kwargs["data"]["client_id"] == gh_auth.GITHUB_CLIENT_ID
+    assert kwargs["data"]["scope"] == "repo read:org read:user user:email"
+
+
+def test_poll_for_access_token_waits_on_authorization_pending() -> None:
+    client = FakeClient(
+        [
+            httpx.Response(200, json={"error": "authorization_pending"}),
+            httpx.Response(
+                200,
+                json={
+                    "access_token": "gho_token",
+                    "token_type": "bearer",
+                    "scope": "repo read:org read:user",
+                },
+            ),
+        ]
+    )
+    sleeps: list[int] = []
+
+    token = gh_auth.poll_for_access_token(
+        gh_auth.DeviceCode(
+            device_code="dev-code",
+            user_code="ABCD-EFGH",
+            verification_uri=gh_auth.GITHUB_VERIFICATION_URI,
+            expires_in=900,
+            interval=5,
+        ),
+        client=client,
+        sleep_fn=sleeps.append,
+    )
+
+    assert token.access_token == "gho_token"
+    assert sleeps == [5, 5]
+
+
+def test_poll_for_access_token_slow_down_increases_interval() -> None:
+    client = FakeClient(
+        [
+            httpx.Response(200, json={"error": "slow_down"}),
+            httpx.Response(
+                200,
+                json={"access_token": "gho_token", "token_type": "bearer", "scope": "repo"},
+            ),
+        ]
+    )
+    sleeps: list[int] = []
+
+    gh_auth.poll_for_access_token(
+        gh_auth.DeviceCode(
+            device_code="dev-code",
+            user_code="ABCD-EFGH",
+            verification_uri=gh_auth.GITHUB_VERIFICATION_URI,
+            expires_in=900,
+            interval=5,
+        ),
+        client=client,
+        sleep_fn=sleeps.append,
+    )
+
+    assert sleeps == [5, 10]
+
+
+@pytest.mark.parametrize("error_code", ["expired_token", "access_denied"])
+def test_poll_for_access_token_exits_cleanly_on_terminal_errors(error_code: str) -> None:
+    client = FakeClient([httpx.Response(200, json={"error": error_code})])
+
+    with pytest.raises(gh_auth.GitHubDeviceFlowError):
+        gh_auth.poll_for_access_token(
+            gh_auth.DeviceCode(
+                device_code="dev-code",
+                user_code="ABCD-EFGH",
+                verification_uri=gh_auth.GITHUB_VERIFICATION_URI,
+                expires_in=900,
+                interval=5,
+            ),
+            client=client,
+            sleep_fn=lambda _seconds: None,
+        )
+
+
+def test_verify_account_parses_user() -> None:
+    client = FakeClient(
+        [
+            httpx.Response(
+                200,
+                json={
+                    "login": "octocat",
+                    "id": 1,
+                    "name": "The Octocat",
+                    "email": "octocat@example.com",
+                },
+            )
+        ]
+    )
+
+    account = gh_auth.verify_account("gho_token", client=client)
+
+    assert account.login == "octocat"
+    assert account.email == "octocat@example.com"
+    assert client.calls[0][2]["headers"]["Authorization"] == "Bearer gho_token"
+
+
+def test_verify_account_uses_primary_verified_email_when_user_email_is_null() -> None:
+    client = FakeClient(
+        [
+            httpx.Response(
+                200,
+                json={"login": "octocat", "id": 1, "name": "The Octocat", "email": None},
+            ),
+            httpx.Response(
+                200,
+                json=[
+                    {
+                        "email": "secondary@example.com",
+                        "primary": False,
+                        "verified": True,
+                    },
+                    {
+                        "email": "octocat@example.com",
+                        "primary": True,
+                        "verified": True,
+                    },
+                ],
+            ),
+        ]
+    )
+
+    account = gh_auth.verify_account("gho_token", client=client)
+
+    assert account.email == "octocat@example.com"
+    assert client.calls[1][0] == "GET"
+    assert client.calls[1][1] == gh_auth.GITHUB_USER_EMAILS_URL
+    assert client.calls[1][2]["headers"]["Authorization"] == "Bearer gho_token"
+
+
+def test_list_user_owned_repositories_uses_owner_affiliation() -> None:
+    client = FakeClient(
+        [
+            httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": 1,
+                        "name": "widgets",
+                        "full_name": "octocat/widgets",
+                        "private": True,
+                        "html_url": "https://github.com/octocat/widgets",
+                        "default_branch": "main",
+                        "updated_at": "2026-05-29T00:00:00Z",
+                    }
+                ],
+            )
+        ]
+    )
+
+    repos = gh_auth.list_user_owned_repositories("gho_token", client=client)
+
+    assert repos == [
+        {
+            "id": 1,
+            "name": "widgets",
+            "full_name": "octocat/widgets",
+            "private": True,
+            "html_url": "https://github.com/octocat/widgets",
+            "default_branch": "main",
+            "updated_at": "2026-05-29T00:00:00Z",
+        }
+    ]
+    method, url, kwargs = client.calls[0]
+    assert method == "GET"
+    assert url == gh_auth.GITHUB_USER_REPOS_URL
+    assert kwargs["headers"]["Authorization"] == "Bearer gho_token"
+    assert kwargs["params"]["affiliation"] == "owner"
+
+
+def test_github_login_stores_token_only_after_verification(
+    monkeypatch: pytest.MonkeyPatch, tmp_path, fake_keyring: dict[tuple[str, str], str]
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    opened_urls: list[str] = []
+    monkeypatch.setattr(
+        gh_cmds.webbrowser,
+        "open",
+        lambda url: opened_urls.append(url) or True,
+    )
+    monkeypatch.setattr(
+        gh_cmds,
+        "request_device_code",
+        lambda: gh_auth.DeviceCode(
+            device_code="dev-code",
+            user_code="ABCD-EFGH",
+            verification_uri=gh_auth.GITHUB_VERIFICATION_URI,
+            expires_in=900,
+            interval=5,
+        ),
+    )
+    monkeypatch.setattr(
+        gh_cmds,
+        "poll_for_access_token",
+        lambda _device: gh_auth.AccessToken(
+            access_token="plaintext-token",
+            token_type="bearer",
+            scopes=["repo", "read:org", "read:user", "user:email"],
+        ),
+    )
+    monkeypatch.setattr(
+        gh_cmds,
+        "verify_account",
+        lambda _token: gh_auth.GitHubAccount(
+            login="octocat", id=1, name="The Octocat", email="octocat@example.com"
+        ),
+    )
+
+    result = runner.invoke(cli_main.app, ["auth", "github", "login"])
+
+    assert result.exit_code == 0, result.stdout
+    stored = cs.get_provider_credentials("github")
+    assert stored["access_token"] == "plaintext-token"
+    assert stored["account"]["login"] == "octocat"
+    assert stored["account"]["email"] == "octocat@example.com"
+    assert fake_keyring[("potpie", "github_token")] == "plaintext-token"
+    raw = cs.read_credentials()
+    assert "access_token" not in raw["integrations"]["github"]
+    assert raw["integrations"]["github"]["account"] == {
+        "login": "octocat",
+        "id": 1,
+        "name": "The Octocat",
+        "email": "octocat@example.com",
+    }
+    assert raw["integrations"]["github"]["token_storage"] == "keychain"
+    assert opened_urls == [gh_auth.GITHUB_VERIFICATION_URI]
+    assert "Enter code ABCD-EFGH at" in result.stdout
+    assert "Waiting for authorization" in result.stdout
+    assert "Logged in to GitHub as octocat (octocat@example.com)" in result.stdout
+
+
+def test_deprecated_git_login_alias(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setattr(gh_cmds, "github_login_impl", lambda: None)
+    result = runner.invoke(cli_main.app, ["git", "login"])
+    assert result.exit_code == 0, result.stdout
+
+
+def test_github_logout_clears_github_credentials(
+    monkeypatch: pytest.MonkeyPatch, tmp_path, fake_keyring: dict[tuple[str, str], str]
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    cs.write_provider_credentials(
+        "github",
+        {
+            "provider": "github",
+            "provider_host": "github.com",
+            "access_token": "plaintext-token",
+            "token_storage": "keychain",
+            "account": {"login": "octocat", "id": 1},
+        },
+    )
+    assert fake_keyring[("potpie", "github_token")] == "plaintext-token"
+
+    result = runner.invoke(cli_main.app, ["auth", "github", "logout"])
+
+    assert result.exit_code == 0, result.stdout
+    assert cs.get_integration_metadata("github") == {}
+    assert ("potpie", "github_token") not in fake_keyring
+    assert "github" not in (cs.read_credentials().get("integrations") or {})
+
+
+def test_git_login_does_not_store_when_account_verification_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setattr(
+        gh_cmds,
+        "request_device_code",
+        lambda: gh_auth.DeviceCode(
+            device_code="dev-code",
+            user_code="ABCD-EFGH",
+            verification_uri=gh_auth.GITHUB_VERIFICATION_URI,
+            expires_in=900,
+            interval=5,
+        ),
+    )
+    monkeypatch.setattr(
+        gh_cmds,
+        "poll_for_access_token",
+        lambda _device: gh_auth.AccessToken(
+            access_token="plaintext-token",
+            token_type="bearer",
+            scopes=["repo"],
+        ),
+    )
+
+    def _fail(_token: str) -> gh_auth.GitHubAccount:
+        raise gh_auth.GitHubDeviceFlowError("verification failed")
+
+    monkeypatch.setattr(gh_cmds, "verify_account", _fail)
+
+    result = runner.invoke(cli_main.app, ["auth", "github", "login"])
+
+    assert result.exit_code == 1, result.stdout
+    assert cs.get_integration_metadata("github") == {}
+
+
+def test_git_test_repos_lists_stored_account_repositories(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    cs.write_provider_credentials(
+        "github",
+        {
+            "provider": "github",
+            "provider_host": "github.com",
+            "access_token": "plaintext-token",
+        },
+    )
+    monkeypatch.setattr(
+        gh_cmds,
+        "list_user_owned_repositories",
+        lambda token: [
+            {
+                "full_name": "octocat/widgets",
+                "private": False,
+                "default_branch": "main",
+            }
+        ]
+        if token == "plaintext-token"
+        else [],
+    )
+
+    result = runner.invoke(cli_main.app, ["github", "test", "repos"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "octocat/widgets" in result.stdout
+    assert "public" in result.stdout
+    assert "main" in result.stdout
+
+
+def test_git_test_repos_requires_stored_github_credentials(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+
+    result = runner.invoke(cli_main.app, ["github", "test", "repos"])
+
+    assert result.exit_code == 1
+    assert (
+        "GitHub token not found in system keychain. Run: potpie auth github login"
+        in result.output
+    )


### PR DESCRIPTION
## Summary
- add GitHub CLI authentication via device flow with the same command shape as the source integration branch
- store the GitHub access token in the system keychain while keeping only non-secret metadata in `credentials.json`
- clean up the login UX by suppressing noisy HTTP polling logs and removing the post-login success page redirect

## Test plan
- [x] `cd app/src/context-engine && uv run pytest tests/unit/test_auth_commands.py tests/unit/test_credentials_store.py tests/unit/test_github_cli_auth.py -q`
- [x] `cd app/src/context-engine && uv run ruff check adapters/inbound/cli/auth/ adapters/inbound/cli/credentials_store.py adapters/inbound/cli/main.py tests/unit/test_credentials_store.py tests/unit/test_github_cli_auth.py`
- [x] run `potpie auth github login`
- [x] run `potpie auth github logout`
- [x] run `potpie github test repos`

## Notes
- PR-scoped coverage for the GitHub auth files is 83%


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub OAuth device-flow authentication support with `github login` and `github logout` commands.
  * Login securely stores access tokens in the system keychain and account metadata locally.
  * Added `github test repos` command to list authenticated user's repositories.
  * Includes proper error handling for device-flow states (pending, slow down, expired, denied) and account verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->