### PR TITLE
feat(context-graph): one-shot GitHub PR-history ingestion skill + CLI trigger

### DIFF
--- a/app/src/context-engine/adapters/inbound/cli/main.py
+++ b/app/src/context-engine/adapters/inbound/cli/main.py
@@ -742,7 +742,10 @@ def pot_repo_ingest_cmd(
         "-n",
         min=1,
         max=500,
-        help="Number of recent merged PRs to ingest (default 50, server may cap).",
+        help=(
+            "Number of recent merged PRs and standalone issues to ingest "
+            "(default 50 per kind, server may cap)."
+        ),
     ),
     cwd: str | None = typer.Option(
         None,
@@ -750,14 +753,15 @@ def pot_repo_ingest_cmd(
         help="Git repo directory for pot inference when --pot is omitted.",
     ),
 ) -> None:
-    """Trigger one-shot PR-history ingestion of an attached repo.
+    """Trigger one-shot PR + issue history ingestion of an attached repo.
 
     Submits a single `(github, repository, one_shot_ingest)` event to
     `/api/v2/context/events/reconcile`. The reconciliation agent picks it up
     asynchronously and follows the `repo_one_shot_ingestion` playbook to
-    backfill recent merged PRs into the context graph. Re-running creates a
-    fresh event; idempotency for already-ingested PRs comes from stable
-    Activity entity keys in the playbook, not from event-level dedupe.
+    backfill recent merged PRs and standalone issues into the context graph.
+    Re-running creates a fresh event; idempotency for already-ingested items
+    comes from stable Activity entity keys in the playbook, not from
+    event-level dedupe.
     """
     load_cli_env()
     j, v = _flags()

--- a/app/src/context-engine/adapters/inbound/cli/main.py
+++ b/app/src/context-engine/adapters/inbound/cli/main.py
@@ -725,6 +725,102 @@ def pot_repo_add_cmd(
         )
 
 
+@pot_repo_app.command("ingest")
+def pot_repo_ingest_cmd(
+    owner_repo: str = typer.Argument(
+        ...,
+        help="GitHub repository as owner/repo (must already be attached to the pot).",
+    ),
+    pot_opt: str | None = typer.Option(
+        None,
+        "--pot",
+        help="Pot UUID or alias (default: active pot / git cwd).",
+    ),
+    count: int = typer.Option(
+        50,
+        "--count",
+        "-n",
+        min=1,
+        max=500,
+        help="Number of recent merged PRs to ingest (default 50, server may cap).",
+    ),
+    cwd: str | None = typer.Option(
+        None,
+        "--cwd",
+        help="Git repo directory for pot inference when --pot is omitted.",
+    ),
+) -> None:
+    """Trigger one-shot PR-history ingestion of an attached repo.
+
+    Submits a single `(github, repository, one_shot_ingest)` event to
+    `/api/v2/context/events/reconcile`. The reconciliation agent picks it up
+    asynchronously and follows the `repo_one_shot_ingestion` playbook to
+    backfill recent merged PRs into the context graph. Re-running creates a
+    fresh event; idempotency for already-ingested PRs comes from stable
+    Activity entity keys in the playbook, not from event-level dedupe.
+    """
+    load_cli_env()
+    j, v = _flags()
+    raw = owner_repo.strip()
+    if "/" not in raw:
+        emit_error("Invalid repo", "Use owner/repo (e.g. org/service).", verbose=v)
+        raise typer.Exit(code=1)
+    o, rn = raw.split("/", 1)
+    o, rn = o.strip().lower(), rn.strip().lower()
+    if not o or not rn:
+        emit_error("Invalid repo", "owner and repo name required.", verbose=v)
+        raise typer.Exit(code=1)
+    pid = _pot_id_or_git(pot_opt, cwd=cwd)
+    client = _cli_client_or_exit(v)
+    # Fresh source_id per invocation — Activity entity keys handle dedupe.
+    now = datetime.now(timezone.utc)
+    source_id = f"one_shot_ingest:{o}/{rn}:{int(now.timestamp() * 1000)}"
+    try:
+        status, body = client.submit_event(
+            pot_id=pid,
+            source_system="github",
+            event_type="repository",
+            action="one_shot_ingest",
+            repo_name=f"{o}/{rn}",
+            source_id=source_id,
+            payload={"owner": o, "repo": rn, "count": count},
+            occurred_at=now,
+        )
+    except PotpieContextApiError as exc:
+        emit_error(
+            "Could not start one-shot ingestion",
+            _format_api_error(exc),
+            verbose=v,
+        )
+        raise typer.Exit(code=1) from exc
+    if j:
+        print_json_blob(
+            {
+                "pot_id": pid,
+                "repo": f"{o}/{rn}",
+                "count": count,
+                "status_code": status,
+                "result": body,
+            },
+            as_json=True,
+        )
+    else:
+        event_id = body.get("event_id") or "?"
+        batch_id = body.get("batch_id") or "?"
+        if status == 409:
+            print_plain_line(
+                f"Duplicate event for {o}/{rn} (event_id {event_id}); "
+                f"already queued.",
+                as_json=False,
+            )
+        else:
+            print_plain_line(
+                f"Queued one-shot ingestion of {o}/{rn} on pot {pid} "
+                f"(event_id {event_id}, batch_id {batch_id}, count={count}).",
+                as_json=False,
+            )
+
+
 pot_app.add_typer(pot_repo_app, name="repo")
 
 

--- a/app/src/context-engine/adapters/outbound/connectors/github/api_client.py
+++ b/app/src/context-engine/adapters/outbound/connectors/github/api_client.py
@@ -198,6 +198,9 @@ class PyGithubSourceControl(GitHubReadPort):
     def get_issue(self, repo_name: str, issue_number: int) -> dict[str, Any]:
         repo = self._client.get_repo(repo_name)
         issue = repo.get_issue(issue_number)
+        labels: List[dict[str, Any]] = []
+        for lb in issue.labels or []:
+            labels.append({"name": lb.name})
         return {
             "number": issue.number,
             "title": issue.title,
@@ -207,6 +210,7 @@ class PyGithubSourceControl(GitHubReadPort):
             "updated_at": issue.updated_at.isoformat() if issue.updated_at else None,
             "url": issue.html_url,
             "author": issue.user.login if issue.user else "unknown",
+            "labels": labels,
         }
 
     def iter_closed_pulls(self, repo_name: str) -> Iterator[Any]:
@@ -286,6 +290,9 @@ class PyGithubSourceControl(GitHubReadPort):
             if getattr(issue, "pull_request", None) is not None:
                 continue  # a PR masquerading as an issue
             updated = getattr(issue, "updated_at", None)
+            labels: List[dict[str, Any]] = []
+            for lb in issue.labels or []:
+                labels.append({"name": lb.name})
             out.append(
                 {
                     "number": issue.number,
@@ -297,6 +304,7 @@ class PyGithubSourceControl(GitHubReadPort):
                     "updated_at": updated.isoformat() if updated else None,
                     "url": issue.html_url,
                     "author": issue.user.login if issue.user else None,
+                    "labels": labels,
                     "comments": getattr(issue, "comments", None),
                 }
             )

--- a/app/src/context-engine/adapters/outbound/http/potpie_context_api_client.py
+++ b/app/src/context-engine/adapters/outbound/http/potpie_context_api_client.py
@@ -190,6 +190,61 @@ class PotpieContextApiClient:
         out = r.json()
         return out if isinstance(out, dict) else {}
 
+    def submit_event(
+        self,
+        *,
+        pot_id: str,
+        source_system: str,
+        event_type: str,
+        action: str,
+        repo_name: str,
+        source_id: str,
+        payload: dict[str, Any] | None = None,
+        provider: str = "github",
+        provider_host: str = "github.com",
+        event_id: str | None = None,
+        ingestion_kind: str | None = None,
+        occurred_at: datetime | None = None,
+    ) -> tuple[int, dict[str, Any]]:
+        """POST /api/v2/context/events/reconcile.
+
+        Used by host-side triggers (CLI, scripts) to drop a normalized context
+        event into the ingestion submission pipeline. Returns the raw status +
+        body so callers can branch on 202 (queued) vs 409 (duplicate).
+        """
+        body: dict[str, Any] = {
+            "pot_id": pot_id,
+            "source_system": source_system,
+            "event_type": event_type,
+            "action": action,
+            "repo_name": repo_name,
+            "source_id": source_id,
+            "provider": provider,
+            "provider_host": provider_host,
+            "payload": payload or {},
+        }
+        if event_id is not None:
+            body["event_id"] = event_id
+        if ingestion_kind is not None:
+            body["ingestion_kind"] = ingestion_kind
+        if occurred_at is not None:
+            body["occurred_at"] = occurred_at
+        r = self.post_context("/events/reconcile", json_body=body)
+        if r.status_code in (200, 202):
+            try:
+                return r.status_code, r.json()
+            except json.JSONDecodeError:
+                raise PotpieContextApiError(r.status_code, r.text) from None
+        if r.status_code == 409:
+            try:
+                detail = r.json().get("detail", {})
+            except Exception:
+                detail = {}
+            if isinstance(detail, dict) and detail.get("error") == "duplicate_event":
+                return r.status_code, detail
+        self._raise_for_status(r)
+        return r.status_code, {}
+
     def get_health(self) -> tuple[int, Optional[dict[str, Any]]]:
         """GET /health on the same host as base_url."""
         with httpx.Client(timeout=min(self._timeout, 30.0)) as client:

--- a/app/src/context-engine/domain/event_playbooks.py
+++ b/app/src/context-engine/domain/event_playbooks.py
@@ -200,7 +200,7 @@ _register(
 )
 
 
-# --- github / repository / one_shot_ingest (PR-history backfill skill) -----
+# --- github / repository / one_shot_ingest (PR + issue backfill skill) -----
 # Source of truth lives in ``domain/playbooks/repo_one_shot_ingestion.md`` so
 # Claude Code and the internal reconciliation agent read the exact same prompt.
 # The markdown body is embedded into ``extract`` at module import.
@@ -210,28 +210,34 @@ _register(
         event_type="repository",
         action="one_shot_ingest",
         summary=(
-            "One-time PR-history ingestion of a repository into the context "
-            "graph. Not incremental — live updates continue via the "
-            "github/pull_request/merged webhook path."
+            "One-time backfill of a repository's recent merged pull requests "
+            "and standalone GitHub issues into the context graph. Not "
+            "incremental — live updates continue via the "
+            "github/pull_request/merged and github/issue/opened webhook paths."
         ),
         available_data=(
-            "The full procedure, tool surface, key formats, mutation shapes, "
-            "bounds, and anti-patterns are spelled out in the embedded skill "
-            "below. Follow it as the authoritative playbook for this event."
+            "Payload may include owner, repo, and count (per-kind list "
+            "limit). The embedded skill below is authoritative for procedure, "
+            "tool surface, key formats, and mutation shapes."
         ),
         extract=_load_skill_body("repo_one_shot_ingestion.md"),
         skip=(
-            "Do NOT re-emit github/repository/added from this path. Do NOT "
-            "page past one github_list_pull_requests call. Do NOT read code "
-            "unless commit + branch + title + body all leave intent unclear."
+            "Do NOT re-emit github/repository/added. Do NOT page past one "
+            "list call per kind (one github_list_pull_requests + one "
+            "github_list_issues). Do NOT read code diffs unless commit + "
+            "branch + title + body + review comments all leave intent "
+            "unclear. Do NOT emit Fix nodes from issue filings alone — Fix "
+            "is reserved for merged PRs."
         ),
         tool_hints=(
             "sandbox_list_repos",
             "github_list_pull_requests",
+            "github_list_issues",
             "github_get_pull_request",
             "github_get_pull_request_commits",
             "github_get_pull_request_review_comments",
             "github_get_pull_request_issue_comments",
+            "github_get_issue",
             "apply_graph_mutations",
             "mark_event_processed",
             "finish_batch",

--- a/app/src/context-engine/domain/event_playbooks.py
+++ b/app/src/context-engine/domain/event_playbooks.py
@@ -17,6 +17,32 @@ having to enumerate every action variant:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
+
+_PLAYBOOKS_DIR = Path(__file__).resolve().parent / "playbooks"
+
+
+def _load_skill_body(filename: str) -> str:
+    """Return the markdown body of a skill file under ``domain/playbooks/``.
+
+    Strips the YAML frontmatter (``---`` … ``---``) so the body is ready to
+    drop into a playbook's ``extract`` field, which ``render_playbooks_section``
+    embeds directly into the agent prompt.
+    """
+    path = _PLAYBOOKS_DIR / filename
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return (
+            f"Skill body {filename!r} is unavailable. Stop and report this "
+            "configuration error instead of attempting this playbook."
+        )
+    if not raw.startswith("---\n"):
+        return raw
+    end = raw.find("\n---\n", 4)
+    if end < 0:
+        return raw
+    return raw[end + 5 :].lstrip()
 
 
 @dataclass(frozen=True, slots=True)
@@ -167,6 +193,48 @@ _register(
             "github_get_issue",
             "context_infra_topology",
             "web_fetch",
+        ),
+        max_tool_calls=400,
+        enables_planner=True,
+    )
+)
+
+
+# --- github / repository / one_shot_ingest (PR-history backfill skill) -----
+# Source of truth lives in ``domain/playbooks/repo_one_shot_ingestion.md`` so
+# Claude Code and the internal reconciliation agent read the exact same prompt.
+# The markdown body is embedded into ``extract`` at module import.
+_register(
+    EventPlaybook(
+        source_system="github",
+        event_type="repository",
+        action="one_shot_ingest",
+        summary=(
+            "One-time PR-history ingestion of a repository into the context "
+            "graph. Not incremental — live updates continue via the "
+            "github/pull_request/merged webhook path."
+        ),
+        available_data=(
+            "The full procedure, tool surface, key formats, mutation shapes, "
+            "bounds, and anti-patterns are spelled out in the embedded skill "
+            "below. Follow it as the authoritative playbook for this event."
+        ),
+        extract=_load_skill_body("repo_one_shot_ingestion.md"),
+        skip=(
+            "Do NOT re-emit github/repository/added from this path. Do NOT "
+            "page past one github_list_pull_requests call. Do NOT read code "
+            "unless commit + branch + title + body all leave intent unclear."
+        ),
+        tool_hints=(
+            "sandbox_list_repos",
+            "github_list_pull_requests",
+            "github_get_pull_request",
+            "github_get_pull_request_commits",
+            "github_get_pull_request_review_comments",
+            "github_get_pull_request_issue_comments",
+            "apply_graph_mutations",
+            "mark_event_processed",
+            "finish_batch",
         ),
         max_tool_calls=400,
         enables_planner=True,

--- a/app/src/context-engine/domain/playbooks/repo_one_shot_ingestion.md
+++ b/app/src/context-engine/domain/playbooks/repo_one_shot_ingestion.md
@@ -1,6 +1,6 @@
 ---
 name: repo-one-shot-ingestion
-description: One-time ingestion of a repository's recent merged PR history into the context graph. Not incremental — live updates go through the pull_request.merged webhook path.
+description: One-time ingestion of a repository's recent merged PRs and standalone GitHub issues into the context graph. Not incremental — live updates go through the pull_request.merged and issue.opened webhook paths.
 source_system: github
 event_type: repository
 action: one_shot_ingest
@@ -9,37 +9,52 @@ enables_planner: true
 
 # Repo one-shot ingestion
 
-A reusable skill for ingesting the last N merged PRs of a repository into the
-context graph in a single pass. Designed to be invoked by either Claude Code
-(as a checklist with a compatible write path) or the internal reconciliation
-agent (loaded as a playbook).
+A reusable skill for ingesting a repository's recent **merged pull requests**
+and **standalone GitHub issues** into the context graph in a single pass.
+Sibling to `linear_team_one_shot_ingestion`: same enumerate → batch → hydrate
+shape, GitHub source. Designed to be invoked by either Claude Code (as a
+checklist with a compatible write path) or the internal reconciliation agent
+(loaded as a playbook).
+
+Does **not** replace `repository.added` — no sandbox file-tree walk, no
+module / feature map. Does **not** cover GitHub Discussions (no connector
+tool yet).
 
 ## When to invoke
 
-- A user wants to seed the context graph from a repo's recent PR history in
-  one pass.
+- A user wants to seed the context graph from a repo's recent **PR merge
+  history + issue history** in one pass.
 - The repo is already attached to the target pot (so tool calls are scoped).
 - You will NOT run this skill repeatedly against the same repo — incremental
-  updates flow through the live `github / pull_request / merged` webhook path,
-  which writes the same Activity keys so a future webhook converges with what
-  this skill already wrote.
+  updates flow through the live `github / pull_request / merged` and
+  `github / issue / opened` webhooks, which write the same Activity keys so
+  a future webhook converges with what this skill already wrote.
 
 ## Inputs
 
 - `repo`: `owner/name` (required). Must be attached to the active pot.
-- `count`: total recent PRs to ingest. Default `50`. Hard ceiling: respect
-  whatever the bounded list tool returns — do not page past it.
-- `batch_size`: how many PRs to mark as one todo. Default `10`.
-- `parallel_per_batch` (`K`): how many PRs to hydrate at once within a batch.
-  Default `5`. Drop lower only after a fetched PR proves unusually expensive
-  to hydrate (large body/comment volume or an optional diff fetch).
-- `event_id`: required for the internal reconciliation agent. This is the
-  single `(github, repository, one_shot_ingest)` event id for the run.
+- `count`: soft per-kind list limit. Default `50`. When the host submits this
+  event, read `count` from `event.payload.count`. Pass it as `limit` on
+  **both** `github_list_pull_requests` and `github_list_issues`. The server
+  still clamps to `CONTEXT_ENGINE_BACKFILL_MAX_ITEMS` (default 300) and the
+  trailing window (`CONTEXT_ENGINE_BACKFILL_WINDOW_DAYS`, default 365 days).
+  Hard ceiling: respect whatever each bounded list tool returns — do not
+  page past it.
+- `batch_size`: how many items to mark as one todo. Default `10`.
+- `parallel_per_batch` (`K`): how many items to hydrate at once within a
+  batch. Default `5`. Drop lower only after a fetched item proves unusually
+  expensive to hydrate (large body / comment volume or an optional diff
+  fetch).
+- `event_id`: required for the internal reconciliation agent. The single
+  `(github, repository, one_shot_ingest)` event id for the run.
 
 ## Tools assumed available
 
-- `github_list_pull_requests(repo)` — bounded enumeration (window + cap, newest
-  first). ONE call.
+- `github_list_pull_requests(repo, limit=count)` — bounded PR refs, newest
+  first. **ONE call.** PRs only.
+- `github_list_issues(repo, limit=count)` — bounded issue refs, newest first.
+  **PRs excluded** by the adapter (the list tool already filters PR-shaped
+  rows out). **ONE call.**
 - `github_get_pull_request(repo, pr_number)` — full PR metadata (no diff by
   default). Same tool accepts optional `include_diff=true`; when set, the
   response also includes a `files` array of per-file objects with `filename`,
@@ -47,7 +62,12 @@ agent (loaded as a playbook).
   see Phase 2).
 - `github_get_pull_request_commits(repo, pr_number)` — commit messages.
 - `github_get_pull_request_review_comments(repo, pr_number)` — inline review.
-- `github_get_pull_request_issue_comments(repo, pr_number)` — discussion.
+- `github_get_pull_request_issue_comments(repo, pr_number)` — PR conversation
+  (NOT the same as standalone issue comments — different surface entirely).
+- `github_get_issue(repo, issue_number)` — title, body, state, author,
+  labels, `created_at`, `updated_at`, `url`. There is **no** separate issue
+  comments tool — use body + labels; do not invent discussion you did not
+  fetch.
 - `apply_graph_mutations(plan, event_id, summary)` — context-graph write. The
   `plan` argument MUST be an object with this shape:
   - `summary`: string.
@@ -62,84 +82,120 @@ agent (loaded as a playbook).
   REQUIRED. The todo list rides in the agent's message history and is
   checkpointed; a resumed run continues the existing list instead of
   re-enumerating.
-- `mark_event_processed(event_id, summary)` + `finish_batch(summary)` — completion.
+- `mark_event_processed(event_id, summary)` + `finish_batch(summary)` —
+  completion.
 
 ## Procedure
 
 ### Phase 0 — Setup
 
-1. Confirm the repo is attached (`sandbox_list_repos` if the tool exists). If
-   not, abort with a warning. Do NOT attempt to attach from this skill.
-2. Initialize the todo list with one entry: `Enumerate last <count> PRs of <repo>`.
+1. Confirm the repo is attached (`sandbox_list_repos` if the tool exists).
+   If not, abort with a warning. Do NOT attempt to attach from this skill.
+2. Initialize the todo list with two entries:
+   - `Enumerate last <count> merged PRs of <repo>`
+   - `Enumerate last <count> issues of <repo>`
 
-### Phase 1 — Enumerate (one call)
+### Phase 1 — Enumerate (two list calls, one each)
 
-1. Call `github_list_pull_requests(repo)` ONCE. The tool is bounded server-side
-   to a trailing window + item cap — never page beyond what it returns.
-2. Filter to merged PRs (skip closed-unmerged).
-3. Split the returned refs into batches of `batch_size` (default 10). For each
-   batch, append a todo: `Process PRs [#a, #b, ...]`.
-4. Use `update_todo_status` or `write_todos` to mark the enumeration todo done.
+1. Call `github_list_pull_requests(repo, limit=count)` ONCE. Bounded
+   server-side. Filter to merged PRs (`merged=true` on refs); skip
+   closed-unmerged with a warning.
+2. Call `github_list_issues(repo, limit=count)` ONCE. Standalone issues
+   only (the list tool already excludes PR-shaped rows).
+3. Drain order: **merged PRs first** (completed work timeline), then
+   **issues newest-first** (bugs, feature requests, questions).
+4. Split returned refs into batches of `batch_size`. For each batch, append
+   a todo:
+   - PRs: `Process PRs [#a, #b, ...]`
+   - issues: `Process issues [#a, #b, ...]`
+5. Use `update_todo_status` or `write_todos` to mark each enumeration todo
+   done.
 
 ### Phase 2 — Drain batches
 
-For each batch todo (process them sequentially; within a batch parallelize):
+Drain todos sequentially across kinds (PRs first, then issues); within a
+batch parallelize up to `K`.
 
-1. Choose `K` (`parallel_per_batch`, default 5). If tool results are large or
-   slow, reduce `K` for the remaining PRs in this batch.
-2. In parallel for `K` PRs at a time:
-   a. `github_get_pull_request(repo, n)` — title, body, author, merged_at,
-      `head_branch`, `base_branch`, labels, milestone, and URL. Do NOT assume
-      `head_ref`, `merge_commit_sha`, `changed_files`, or diff-size fields
-      exist in this response.
-   b. Read source signals in PRIORITY ORDER, stopping when intent is clear:
-      1. **Commit messages** (`github_get_pull_request_commits`) — concise,
-         declarative, often conventional-commit prefixed.
-      2. **Branch name** (`head_branch`) — `feat/...`, `fix/...`, `chore/...`
-         carry intent.
-      3. **PR title** — author-stated headline.
-      4. **PR description / body** — author rationale; check for
-         `Why:` / `Fixes #` / `Closes #` / linked issues.
-      5. **Review / issue comments** — only if higher signals are ambiguous.
-      6. **Code diff** — LAST RESORT. If needed, call
-         `github_get_pull_request(repo, n, include_diff=true)` (optional
-         `include_diff` boolean on the same tool as step 2a). The response adds
-         a `files` array; each element is an object with `filename`, `status`,
-         `additions`, `deletions`, and `patch` — use `filename` for path-based
-         reasoning, not a separate path/id field. Reading patches burns budget
-         rediscovering intent the author already wrote.
-   c. Classify the PR:
-      - **Author handle(s)** — primary author + co-authors (from
-        `Co-authored-by:` trailers).
-      - **Kind** — `feat | fix | chore | refactor | docs | test | other` from
-        conventional commit prefix, branch prefix, or title.
-      - **Summary** — 1-2 sentence functional summary (what changed in user-
-        visible terms).
-      - **Bug evidence** — does the PR fix a bug? If yes, capture the symptom
-        signature (from PR body or referenced issue title) and whether a
-        BugPattern key can be derived.
-      - **Decision evidence** — does the PR body explicitly state a design
-        choice with rationale and/or alternatives_rejected? Most PRs do NOT —
-        only emit Decision when the body actually documents the decision.
+#### PR items
 
-3. Build one `LlmReconciliationPlan`-shaped object for the batch (see Mutations
-   section). Call `apply_graph_mutations(plan, event_id, summary)` once per
-   batch.
-4. Use `update_todo_status` or `write_todos` to mark the batch todo done. Move
-   to the next batch.
+For each batch of PR todos, in parallel for `K` PRs at a time:
+
+1. `github_get_pull_request(repo, n)` — title, body, author, merged_at,
+   `head_branch`, `base_branch`, labels, milestone, and URL. Do NOT assume
+   `head_ref`, `merge_commit_sha`, `changed_files`, or diff-size fields
+   exist in this response.
+2. Read source signals in PRIORITY ORDER, stopping when intent is clear:
+   1. **Commit messages** (`github_get_pull_request_commits`) — concise,
+      declarative, often conventional-commit prefixed.
+   2. **Branch name** (`head_branch`) — `feat/...`, `fix/...`, `chore/...`
+      carry intent.
+   3. **PR title** — author-stated headline.
+   4. **PR description / body** — author rationale; check for
+      `Why:` / `Fixes #` / `Closes #` / linked issues.
+   5. **Review / PR comments** — only if higher signals are ambiguous.
+   6. **Code diff** — LAST RESORT. If needed, call
+      `github_get_pull_request(repo, n, include_diff=true)` (optional
+      `include_diff` boolean on the same tool as step 1). The response adds
+      a `files` array; each element is an object with `filename`, `status`,
+      `additions`, `deletions`, and `patch` — use `filename` for path-based
+      reasoning, not a separate path/id field. Reading patches burns budget
+      rediscovering intent the author already wrote.
+3. Classify:
+   - **Author handle(s)** — primary author + co-authors (from
+     `Co-authored-by:` trailers).
+   - **Kind** — `feat | fix | chore | refactor | docs | test | other` from
+     conventional commit prefix, branch prefix, or title.
+   - **Summary** — 1-2 sentence functional summary.
+   - **Bug evidence** — does the PR fix a bug? capture symptom signature;
+     emit Fix + BugPattern only when symptom is clear.
+   - **Decision evidence** — body explicitly documents rationale +
+     alternatives_rejected (most PRs do NOT — be conservative).
+
+#### Issue items
+
+For each batch of issue todos, in parallel for `K` issues at a time:
+
+1. `github_get_issue(repo, n)` — title, body, state, author, labels,
+   `created_at`, `updated_at`, `url`.
+2. Read source signals in PRIORITY ORDER, stopping when intent is clear:
+   1. **Labels** — `bug` / `enhancement` / `documentation` / `question` are
+      the highest-signal kind classifier — author-applied and standardized
+      per repo.
+   2. **State** — `open` vs `closed`. Do NOT treat closed as auto-resolved;
+      closure can mean fixed, won't-fix, or duplicate.
+   3. **Title** — author-stated headline.
+   4. **Body** — rationale, repro steps, `Why:` / linked PRs / linked
+      issues. If body is empty, summarize from title + labels only.
+   5. There is **no** separate issue-comments tool — do not invent
+      discussion you did not fetch.
+3. Classify:
+   - **Reporter** — `author` from `github_get_issue`.
+   - **Kind** — `bug | feat | chore | question | docs | other` from labels
+     first, then title.
+   - **Summary** — 1-2 sentence summary of what was reported or requested.
+   - **Bug report** (open or closed) — capture symptom signature for
+     BugPattern. **Do NOT emit `Fix` from an issue** — Fix is reserved for
+     merged PRs that shipped a fix.
+   - **Decision** — only when the body explicitly documents rationale +
+     alternatives (rare on issues).
+
+Build one `LlmReconciliationPlan`-shaped object for the batch (see Mutations
+section). Call `apply_graph_mutations(plan, event_id, summary)` once per
+batch. Use `update_todo_status` or `write_todos` to mark each batch todo
+done.
 
 ### Phase 3 — Finalize
 
 1. When all todos are drained (or you've hit the tool-call budget with a
    coherent subset complete), tally:
-   - PRs ingested
-   - Distinct authors
-   - Bug fixes (Fix nodes emitted)
-   - Decisions emitted
-   - PRs skipped (and why)
+   - PRs ingested / skipped
+   - Issues ingested by state (open / closed) and by kind
+   - Distinct authors / reporters
+   - Fix nodes emitted (PR-only), BugPattern nodes emitted, Decision
+     nodes emitted
 2. `mark_event_processed(event_id, summary)` then `finish_batch(summary)`.
 
-## Mutations (per PR)
+## Mutations (per item)
 
 Use the existing ontology. Stable keys ensure backfill + future webhook
 converge. Key formats below follow `domain.identity.mint_entity_key` rules
@@ -155,22 +211,25 @@ Identity rules to respect (these are NOT free-form strings):
   (the GitHub login lowercased; usually already slug-clean).
 - `Period` uses the production builder `timeline:period:daily:<pot>:<yyyy-mm-dd>`
   (matches `adapters/outbound/reconciliation/timeline_plan.py::_period_key`).
-- `Activity` is `EXTERNAL_ID` with `key_prefix=activity`. Use
-  `activity:github:pr:<owner>/<repo>:<n>` (segments after `activity:` may
-  contain `/` per `_EXTERNAL_ID_SAFE_RE`). Lowercase the owner/repo segment.
-  Write this key directly as a string in your JSON `entity_key`. If you ever
-  route through `mint_entity_key`, pass the PR number as `external_id` and
-  the path as `extra_segments=("github","pr","<owner>/<repo>")` — do NOT
+- `Activity` is `EXTERNAL_ID` with `key_prefix=activity`. Two distinct forms:
+  - PR: `activity:github:pr:<owner>/<repo>:<n>`
+  - Issue: `activity:github:issue:<owner>/<repo>:<n>`
+  Segments after `activity:` may contain `/` per `_EXTERNAL_ID_SAFE_RE`.
+  Lowercase the owner/repo segment. Write this key directly as a string in
+  your JSON `entity_key`. If you ever route through `mint_entity_key`, pass
+  the issue/PR number as `external_id` and the path as
+  `extra_segments=("github","pr","<owner>/<repo>")` (or `"issue"`) — do NOT
   pass the full colon-joined string as a single `external_id`, because
   `_normalize_external_id` strips colons and the key collapses to
   `activity:github-pr-<owner>-<repo>-<n>`.
 - `Fix` and `Decision` are `CONTENT_HASH`. The body must be a 12-hex
-  fingerprint of canonical content — NEVER encode the PR number into the key.
-  Use `fix:<12-hex-sha256>` and `decision:<12-hex-sha256>` (mint via
-  `mint_entity_key(spec, content=<stable-string>)` or hash inline).
+  fingerprint of canonical content — NEVER encode the PR / issue number into
+  the key. Use `fix:<12-hex-sha256>` and `decision:<12-hex-sha256>` (mint
+  via `mint_entity_key(spec, content=<stable-string>)` or hash inline).
 - `BugPattern` is `SLUG_ALIAS` with `key_prefix=bug_pattern`. Use
-  `bug_pattern:<repo-slug>:<symptom-slug>` (e.g. `bug_pattern:acme-api:db-timeout`)
-  — each colon-separated segment must be a valid slug.
+  `bug_pattern:<repo-slug>:<symptom-slug>` (e.g.
+  `bug_pattern:acme-api:db-timeout`) — each colon-separated segment must be
+  a valid slug.
 
 ### Always emit (endpoint entities, at least once per batch)
 
@@ -181,42 +240,38 @@ Identity rules to respect (these are NOT free-form strings):
   - labels: `["Entity", "Repository"]`.
   - properties: `name="<owner>/<repo>"`, `provider="github"`,
     `provider_host="github.com"`, `owner=<owner>`, `repo=<repo>`.
-- **Entity** `Period` — one per distinct PR-merge date in the batch.
-  - key: `timeline:period:daily:<pot>:<yyyy-mm-dd>` (pot id is available from
-    the agent's run state / event scope).
+- **Entity** `Period` — one per distinct activity date in the batch.
+  - key: `timeline:period:daily:<pot>:<yyyy-mm-dd>`.
   - labels: `["Entity", "Period"]`.
   - properties: `period_kind="daily"`, `date="<yyyy-mm-dd>"`.
 
-### Always emit per PR
+### Per merged PR — always emit
 
 - **Entity** `Activity`
   - key: `activity:github:pr:<owner>/<repo>:<n>` (owner/repo lowercased).
   - labels: `["Entity", "Activity"]`.
   - properties: `occurred_at=<merged_at>`, `verb_class="pr_merged"`,
-    `title=<pr_title>`, `summary=<your 1-2 sentence functional summary>`,
-    `head_branch`, `base_branch`, `kind` (one of feat/fix/chore/refactor/
-    docs/test/other), `pr_url`.
+    `title=<pr_title>`, `summary=<your 1-2 sentence summary>`,
+    `head_branch`, `base_branch`, `kind` (feat/fix/...), `pr_url`.
 - **Entity** `Person` — one per author / co-author.
   - key: `person:<handle-lowercased>`.
   - labels: `["Entity", "Person"]`.
-  - properties: `name=<handle>`, `handle=<handle>`.
 - **Edge** `PERFORMED` — `person:<primary_author>` → activity key.
 - **Edge** `AUTHORED` — `person:<co_author>` → activity key, per co-author.
 - **Edge** `TOUCHED` — activity key → repository key.
 - **Edge** `IN_PERIOD` — activity key → period key.
 
-### Conditionally emit (only when evidenced)
+### Per merged PR — conditionally emit
 
 - **Bug fix** (kind=`fix` AND PR body / linked issue has a clear symptom):
   - **Entity** `BugPattern`
-    - key: `bug_pattern:<repo-slug>:<symptom-slug>` (segments must be slugs).
+    - key: `bug_pattern:<repo-slug>:<symptom-slug>` (segments slug-valid).
     - labels: `["Entity", "BugPattern"]`.
     - properties: `symptom_signature=<short canonical sentence>`,
       `name=<symptom title>`.
   - **Entity** `Fix`
     - key: `fix:<12-hex-sha256>` minted from a stable canonical string such
-      as `"github:pr:<owner>/<repo>:<n>|fix|<symptom-signature>"`. Do NOT
-      put PR identifiers in the key body — they go in `properties`.
+      as `"github:pr:<owner>/<repo>:<n>|fix|<symptom-signature>"`.
     - labels: `["Entity", "Fix"]`.
     - properties: `fix_steps=<short description>`,
       `verification_status="unverified"`, `source_pr=<activity_key>`.
@@ -224,65 +279,121 @@ Identity rules to respect (these are NOT free-form strings):
   - **Edge** `REPRODUCES` — bug_pattern key → repository key.
 - **Design decision** (PR body explicitly documents rationale + alternatives):
   - **Entity** `Decision`
-    - key: `decision:<12-hex-sha256>` minted from a stable canonical string
-      such as `"github:pr:<owner>/<repo>:<n>|decision|<title>"`.
+    - key: `decision:<12-hex-sha256>` from
+      `"github:pr:<owner>/<repo>:<n>|decision|<title>"`.
     - labels: `["Entity", "Decision"]`.
     - properties: `name=<short title>`, `rationale=<stated rationale>`,
       `alternatives_rejected=<list or string>`, `source_pr=<activity_key>`.
-  - **Edge** `DECIDED` — decision key → repository key (or a Service key if
-    the PR clearly touches a single known Service).
+  - **Edge** `DECIDED` — decision key → repository key.
   - **Edge** `AFFECTS` — decision key → repository key.
 
 Touched services (optional, only if obvious): if an optional
 `github_get_pull_request(repo, n, include_diff=true)` fetch returns `files`,
-inspect each entry's `filename` (repo-relative path). When those paths clearly
-map to an existing `Service` entity (e.g. every changed `filename` under
-`services/auth/`), emit an extra `TOUCHED` edge activity → that service. Do
-NOT invent Services that don't already exist in the graph.
+inspect each entry's `filename` (repo-relative path). When those paths
+clearly map to an existing `Service` entity (e.g. every changed `filename`
+under `services/auth/`), emit an extra `TOUCHED` edge activity → that
+service. Do NOT invent Services that don't already exist in the graph.
+
+### Per issue — always emit
+
+- **Entity** `Activity`
+  - key: `activity:github:issue:<owner>/<repo>:<n>` (owner/repo lowercased).
+  - labels: `["Entity", "Activity"]`.
+  - properties: `occurred_at=<created_at>`,
+    `verb_class="github_issue_<state>"` where `<state>` is `open` or
+    `closed` — these are property VALUES, not tool names; `title`,
+    `summary=<your 1-2 sentence summary>`, `state`, `kind`
+    (bug/feat/chore/question/...), `issue_url`.
+- **Entity** `Person` — the reporter (issue author).
+  - key: `person:<handle-lowercased>`.
+  - labels: `["Entity", "Person"]`.
+- **Edge** `PERFORMED` — `person:<reporter>` → activity key.
+- **Edge** `TOUCHED` — activity key → repository key.
+- **Edge** `IN_PERIOD` — activity key → period key.
+
+### Per issue — conditionally emit
+
+- **Bug report** (labels include `bug` AND body or title carries a clear
+  symptom):
+  - **Entity** `BugPattern`
+    - key: `bug_pattern:<repo-slug>:<symptom-slug>`.
+    - labels: `["Entity", "BugPattern"]`.
+    - properties: `symptom_signature=<short canonical sentence>`,
+      `name=<symptom title>`, `source_issue=<activity_key>`.
+  - **Edge** `REPRODUCES` — bug_pattern key → repository key.
+  - **Do NOT emit `Fix`** — Fix is reserved for merged PRs that shipped a
+    fix. Closing an issue is not evidence that a fix exists.
+- **Design decision** (issue body explicitly documents rationale +
+  alternatives — rare on issues, common on spec / RFC issues):
+  - **Entity** `Decision`
+    - key: `decision:<12-hex-sha256>` from
+      `"github:issue:<owner>/<repo>:<n>|decision|<title>"`.
+    - labels: `["Entity", "Decision"]`.
+    - properties: `name=<short title>`, `rationale=<stated rationale>`,
+      `alternatives_rejected=<list or string>`,
+      `source_issue=<activity_key>`.
+  - **Edge** `DECIDED` — decision key → repository key.
+  - **Edge** `AFFECTS` — decision key → repository key.
+
+When a PR you ingested references `Fixes #n` or `Closes #n` in its body,
+prefer recording the linkage in the PR Activity's `properties` (e.g. a
+`closes_issues` list) or the plan's `evidence` array, rather than
+duplicating an issue Activity inside the PR pass — the issue pass will emit
+its own Activity with the stable `activity:github:issue:...` key, and the
+two converge on the entity_keys.
 
 ## Source-priority rationale (why)
 
-Commit messages and branch names are concise, structured, and produced by the
-author at intent-time. PR title and description are author-stated rationale.
-Code diffs are voluminous and require inference. Reading code burns budget on
-rediscovering intent that the author already wrote in 1-2 lines elsewhere.
-Stop climbing the priority ladder as soon as you can answer kind + summary +
-bug/decision evidence.
+Commit messages, branch names, and GitHub issue labels are author-applied at
+intent time. PR / issue titles are author-stated headlines. Bodies carry
+stated rationale. Review threads / linked discussion are context, not
+standalone facts. Code diffs and full comment threads are voluminous and
+require inference. Reading code burns budget on rediscovering intent the
+author already encoded in 1-2 lines elsewhere. Stop climbing the priority
+ladder as soon as you can answer kind + summary + bug/decision evidence.
 
 ## Bounds and budget
 
-- ONE `github_list_pull_requests` call. No pagination.
-- Soft tool-call cap: `30 + 5 * count`. Plan accordingly.
-- If you approach the cap with a coherent recent subset of PRs ingested
-  cleanly, FINISH — do not partially ingest a PR. The tail can be re-run later
-  by invoking this skill with a smaller `count` (but stable keys mean already-
-  ingested PRs will be deduplicated, not duplicated).
+- **Two** bounded list calls only — one `github_list_pull_requests` and one
+  `github_list_issues`. No pagination beyond what the bounded tools return.
+- Soft tool-call cap: `40 + 8 × count` (two kinds, each item averages
+  ~4 calls when comments / diff are unused). Plan accordingly.
+- If you approach the cap with a coherent recent subset of items ingested
+  cleanly, FINISH — do not partially ingest an item. The tail can be re-run
+  later with a smaller `count` (stable keys mean already-ingested items will
+  be deduplicated, not duplicated).
 
 ## Anti-patterns
 
 - Do NOT re-emit `repository.added` from this skill — that re-triggers the
-  agent's full bootstrap.
+  agent's full sandbox bootstrap.
 - Do NOT walk the file tree or read source files unless commit + branch +
   title + body + comments all leave intent unclear.
-- Do NOT page past the bounded list call.
+- Do NOT page past the bounded list calls.
+- Do NOT ingest the same PR number twice — the issues list tool already
+  excludes PR-shaped rows; trust it.
+- Do NOT emit `Fix` for an issue filing. Fix is for merged PRs only.
+- Do NOT auto-close any existing Incident or open issue / BugPattern based
+  on a PR merge or issue closure alone — that is evidence, not closure.
 - Do NOT invent BugPatterns, Decisions, Services, or Persons not actually
-  evidenced in the PR data you read. Emit a warning record instead.
-- Do NOT auto-close / auto-resolve any existing Incident or open issue based
-  on a PR merge alone — the PR is evidence, not closure.
-- Do NOT run this skill on a repo that already has live webhook ingestion
-  going against the SAME date window — let the webhook handle live updates.
+  evidenced in the data you read. Emit a warning record instead.
+- Do NOT ingest GitHub Discussions — unsupported (no connector tool).
+- Do NOT invent issue comments — there is no separate issue-comments tool;
+  if you need discussion context for an issue, the body + labels are all
+  you get.
 
 ## Single-event contract
 
 This skill, when invoked by the internal agent, runs as a single
 `(github, repository, one_shot_ingest)` event. Pass that ONE `event_id` to
 every `apply_graph_mutations` call and to the final `mark_event_processed` —
-per-PR identity is the entity_key (`activity:github:pr:...`), not the event id,
-so multiple Activities under one event id is correct.
+per-artifact identity is the entity_key (`activity:github:pr:...` /
+`activity:github:issue:...`), not the event id, so multiple Activities under
+one event id is correct.
 
 When invoked by Claude Code outside the event pipeline, there is no
 internal-agent event state, so the internal `apply_graph_mutations` tool will
 reject an empty or invented event id. Use this document as the extraction
-procedure only when the host provides a compatible context-graph write path and
-a valid event/provenance id. Otherwise stop after producing the proposed plan;
-do not pretend to apply it.
+procedure only when the host provides a compatible context-graph write path
+and a valid event/provenance id. Otherwise stop after producing the proposed
+plan; do not pretend to apply it.

--- a/app/src/context-engine/domain/playbooks/repo_one_shot_ingestion.md
+++ b/app/src/context-engine/domain/playbooks/repo_one_shot_ingestion.md
@@ -40,7 +40,11 @@ agent (loaded as a playbook).
 
 - `github_list_pull_requests(repo)` — bounded enumeration (window + cap, newest
   first). ONE call.
-- `github_get_pull_request(repo, pr_number)` — full PR metadata.
+- `github_get_pull_request(repo, pr_number)` — full PR metadata (no diff by
+  default). Same tool accepts optional `include_diff=true`; when set, the
+  response also includes a `files` array of per-file objects with `filename`,
+  `status`, `additions`, `deletions`, and `patch` (use only as a last resort;
+  see Phase 2).
 - `github_get_pull_request_commits(repo, pr_number)` — commit messages.
 - `github_get_pull_request_review_comments(repo, pr_number)` — inline review.
 - `github_get_pull_request_issue_comments(repo, pr_number)` — discussion.
@@ -98,9 +102,12 @@ For each batch todo (process them sequentially; within a batch parallelize):
          `Why:` / `Fixes #` / `Closes #` / linked issues.
       5. **Review / issue comments** — only if higher signals are ambiguous.
       6. **Code diff** — LAST RESORT. If needed, call
-         `github_get_pull_request(repo, n, include_diff=true)` and inspect the
-         returned `files` list. Reading code burns budget rediscovering intent
-         the author already wrote.
+         `github_get_pull_request(repo, n, include_diff=true)` (optional
+         `include_diff` boolean on the same tool as step 2a). The response adds
+         a `files` array; each element is an object with `filename`, `status`,
+         `additions`, `deletions`, and `patch` — use `filename` for path-based
+         reasoning, not a separate path/id field. Reading patches burns budget
+         rediscovering intent the author already wrote.
    c. Classify the PR:
       - **Author handle(s)** — primary author + co-authors (from
         `Co-authored-by:` trailers).
@@ -226,10 +233,12 @@ Identity rules to respect (these are NOT free-form strings):
     the PR clearly touches a single known Service).
   - **Edge** `AFFECTS` — decision key → repository key.
 
-Touched services (optional, only if obvious): if an optional `include_diff=true`
-fetch returns `files` whose paths clearly map to an existing `Service` entity
-(e.g. all changes in `services/auth/`), emit an extra `TOUCHED` edge activity
-→ that service. Do NOT invent Services that don't already exist in the graph.
+Touched services (optional, only if obvious): if an optional
+`github_get_pull_request(repo, n, include_diff=true)` fetch returns `files`,
+inspect each entry's `filename` (repo-relative path). When those paths clearly
+map to an existing `Service` entity (e.g. every changed `filename` under
+`services/auth/`), emit an extra `TOUCHED` edge activity → that service. Do
+NOT invent Services that don't already exist in the graph.
 
 ## Source-priority rationale (why)
 

--- a/app/src/context-engine/domain/playbooks/repo_one_shot_ingestion.md
+++ b/app/src/context-engine/domain/playbooks/repo_one_shot_ingestion.md
@@ -1,0 +1,279 @@
+---
+name: repo-one-shot-ingestion
+description: One-time ingestion of a repository's recent merged PR history into the context graph. Not incremental — live updates go through the pull_request.merged webhook path.
+source_system: github
+event_type: repository
+action: one_shot_ingest
+enables_planner: true
+---
+
+# Repo one-shot ingestion
+
+A reusable skill for ingesting the last N merged PRs of a repository into the
+context graph in a single pass. Designed to be invoked by either Claude Code
+(as a checklist with a compatible write path) or the internal reconciliation
+agent (loaded as a playbook).
+
+## When to invoke
+
+- A user wants to seed the context graph from a repo's recent PR history in
+  one pass.
+- The repo is already attached to the target pot (so tool calls are scoped).
+- You will NOT run this skill repeatedly against the same repo — incremental
+  updates flow through the live `github / pull_request / merged` webhook path,
+  which writes the same Activity keys so a future webhook converges with what
+  this skill already wrote.
+
+## Inputs
+
+- `repo`: `owner/name` (required). Must be attached to the active pot.
+- `count`: total recent PRs to ingest. Default `50`. Hard ceiling: respect
+  whatever the bounded list tool returns — do not page past it.
+- `batch_size`: how many PRs to mark as one todo. Default `10`.
+- `parallel_per_batch` (`K`): how many PRs to hydrate at once within a batch.
+  Default `5`. Drop lower only after a fetched PR proves unusually expensive
+  to hydrate (large body/comment volume or an optional diff fetch).
+- `event_id`: required for the internal reconciliation agent. This is the
+  single `(github, repository, one_shot_ingest)` event id for the run.
+
+## Tools assumed available
+
+- `github_list_pull_requests(repo)` — bounded enumeration (window + cap, newest
+  first). ONE call.
+- `github_get_pull_request(repo, pr_number)` — full PR metadata.
+- `github_get_pull_request_commits(repo, pr_number)` — commit messages.
+- `github_get_pull_request_review_comments(repo, pr_number)` — inline review.
+- `github_get_pull_request_issue_comments(repo, pr_number)` — discussion.
+- `apply_graph_mutations(plan, event_id, summary)` — context-graph write. The
+  `plan` argument MUST be an object with this shape:
+  - `summary`: string.
+  - `entity_upserts`: list of `{entity_key, labels, properties}`.
+  - `edge_upserts`: list of `{edge_type, from_entity_key, to_entity_key, properties}`.
+  - `edge_deletes`: usually `[]`.
+  - `invalidations`: usually `[]`.
+  - `evidence`: list of `{kind, ref, metadata}`.
+  - `confidence`: optional number.
+  - `warnings`: list of strings.
+- Planner / todo tools (`read_todos`, `write_todos`, `update_todo_status`) —
+  REQUIRED. The todo list rides in the agent's message history and is
+  checkpointed; a resumed run continues the existing list instead of
+  re-enumerating.
+- `mark_event_processed(event_id, summary)` + `finish_batch(summary)` — completion.
+
+## Procedure
+
+### Phase 0 — Setup
+
+1. Confirm the repo is attached (`sandbox_list_repos` if the tool exists). If
+   not, abort with a warning. Do NOT attempt to attach from this skill.
+2. Initialize the todo list with one entry: `Enumerate last <count> PRs of <repo>`.
+
+### Phase 1 — Enumerate (one call)
+
+1. Call `github_list_pull_requests(repo)` ONCE. The tool is bounded server-side
+   to a trailing window + item cap — never page beyond what it returns.
+2. Filter to merged PRs (skip closed-unmerged).
+3. Split the returned refs into batches of `batch_size` (default 10). For each
+   batch, append a todo: `Process PRs [#a, #b, ...]`.
+4. Use `update_todo_status` or `write_todos` to mark the enumeration todo done.
+
+### Phase 2 — Drain batches
+
+For each batch todo (process them sequentially; within a batch parallelize):
+
+1. Choose `K` (`parallel_per_batch`, default 5). If tool results are large or
+   slow, reduce `K` for the remaining PRs in this batch.
+2. In parallel for `K` PRs at a time:
+   a. `github_get_pull_request(repo, n)` — title, body, author, merged_at,
+      `head_branch`, `base_branch`, labels, milestone, and URL. Do NOT assume
+      `head_ref`, `merge_commit_sha`, `changed_files`, or diff-size fields
+      exist in this response.
+   b. Read source signals in PRIORITY ORDER, stopping when intent is clear:
+      1. **Commit messages** (`github_get_pull_request_commits`) — concise,
+         declarative, often conventional-commit prefixed.
+      2. **Branch name** (`head_branch`) — `feat/...`, `fix/...`, `chore/...`
+         carry intent.
+      3. **PR title** — author-stated headline.
+      4. **PR description / body** — author rationale; check for
+         `Why:` / `Fixes #` / `Closes #` / linked issues.
+      5. **Review / issue comments** — only if higher signals are ambiguous.
+      6. **Code diff** — LAST RESORT. If needed, call
+         `github_get_pull_request(repo, n, include_diff=true)` and inspect the
+         returned `files` list. Reading code burns budget rediscovering intent
+         the author already wrote.
+   c. Classify the PR:
+      - **Author handle(s)** — primary author + co-authors (from
+        `Co-authored-by:` trailers).
+      - **Kind** — `feat | fix | chore | refactor | docs | test | other` from
+        conventional commit prefix, branch prefix, or title.
+      - **Summary** — 1-2 sentence functional summary (what changed in user-
+        visible terms).
+      - **Bug evidence** — does the PR fix a bug? If yes, capture the symptom
+        signature (from PR body or referenced issue title) and whether a
+        BugPattern key can be derived.
+      - **Decision evidence** — does the PR body explicitly state a design
+        choice with rationale and/or alternatives_rejected? Most PRs do NOT —
+        only emit Decision when the body actually documents the decision.
+
+3. Build one `LlmReconciliationPlan`-shaped object for the batch (see Mutations
+   section). Call `apply_graph_mutations(plan, event_id, summary)` once per
+   batch.
+4. Use `update_todo_status` or `write_todos` to mark the batch todo done. Move
+   to the next batch.
+
+### Phase 3 — Finalize
+
+1. When all todos are drained (or you've hit the tool-call budget with a
+   coherent subset complete), tally:
+   - PRs ingested
+   - Distinct authors
+   - Bug fixes (Fix nodes emitted)
+   - Decisions emitted
+   - PRs skipped (and why)
+2. `mark_event_processed(event_id, summary)` then `finish_batch(summary)`.
+
+## Mutations (per PR)
+
+Use the existing ontology. Stable keys ensure backfill + future webhook
+converge. Key formats below follow `domain.identity.mint_entity_key` rules
+(see `domain.ontology.ENTITY_TYPES`).
+
+Identity rules to respect (these are NOT free-form strings):
+
+- `Repository` is `SLUG_ALIAS` with `key_prefix=repo`. The body must be a
+  lowercase slug — letters/digits/hyphens only — NO dots, NO slashes. So
+  `repo:github.com/acme/api` is INVALID. Use `repo:<owner>-<repo>` (slugified,
+  matches what `_repo_key` in scanners produces, e.g. `repo:acme-api`).
+- `Person` is `SLUG_ALIAS` with `key_prefix=person`. Use `person:<handle>`
+  (the GitHub login lowercased; usually already slug-clean).
+- `Period` uses the production builder `timeline:period:daily:<pot>:<yyyy-mm-dd>`
+  (matches `adapters/outbound/reconciliation/timeline_plan.py::_period_key`).
+- `Activity` is `EXTERNAL_ID` with `key_prefix=activity`. Use
+  `activity:github:pr:<owner>/<repo>:<n>` (segments after `activity:` may
+  contain `/` per `_EXTERNAL_ID_SAFE_RE`). Lowercase the owner/repo segment.
+  Write this key directly as a string in your JSON `entity_key`. If you ever
+  route through `mint_entity_key`, pass the PR number as `external_id` and
+  the path as `extra_segments=("github","pr","<owner>/<repo>")` — do NOT
+  pass the full colon-joined string as a single `external_id`, because
+  `_normalize_external_id` strips colons and the key collapses to
+  `activity:github-pr-<owner>-<repo>-<n>`.
+- `Fix` and `Decision` are `CONTENT_HASH`. The body must be a 12-hex
+  fingerprint of canonical content — NEVER encode the PR number into the key.
+  Use `fix:<12-hex-sha256>` and `decision:<12-hex-sha256>` (mint via
+  `mint_entity_key(spec, content=<stable-string>)` or hash inline).
+- `BugPattern` is `SLUG_ALIAS` with `key_prefix=bug_pattern`. Use
+  `bug_pattern:<repo-slug>:<symptom-slug>` (e.g. `bug_pattern:acme-api:db-timeout`)
+  — each colon-separated segment must be a valid slug.
+
+### Always emit (endpoint entities, at least once per batch)
+
+- **Entity** `Repository`
+  - key: `repo:<owner>-<repo>` (slugified). Prefer reusing the existing
+    Repository entity_key already in the graph if the read path lets you
+    look it up by `name=<owner>/<repo>`.
+  - labels: `["Entity", "Repository"]`.
+  - properties: `name="<owner>/<repo>"`, `provider="github"`,
+    `provider_host="github.com"`, `owner=<owner>`, `repo=<repo>`.
+- **Entity** `Period` — one per distinct PR-merge date in the batch.
+  - key: `timeline:period:daily:<pot>:<yyyy-mm-dd>` (pot id is available from
+    the agent's run state / event scope).
+  - labels: `["Entity", "Period"]`.
+  - properties: `period_kind="daily"`, `date="<yyyy-mm-dd>"`.
+
+### Always emit per PR
+
+- **Entity** `Activity`
+  - key: `activity:github:pr:<owner>/<repo>:<n>` (owner/repo lowercased).
+  - labels: `["Entity", "Activity"]`.
+  - properties: `occurred_at=<merged_at>`, `verb_class="pr_merged"`,
+    `title=<pr_title>`, `summary=<your 1-2 sentence functional summary>`,
+    `head_branch`, `base_branch`, `kind` (one of feat/fix/chore/refactor/
+    docs/test/other), `pr_url`.
+- **Entity** `Person` — one per author / co-author.
+  - key: `person:<handle-lowercased>`.
+  - labels: `["Entity", "Person"]`.
+  - properties: `name=<handle>`, `handle=<handle>`.
+- **Edge** `PERFORMED` — `person:<primary_author>` → activity key.
+- **Edge** `AUTHORED` — `person:<co_author>` → activity key, per co-author.
+- **Edge** `TOUCHED` — activity key → repository key.
+- **Edge** `IN_PERIOD` — activity key → period key.
+
+### Conditionally emit (only when evidenced)
+
+- **Bug fix** (kind=`fix` AND PR body / linked issue has a clear symptom):
+  - **Entity** `BugPattern`
+    - key: `bug_pattern:<repo-slug>:<symptom-slug>` (segments must be slugs).
+    - labels: `["Entity", "BugPattern"]`.
+    - properties: `symptom_signature=<short canonical sentence>`,
+      `name=<symptom title>`.
+  - **Entity** `Fix`
+    - key: `fix:<12-hex-sha256>` minted from a stable canonical string such
+      as `"github:pr:<owner>/<repo>:<n>|fix|<symptom-signature>"`. Do NOT
+      put PR identifiers in the key body — they go in `properties`.
+    - labels: `["Entity", "Fix"]`.
+    - properties: `fix_steps=<short description>`,
+      `verification_status="unverified"`, `source_pr=<activity_key>`.
+  - **Edge** `RESOLVED` — fix key → bug_pattern key.
+  - **Edge** `REPRODUCES` — bug_pattern key → repository key.
+- **Design decision** (PR body explicitly documents rationale + alternatives):
+  - **Entity** `Decision`
+    - key: `decision:<12-hex-sha256>` minted from a stable canonical string
+      such as `"github:pr:<owner>/<repo>:<n>|decision|<title>"`.
+    - labels: `["Entity", "Decision"]`.
+    - properties: `name=<short title>`, `rationale=<stated rationale>`,
+      `alternatives_rejected=<list or string>`, `source_pr=<activity_key>`.
+  - **Edge** `DECIDED` — decision key → repository key (or a Service key if
+    the PR clearly touches a single known Service).
+  - **Edge** `AFFECTS` — decision key → repository key.
+
+Touched services (optional, only if obvious): if an optional `include_diff=true`
+fetch returns `files` whose paths clearly map to an existing `Service` entity
+(e.g. all changes in `services/auth/`), emit an extra `TOUCHED` edge activity
+→ that service. Do NOT invent Services that don't already exist in the graph.
+
+## Source-priority rationale (why)
+
+Commit messages and branch names are concise, structured, and produced by the
+author at intent-time. PR title and description are author-stated rationale.
+Code diffs are voluminous and require inference. Reading code burns budget on
+rediscovering intent that the author already wrote in 1-2 lines elsewhere.
+Stop climbing the priority ladder as soon as you can answer kind + summary +
+bug/decision evidence.
+
+## Bounds and budget
+
+- ONE `github_list_pull_requests` call. No pagination.
+- Soft tool-call cap: `30 + 5 * count`. Plan accordingly.
+- If you approach the cap with a coherent recent subset of PRs ingested
+  cleanly, FINISH — do not partially ingest a PR. The tail can be re-run later
+  by invoking this skill with a smaller `count` (but stable keys mean already-
+  ingested PRs will be deduplicated, not duplicated).
+
+## Anti-patterns
+
+- Do NOT re-emit `repository.added` from this skill — that re-triggers the
+  agent's full bootstrap.
+- Do NOT walk the file tree or read source files unless commit + branch +
+  title + body + comments all leave intent unclear.
+- Do NOT page past the bounded list call.
+- Do NOT invent BugPatterns, Decisions, Services, or Persons not actually
+  evidenced in the PR data you read. Emit a warning record instead.
+- Do NOT auto-close / auto-resolve any existing Incident or open issue based
+  on a PR merge alone — the PR is evidence, not closure.
+- Do NOT run this skill on a repo that already has live webhook ingestion
+  going against the SAME date window — let the webhook handle live updates.
+
+## Single-event contract
+
+This skill, when invoked by the internal agent, runs as a single
+`(github, repository, one_shot_ingest)` event. Pass that ONE `event_id` to
+every `apply_graph_mutations` call and to the final `mark_event_processed` —
+per-PR identity is the entity_key (`activity:github:pr:...`), not the event id,
+so multiple Activities under one event id is correct.
+
+When invoked by Claude Code outside the event pipeline, there is no
+internal-agent event state, so the internal `apply_graph_mutations` tool will
+reject an empty or invented event id. Use this document as the extraction
+procedure only when the host provides a compatible context-graph write path and
+a valid event/provenance id. Otherwise stop after producing the proposed plan;
+do not pretend to apply it.

--- a/app/src/context-engine/pyproject.toml
+++ b/app/src/context-engine/pyproject.toml
@@ -73,6 +73,7 @@ potpie-mcp = "adapters.inbound.mcp.server:main"
 [tool.hatch.build.targets.wheel]
 packages = ["domain", "application", "adapters", "bootstrap", "benchmarks"]
 include = [
+    "domain/playbooks/**/*.md",
     "adapters/inbound/cli/templates/**/*.md",
     "adapters/inbound/cli/templates/**/*.yaml",
     "scripts/**/*.py",
@@ -89,6 +90,7 @@ include = [
     "adapters",
     "bootstrap",
     "benchmarks",
+    "domain/playbooks/**/*.md",
     "adapters/inbound/cli/templates/**/*.md",
     "adapters/inbound/cli/templates/**/*.yaml",
     "scripts/**/*.py",

--- a/app/src/context-engine/tests/unit/test_backfill_seed.py
+++ b/app/src/context-engine/tests/unit/test_backfill_seed.py
@@ -109,16 +109,29 @@ class _FakePull:
         self.user = _FakeUser("octocat")
 
 
+class _FakeLabel:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
 class _FakeIssue:
-    def __init__(self, number: int, updated: datetime, is_pr: bool = False) -> None:
+    def __init__(
+        self,
+        number: int,
+        updated: datetime,
+        is_pr: bool = False,
+        labels: list[str] | None = None,
+    ) -> None:
         self.number = number
         self.title = f"Issue {number}"
+        self.body = f"Body {number}"
         self.state = "open"
         self.created_at = updated
         self.updated_at = updated
         self.html_url = f"https://x/i/{number}"
         self.user = _FakeUser("octocat")
         self.comments = 0
+        self.labels = [_FakeLabel(name) for name in (labels or [])]
         # PyGithub sets .pull_request on issues that are actually PRs.
         self.pull_request = object() if is_pr else None
 
@@ -133,6 +146,12 @@ class _FakeRepo:
 
     def get_issues(self, **_kw):
         return list(self._issues)
+
+    def get_issue(self, issue_number: int):
+        for issue in self._issues:
+            if issue.number == issue_number:
+                return issue
+        raise KeyError(issue_number)
 
 
 class _FakeGithub:
@@ -190,6 +209,19 @@ def test_list_issues_excludes_pull_requests(
     ]
     out = _client(issues=issues).list_issues("o/r")
     assert [i["number"] for i in out] == [1, 3]
+
+
+def test_issue_reads_include_labels(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CONTEXT_ENGINE_BACKFILL_WINDOW_DAYS", "0")
+    monkeypatch.setenv("CONTEXT_ENGINE_BACKFILL_MAX_ITEMS", "100")
+    now = datetime.now(timezone.utc)
+    client = _client(issues=[_FakeIssue(1, now, labels=["bug", "question"])])
+
+    listed = client.list_issues("o/r")
+    hydrated = client.get_issue("o/r", 1)
+
+    assert listed[0]["labels"] == [{"name": "bug"}, {"name": "question"}]
+    assert hydrated["labels"] == [{"name": "bug"}, {"name": "question"}]
 
 
 def test_list_handles_naive_datetimes(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/app/src/context-engine/tests/unit/test_pot_repo_ingest_cli.py
+++ b/app/src/context-engine/tests/unit/test_pot_repo_ingest_cli.py
@@ -1,0 +1,292 @@
+"""Contract tests for the `potpie pot repo ingest` CLI + its API client method.
+
+This wires the one-shot ingestion skill to a host trigger. Two surfaces under
+test:
+
+1. ``PotpieContextApiClient.submit_event`` — POSTs a normalized event to
+   ``/api/v2/context/events/reconcile``. Pins URL, body shape, and status
+   code branching (202 queued / 409 duplicate).
+2. ``potpie pot repo ingest`` (Typer command) — argument parsing, owner/repo
+   normalization, pot resolution, and that the resulting `submit_event` call
+   carries the right (source_system, event_type, action) tuple so the
+   reconciliation agent routes to the ``repo_one_shot_ingestion`` playbook.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from adapters.inbound.cli import main as cli_main
+from adapters.outbound.http.potpie_context_api_client import (
+    PotpieContextApiClient,
+    PotpieContextApiError,
+)
+
+pytestmark = pytest.mark.unit
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# API client — POST /events/reconcile
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_httpx(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    response: httpx.Response,
+    captured: dict[str, Any],
+) -> None:
+    """Replace httpx.Client with a fake that records the outgoing request."""
+
+    class FakeClient:
+        def __init__(self, *a: Any, **k: Any) -> None:
+            pass
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *a: Any, **k: Any) -> None:
+            pass
+
+        def post(self, url: str, **kwargs: Any) -> httpx.Response:
+            captured["url"] = url
+            captured["json"] = kwargs.get("json")
+            captured["headers"] = kwargs.get("headers")
+            return response
+
+        def get(self, *a: Any, **k: Any) -> httpx.Response:
+            raise AssertionError("unused")
+
+    monkeypatch.setattr(
+        "adapters.outbound.http.potpie_context_api_client.httpx.Client",
+        FakeClient,
+    )
+
+
+def test_submit_event_queued_202(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+    _install_fake_httpx(
+        monkeypatch,
+        response=httpx.Response(
+            202, json={"status": "queued", "event_id": "evt-1", "batch_id": "b-1"}
+        ),
+        captured=captured,
+    )
+
+    c = PotpieContextApiClient("http://example.com", "k")
+    status, body = c.submit_event(
+        pot_id="pot-1",
+        source_system="github",
+        event_type="repository",
+        action="one_shot_ingest",
+        repo_name="acme/api",
+        source_id="one_shot_ingest:acme/api:42",
+        payload={"owner": "acme", "repo": "api", "count": 50},
+    )
+
+    assert status == 202
+    assert body == {"status": "queued", "event_id": "evt-1", "batch_id": "b-1"}
+
+    # URL targets the canonical reconcile endpoint.
+    assert captured["url"].endswith("/api/v2/context/events/reconcile")
+
+    # Request body has every field /events/reconcile requires.
+    sent = captured["json"]
+    assert sent["pot_id"] == "pot-1"
+    assert sent["source_system"] == "github"
+    assert sent["event_type"] == "repository"
+    assert sent["action"] == "one_shot_ingest"
+    assert sent["repo_name"] == "acme/api"
+    assert sent["source_id"] == "one_shot_ingest:acme/api:42"
+    assert sent["provider"] == "github"
+    assert sent["provider_host"] == "github.com"
+    assert sent["payload"] == {"owner": "acme", "repo": "api", "count": 50}
+
+
+def test_submit_event_duplicate_409_returns_detail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    _install_fake_httpx(
+        monkeypatch,
+        response=httpx.Response(
+            409,
+            json={
+                "detail": {
+                    "error": "duplicate_event",
+                    "event_id": "evt-existing",
+                    "message": "Event already recorded for this scope and source_id.",
+                }
+            },
+        ),
+        captured=captured,
+    )
+
+    c = PotpieContextApiClient("http://example.com", "k")
+    status, body = c.submit_event(
+        pot_id="pot-1",
+        source_system="github",
+        event_type="repository",
+        action="one_shot_ingest",
+        repo_name="acme/api",
+        source_id="dup-source-id",
+    )
+
+    assert status == 409
+    assert body["error"] == "duplicate_event"
+    assert body["event_id"] == "evt-existing"
+
+
+def test_submit_event_400_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+    _install_fake_httpx(
+        monkeypatch,
+        response=httpx.Response(400, json={"detail": "missing repo_name"}),
+        captured=captured,
+    )
+
+    c = PotpieContextApiClient("http://example.com", "k")
+    with pytest.raises(PotpieContextApiError) as ei:
+        c.submit_event(
+            pot_id="pot-1",
+            source_system="github",
+            event_type="repository",
+            action="one_shot_ingest",
+            repo_name="",
+            source_id="x",
+        )
+    assert ei.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# CLI — potpie pot repo ingest
+# ---------------------------------------------------------------------------
+
+
+class _FakeIngestClient:
+    """Captures submit_event calls. Mirrors the API client surface the CLI uses."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.response: tuple[int, dict[str, Any]] = (
+            202,
+            {"status": "queued", "event_id": "evt-1", "batch_id": "b-1"},
+        )
+
+    def submit_event(self, **kwargs: Any) -> tuple[int, dict[str, Any]]:
+        self.calls.append(kwargs)
+        return self.response
+
+
+@pytest.fixture
+def fake_ingest(monkeypatch: pytest.MonkeyPatch) -> _FakeIngestClient:
+    client = _FakeIngestClient()
+    monkeypatch.setattr(cli_main, "_cli_client_or_exit", lambda _verbose: client)
+    monkeypatch.setattr(
+        cli_main, "_pot_id_or_git", lambda _ref, cwd=None: "pot-1"
+    )
+    monkeypatch.setattr(cli_main, "load_cli_env", lambda: None)
+    return client
+
+
+def test_cli_ingest_happy_path_json(fake_ingest: _FakeIngestClient) -> None:
+    result = runner.invoke(
+        cli_main.app,
+        ["--json", "pot", "repo", "ingest", "Acme/API", "--pot", "pot-1"],
+    )
+    assert result.exit_code == 0, result.stdout
+
+    assert len(fake_ingest.calls) == 1
+    call = fake_ingest.calls[0]
+    # Repo is lowercased before submission.
+    assert call["repo_name"] == "acme/api"
+    assert call["payload"]["owner"] == "acme"
+    assert call["payload"]["repo"] == "api"
+    # Routes to the one-shot ingestion playbook.
+    assert call["source_system"] == "github"
+    assert call["event_type"] == "repository"
+    assert call["action"] == "one_shot_ingest"
+    # Pot resolution is respected.
+    assert call["pot_id"] == "pot-1"
+    # source_id has the stable prefix and a per-invocation suffix.
+    assert call["source_id"].startswith("one_shot_ingest:acme/api:")
+    # Default count.
+    assert call["payload"]["count"] == 50
+    # JSON output contains the event id.
+    assert "evt-1" in result.stdout
+
+
+def test_cli_ingest_count_flag_is_forwarded(fake_ingest: _FakeIngestClient) -> None:
+    result = runner.invoke(
+        cli_main.app,
+        ["pot", "repo", "ingest", "acme/api", "--count", "25"],
+    )
+    assert result.exit_code == 0, result.stdout
+    call = fake_ingest.calls[0]
+    assert call["payload"]["count"] == 25
+
+
+def test_cli_ingest_rejects_invalid_owner_repo(
+    fake_ingest: _FakeIngestClient,
+) -> None:
+    result = runner.invoke(
+        cli_main.app, ["pot", "repo", "ingest", "not-a-slash-form"]
+    )
+    assert result.exit_code != 0
+    assert not fake_ingest.calls, (
+        "CLI should reject before any API call when owner/repo is malformed"
+    )
+
+
+def test_cli_ingest_handles_409_duplicate(fake_ingest: _FakeIngestClient) -> None:
+    fake_ingest.response = (
+        409,
+        {
+            "error": "duplicate_event",
+            "event_id": "evt-existing",
+            "message": "Event already recorded for this scope and source_id.",
+        },
+    )
+    result = runner.invoke(
+        cli_main.app, ["pot", "repo", "ingest", "acme/api"]
+    )
+    # Duplicate is not a hard failure — the event already exists.
+    assert result.exit_code == 0, result.stdout
+    assert "Duplicate" in result.stdout or "duplicate" in result.stdout
+    assert "evt-existing" in result.stdout
+
+
+def test_cli_ingest_api_error_surfaces_nonzero_exit(
+    fake_ingest: _FakeIngestClient,
+) -> None:
+    def boom(**_: Any) -> tuple[int, dict[str, Any]]:
+        raise PotpieContextApiError(404, {"detail": "pot not found"})
+
+    fake_ingest.submit_event = boom  # type: ignore[method-assign]
+    result = runner.invoke(
+        cli_main.app, ["pot", "repo", "ingest", "acme/api"]
+    )
+    assert result.exit_code != 0
+
+
+def test_cli_ingest_count_bounds_enforced(fake_ingest: _FakeIngestClient) -> None:
+    # min=1
+    r1 = runner.invoke(
+        cli_main.app, ["pot", "repo", "ingest", "acme/api", "--count", "0"]
+    )
+    assert r1.exit_code != 0
+    # max=500
+    r2 = runner.invoke(
+        cli_main.app,
+        ["pot", "repo", "ingest", "acme/api", "--count", "9999"],
+    )
+    assert r2.exit_code != 0
+    assert not fake_ingest.calls, (
+        "out-of-range count should be rejected before any API call"
+    )

--- a/app/src/context-engine/tests/unit/test_repo_one_shot_ingestion_skill.py
+++ b/app/src/context-engine/tests/unit/test_repo_one_shot_ingestion_skill.py
@@ -227,6 +227,18 @@ def test_github_tool_names_match_adapter() -> None:
     )
 
 
+def test_skill_documents_include_diff_files_contract() -> None:
+    """include_diff=true must match PyGithubSourceControl.get_pull_request."""
+    _, body = _read_skill()
+    assert "include_diff=true" in body
+    proc = _section(body, "Procedure")
+    assert "LAST RESORT" in proc
+    for fld in ("filename", "status", "additions", "deletions", "patch"):
+        assert fld in proc, f"Procedure must document diff file field {fld!r}"
+    touched = body[body.find("Touched services") : body.find("## Source-priority")]
+    assert "filename" in touched, "Touched services must reference filename"
+
+
 def test_skill_uses_real_pr_response_fields() -> None:
     """The skill must reference the real field names in get_pull_request."""
     _, body = _read_skill()

--- a/app/src/context-engine/tests/unit/test_repo_one_shot_ingestion_skill.py
+++ b/app/src/context-engine/tests/unit/test_repo_one_shot_ingestion_skill.py
@@ -130,7 +130,7 @@ def test_all_required_sections_present() -> None:
         "Inputs",
         "Tools assumed available",
         "Procedure",
-        "Mutations (per PR)",
+        "Mutations (per item)",
         "Bounds and budget",
         "Anti-patterns",
         "Single-event contract",
@@ -280,7 +280,7 @@ def test_skill_uses_real_pr_response_fields() -> None:
 
 def test_all_referenced_entity_labels_are_canonical() -> None:
     _, body = _read_skill()
-    section = _section(body, "Mutations (per PR)")
+    section = _section(body, "Mutations (per item)")
     labels = _all_entity_labels_in(section)
     # Sanity: skill should reference at least these.
     expected = {
@@ -300,7 +300,7 @@ def test_all_referenced_entity_labels_are_canonical() -> None:
 
 def test_all_referenced_edge_types_are_canonical() -> None:
     _, body = _read_skill()
-    section = _section(body, "Mutations (per PR)")
+    section = _section(body, "Mutations (per item)")
     edges = _all_edge_types_in(section)
     expected = {
         "PERFORMED",
@@ -348,7 +348,7 @@ def test_skill_edge_endpoints_match_ontology(
 def test_repository_key_is_slug_format_not_url_format() -> None:
     """Repository is SLUG_ALIAS — `repo:github.com/owner/repo` would be invalid."""
     _, body = _read_skill()
-    section = _section(body, "Mutations (per PR)")
+    section = _section(body, "Mutations (per item)")
     # Skill must NOT positively recommend the URL-style key. Mentions inside
     # an explicit "INVALID" / "do NOT" guard are fine (they teach the rule).
     for m in re.finditer(r"repo:github\.com/", section):
@@ -370,7 +370,7 @@ def test_repository_key_is_slug_format_not_url_format() -> None:
 def test_fix_and_decision_keys_are_content_hash() -> None:
     """Fix and Decision are CONTENT_HASH — keys must be `<prefix>:<12-hex>`."""
     _, body = _read_skill()
-    section = _section(body, "Mutations (per PR)")
+    section = _section(body, "Mutations (per item)")
     # Skill must NOT recommend PR-number-encoded keys.
     assert "fix:github:pr:" not in section, (
         "Fix is CONTENT_HASH; key body must be a hash, not `github:pr:<owner>/<repo>:<n>`"
@@ -387,7 +387,7 @@ def test_fix_and_decision_keys_are_content_hash() -> None:
 
 def test_period_key_matches_production_builder() -> None:
     _, body = _read_skill()
-    section = _section(body, "Mutations (per PR)")
+    section = _section(body, "Mutations (per item)")
     assert "timeline:period:daily:<pot>:<yyyy-mm-dd>" in section, (
         "Period key must match production builder "
         "(timeline_plan._period_key)"
@@ -396,7 +396,7 @@ def test_period_key_matches_production_builder() -> None:
 
 def test_activity_key_external_id_form() -> None:
     _, body = _read_skill()
-    section = _section(body, "Mutations (per PR)")
+    section = _section(body, "Mutations (per item)")
     # The example key from the skill must pass _EXTERNAL_ID_SAFE_RE for each
     # post-prefix segment.
     example = "activity:github:pr:acme/api:1042"
@@ -412,7 +412,7 @@ def test_activity_key_external_id_form() -> None:
 
 def test_person_key_is_slug_safe_for_typical_github_handles() -> None:
     _, body = _read_skill()
-    section = _section(body, "Mutations (per PR)")
+    section = _section(body, "Mutations (per item)")
     assert "person:<handle" in section
     # Typical GitHub handles slugify cleanly.
     for handle in ("alice", "bob-smith", "user123"):
@@ -422,7 +422,7 @@ def test_person_key_is_slug_safe_for_typical_github_handles() -> None:
 
 def test_bug_pattern_key_segments_are_slugs() -> None:
     _, body = _read_skill()
-    section = _section(body, "Mutations (per PR)")
+    section = _section(body, "Mutations (per item)")
     assert "bug_pattern:<repo-slug>:<symptom-slug>" in section, (
         "skill should clarify BugPattern key uses slug segments"
     )
@@ -473,10 +473,20 @@ def test_skill_explicitly_forbids_repository_added_reemit() -> None:
     assert "do not" in anti.lower(), "Anti-patterns section should be imperative"
 
 
-def test_skill_caps_list_pagination_to_one_call() -> None:
+def test_skill_caps_list_pagination_to_two_calls_one_per_kind() -> None:
+    """Two list calls total — one for PRs, one for issues. No pagination."""
     _, body = _read_skill()
     bounds = _section(body, "Bounds and budget")
-    assert "ONE" in bounds and "github_list_pull_requests" in bounds
+    # Either "Two" or explicit per-tool "one" each is acceptable phrasing.
+    assert (
+        "Two" in bounds
+        or "two" in bounds
+        or ("one `github_list_pull_requests`" in bounds
+            and "one `github_list_issues`" in bounds)
+    ), "Bounds must state two list calls (one per kind)"
+    assert "github_list_pull_requests" in bounds
+    assert "github_list_issues" in bounds
+    assert "No pagination" in bounds or "no pagination" in bounds.lower()
 
 
 # ---------------------------------------------------------------------------
@@ -512,7 +522,7 @@ def test_one_shot_playbook_extract_is_the_markdown_body() -> None:
     # rendered playbook so they end up in the agent prompt.
     for marker in (
         "# Repo one-shot ingestion",
-        "## Mutations (per PR)",
+        "## Mutations (per item)",
         "## Anti-patterns",
         "Source-priority rationale",
         "Single-event contract",
@@ -562,7 +572,7 @@ def test_one_shot_playbook_renders_into_agent_prompt() -> None:
     pb = find_playbook("github", "repository", "one_shot_ingest")
     rendered = render_playbooks_section([pb])
     assert "github / repository / one_shot_ingest" in rendered
-    assert "## Mutations (per PR)" in rendered
+    assert "## Mutations (per item)" in rendered
     assert "Anti-patterns" in rendered
 
 
@@ -586,3 +596,119 @@ def test_skill_documents_source_priority_order() -> None:
             f"source priority broken: {earlier!r} must come before {later!r}"
         )
     assert "LAST RESORT" in proc, "Procedure must call code-reading LAST RESORT"
+
+
+# ---------------------------------------------------------------------------
+# Issue ingestion path (expansion: PRs + issues)
+# ---------------------------------------------------------------------------
+
+
+def test_skill_covers_both_prs_and_issues() -> None:
+    """Frontmatter + body must announce the two-kind scope."""
+    fm, body = _read_skill()
+    assert "issues" in fm["description"].lower()
+    assert "pull request" in fm["description"].lower() or "pr" in fm["description"].lower()
+    assert "github_list_issues" in body
+    assert "github_get_issue" in body
+    assert "activity:github:issue:" in body
+    assert "activity:github:pr:" in body
+
+
+def test_skill_phase_1_calls_both_list_tools_with_limit_count() -> None:
+    """count is read from event.payload.count and passed as limit on BOTH lists."""
+    _, body = _read_skill()
+    assert "event.payload.count" in body, (
+        "skill must tell the agent to read count from event.payload.count"
+    )
+    assert "github_list_pull_requests(repo, limit=count)" in body
+    assert "github_list_issues(repo, limit=count)" in body
+
+
+def test_phase_0_initializes_two_todos_one_per_kind() -> None:
+    _, body = _read_skill()
+    proc = _section(body, "Procedure")
+    # Both enumeration todos must be initialized in Phase 0.
+    assert "Enumerate" in proc and "merged PRs" in proc
+    assert "Enumerate" in proc and "issues" in proc
+
+
+def test_issue_activity_key_form_documented() -> None:
+    _, body = _read_skill()
+    section = _section(body, "Mutations (per item)")
+    assert "activity:github:issue:<owner>/<repo>:<n>" in section, (
+        "issue Activity key must be activity:github:issue:<owner>/<repo>:<n>"
+    )
+
+
+def test_issue_verb_class_uses_state() -> None:
+    _, body = _read_skill()
+    section = _section(body, "Mutations (per item)")
+    # verb_class value pattern (not a tool name).
+    assert "github_issue_<state>" in section or "github_issue_open" in section
+    assert "github_issue_closed" in section or "github_issue_<state>" in section
+
+
+def test_no_fix_emitted_from_issues() -> None:
+    """Fix is reserved for merged PRs; issues never emit Fix."""
+    _, body = _read_skill()
+    anti = _section(body, "Anti-patterns")
+    assert "Do NOT emit `Fix` for an issue" in anti, (
+        "Anti-patterns must explicitly forbid Fix from issue filings"
+    )
+    section = _section(body, "Mutations (per item)")
+    # Inside the per-issue conditional block, must call this out too.
+    issue_block_start = section.find("### Per issue — conditionally emit")
+    assert issue_block_start >= 0, "Per issue — conditionally emit block missing"
+    issue_block = section[issue_block_start:]
+    assert "Do NOT emit `Fix`" in issue_block, (
+        "Per-issue conditional must say Do NOT emit Fix"
+    )
+
+
+def test_playbook_tool_hints_include_issue_tools() -> None:
+    """Playbook registration must expose the issue-side tools."""
+    from domain.event_playbooks import find_playbook
+
+    pb = find_playbook("github", "repository", "one_shot_ingest")
+    assert "github_list_issues" in pb.tool_hints
+    assert "github_get_issue" in pb.tool_hints
+    # Sandbox attach-check must also be allowlisted (per prior review fix).
+    assert "sandbox_list_repos" in pb.tool_hints
+
+
+def test_skill_documents_issue_source_priority_order() -> None:
+    """For issues: labels > state > title > body."""
+    _, body = _read_skill()
+    proc = _section(body, "Procedure")
+    # Anchor on the issue items section to scope the search.
+    issue_idx = proc.find("Issue items")
+    assert issue_idx >= 0, "Procedure must have an Issue items subsection"
+    issue_section = proc[issue_idx:]
+    for earlier, later in [
+        ("Labels", "State"),
+        ("State", "Title"),
+        ("Title", "Body"),
+    ]:
+        i_e = issue_section.find(earlier)
+        i_l = issue_section.find(later)
+        assert i_e >= 0 and i_l >= 0, (
+            f"Issue procedure missing priority label: {earlier!r}/{later!r}"
+        )
+        assert i_e < i_l, (
+            f"issue source priority broken: {earlier!r} must precede {later!r}"
+        )
+
+
+def test_discussions_explicitly_out_of_scope() -> None:
+    """GitHub Discussions have no connector tool; skill must call this out."""
+    _, body = _read_skill()
+    assert "Discussions" in body
+    anti = _section(body, "Anti-patterns")
+    assert "Discussions" in anti and "unsupported" in anti.lower()
+
+
+def test_issue_anti_pattern_no_invented_issue_comments() -> None:
+    """There's no separate issue-comments tool; skill must forbid inventing them."""
+    _, body = _read_skill()
+    anti = _section(body, "Anti-patterns")
+    assert "issue comments" in anti.lower() or "issue-comments" in anti.lower()

--- a/app/src/context-engine/tests/unit/test_repo_one_shot_ingestion_skill.py
+++ b/app/src/context-engine/tests/unit/test_repo_one_shot_ingestion_skill.py
@@ -273,6 +273,28 @@ def test_skill_uses_real_pr_response_fields() -> None:
             )
 
 
+def test_skill_uses_real_issue_response_fields() -> None:
+    """The issue path must rely only on fields returned by get_issue."""
+    _, body = _read_skill()
+    issue_section = _section(body, "Procedure")
+    issue_idx = issue_section.find("Issue items")
+    assert issue_idx >= 0, "Procedure must have an Issue items subsection"
+    issue_section = issue_section[issue_idx:]
+    for fld in (
+        "title",
+        "body",
+        "state",
+        "author",
+        "labels",
+        "created_at",
+        "updated_at",
+        "url",
+    ):
+        assert fld in issue_section, (
+            f"issue procedure should mention real issue field {fld!r}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Ontology references
 # ---------------------------------------------------------------------------

--- a/app/src/context-engine/tests/unit/test_repo_one_shot_ingestion_skill.py
+++ b/app/src/context-engine/tests/unit/test_repo_one_shot_ingestion_skill.py
@@ -1,0 +1,576 @@
+"""Contract test for the repo one-shot ingestion skill markdown.
+
+The skill at ``domain/playbooks/repo_one_shot_ingestion.md`` is read by
+Claude Code and (later) embedded into the internal reconciliation agent
+prompt. It documents tool signatures, entity labels, edge types, and stable
+key formats — every one of those is a real promise about the surrounding
+code. This test pins each promise so the skill cannot silently drift away
+from the ontology, the GitHub adapter, or the deep agent's tool surface.
+
+Failures here mean either: (a) the skill names something that no longer
+exists, or (b) the code moved and the skill was not updated.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from adapters.outbound.connectors.github.api_client import PyGithubSourceControl
+from adapters.outbound.reconciliation.llm_plan_schema import LlmReconciliationPlan
+from adapters.outbound.reconciliation.pydantic_deep_agent import (
+    PydanticDeepReconciliationAgent,
+)
+from domain.identity import (
+    IdentityClass,
+    _EXTERNAL_ID_SAFE_RE,
+    _SLUG_BODY_RE,
+    get_identity,
+    mint_entity_key,
+)
+from domain.ontology import EDGE_TYPES, ENTITY_TYPES
+
+pytestmark = pytest.mark.unit
+
+
+SKILL_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "domain"
+    / "playbooks"
+    / "repo_one_shot_ingestion.md"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_skill() -> tuple[dict[str, str], str]:
+    """Return (frontmatter, body) for the skill markdown."""
+    raw = SKILL_PATH.read_text(encoding="utf-8")
+    assert raw.startswith("---\n"), "skill must open with a YAML frontmatter fence"
+    end = raw.find("\n---\n", 4)
+    assert end > 0, "skill frontmatter is not terminated"
+    fm_block = raw[4:end]
+    body = raw[end + 5 :]
+    fm: dict[str, str] = {}
+    for line in fm_block.splitlines():
+        if not line.strip() or ":" not in line:
+            continue
+        k, _, v = line.partition(":")
+        fm[k.strip()] = v.strip()
+    return fm, body
+
+
+def _section(body: str, heading: str) -> str:
+    """Extract the text under a `## heading` until the next `## ` heading."""
+    pattern = re.compile(
+        rf"(?m)^##\s+{re.escape(heading)}\s*$(.+?)(?=^##\s|\Z)",
+        re.DOTALL,
+    )
+    m = pattern.search(body)
+    assert m, f"section ## {heading!r} not found in skill"
+    return m.group(1)
+
+
+def _all_entity_labels_in(text: str) -> set[str]:
+    """Canonical entity labels referenced as inline code, e.g. ``Repository``."""
+    return {
+        token
+        for token in re.findall(r"`([A-Z][A-Za-z]+)`", text)
+        if token in ENTITY_TYPES
+    }
+
+
+def _all_edge_types_in(text: str) -> set[str]:
+    """Canonical edge types referenced as inline code, e.g. ``TOUCHED``."""
+    return {
+        token
+        for token in re.findall(r"`([A-Z_]{3,})`", text)
+        if token in EDGE_TYPES
+    }
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter + structure
+# ---------------------------------------------------------------------------
+
+
+def test_skill_file_exists() -> None:
+    assert SKILL_PATH.is_file(), f"skill missing at {SKILL_PATH}"
+
+
+def test_frontmatter_has_required_keys() -> None:
+    fm, _ = _read_skill()
+    required = {
+        "name",
+        "description",
+        "source_system",
+        "event_type",
+        "action",
+        "enables_planner",
+    }
+    missing = required - fm.keys()
+    assert not missing, f"frontmatter missing keys: {missing}"
+    assert fm["source_system"] == "github"
+    assert fm["event_type"] == "repository"
+    assert fm["action"] == "one_shot_ingest"
+    assert fm["enables_planner"].lower() == "true"
+
+
+def test_all_required_sections_present() -> None:
+    _, body = _read_skill()
+    for heading in (
+        "When to invoke",
+        "Inputs",
+        "Tools assumed available",
+        "Procedure",
+        "Mutations (per PR)",
+        "Bounds and budget",
+        "Anti-patterns",
+        "Single-event contract",
+    ):
+        assert re.search(
+            rf"(?m)^##\s+{re.escape(heading)}\s*$", body
+        ), f"missing required section: ## {heading}"
+
+
+# ---------------------------------------------------------------------------
+# Tool surface
+# ---------------------------------------------------------------------------
+
+
+def test_apply_graph_mutations_signature_matches_real_tool() -> None:
+    """Skill documents apply_graph_mutations(plan, event_id, summary)."""
+    _, body = _read_skill()
+    sig = inspect.signature(
+        PydanticDeepReconciliationAgent._build_mutation_tools.__wrapped__
+        if hasattr(PydanticDeepReconciliationAgent._build_mutation_tools, "__wrapped__")
+        else PydanticDeepReconciliationAgent._build_mutation_tools
+    )
+    del sig  # we inspect via source instead — the closure is what matters
+    source = inspect.getsource(
+        PydanticDeepReconciliationAgent._build_mutation_tools
+    )
+    # Real signature in the source:
+    assert (
+        "async def apply_graph_mutations(\n"
+        "            plan: dict[str, Any],\n"
+        "            event_id: str,\n"
+        "            summary: str,\n"
+        in source
+    ), "apply_graph_mutations signature changed; update the skill"
+    # Skill documents the same arg order:
+    assert "apply_graph_mutations(plan, event_id, summary)" in body, (
+        "skill must document the real (plan, event_id, summary) signature"
+    )
+
+
+def test_llm_reconciliation_plan_fields_documented() -> None:
+    """Skill enumerates every required LlmReconciliationPlan field."""
+    _, body = _read_skill()
+    plan_fields = set(LlmReconciliationPlan.model_fields.keys())
+    # Required fields in the plan dict the agent passes to apply_graph_mutations.
+    for fld in (
+        "summary",
+        "entity_upserts",
+        "edge_upserts",
+        "edge_deletes",
+        "invalidations",
+        "evidence",
+        "confidence",
+        "warnings",
+    ):
+        assert fld in plan_fields, (
+            f"LlmReconciliationPlan no longer has field {fld!r}; "
+            f"adjust the test and skill"
+        )
+        assert f"`{fld}`" in body, (
+            f"skill must mention LlmReconciliationPlan field `{fld}`"
+        )
+
+
+def test_completion_tools_documented() -> None:
+    _, body = _read_skill()
+    assert "mark_event_processed(event_id, summary)" in body
+    assert "finish_batch(summary)" in body
+
+
+def test_todo_tool_names_match_pydantic_deep_toolset() -> None:
+    _, body = _read_skill()
+    assert "read_todos" in body
+    assert "write_todos" in body
+    assert "update_todo_status" in body
+    assert "mark_todo_done" not in body
+
+
+def test_github_tool_names_match_adapter() -> None:
+    """Every `github_*` tool the skill references must exist on the read port."""
+    _, body = _read_skill()
+    referenced = set(re.findall(r"`(github_[a-z_]+)\b", body))
+    # The PyGithub adapter is the source of truth for available methods.
+    adapter_methods = {
+        f"github_{name}"
+        for name, _ in inspect.getmembers(
+            PyGithubSourceControl, predicate=inspect.isfunction
+        )
+        if not name.startswith("_")
+    }
+    unknown = referenced - adapter_methods
+    assert not unknown, (
+        f"skill names github_* tools that have no adapter method: {unknown}"
+    )
+
+
+def test_skill_uses_real_pr_response_fields() -> None:
+    """The skill must reference the real field names in get_pull_request."""
+    _, body = _read_skill()
+    real_fields = {
+        "head_branch",
+        "base_branch",
+        "merged_at",
+        "title",
+        "body",
+        "author",
+        "url",
+    }
+    # Each field the skill explicitly relies on must exist in adapter output.
+    for fld in real_fields:
+        assert f"`{fld}`" in body or fld in body, (
+            f"skill should mention real PR field {fld!r}"
+        )
+    # Fields the adapter does NOT produce may only appear in a "do not
+    # assume" guard. Flag any positive recommendation.
+    for fld in ("head_ref", "merge_commit_sha", "changed_files"):
+        for m in re.finditer(rf"`{re.escape(fld)}`", body):
+            window = body[max(0, m.start() - 200) : m.end() + 50]
+            assert (
+                "do NOT assume" in window
+                or "Do NOT assume" in window
+                or "NOT in this response" in window
+                or "does NOT return" in window
+                or "do not return" in window.lower()
+            ), (
+                f"skill references {fld!r} without flagging it as missing "
+                f"from the adapter response"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Ontology references
+# ---------------------------------------------------------------------------
+
+
+def test_all_referenced_entity_labels_are_canonical() -> None:
+    _, body = _read_skill()
+    section = _section(body, "Mutations (per PR)")
+    labels = _all_entity_labels_in(section)
+    # Sanity: skill should reference at least these.
+    expected = {
+        "Repository",
+        "Person",
+        "Activity",
+        "Period",
+        "BugPattern",
+        "Fix",
+        "Decision",
+    }
+    missing = expected - labels
+    assert not missing, (
+        f"skill Mutations section missing expected labels: {missing}"
+    )
+
+
+def test_all_referenced_edge_types_are_canonical() -> None:
+    _, body = _read_skill()
+    section = _section(body, "Mutations (per PR)")
+    edges = _all_edge_types_in(section)
+    expected = {
+        "PERFORMED",
+        "AUTHORED",
+        "TOUCHED",
+        "IN_PERIOD",
+        "RESOLVED",
+        "REPRODUCES",
+        "DECIDED",
+        "AFFECTS",
+    }
+    missing = expected - edges
+    assert not missing, f"skill missing expected edge types: {missing}"
+
+
+@pytest.mark.parametrize(
+    "edge_type, from_label, to_label",
+    [
+        ("PERFORMED", "Person", "Activity"),
+        ("AUTHORED", "Person", "Activity"),
+        ("TOUCHED", "Activity", "Repository"),
+        ("IN_PERIOD", "Activity", "Period"),
+        ("RESOLVED", "Fix", "BugPattern"),
+        ("REPRODUCES", "BugPattern", "Repository"),
+        ("DECIDED", "Decision", "Repository"),
+        ("AFFECTS", "Decision", "Repository"),
+    ],
+)
+def test_skill_edge_endpoints_match_ontology(
+    edge_type: str, from_label: str, to_label: str
+) -> None:
+    """Each edge the skill emits must be allowed by EDGE_TYPES.allowed_pairs."""
+    spec = EDGE_TYPES[edge_type]
+    assert spec.allows([from_label], [to_label]), (
+        f"{edge_type}: {from_label} → {to_label} is NOT in allowed_pairs "
+        f"{spec.allowed_pairs}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stable key formats
+# ---------------------------------------------------------------------------
+
+
+def test_repository_key_is_slug_format_not_url_format() -> None:
+    """Repository is SLUG_ALIAS — `repo:github.com/owner/repo` would be invalid."""
+    _, body = _read_skill()
+    section = _section(body, "Mutations (per PR)")
+    # Skill must NOT positively recommend the URL-style key. Mentions inside
+    # an explicit "INVALID" / "do NOT" guard are fine (they teach the rule).
+    for m in re.finditer(r"repo:github\.com/", section):
+        window = section[max(0, m.start() - 200) : m.end() + 200]
+        assert "INVALID" in window or "do NOT" in window or "Do NOT" in window, (
+            "Repository is SLUG_ALIAS; `repo:github.com/<owner>/<repo>` is "
+            "invalid (slashes/dots fail _SLUG_BODY_RE). Skill mentions it "
+            "outside a negative-example guard. Use `repo:<owner>-<repo>`."
+        )
+    # And must mention the slug form somewhere in the Mutations section.
+    assert "repo:<owner>-<repo>" in section or "repo:acme-api" in section, (
+        "skill should show the real slug Repository key format"
+    )
+    # Sanity: the slug form actually mints cleanly.
+    minted = mint_entity_key(get_identity("Repository"), name="acme/api")
+    assert minted == "repo:acme-api"
+
+
+def test_fix_and_decision_keys_are_content_hash() -> None:
+    """Fix and Decision are CONTENT_HASH — keys must be `<prefix>:<12-hex>`."""
+    _, body = _read_skill()
+    section = _section(body, "Mutations (per PR)")
+    # Skill must NOT recommend PR-number-encoded keys.
+    assert "fix:github:pr:" not in section, (
+        "Fix is CONTENT_HASH; key body must be a hash, not `github:pr:<owner>/<repo>:<n>`"
+    )
+    assert "decision:github:pr:" not in section, (
+        "Decision is CONTENT_HASH; key body must be a hash, not PR-encoded"
+    )
+    # Skill should explicitly show the content-hash form.
+    assert "fix:<12-hex" in section, "skill should show fix:<12-hex-sha256> form"
+    assert "decision:<12-hex" in section, (
+        "skill should show decision:<12-hex-sha256> form"
+    )
+
+
+def test_period_key_matches_production_builder() -> None:
+    _, body = _read_skill()
+    section = _section(body, "Mutations (per PR)")
+    assert "timeline:period:daily:<pot>:<yyyy-mm-dd>" in section, (
+        "Period key must match production builder "
+        "(timeline_plan._period_key)"
+    )
+
+
+def test_activity_key_external_id_form() -> None:
+    _, body = _read_skill()
+    section = _section(body, "Mutations (per PR)")
+    # The example key from the skill must pass _EXTERNAL_ID_SAFE_RE for each
+    # post-prefix segment.
+    example = "activity:github:pr:acme/api:1042"
+    assert example.startswith("activity:")
+    segments = example.split(":")[1:]
+    for seg in segments:
+        assert _EXTERNAL_ID_SAFE_RE.match(seg), (
+            f"Activity key segment {seg!r} is not external-id safe"
+        )
+    # And the skill must mention the canonical form.
+    assert "activity:github:pr:<owner>/<repo>:<n>" in section
+
+
+def test_person_key_is_slug_safe_for_typical_github_handles() -> None:
+    _, body = _read_skill()
+    section = _section(body, "Mutations (per PR)")
+    assert "person:<handle" in section
+    # Typical GitHub handles slugify cleanly.
+    for handle in ("alice", "bob-smith", "user123"):
+        minted = mint_entity_key(get_identity("Person"), name=handle)
+        assert minted == f"person:{handle}"
+
+
+def test_bug_pattern_key_segments_are_slugs() -> None:
+    _, body = _read_skill()
+    section = _section(body, "Mutations (per PR)")
+    assert "bug_pattern:<repo-slug>:<symptom-slug>" in section, (
+        "skill should clarify BugPattern key uses slug segments"
+    )
+    # Sanity: each segment of an example key matches the slug body regex.
+    example = "bug_pattern:acme-api:db-timeout"
+    parts = example.split(":")
+    assert parts[0] == "bug_pattern"
+    for seg in parts[1:]:
+        assert _SLUG_BODY_RE.match(seg), f"BugPattern segment {seg!r} not slug-valid"
+
+
+# ---------------------------------------------------------------------------
+# Identity-class invariants — guard against ontology silently flipping a class.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "label, expected_class, expected_prefix",
+    [
+        ("Repository", IdentityClass.SLUG_ALIAS, "repo"),
+        ("Person", IdentityClass.SLUG_ALIAS, "person"),
+        ("Activity", IdentityClass.EXTERNAL_ID, "activity"),
+        ("Period", IdentityClass.SLUG_ALIAS, "period"),
+        ("BugPattern", IdentityClass.SLUG_ALIAS, "bug_pattern"),
+        ("Fix", IdentityClass.CONTENT_HASH, "fix"),
+        ("Decision", IdentityClass.CONTENT_HASH, "decision"),
+    ],
+)
+def test_ontology_identity_classes_unchanged(
+    label: str, expected_class: IdentityClass, expected_prefix: str
+) -> None:
+    spec = ENTITY_TYPES[label]
+    assert spec.identity_class is expected_class, (
+        f"{label} identity_class changed; re-validate the skill's key guidance"
+    )
+    assert spec.key_prefix == expected_prefix
+
+
+# ---------------------------------------------------------------------------
+# Anti-pattern guarantees
+# ---------------------------------------------------------------------------
+
+
+def test_skill_explicitly_forbids_repository_added_reemit() -> None:
+    _, body = _read_skill()
+    anti = _section(body, "Anti-patterns")
+    assert "repository.added" in anti.lower() or "repository.added" in anti
+    assert "do not" in anti.lower(), "Anti-patterns section should be imperative"
+
+
+def test_skill_caps_list_pagination_to_one_call() -> None:
+    _, body = _read_skill()
+    bounds = _section(body, "Bounds and budget")
+    assert "ONE" in bounds and "github_list_pull_requests" in bounds
+
+
+# ---------------------------------------------------------------------------
+# EventPlaybook registration (slice 2)
+# ---------------------------------------------------------------------------
+
+
+def test_one_shot_ingest_playbook_is_registered() -> None:
+    """The internal agent must be able to resolve the one-shot event-kind."""
+    from domain.event_playbooks import find_playbook, is_default_playbook
+
+    pb = find_playbook("github", "repository", "one_shot_ingest")
+    assert not is_default_playbook(pb), (
+        "(github, repository, one_shot_ingest) fell through to the default "
+        "playbook — registration missing"
+    )
+    assert pb.source_system == "github"
+    assert pb.event_type == "repository"
+    assert pb.action == "one_shot_ingest"
+    assert pb.enables_planner is True
+    assert pb.max_tool_calls >= 100, (
+        "one-shot ingestion needs a generous tool-call budget"
+    )
+
+
+def test_one_shot_playbook_extract_is_the_markdown_body() -> None:
+    """The skill markdown body must be embedded verbatim in the playbook."""
+    from domain.event_playbooks import find_playbook
+
+    pb = find_playbook("github", "repository", "one_shot_ingest")
+    _, body = _read_skill()
+    # Sanity: a few distinctive markers from the markdown must appear in the
+    # rendered playbook so they end up in the agent prompt.
+    for marker in (
+        "# Repo one-shot ingestion",
+        "## Mutations (per PR)",
+        "## Anti-patterns",
+        "Source-priority rationale",
+        "Single-event contract",
+        "activity:github:pr:<owner>/<repo>:<n>",
+    ):
+        assert marker in pb.extract, (
+            f"playbook extract missing skill marker: {marker!r}"
+        )
+    # And it must NOT contain the YAML frontmatter — the loader strips it.
+    assert not pb.extract.startswith("---"), (
+        "playbook extract should strip the markdown frontmatter"
+    )
+    # Body length should be roughly the same as the markdown body (the loader
+    # only strips frontmatter, no other transformation).
+    assert abs(len(pb.extract) - len(body.lstrip())) < 50, (
+        "playbook extract length diverges from skill body — loader transform?"
+    )
+
+
+def test_one_shot_playbook_tool_hints_reference_real_tools() -> None:
+    from domain.event_playbooks import find_playbook
+
+    pb = find_playbook("github", "repository", "one_shot_ingest")
+    assert "sandbox_list_repos" in pb.tool_hints, (
+        "skill asks the agent to confirm repo attachment, so the sandbox repo "
+        "listing tool must survive the playbook allowlist"
+    )
+    # Every hinted github_* tool must exist on the adapter.
+    adapter_methods = {
+        f"github_{name}"
+        for name, _ in inspect.getmembers(
+            PyGithubSourceControl, predicate=inspect.isfunction
+        )
+        if not name.startswith("_")
+    }
+    for hint in pb.tool_hints:
+        if hint.startswith("github_"):
+            assert hint in adapter_methods, (
+                f"tool_hint {hint!r} not in adapter methods"
+            )
+
+
+def test_one_shot_playbook_renders_into_agent_prompt() -> None:
+    """render_playbooks_section must include the one-shot skill body."""
+    from domain.event_playbooks import find_playbook, render_playbooks_section
+
+    pb = find_playbook("github", "repository", "one_shot_ingest")
+    rendered = render_playbooks_section([pb])
+    assert "github / repository / one_shot_ingest" in rendered
+    assert "## Mutations (per PR)" in rendered
+    assert "Anti-patterns" in rendered
+
+
+def test_skill_documents_source_priority_order() -> None:
+    """Code is last-resort; the skill must enforce that priority."""
+    _, body = _read_skill()
+    proc = _section(body, "Procedure")
+    # Priority list appears in order. We assert the ordering by relative index.
+    for earlier, later in [
+        ("Commit messages", "Branch name"),
+        ("Branch name", "PR title"),
+        ("PR title", "PR description"),
+        ("PR description", "Code diff"),
+    ]:
+        i_e = proc.find(earlier)
+        i_l = proc.find(later)
+        assert i_e >= 0 and i_l >= 0, (
+            f"Procedure missing source-priority label: {earlier!r} / {later!r}"
+        )
+        assert i_e < i_l, (
+            f"source priority broken: {earlier!r} must come before {later!r}"
+        )
+    assert "LAST RESORT" in proc, "Procedure must call code-reading LAST RESORT"


### PR DESCRIPTION
## Summary

This PR adds a one-time GitHub history ingestion path for the context graph.

It lets an operator run:

```bash
potpie pot repo ingest owner/repo --count 50
```

That command submits a single `github / repository / one_shot_ingest` event to the existing `/api/v2/context/events/reconcile` endpoint. The reconciliation agent then loads the new markdown playbook and uses GitHub read tools plus context-graph mutation tools to ingest recent merged PRs and standalone issues.

Live incremental updates are unchanged. Future merged PRs still flow through the existing `pull_request.merged` webhook path, and live issue events continue through the GitHub issue webhook path when wired.

## What changed

- Added `domain/playbooks/repo_one_shot_ingestion.md`, a reusable markdown playbook for one-shot GitHub history ingestion.
- Registered a new `EventPlaybook` for `(github, repository, one_shot_ingest)` that loads the markdown body directly, so Claude Code and the internal agent use the same instructions.
- Added `PotpieContextApiClient.submit_event(...)` for posting normalized events to `/events/reconcile`.
- Added the CLI command `potpie pot repo ingest <owner/repo>` with `--pot`, `--count`, and `--cwd` options.
- Expanded GitHub issue reads to include labels, so issue classification can use the playbook's labels-first priority.
- Included the markdown playbook in wheel and sdist packaging.
- Added tests for the skill contract, playbook registration, CLI behavior, API client event submission, and GitHub issue label reads.

## How the skill works

1. Confirm the repo is already attached to the pot.
2. Read `count` from `event.payload.count`.
3. List recent PRs once with `github_list_pull_requests(repo, limit=count)`.
4. List recent standalone issues once with `github_list_issues(repo, limit=count)`.
5. Skip closed-unmerged PRs.
6. Process merged PRs first, then issues newest-first.
7. For PRs, hydrate metadata and read signals in this order: commits, branch, title, body, comments, diff as last resort.
8. For issues, hydrate metadata and read signals in this order: labels, state, title, body.
9. Write graph mutations for `Repository`, `Period`, `Activity`, `Person`, and related edges.
10. Emit `Fix` only from merged PR fix evidence. Issues can emit `BugPattern` or `Decision` when clearly supported, but never `Fix`.

## Identity and graph behavior

The playbook uses stable entity keys so one-shot backfill and later webhook ingestion converge instead of duplicating graph nodes.

Examples:

- Repository: `repo:<owner>-<repo>`
- PR Activity: `activity:github:pr:<owner>/<repo>:<number>`
- Issue Activity: `activity:github:issue:<owner>/<repo>:<number>`
- Person: `person:<github-handle>`
- Period: `timeline:period:daily:<pot>:<yyyy-mm-dd>`
- Fix / Decision: content-hash keys

## Test plan

Focused verification:

```bash
cd app/src/context-engine && PYTHONPATH=. uv run --extra github --extra reconciliation-agent pytest \
  tests/unit/test_repo_one_shot_ingestion_skill.py \
  tests/unit/test_event_playbooks.py \
  tests/unit/test_pot_repo_ingest_cli.py \
  tests/unit/test_backfill_seed.py
```

Result: `83 passed`.

Independent dry-run: executed the skill flow against a synthetic mixed dataset with merged PRs, a closed-unmerged PR, and standalone issues. The generated plan validated under `LlmReconciliationPlan` and `validate_structural_mutations`.

## Out of scope

- No new backend route; this reuses `/events/reconcile`.
- No UI button yet.
- No CLI `--wait` mode for progress polling.
- GitHub Discussions are not ingested because there is no connector tool for them.
- Existing `github / repository / added` prompt identity drift is left for a separate cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `pot repo ingest` CLI command to queue one-shot ingestion of pull request and issue history for attached GitHub repositories, with support for JSON output and configurable result limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->