### PR TITLE
Add Linear OAuth and Atlassian Jira/Confluence CLI auth

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -230,8 +230,8 @@ CODE_PROVIDER_TOKEN=
 # Testing
 PRIVATE_TEST_REPO_NAME=<yourGithubUsername>/potpie-private-test-repo
 
-# Linear OAuth
-LINEAR_CLIENT_ID=
+# Linear OAuth (backend / web integrations; CLI ships a default client id in provider_config.py)
+# LINEAR_CLIENT_ID=  # optional override for CLI or required for API server Linear OAuth
 LINEAR_CLIENT_SECRET=
 LINEAR_REDIRECT_URI=
 LINEAR_WEBHOOK_SECRET=

--- a/app/src/context-engine/adapters/inbound/cli/atlassian_auth.py
+++ b/app/src/context-engine/adapters/inbound/cli/atlassian_auth.py
@@ -1,0 +1,672 @@
+"""Atlassian Cloud API token authentication for Jira and Confluence CLI integrations."""
+
+from __future__ import annotations
+
+import base64
+import enum
+import re
+import sys
+import time
+import webbrowser
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+import typer
+
+from adapters.inbound.cli.credentials_store import (
+    ProviderCredentialError,
+    credentials_path,
+    get_confluence_credentials,
+    get_jira_credentials,
+    save_confluence_credentials,
+    save_jira_credentials,
+)
+from adapters.inbound.cli.output import emit_error, print_plain_line
+from adapters.inbound.cli.provider_config import (
+    ATLASSIAN_ACCESSIBLE_RESOURCES_URL,
+    ATLASSIAN_API_TOKEN_PAGE,
+    AtlassianProduct,
+    atlassian_confluence_gateway_url,
+    atlassian_jira_gateway_url,
+)
+
+_HTTP_TIMEOUT = 30.0
+_SITE_PROBE_TIMEOUT = 15.0
+
+_JIRA_GATEWAY_PROBE_PATHS = (
+    "/rest/api/3/project/search?maxResults=1",
+    "/rest/api/3/myself",
+)
+_CONFLUENCE_GATEWAY_PROBE_PATHS = (
+    "/wiki/rest/api/space?limit=1",
+    "/wiki/rest/api/user/current",
+)
+
+
+class AtlassianAuthErrorKind(enum.StrEnum):
+    INVALID_CREDENTIALS = "invalid_credentials"
+    INSUFFICIENT_SCOPES = "insufficient_scopes"
+    SITE_DISCOVERY_FAILED = "site_discovery_failed"
+    PRODUCT_ACCESS_DENIED = "product_access_denied"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class AtlassianVerifyResult:
+    ok: bool
+    error_kind: AtlassianAuthErrorKind | None = None
+    http_status: int | None = None
+    display_name: str = ""
+
+
+def atlassian_basic_auth_header(email: str, api_token: str) -> str:
+    raw = f"{email.strip()}:{api_token.strip()}".encode("utf-8")
+    return "Basic " + base64.b64encode(raw).decode("ascii")
+
+
+def atlassian_bearer_auth_header(api_token: str) -> str:
+    return f"Bearer {api_token.strip()}"
+
+
+def _auth_header_variants(email: str, api_token: str) -> list[dict[str, str]]:
+    accept = {"Accept": "application/json"}
+    return [
+        {
+            **accept,
+            "Authorization": atlassian_basic_auth_header(email, api_token),
+        },
+        {
+            **accept,
+            "Authorization": atlassian_bearer_auth_header(api_token),
+        },
+    ]
+
+
+def normalize_site_url(url: str) -> str:
+    value = url.strip().rstrip("/")
+    if not value:
+        return ""
+    if not value.startswith(("http://", "https://")):
+        value = f"https://{value}"
+    parsed = urlparse(value)
+    if not parsed.netloc:
+        return ""
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def site_url_from_subdomain(subdomain: str) -> str:
+    slug = subdomain.strip().lower().removesuffix(".atlassian.net")
+    slug = slug.removeprefix("https://").removeprefix("http://")
+    if not slug or not re.fullmatch(r"[a-z0-9][a-z0-9-]*", slug):
+        return ""
+    return f"https://{slug}.atlassian.net"
+
+
+def _gateway_base_url(cloud_id: str, product: AtlassianProduct) -> str:
+    if product == "jira":
+        return atlassian_jira_gateway_url(cloud_id)
+    return atlassian_confluence_gateway_url(cloud_id)
+
+
+def _gateway_probe_paths(product: AtlassianProduct) -> tuple[str, ...]:
+    if product == "jira":
+        return _JIRA_GATEWAY_PROBE_PATHS
+    return _CONFLUENCE_GATEWAY_PROBE_PATHS
+
+
+def _classify_gateway_status(status: int) -> AtlassianAuthErrorKind:
+    if status == 401:
+        return AtlassianAuthErrorKind.INVALID_CREDENTIALS
+    if status == 403:
+        return AtlassianAuthErrorKind.INSUFFICIENT_SCOPES
+    if status == 404:
+        return AtlassianAuthErrorKind.PRODUCT_ACCESS_DENIED
+    return AtlassianAuthErrorKind.UNKNOWN
+
+
+def _parse_profile_name(data: Any, *, product: AtlassianProduct) -> str:
+    if not isinstance(data, dict):
+        return ""
+    if product == "jira":
+        return str(
+            data.get("displayName") or data.get("emailAddress") or ""
+        ).strip()
+    return str(data.get("displayName") or data.get("username") or "").strip()
+
+
+def _parse_gateway_probe_success(
+    data: Any,
+    *,
+    product: AtlassianProduct,
+    path: str,
+) -> str:
+    if product == "jira" and "myself" in path:
+        return _parse_profile_name(data, product=product)
+    if product == "jira" and isinstance(data, dict):
+        values = data.get("values")
+        if isinstance(values, list) and values:
+            first = values[0]
+            if isinstance(first, dict):
+                return str(first.get("name") or first.get("key") or "").strip()
+        if isinstance(data, list) and data and isinstance(data[0], dict):
+            return str(data[0].get("name") or data[0].get("key") or "").strip()
+    if product == "confluence" and "user/current" in path:
+        return _parse_profile_name(data, product=product)
+    if product == "confluence" and isinstance(data, dict):
+        results = data.get("results")
+        if isinstance(results, list) and results:
+            first = results[0]
+            if isinstance(first, dict):
+                return str(first.get("name") or first.get("key") or "").strip()
+    return _parse_profile_name(data, product=product)
+
+
+def verify_gateway_product(
+    email: str,
+    api_token: str,
+    cloud_id: str,
+    product: AtlassianProduct,
+) -> AtlassianVerifyResult:
+    """Verify credentials against the Atlassian scoped-token gateway."""
+    cloud_id = cloud_id.strip()
+    if not cloud_id:
+        return AtlassianVerifyResult(
+            ok=False,
+            error_kind=AtlassianAuthErrorKind.SITE_DISCOVERY_FAILED,
+        )
+
+    base = _gateway_base_url(cloud_id, product)
+    last_status: int | None = None
+    last_kind = AtlassianAuthErrorKind.UNKNOWN
+    saw_403 = False
+
+    with httpx.Client(timeout=_SITE_PROBE_TIMEOUT) as client:
+        for path in _gateway_probe_paths(product):
+            url = f"{base}{path}"
+            for headers in _auth_header_variants(email, api_token):
+                response = client.get(url, headers=headers)
+                last_status = response.status_code
+                if response.status_code == 200:
+                    payload = response.json() if response.content else {}
+                    return AtlassianVerifyResult(
+                        ok=True,
+                        display_name=_parse_gateway_probe_success(
+                            payload,
+                            product=product,
+                            path=path,
+                        ),
+                    )
+                kind = _classify_gateway_status(response.status_code)
+                last_kind = kind
+                if response.status_code == 403:
+                    saw_403 = True
+                if response.status_code == 401:
+                    continue
+                break
+
+    if saw_403 and last_kind != AtlassianAuthErrorKind.INVALID_CREDENTIALS:
+        last_kind = AtlassianAuthErrorKind.INSUFFICIENT_SCOPES
+
+    return AtlassianVerifyResult(
+        ok=False,
+        error_kind=last_kind,
+        http_status=last_status,
+    )
+
+
+def fetch_cloud_id_for_site(site_url: str) -> str:
+    normalized = normalize_site_url(site_url)
+    if not normalized:
+        return ""
+    url = f"{normalized}/_edge/tenant_info"
+    with httpx.Client(timeout=_SITE_PROBE_TIMEOUT) as client:
+        response = client.get(url, headers={"Accept": "application/json"})
+    if response.status_code != 200:
+        return ""
+    data = response.json()
+    if isinstance(data, dict):
+        cloud_id = data.get("cloudId") or data.get("cloud_id")
+        return str(cloud_id).strip() if cloud_id else ""
+    return ""
+
+
+def _parse_accessible_resources(data: Any) -> list[dict[str, Any]]:
+    if not isinstance(data, list):
+        return []
+    sites: list[dict[str, Any]] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        site_url = normalize_site_url(str(item.get("url") or ""))
+        cloud_id = str(item.get("id") or "").strip()
+        if site_url and cloud_id:
+            sites.append(
+                {
+                    "cloud_id": cloud_id,
+                    "site_url": site_url,
+                    "site_name": str(item.get("name") or site_url).strip(),
+                }
+            )
+    return sites
+
+
+def _fetch_accessible_resources(
+    email: str,
+    api_token: str,
+) -> list[dict[str, Any]]:
+    with httpx.Client(timeout=_HTTP_TIMEOUT) as client:
+        basic_response = client.get(
+            ATLASSIAN_ACCESSIBLE_RESOURCES_URL,
+            headers={
+                "Authorization": atlassian_basic_auth_header(email, api_token),
+                "Accept": "application/json",
+            },
+        )
+        if basic_response.status_code == 200:
+            sites = _parse_accessible_resources(basic_response.json())
+            if sites:
+                return sites
+
+        bearer_response = client.get(
+            ATLASSIAN_ACCESSIBLE_RESOURCES_URL,
+            headers={
+                "Authorization": atlassian_bearer_auth_header(api_token),
+                "Accept": "application/json",
+            },
+        )
+        if bearer_response.status_code == 200:
+            return _parse_accessible_resources(bearer_response.json())
+    return []
+
+
+def _merge_site_candidate(
+    candidates: list[dict[str, Any]],
+    seen_urls: set[str],
+    *,
+    site_url: str,
+    cloud_id: str = "",
+    site_name: str = "",
+    source: str = "",
+) -> None:
+    normalized = normalize_site_url(site_url)
+    if not normalized or normalized in seen_urls:
+        return
+    cid = cloud_id.strip() or fetch_cloud_id_for_site(normalized)
+    if not cid:
+        return
+    seen_urls.add(normalized)
+    slug = urlparse(normalized).netloc.removesuffix(".atlassian.net")
+    candidates.append(
+        {
+            "cloud_id": cid,
+            "site_url": normalized,
+            "site_name": (site_name or slug or normalized).strip(),
+            "source": source,
+        }
+    )
+
+
+def _site_record(
+    *,
+    site_url: str,
+    cloud_id: str,
+    site_name: str = "",
+) -> dict[str, Any]:
+    normalized = normalize_site_url(site_url)
+    slug = urlparse(normalized).netloc.removesuffix(".atlassian.net") if normalized else ""
+    return {
+        "cloud_id": cloud_id,
+        "site_url": normalized,
+        "site_name": site_name or slug or normalized,
+    }
+
+
+def verify_site_with_api_token(
+    email: str,
+    api_token: str,
+    site_url: str,
+    product: AtlassianProduct = "jira",
+) -> dict[str, Any] | None:
+    """Resolve cloudId and verify API token access via the Atlassian gateway."""
+    normalized = normalize_site_url(site_url)
+    if not normalized:
+        return None
+
+    cloud_id = fetch_cloud_id_for_site(normalized)
+    if not cloud_id:
+        return None
+
+    result = verify_gateway_product(email, api_token, cloud_id, product)
+    if not result.ok:
+        return None
+
+    slug = urlparse(normalized).netloc.removesuffix(".atlassian.net")
+    site_name = result.display_name or slug or normalized
+    return _site_record(
+        site_url=normalized,
+        cloud_id=cloud_id,
+        site_name=site_name,
+    )
+
+
+def _candidate_subdomains_from_email(email: str) -> list[str]:
+    local, _, domain = email.strip().lower().partition("@")
+    candidates: list[str] = []
+    if domain:
+        org = domain.split(".", 1)[0]
+        if org and org not in {"gmail", "yahoo", "hotmail", "outlook", "icloud"}:
+            candidates.append(org)
+    if local and local not in candidates:
+        candidates.append(local)
+    return candidates
+
+
+def collect_site_candidates(email: str, api_token: str) -> list[dict[str, Any]]:
+    """List plausible Atlassian Cloud sites for this account."""
+    return collect_login_site_candidates(email, api_token, include_email_hints=True)
+
+
+def collect_login_site_candidates(
+    email: str,
+    api_token: str,
+    *,
+    include_email_hints: bool = False,
+) -> list[dict[str, Any]]:
+    """Sites for login: Atlassian accessible-resources (optional email-domain hints)."""
+    candidates: list[dict[str, Any]] = []
+    seen_urls: set[str] = set()
+
+    for site in _fetch_accessible_resources(email, api_token):
+        _merge_site_candidate(
+            candidates,
+            seen_urls,
+            site_url=str(site.get("site_url") or ""),
+            cloud_id=str(site.get("cloud_id") or ""),
+            site_name=str(site.get("site_name") or ""),
+            source="accessible-resources",
+        )
+
+    if include_email_hints:
+        for subdomain in _candidate_subdomains_from_email(email):
+            site_url = site_url_from_subdomain(subdomain)
+            if site_url:
+                _merge_site_candidate(
+                    candidates,
+                    seen_urls,
+                    site_url=site_url,
+                    site_name=subdomain,
+                    source="email-hint",
+                )
+
+    return candidates
+
+
+def _finalize_atlassian_site_unscoped(
+    email: str,
+    api_token: str,
+    site: dict[str, Any],
+) -> tuple[dict[str, Any] | None, AtlassianAuthErrorKind | None]:
+    """Verify Jira and Confluence gateway access for a classic (unscoped) API token."""
+    site, err = _finalize_selected_site(email, api_token, site, "jira")
+    if not site:
+        return None, err
+    cloud_id = str(site.get("cloud_id") or "").strip()
+    confluence = verify_gateway_product(email, api_token, cloud_id, "confluence")
+    if not confluence.ok:
+        return None, confluence.error_kind
+    return site, None
+
+
+def discover_sites_with_api_token(
+    email: str,
+    api_token: str,
+    product: AtlassianProduct = "jira",
+) -> list[dict[str, Any]]:
+    """Return site candidates that pass gateway verification for the given product."""
+    found: list[dict[str, Any]] = []
+    for candidate in collect_site_candidates(email, api_token):
+        cloud_id = str(candidate.get("cloud_id") or "").strip()
+        if not cloud_id:
+            continue
+        verify = verify_gateway_product(email, api_token, cloud_id, product)
+        if not verify.ok:
+            continue
+        name = verify.display_name or candidate.get("site_name") or candidate["site_url"]
+        found.append(
+            _site_record(
+                site_url=candidate["site_url"],
+                cloud_id=cloud_id,
+                site_name=str(name),
+            )
+        )
+    return found
+
+
+def _prompt_site_subdomain() -> str:
+    return typer.prompt(
+        "Enter your Atlassian site subdomain "
+        "(e.g. 'potpie-team' for potpie-team.atlassian.net)"
+    ).strip()
+
+
+def _prompt_and_resolve_site() -> tuple[dict[str, Any] | None, AtlassianAuthErrorKind | None]:
+    """Prompt once for site subdomain and resolve cloud ID."""
+    subdomain = _prompt_site_subdomain()
+    if not subdomain:
+        return None, AtlassianAuthErrorKind.SITE_DISCOVERY_FAILED
+    site_url = site_url_from_subdomain(subdomain)
+    if not site_url:
+        return None, AtlassianAuthErrorKind.SITE_DISCOVERY_FAILED
+    cloud_id = fetch_cloud_id_for_site(site_url)
+    if not cloud_id:
+        return None, AtlassianAuthErrorKind.SITE_DISCOVERY_FAILED
+    slug = urlparse(site_url).netloc.removesuffix(".atlassian.net")
+    return (
+        _site_record(
+            site_url=site_url,
+            cloud_id=cloud_id,
+            site_name=slug or site_url,
+        ),
+        None,
+    )
+
+
+def _finalize_selected_site(
+    email: str,
+    api_token: str,
+    site: dict[str, Any],
+    product: AtlassianProduct,
+) -> tuple[dict[str, Any] | None, AtlassianAuthErrorKind | None]:
+    cloud_id = str(site.get("cloud_id") or "").strip()
+    if not cloud_id:
+        cloud_id = fetch_cloud_id_for_site(str(site.get("site_url") or ""))
+    if not cloud_id:
+        return None, AtlassianAuthErrorKind.SITE_DISCOVERY_FAILED
+
+    result = verify_gateway_product(email, api_token, cloud_id, product)
+    if not result.ok:
+        return None, result.error_kind
+
+    site = {**site, "cloud_id": cloud_id}
+    return site, None
+
+
+def _prompt_credentials() -> tuple[str, str]:
+    email = typer.prompt("Enter your Atlassian email").strip()
+    if not email:
+        raise typer.Exit(code=1)
+    api_token = typer.prompt("Enter your API token", hide_input=True).strip()
+    if not api_token:
+        raise typer.Exit(code=1)
+    return email, api_token
+
+
+def _auth_failure_message(
+    product: AtlassianProduct,
+    error_kind: AtlassianAuthErrorKind | None = None,
+) -> str:
+    name = product.capitalize()
+    lines = [
+        f"Could not authenticate {name} with Atlassian.",
+        "  - Use an API token from id.atlassian.com (scoped tokens are supported)",
+        "  - Email must match the Atlassian account that created the token",
+        "  - Your account must have access to the product on the selected site",
+    ]
+    lines.append(
+        "  - Use Create API token (without scopes) for Jira + Confluence on one token"
+    )
+    lines.append(
+        "  - Or use scoped tokens: Jira needs read:jira-work; "
+        "Confluence needs read/content scopes (one product per token)"
+    )
+    if error_kind == AtlassianAuthErrorKind.INVALID_CREDENTIALS:
+        lines.insert(1, "  - Invalid email or API token")
+    elif error_kind == AtlassianAuthErrorKind.INSUFFICIENT_SCOPES:
+        lines.insert(
+            1,
+            "  - Token is missing required read scopes "
+            "(Jira: read:jira-work at minimum)",
+        )
+    elif error_kind == AtlassianAuthErrorKind.SITE_DISCOVERY_FAILED:
+        lines.insert(1, "  - Could not resolve cloud ID for the site")
+    elif error_kind == AtlassianAuthErrorKind.PRODUCT_ACCESS_DENIED:
+        lines.insert(
+            1,
+            f"  - Token or account cannot access {name} on this site",
+        )
+    else:
+        lines.insert(
+            1,
+            "  - Check the site subdomain from your Jira URL (e.g. acme.atlassian.net)",
+        )
+    return "\n".join(lines)
+
+
+def _get_product_credentials(product: AtlassianProduct) -> dict[str, Any]:
+    if product == "jira":
+        return get_jira_credentials()
+    return get_confluence_credentials()
+
+
+def _save_product_credentials(product: AtlassianProduct, payload: dict[str, Any]) -> None:
+    if product == "jira":
+        save_jira_credentials(payload)
+    else:
+        save_confluence_credentials(payload)
+
+
+def run_atlassian_api_token_auth(
+    product: AtlassianProduct,
+    *,
+    force: bool = False,
+    as_json: bool = False,
+    verbose: bool = False,
+) -> None:
+    """Authenticate Jira or Confluence using an Atlassian API token (one product only)."""
+    product_label = product.capitalize()
+    try:
+        existing = _get_product_credentials(product)
+    except ProviderCredentialError as exc:
+        emit_error(f"{product_label} credential lookup failed", str(exc), verbose=verbose)
+        existing = {}
+
+    if existing.get("api_token") and existing.get("site_url") and not force:
+        print_plain_line(
+            f"{product_label} is already connected.",
+            as_json=as_json,
+            json_payload={
+                "ok": True,
+                "already_connected": True,
+                "provider": product,
+                "site_url": existing.get("site_url"),
+                "site_name": existing.get("site_name"),
+                "cloud_id": existing.get("cloud_id"),
+            },
+        )
+        return
+
+    if not as_json:
+        print_plain_line("Opening Atlassian API token page...", as_json=False)
+        print_plain_line(
+            f"If the browser does not open, visit:\n{ATLASSIAN_API_TOKEN_PAGE}",
+            as_json=False,
+        )
+        print_plain_line(
+            f"Create an API token (without scopes) with access to {product_label}.",
+            as_json=False,
+        )
+        print_plain_line(
+            "At id.atlassian.com choose Create API token — not Create API token with scopes.",
+            as_json=False,
+        )
+    webbrowser.open(ATLASSIAN_API_TOKEN_PAGE, new=1)
+
+    if not sys.stdin.isatty() and not as_json:
+        emit_error(
+            f"{product.capitalize()} authentication requires a terminal",
+            "Run this command in an interactive shell to enter your email and API token.",
+            verbose=verbose,
+        )
+        raise typer.Exit(code=1)
+
+    email, api_token = _prompt_credentials()
+    site, last_error = _prompt_and_resolve_site()
+    if not site:
+        emit_error(
+            f"{product.capitalize()} authentication failed",
+            _auth_failure_message(product, last_error),
+            verbose=verbose,
+        )
+        raise typer.Exit(code=1)
+
+    site, last_error = _finalize_selected_site(email, api_token, site, product)
+    if not site:
+        emit_error(
+            f"{product_label} authentication failed",
+            _auth_failure_message(product, last_error),
+            verbose=verbose,
+        )
+        raise typer.Exit(code=1)
+
+    payload = {
+        "auth_type": "api_token",
+        "token_style": "classic",
+        "email": email,
+        "api_token": api_token,
+        "cloud_id": str(site.get("cloud_id") or "").strip(),
+        "site_url": site["site_url"],
+        "site_name": site["site_name"],
+        "stored_at": time.time(),
+    }
+    try:
+        _save_product_credentials(product, payload)
+    except ProviderCredentialError as exc:
+        emit_error(f"{product_label} credential storage failed", str(exc), verbose=verbose)
+        raise typer.Exit(code=1) from exc
+
+    summary = (
+        f"Connected {product_label} to {site['site_url']}. "
+        f"Stored tokens in system keychain; metadata saved to {credentials_path()}."
+    )
+    print_plain_line(
+        summary,
+        as_json=as_json,
+        json_payload={
+            "ok": True,
+            "provider": product,
+            "token_style": "classic",
+            "site_url": site["site_url"],
+            "site_name": site["site_name"],
+            "cloud_id": payload["cloud_id"],
+            "path": str(credentials_path()),
+            "token_storage": "keychain",
+            "product_verified": product,
+        },
+    )
+
+
+def fetch_accessible_resources(email: str, api_token: str) -> list[dict[str, Any]]:
+    """Backwards-compatible alias for tests."""
+    return discover_sites_with_api_token(email, api_token, "jira")

--- a/app/src/context-engine/adapters/inbound/cli/atlassian_read.py
+++ b/app/src/context-engine/adapters/inbound/cli/atlassian_read.py
@@ -1,0 +1,719 @@
+"""Read-only Atlassian Cloud helpers for CLI (classic unscoped API tokens)."""
+
+from __future__ import annotations
+
+import re
+import sys
+from html import unescape
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+import typer
+
+from adapters.inbound.cli.atlassian_auth import (
+    AtlassianProduct,
+    atlassian_basic_auth_header,
+    atlassian_bearer_auth_header,
+    normalize_site_url,
+)
+from adapters.inbound.cli.credentials_store import (
+    ProviderCredentialError,
+    get_confluence_credentials,
+    get_jira_credentials,
+    save_confluence_workspace_prefs,
+    save_jira_workspace_prefs,
+)
+from adapters.inbound.cli.integration_profile import (
+    atlassian_site_from_entry,
+    atlassian_workspaces_from_entry,
+)
+from adapters.inbound.cli.output import print_plain_line
+from adapters.inbound.cli.provider_config import (
+    atlassian_confluence_gateway_url,
+    atlassian_jira_gateway_url,
+)
+
+_HTTP_TIMEOUT = 30.0
+_DEFAULT_JIRA_LIMIT = 10
+_DEFAULT_CONFLUENCE_LIMIT = 10
+_EXCERPT_LEN = 280
+
+
+class AtlassianReadError(Exception):
+    """Failed to read Jira or Confluence data with stored credentials."""
+
+
+def _is_gateway_base(base: str) -> bool:
+    return "api.atlassian.com" in base.lower()
+
+
+def _auth_header_variants(
+    email: str,
+    api_token: str,
+    *,
+    base: str,
+) -> list[dict[str, str]]:
+    """Build auth headers for a request base URL.
+
+    Tenant URLs (*.atlassian.net) require Basic email:token. Bearer is interpreted
+    as a Connect JWT and returns 403 "Failed to parse Connect Session Auth Token".
+    """
+    accept = {"Accept": "application/json"}
+    basic = {**accept, "Authorization": atlassian_basic_auth_header(email, api_token)}
+    if _is_gateway_base(base):
+        bearer = {**accept, "Authorization": atlassian_bearer_auth_header(api_token)}
+        return [basic, bearer]
+    return [basic]
+
+
+def _ordered_bases(
+    product: AtlassianProduct,
+    cloud_id: str,
+    site_url: str,
+    *,
+    site_first: bool = False,
+) -> list[str]:
+    gateway = _gateway_bases(product, cloud_id)
+    site = _site_bases(product, site_url)
+    if site_first:
+        return site + gateway
+    return gateway + site
+
+
+def _cloud_id_from_credentials(credentials: dict[str, Any]) -> str:
+    site = atlassian_site_from_entry(credentials)
+    cloud_id = str(site.get("cloud_id") or credentials.get("cloud_id") or "").strip()
+    if not cloud_id:
+        raise AtlassianReadError(
+            "Missing cloud_id. Run: potpie auth jira login or potpie auth confluence login"
+        )
+    return cloud_id
+
+
+def _site_url_from_credentials(credentials: dict[str, Any]) -> str:
+    site = atlassian_site_from_entry(credentials)
+    site_url = normalize_site_url(
+        str(site.get("site_url") or credentials.get("site_url") or "")
+    )
+    if not site_url:
+        raise AtlassianReadError(
+            "Missing site_url. Run: potpie auth jira login or potpie auth confluence login"
+        )
+    return site_url
+
+
+def _gateway_bases(product: AtlassianProduct, cloud_id: str) -> list[str]:
+    if product == "jira":
+        return [atlassian_jira_gateway_url(cloud_id).rstrip("/")]
+    return [atlassian_confluence_gateway_url(cloud_id).rstrip("/")]
+
+
+def _site_bases(product: AtlassianProduct, site_url: str) -> list[str]:
+    base = normalize_site_url(site_url)
+    if not base:
+        return []
+    if product == "jira":
+        return [base]
+    return [base]
+
+
+def _get_json(
+    *,
+    email: str,
+    api_token: str,
+    product: AtlassianProduct,
+    cloud_id: str,
+    site_url: str,
+    path: str,
+    site_first: bool = False,
+) -> dict[str, Any]:
+    path = path if path.startswith("/") else f"/{path}"
+    paths = [path]
+    if product == "confluence" and not path.startswith("/wiki/"):
+        paths.append(f"/wiki{path}")
+    bases = _ordered_bases(product, cloud_id, site_url, site_first=site_first)
+    last_status: int | None = None
+    last_body = ""
+
+    with httpx.Client(timeout=_HTTP_TIMEOUT) as client:
+        for candidate_path in paths:
+            for base in bases:
+                url = f"{base}{candidate_path}"
+                for headers in _auth_header_variants(
+                    email, api_token, base=base
+                ):
+                    response = client.get(url, headers=headers)
+                    last_status = response.status_code
+                    if response.status_code == 200:
+                        data = response.json()
+                        if isinstance(data, dict):
+                            return data
+                        return {"data": data}
+                    last_body = response.text[:500]
+
+    raise AtlassianReadError(
+        f"{product} read failed (HTTP {last_status}): {last_body or 'no response body'}"
+    )
+
+
+def _post_json(
+    *,
+    email: str,
+    api_token: str,
+    product: AtlassianProduct,
+    cloud_id: str,
+    site_url: str,
+    path: str,
+    body: dict[str, Any],
+    site_first: bool = False,
+) -> dict[str, Any]:
+    path = path if path.startswith("/") else f"/{path}"
+    bases = _ordered_bases(product, cloud_id, site_url, site_first=site_first)
+    last_status: int | None = None
+    last_body = ""
+    headers_base = {"Accept": "application/json", "Content-Type": "application/json"}
+
+    with httpx.Client(timeout=_HTTP_TIMEOUT) as client:
+        for base in bases:
+            url = f"{base}{path}"
+            for auth in _auth_header_variants(email, api_token, base=base):
+                headers = {**headers_base, **auth}
+                response = client.post(url, headers=headers, json=body)
+                last_status = response.status_code
+                if response.status_code == 200:
+                    data = response.json()
+                    if isinstance(data, dict):
+                        return data
+                    return {"data": data}
+                last_body = response.text[:500]
+
+    raise AtlassianReadError(
+        f"{product} read failed (HTTP {last_status}): {last_body or 'no response body'}"
+    )
+
+
+_JIRA_ISSUE_FIELDS = [
+    "summary",
+    "status",
+    "created",
+    "updated",
+    "project",
+    "assignee",
+    "reporter",
+    "priority",
+    "issuetype",
+    "description",
+]
+
+
+def _jira_search(
+    ctx: dict[str, Any],
+    *,
+    jql: str,
+    max_results: int,
+    fields: list[str] | None = None,
+) -> dict[str, Any]:
+    """Run Jira issue search preferring tenant Basic auth and GET /search/jql."""
+    field_list = fields or _JIRA_ISSUE_FIELDS
+    fields_param = ",".join(field_list)
+    encoded_jql = quote(jql, safe="")
+    get_path = (
+        f"/rest/api/3/search/jql?jql={encoded_jql}"
+        f"&maxResults={max_results}&fields={fields_param}"
+    )
+    try:
+        return _get_json(
+            email=ctx["email"],
+            api_token=ctx["api_token"],
+            product="jira",
+            cloud_id=ctx["cloud_id"],
+            site_url=ctx["site_url"],
+            path=get_path,
+            site_first=True,
+        )
+    except AtlassianReadError:
+        return _post_json(
+            email=ctx["email"],
+            api_token=ctx["api_token"],
+            product="jira",
+            cloud_id=ctx["cloud_id"],
+            site_url=ctx["site_url"],
+            path="/rest/api/3/search",
+            body={
+                "jql": jql,
+                "maxResults": max_results,
+                "fields": field_list,
+            },
+            site_first=True,
+        )
+
+
+def _normalize_jira_datetime(value: Any) -> str:
+    """Return a compact date/time string from Jira ISO timestamps."""
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if "T" in text:
+        date_part, time_part = text.split("T", 1)
+        time_part = time_part.rstrip("Zz")
+        for offset_marker in ("+", "-"):
+            if offset_marker in time_part:
+                time_part = time_part.split(offset_marker, 1)[0]
+                break
+        time_part = time_part.split(".", 1)[0]
+        if time_part:
+            return f"{date_part} {time_part}"
+        return date_part
+    return text
+
+
+def _parse_jira_issues(
+    payload: dict[str, Any],
+    *,
+    site_url: str,
+    excerpt_description: bool = True,
+) -> list[dict[str, Any]]:
+    issues: list[dict[str, Any]] = []
+    for item in payload.get("issues") or []:
+        if not isinstance(item, dict):
+            continue
+        fields = item.get("fields") if isinstance(item.get("fields"), dict) else {}
+        status = fields.get("status") if isinstance(fields.get("status"), dict) else {}
+        project = fields.get("project") if isinstance(fields.get("project"), dict) else {}
+        assignee = (
+            fields.get("assignee") if isinstance(fields.get("assignee"), dict) else {}
+        )
+        reporter = (
+            fields.get("reporter") if isinstance(fields.get("reporter"), dict) else {}
+        )
+        priority = (
+            fields.get("priority") if isinstance(fields.get("priority"), dict) else {}
+        )
+        issue_type = (
+            fields.get("issuetype") if isinstance(fields.get("issuetype"), dict) else {}
+        )
+        description = fields.get("description")
+        if isinstance(description, dict):
+            description_text = _adf_to_plain(description)
+        else:
+            description_text = str(description or "")
+        issue_key = str(item.get("key") or "")
+        row: dict[str, Any] = {
+            "key": issue_key,
+            "summary": fields.get("summary"),
+            "status": status.get("name"),
+            "project": project.get("key") or project.get("name"),
+            "created": _normalize_jira_datetime(fields.get("created")),
+            "updated": _normalize_jira_datetime(fields.get("updated")),
+            "assignee": assignee.get("displayName") or assignee.get("emailAddress"),
+            "reporter": reporter.get("displayName") or reporter.get("emailAddress"),
+            "priority": priority.get("name"),
+            "type": issue_type.get("name"),
+            "url": _issue_browse_url(site_url, issue_key) if issue_key else None,
+        }
+        if excerpt_description:
+            row["description"] = _excerpt(description_text)
+        issues.append(row)
+    return issues
+
+
+def _excerpt(text: str, *, max_len: int = _EXCERPT_LEN) -> str:
+    collapsed = " ".join(str(text or "").split())
+    if len(collapsed) <= max_len:
+        return collapsed
+    return collapsed[: max_len - 3].rstrip() + "..."
+
+
+def _adf_to_plain(node: Any) -> str:
+    if node is None:
+        return ""
+    if isinstance(node, str):
+        return node
+    if not isinstance(node, dict):
+        return ""
+    if node.get("type") == "text":
+        return str(node.get("text") or "")
+    parts: list[str] = []
+    for child in node.get("content") or []:
+        parts.append(_adf_to_plain(child))
+    return "".join(parts)
+
+
+def _html_to_plain(html: str) -> str:
+    text = re.sub(r"<[^>]+>", " ", str(html or ""))
+    return _excerpt(unescape(text))
+
+
+def _normalize_confluence_date(value: Any) -> str:
+    """Return a human-readable date from Confluence history/version fields."""
+    if isinstance(value, dict):
+        return str(value.get("friendlyWhen") or value.get("when") or "").strip()
+    return str(value or "").strip()
+
+
+def _confluence_author_name(value: Any) -> str:
+    if not isinstance(value, dict):
+        return ""
+    by = value.get("by")
+    if not isinstance(by, dict):
+        return ""
+    return str(by.get("displayName") or by.get("publicName") or "").strip()
+
+
+def _parse_confluence_timestamps(
+    history: dict[str, Any],
+    version: dict[str, Any],
+) -> tuple[str, str, str, str]:
+    """Return updated, updated_by, created, created_by from Confluence metadata."""
+    updated = _normalize_confluence_date(history.get("lastUpdated"))
+    updated_by = _confluence_author_name(history.get("lastUpdated"))
+    if not updated:
+        updated = _normalize_confluence_date(version.get("when"))
+
+    created = _normalize_confluence_date(history.get("createdDate"))
+    created_by = _confluence_person_name(history.get("createdBy"))
+    return updated, updated_by, created, created_by
+
+
+def _confluence_person_name(value: Any) -> str:
+    if not isinstance(value, dict):
+        return ""
+    return str(value.get("displayName") or value.get("publicName") or "").strip()
+
+
+def _issue_browse_url(site_url: str, issue_key: str) -> str:
+    base = normalize_site_url(site_url).rstrip("/")
+    return f"{base}/browse/{issue_key}"
+
+
+def _jira_project_url(site_url: str, project_key: str) -> str:
+    base = normalize_site_url(site_url).rstrip("/")
+    key = str(project_key or "").strip()
+    return f"{base}/browse/{key}" if key else base
+
+
+def _confluence_page_url(site_url: str, webui: str | None) -> str:
+    base = normalize_site_url(site_url).rstrip("/")
+    path = str(webui or "").strip()
+    if not path:
+        return base
+    if path.startswith("http"):
+        return path
+    if not path.startswith("/"):
+        path = f"/{path}"
+    if path.startswith("/wiki/"):
+        return f"{base}{path}"
+    return f"{base}/wiki{path}"
+
+
+def _load_product_read_credentials(product: AtlassianProduct) -> dict[str, Any]:
+    label = product.capitalize()
+    login_cmd = f"potpie auth {product} login"
+    try:
+        credentials = (
+            get_jira_credentials() if product == "jira" else get_confluence_credentials()
+        )
+    except ProviderCredentialError as exc:
+        raise AtlassianReadError(str(exc)) from exc
+    if not credentials:
+        raise AtlassianReadError(f"{label} is not connected. Run: {login_cmd}")
+    email = str(credentials.get("email") or "").strip()
+    api_token = str(credentials.get("api_token") or "").strip()
+    if not email or not api_token:
+        raise AtlassianReadError(f"{label} API token missing. Run: {login_cmd}")
+    workspaces = atlassian_workspaces_from_entry(credentials)
+    return {
+        "email": email,
+        "api_token": api_token,
+        "cloud_id": _cloud_id_from_credentials(credentials),
+        "site_url": _site_url_from_credentials(credentials),
+        "site_name": str(
+            atlassian_site_from_entry(credentials).get("site_name")
+            or credentials.get("site_name")
+            or ""
+        ).strip(),
+        "workspaces": workspaces,
+    }
+
+
+def load_jira_read_credentials() -> dict[str, Any]:
+    """Return Jira API credentials from stored integration metadata."""
+    return _load_product_read_credentials("jira")
+
+
+def load_confluence_read_credentials() -> dict[str, Any]:
+    """Return Confluence API credentials from stored integration metadata."""
+    return _load_product_read_credentials("confluence")
+
+
+def load_atlassian_read_credentials() -> dict[str, Any]:
+    """Backwards-compatible alias; prefers Jira credentials."""
+    try:
+        return load_jira_read_credentials()
+    except AtlassianReadError:
+        return load_confluence_read_credentials()
+
+
+def fetch_jira_projects(*, limit: int = 50) -> list[dict[str, Any]]:
+    """Return Jira projects (workspaces) for the connected site."""
+    ctx = load_jira_read_credentials()
+    max_results = max(1, min(int(limit), 50))
+    payload = _get_json(
+        email=ctx["email"],
+        api_token=ctx["api_token"],
+        product="jira",
+        cloud_id=ctx["cloud_id"],
+        site_url=ctx["site_url"],
+        path=f"/rest/api/3/project/search?maxResults={max_results}",
+    )
+    projects: list[dict[str, Any]] = []
+    for item in payload.get("values") or []:
+        if not isinstance(item, dict):
+            continue
+        key = str(item.get("key") or "").strip()
+        if not key:
+            continue
+        projects.append(
+            {
+                "key": key,
+                "name": item.get("name"),
+                "type": item.get("projectTypeKey") or item.get("style"),
+                "lead": (item.get("lead") or {}).get("displayName")
+                if isinstance(item.get("lead"), dict)
+                else None,
+                "url": _jira_project_url(ctx["site_url"], key),
+            }
+        )
+    return projects
+
+
+def fetch_jira_issues_in_project(
+    project_key: str,
+    *,
+    limit: int = _DEFAULT_JIRA_LIMIT,
+) -> list[dict[str, Any]]:
+    """Return recent Jira issues in a project with summary and description excerpts."""
+    ctx = load_jira_read_credentials()
+    key = str(project_key or "").strip().upper()
+    if not key:
+        raise AtlassianReadError("Jira project key is required.")
+    max_results = max(1, min(int(limit), 50))
+    payload = _jira_search(
+        ctx,
+        jql=f'project = "{key}" ORDER BY updated DESC',
+        max_results=max_results,
+    )
+    return _parse_jira_issues(payload, site_url=ctx["site_url"])
+
+
+def fetch_confluence_pages_in_space(
+    space_key: str,
+    *,
+    limit: int = _DEFAULT_CONFLUENCE_LIMIT,
+) -> list[dict[str, Any]]:
+    """Return Confluence pages in a space with title and body excerpt."""
+    ctx = load_confluence_read_credentials()
+    key = str(space_key or "").strip().upper()
+    if not key:
+        raise AtlassianReadError("Confluence space key is required.")
+    max_results = max(1, min(int(limit), 50))
+    payload = _get_json(
+        email=ctx["email"],
+        api_token=ctx["api_token"],
+        product="confluence",
+        cloud_id=ctx["cloud_id"],
+        site_url=ctx["site_url"],
+        path=(
+            f"/wiki/rest/api/content?spaceKey={key}&type=page"
+            f"&limit={max_results}"
+            f"&expand=body.storage,version,history.lastUpdated,history.createdDate,history.createdBy"
+        ),
+        site_first=True,
+    )
+    pages: list[dict[str, Any]] = []
+    for item in payload.get("results") or []:
+        if not isinstance(item, dict):
+            continue
+        body = item.get("body") if isinstance(item.get("body"), dict) else {}
+        storage = body.get("storage") if isinstance(body.get("storage"), dict) else {}
+        history = item.get("history") if isinstance(item.get("history"), dict) else {}
+        version = item.get("version") if isinstance(item.get("version"), dict) else {}
+        links = item.get("_links") if isinstance(item.get("_links"), dict) else {}
+        title = str(item.get("title") or "").strip()
+        updated, updated_by, created, created_by = _parse_confluence_timestamps(
+            history,
+            version,
+        )
+        pages.append(
+            {
+                "id": item.get("id"),
+                "title": title,
+                "space": key,
+                "status": item.get("status"),
+                "updated": updated,
+                "updated_by": updated_by,
+                "created": created,
+                "created_by": created_by,
+                "excerpt": _html_to_plain(str(storage.get("value") or "")),
+                "url": _confluence_page_url(ctx["site_url"], links.get("webui")),
+            }
+        )
+    return pages
+
+
+def _prompt_choice(label: str, *, default: str = "1") -> int:
+    while True:
+        choice = typer.prompt(label, default=default).strip()
+        try:
+            return int(choice)
+        except ValueError:
+            print_plain_line("Enter a number from the list.", as_json=False)
+
+
+def _prompt_workspace(
+    items: list[dict[str, Any]],
+    *,
+    label: str,
+) -> dict[str, Any]:
+    if not items:
+        raise AtlassianReadError(f"No {label} found for this account.")
+    print_plain_line(f"Select {label}:", as_json=False)
+    for index, item in enumerate(items, start=1):
+        print_plain_line(
+            f"  {index}. {item.get('key')}\t{item.get('name')}",
+            as_json=False,
+        )
+    while True:
+        selected = _prompt_choice(f"{label.capitalize()} number")
+        if 1 <= selected <= len(items):
+            return items[selected - 1]
+        print_plain_line("Enter a number from the list.", as_json=False)
+
+
+def run_jira_use_flow(
+    *,
+    workspace_key: str | None = None,
+    limit: int = 10,
+) -> dict[str, Any]:
+    """Pick a Jira project, persist choice, and fetch issues."""
+    if not sys.stdin.isatty() and not workspace_key:
+        raise AtlassianReadError(
+            "Interactive workspace selection requires a terminal. "
+            "Use: potpie auth jira use --key ENG"
+        )
+    ctx = load_jira_read_credentials()
+    prefs = ctx.get("workspaces") if isinstance(ctx.get("workspaces"), dict) else {}
+    items = fetch_jira_projects()
+    default_key = str(workspace_key or prefs.get("jira_project") or "").strip().upper()
+    if workspace_key or (default_key and (not sys.stdin.isatty() or workspace_key)):
+        match = next((i for i in items if i.get("key") == default_key), None)
+        picked = match or {"key": default_key, "name": default_key}
+    else:
+        picked = _prompt_workspace(items, label="Jira project")
+    project_key = str(picked.get("key") or "").strip().upper()
+    save_jira_workspace_prefs(project_key=project_key)
+    rows = fetch_jira_issues_in_project(project_key, limit=limit)
+    return {
+        "product": "jira",
+        "workspace_key": project_key,
+        "workspace_name": picked.get("name"),
+        "items": rows,
+    }
+
+
+def run_confluence_use_flow(
+    *,
+    workspace_key: str | None = None,
+    limit: int = 10,
+) -> dict[str, Any]:
+    """Pick a Confluence space, persist choice, and fetch pages."""
+    if not sys.stdin.isatty() and not workspace_key:
+        raise AtlassianReadError(
+            "Interactive workspace selection requires a terminal. "
+            "Use: potpie auth confluence use --key DOCS"
+        )
+    ctx = load_confluence_read_credentials()
+    prefs = ctx.get("workspaces") if isinstance(ctx.get("workspaces"), dict) else {}
+    items = fetch_confluence_spaces_sample()
+    default_key = str(workspace_key or prefs.get("confluence_space") or "").strip().upper()
+    if workspace_key or (default_key and (not sys.stdin.isatty() or workspace_key)):
+        match = next((i for i in items if i.get("key") == default_key), None)
+        picked = match or {"key": default_key, "name": default_key}
+    else:
+        picked = _prompt_workspace(items, label="Confluence space")
+    space_key = str(picked.get("key") or "").strip().upper()
+    save_confluence_workspace_prefs(space_key=space_key)
+    rows = fetch_confluence_pages_in_space(space_key, limit=limit)
+    return {
+        "product": "wiki",
+        "workspace_key": space_key,
+        "workspace_name": picked.get("name"),
+        "items": rows,
+    }
+
+
+def fetch_jira_issues_sample(*, limit: int = _DEFAULT_JIRA_LIMIT) -> list[dict[str, Any]]:
+    """Return recent Jira issues using saved project or the first available project."""
+    ctx = load_jira_read_credentials()
+    prefs = ctx.get("workspaces") if isinstance(ctx.get("workspaces"), dict) else {}
+    project_key = str(prefs.get("jira_project") or "").strip().upper()
+    if not project_key:
+        projects = fetch_jira_projects(limit=1)
+        if projects:
+            project_key = str(projects[0].get("key") or "").strip().upper()
+    if project_key:
+        return fetch_jira_issues_in_project(project_key, limit=limit)
+    max_results = max(1, min(int(limit), 50))
+    payload = _jira_search(
+        ctx,
+        jql="order by updated DESC",
+        max_results=max_results,
+        fields=["summary", "status", "updated", "project"],
+    )
+    return _parse_jira_issues(
+        payload, site_url=ctx["site_url"], excerpt_description=False
+    )
+
+
+def fetch_confluence_content_sample(
+    *, limit: int = _DEFAULT_CONFLUENCE_LIMIT
+) -> list[dict[str, Any]]:
+    """Return pages in saved Confluence space, or spaces if none is saved yet."""
+    ctx = load_confluence_read_credentials()
+    prefs = ctx.get("workspaces") if isinstance(ctx.get("workspaces"), dict) else {}
+    space_key = str(prefs.get("confluence_space") or "").strip().upper()
+    if space_key:
+        return fetch_confluence_pages_in_space(space_key, limit=limit)
+    return fetch_confluence_spaces_sample(limit=limit)
+
+
+def fetch_confluence_spaces_sample(
+    *, limit: int = _DEFAULT_CONFLUENCE_LIMIT
+) -> list[dict[str, Any]]:
+    """Return Confluence spaces (read-only) using the stored API token."""
+    ctx = load_confluence_read_credentials()
+    max_results = max(1, min(int(limit), 50))
+    payload = _get_json(
+        email=ctx["email"],
+        api_token=ctx["api_token"],
+        product="confluence",
+        cloud_id=ctx["cloud_id"],
+        site_url=ctx["site_url"],
+        path=f"/wiki/rest/api/space?limit={max_results}",
+    )
+    spaces: list[dict[str, Any]] = []
+    for item in payload.get("results") or []:
+        if not isinstance(item, dict):
+            continue
+        links = item.get("_links") if isinstance(item.get("_links"), dict) else {}
+        spaces.append(
+            {
+                "key": item.get("key"),
+                "name": item.get("name"),
+                "type": item.get("type"),
+                "webui": links.get("webui"),
+                "url": _confluence_page_url(ctx["site_url"], links.get("webui")),
+            }
+        )
+    return spaces

--- a/app/src/context-engine/adapters/inbound/cli/auth_commands.py
+++ b/app/src/context-engine/adapters/inbound/cli/auth_commands.py
@@ -1,10 +1,61 @@
-"""Generic CLI auth command foundation."""
+"""CLI commands for external integration authentication."""
 
 from __future__ import annotations
 
+import secrets
+import threading
+import time
+import urllib.parse
+import webbrowser
+from typing import Any
+
 import typer
 
+from adapters.inbound.cli.atlassian_auth import run_atlassian_api_token_auth
+from adapters.inbound.cli.atlassian_read import (
+    AtlassianReadError,
+    fetch_confluence_content_sample,
+    fetch_confluence_spaces_sample,
+    fetch_jira_issues_sample,
+    fetch_jira_projects,
+    run_confluence_use_flow,
+    run_jira_use_flow,
+)
+from adapters.inbound.cli.callback_server import OAuthCallbackResult, wait_for_oauth_callback
+from adapters.inbound.cli.credentials_store import (
+    ProviderCredentialError,
+    clear_integration_tokens,
+    credentials_path,
+    get_integration_status,
+    save_integration_tokens,
+)
+from adapters.inbound.cli.env_bootstrap import load_cli_env
+from adapters.inbound.cli.integration_session import (
+    ensure_valid_integration_tokens,
+    token_needs_refresh,
+)
+from adapters.inbound.cli.integration_verify import verify_integration_access
+from adapters.inbound.cli.output import emit_error, print_json_blob, print_plain_line
+from adapters.inbound.cli.pkce import generate_pkce_pair
+from adapters.inbound.cli.provider_config import (
+    Provider,
+    authorization_url,
+    get_callback_host,
+    get_callback_path,
+    get_callback_port,
+    get_client_id,
+    get_redirect_uri,
+    get_scopes,
+)
+from adapters.inbound.cli.token_exchange import exchange_authorization_code
+
 auth_app = typer.Typer(help="Authenticate CLI integrations.")
+jira_app = typer.Typer(help="Jira authentication and read.")
+confluence_app = typer.Typer(help="Confluence authentication and read.")
+linear_app = typer.Typer(help="Linear authentication.")
+
+_OAUTH_CALLBACK_TIMEOUT = 300.0
+_ALL_PROVIDERS: tuple[str, ...] = ("linear", "jira", "confluence")
 
 
 def register_provider_app(name: str, provider_app: typer.Typer) -> None:
@@ -13,3 +64,691 @@ def register_provider_app(name: str, provider_app: typer.Typer) -> None:
     if not key:
         raise ValueError("provider app name must be non-empty")
     auth_app.add_typer(provider_app, name=key)
+
+
+def _flags() -> tuple[bool, bool]:
+    from adapters.inbound.cli.main import _flags as main_flags
+
+    return main_flags()
+
+
+def _build_linear_authorization_url(
+    *,
+    redirect_uri: str,
+    state: str,
+    code_challenge: str,
+) -> str:
+    params = {
+        "client_id": get_client_id("linear"),
+        "response_type": "code",
+        "redirect_uri": redirect_uri,
+        "scope": get_scopes("linear"),
+        "state": state,
+        "prompt": "consent",
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    }
+    query = urllib.parse.urlencode(params, quote_via=urllib.parse.quote)
+    return f"{authorization_url('linear')}?{query}"
+
+
+def _wait_for_callback(*, host: str, port: int, path: str) -> OAuthCallbackResult:
+    return wait_for_oauth_callback(
+        host=host,
+        port=port,
+        path=path,
+        timeout=_OAUTH_CALLBACK_TIMEOUT,
+    )
+
+
+def _token_is_expired(expires_at: Any) -> bool:
+    if expires_at is None:
+        return False
+    try:
+        return time.time() > float(expires_at)
+    except (TypeError, ValueError):
+        return False
+
+
+def _try_refresh_linear_session() -> bool:
+    try:
+        tokens = ensure_valid_integration_tokens("linear")
+    except (ValueError, RuntimeError, ProviderCredentialError):
+        return False
+    return bool(tokens.get("access_token")) and not _token_is_expired(
+        tokens.get("expires_at")
+    )
+
+
+def _handle_already_connected(provider: Provider, status: dict[str, Any]) -> None:
+    j, _ = _flags()
+    name = provider.capitalize()
+    print_plain_line(
+        f"{name} is already connected.",
+        as_json=j,
+        json_payload={
+            "ok": True,
+            "already_connected": True,
+            "provider": provider,
+            "auth_type": status.get("auth_type"),
+            "expires_at": status.get("expires_at"),
+            "cloud_id": status.get("cloud_id"),
+            "site_url": status.get("site_url"),
+            "site_name": status.get("site_name"),
+            "token_storage": status.get("token_storage"),
+        },
+    )
+
+
+def _run_linear_oauth_flow(*, force: bool = False) -> None:
+    load_cli_env()
+    j, v = _flags()
+
+    status = get_integration_status("linear")
+    if status.get("authenticated") and not force:
+        if token_needs_refresh(status.get("expires_at")):
+            if _try_refresh_linear_session():
+                if not j:
+                    print_plain_line("Linear session refreshed.", as_json=False)
+                return
+            if not j:
+                print_plain_line(
+                    "Linear session expired; re-authenticating...",
+                    as_json=False,
+                )
+        else:
+            _handle_already_connected("linear", status)
+            return
+
+    client_id = get_client_id("linear")
+    if not client_id:
+        emit_error(
+            "Linear OAuth not configured",
+            "Linear OAuth client id is missing (set LINEAR_CLIENT_ID to override the built-in CLI default).",
+            verbose=v,
+        )
+        raise typer.Exit(code=1)
+
+    try:
+        redirect_uri = get_redirect_uri()
+        port = get_callback_port()
+        host = get_callback_host()
+        callback_path = get_callback_path()
+    except ValueError as exc:
+        emit_error("Linear OAuth redirect is invalid", str(exc), verbose=v)
+        raise typer.Exit(code=1) from exc
+    state = secrets.token_urlsafe(24)
+    code_verifier, code_challenge = generate_pkce_pair()
+    auth_url = _build_linear_authorization_url(
+        redirect_uri=redirect_uri,
+        state=state,
+        code_challenge=code_challenge,
+    )
+
+    callback_result: OAuthCallbackResult | None = None
+    callback_error: BaseException | None = None
+
+    def _capture_callback() -> None:
+        nonlocal callback_result, callback_error
+        try:
+            callback_result = _wait_for_callback(
+                host=host,
+                port=port,
+                path=callback_path,
+            )
+        except BaseException as exc:
+            callback_error = exc
+
+    server_thread = threading.Thread(target=_capture_callback, daemon=True)
+    server_thread.start()
+    time.sleep(0.15)
+    if callback_error is not None:
+        emit_error(
+            "OAuth callback failed to start",
+            str(callback_error),
+            verbose=v,
+            exc=callback_error if v else None,
+        )
+        raise typer.Exit(code=1) from callback_error
+
+    print_plain_line(
+        "Opening browser for Linear authentication...",
+        as_json=j,
+        json_payload={"provider": "linear", "redirect_uri": redirect_uri},
+    )
+    if not j:
+        print_plain_line(
+            f"If the browser does not open, visit:\n{auth_url}",
+            as_json=False,
+        )
+
+    opened = webbrowser.open(auth_url, new=1)
+    if not opened and not j:
+        print_plain_line(
+            "Could not open a browser automatically; use the URL above.",
+            as_json=False,
+        )
+
+    server_thread.join(timeout=_OAUTH_CALLBACK_TIMEOUT + 5.0)
+
+    if callback_error is not None:
+        if isinstance(callback_error, TimeoutError):
+            emit_error("OAuth callback timed out", str(callback_error), verbose=v)
+        else:
+            emit_error(
+                "OAuth callback failed",
+                str(callback_error),
+                verbose=v,
+                exc=callback_error if v else None,
+            )
+        raise typer.Exit(code=1) from callback_error
+
+    if callback_result is None:
+        emit_error(
+            "OAuth callback timed out",
+            f"No response on {redirect_uri} within {_OAUTH_CALLBACK_TIMEOUT:.0f}s.",
+            verbose=v,
+        )
+        raise typer.Exit(code=1)
+
+    callback = callback_result
+    if callback.error:
+        msg = callback.error
+        if callback.error_description:
+            msg = f"{msg}: {callback.error_description}"
+        emit_error("Linear OAuth failed", msg, verbose=v)
+        raise typer.Exit(code=1)
+
+    if not callback.code:
+        emit_error(
+            "Linear OAuth failed",
+            "No authorization code received.",
+            verbose=v,
+        )
+        raise typer.Exit(code=1)
+
+    if callback.state != state:
+        emit_error(
+            "Linear OAuth failed",
+            "State mismatch; aborting for safety.",
+            verbose=v,
+        )
+        raise typer.Exit(code=1)
+
+    try:
+        tokens = exchange_authorization_code(
+            "linear",
+            code=callback.code,
+            code_verifier=code_verifier,
+            redirect_uri=redirect_uri,
+        )
+        save_integration_tokens("linear", tokens)
+    except (ValueError, RuntimeError, ProviderCredentialError) as exc:
+        emit_error("Linear token exchange failed", str(exc), verbose=v)
+        raise typer.Exit(code=1) from exc
+
+    status = get_integration_status("linear")
+    account = (
+        status.get("login"),
+        status.get("email"),
+        status.get("site_name"),
+    )
+    who = account[0] or account[1] or "Linear"
+    org_suffix = f" @ {account[2]}" if account[2] else ""
+    summary = (
+        f"Logged in to Linear as {who}{org_suffix}. "
+        f"Stored tokens in system keychain; metadata saved to {credentials_path()}."
+    )
+    print_plain_line(
+        summary,
+        as_json=j,
+        json_payload={
+            "ok": True,
+            "provider": "linear",
+            "path": str(credentials_path()),
+            "login": status.get("login"),
+            "email": status.get("email"),
+            "organization": status.get("site_name"),
+            "scope": tokens.get("scope"),
+            "token_storage": "keychain",
+        },
+    )
+
+
+@auth_app.command("status")
+def auth_status(
+    verify: bool = typer.Option(
+        False,
+        "--verify",
+        help="Run a lightweight read-only API check for authenticated providers.",
+    ),
+) -> None:
+    """Show local integration auth status."""
+    load_cli_env()
+    j, _ = _flags()
+    rows: list[dict[str, Any]] = []
+
+    for provider in _ALL_PROVIDERS:
+        meta = get_integration_status(provider)
+        row = dict(meta)
+        if verify and meta.get("authenticated"):
+            try:
+                credentials = ensure_valid_integration_tokens(provider)
+            except (ValueError, RuntimeError, ProviderCredentialError) as exc:
+                row["verified"] = False
+                row["verify_message"] = str(exc)
+            else:
+                ok, message = verify_integration_access(provider, credentials)
+                row["verified"] = ok
+                row["verify_message"] = message
+                if provider == "linear":
+                    refreshed = get_integration_status(provider)
+                    row["expires_at"] = refreshed.get("expires_at")
+        rows.append(row)
+
+    if j:
+        print_json_blob({"integrations": rows}, as_json=True)
+        return
+
+    for row in rows:
+        provider = row["provider"]
+        if not row.get("authenticated"):
+            print_plain_line(f"{provider}: not authenticated", as_json=False)
+            continue
+        parts = [f"{provider}: authenticated"]
+        if row.get("login"):
+            parts.append(f"login={row['login']}")
+        if row.get("email"):
+            parts.append(f"email={row['email']}")
+        if row.get("site_name"):
+            parts.append(f"site={row['site_name']}")
+        if row.get("site_url"):
+            parts.append(f"url={row['site_url']}")
+        if row.get("expires_at") is not None:
+            parts.append(f"expires_at={row['expires_at']}")
+        if row.get("cloud_id"):
+            parts.append(f"cloud_id={row['cloud_id']}")
+        if row.get("token_storage"):
+            parts.append(f"token_storage={row['token_storage']}")
+        if verify:
+            verified = row.get("verified")
+            message = row.get("verify_message") or ""
+            if verified is True:
+                parts.append(f"verify={message}")
+            else:
+                parts.append(f"verify failed ({message})")
+        print_plain_line("  ".join(parts), as_json=False)
+
+
+@auth_app.command("logout")
+def auth_logout(
+    provider: str = typer.Argument(
+        ...,
+        help="Provider to log out: linear, jira, or confluence.",
+    ),
+) -> None:
+    """Remove locally stored credentials for a provider."""
+    load_cli_env()
+    j, v = _flags()
+    key = provider.strip().lower()
+    if key in {"wiki", "conf"}:
+        key = "confluence"
+    if key not in _ALL_PROVIDERS:
+        emit_error(
+            "Unknown provider",
+            f"Expected one of: {', '.join(_ALL_PROVIDERS)}.",
+            verbose=v,
+        )
+        raise typer.Exit(code=1)
+
+    existing = get_integration_status(key)
+    if not existing.get("authenticated"):
+        emit_error(
+            f"{key} not authenticated",
+            "No stored credentials to revoke.",
+            verbose=v,
+        )
+        raise typer.Exit(code=1)
+
+    try:
+        clear_integration_tokens(key)
+    except (ProviderCredentialError, ValueError) as exc:
+        emit_error(f"{key} logout failed", str(exc), verbose=v)
+        raise typer.Exit(code=1) from exc
+
+    message = f"Logged out of {key}."
+    print_plain_line(
+        message,
+        as_json=j,
+        json_payload={"ok": True, "provider": key},
+    )
+
+
+@auth_app.command("revoke", hidden=True)
+def auth_revoke(
+    provider: str = typer.Argument(
+        ...,
+        help="Deprecated. Use `potpie auth logout <provider>`.",
+    ),
+) -> None:
+    """Deprecated alias for `potpie auth logout`."""
+    auth_logout(provider)
+
+
+
+
+@auth_app.command("linear-login", hidden=True)
+def auth_linear(
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Re-authenticate even if Linear is already connected.",
+    ),
+) -> None:
+    """Authenticate with Linear via OAuth (PKCE)."""
+    _run_linear_oauth_flow(force=force)
+
+
+def _print_jira_issue_row(row: dict[str, Any]) -> None:
+    print_plain_line(f"\n{row.get('key')}  {row.get('summary') or ''}".rstrip(), as_json=False)
+    if row.get("project"):
+        print_plain_line(f"  Project: {row.get('project')}", as_json=False)
+    if row.get("status"):
+        print_plain_line(f"  Status: {row.get('status')}", as_json=False)
+    if row.get("type"):
+        print_plain_line(f"  Type: {row.get('type')}", as_json=False)
+    if row.get("assignee"):
+        print_plain_line(f"  Assignee: {row.get('assignee')}", as_json=False)
+    if row.get("priority"):
+        print_plain_line(f"  Priority: {row.get('priority')}", as_json=False)
+    if row.get("created"):
+        created_line = f"  Created: {row.get('created')}"
+        if row.get("reporter"):
+            created_line = f"{created_line} · {row.get('reporter')}"
+        print_plain_line(created_line, as_json=False)
+    if row.get("updated"):
+        print_plain_line(f"  Updated: {row.get('updated')}", as_json=False)
+    if row.get("description"):
+        print_plain_line(f"  Description: {row.get('description')}", as_json=False)
+    if row.get("url"):
+        print_plain_line(f"  URL: {row.get('url')}", as_json=False)
+
+
+def _print_wiki_row(row: dict[str, Any], *, pages: bool) -> None:
+    if pages:
+        print_plain_line(f"\n{row.get('title')}", as_json=False)
+        if row.get("space"):
+            print_plain_line(f"  Space: {row.get('space')}", as_json=False)
+        if row.get("status"):
+            print_plain_line(f"  Status: {row.get('status')}", as_json=False)
+        if row.get("created"):
+            created_line = f"  Created: {row.get('created')}"
+            if row.get("created_by"):
+                created_line = f"{created_line} · {row.get('created_by')}"
+            print_plain_line(created_line, as_json=False)
+        if row.get("updated"):
+            updated_line = f"  Updated: {row.get('updated')}"
+            if row.get("updated_by"):
+                updated_line = f"{updated_line} · {row.get('updated_by')}"
+            print_plain_line(updated_line, as_json=False)
+        if row.get("excerpt"):
+            print_plain_line(f"  Excerpt: {row.get('excerpt')}", as_json=False)
+        if row.get("url"):
+            print_plain_line(f"  URL: {row.get('url')}", as_json=False)
+        return
+    line = f"  {row.get('key')}\t{row.get('name')}\t{row.get('type') or ''}"
+    print_plain_line(line, as_json=False)
+    if row.get("url"):
+        print_plain_line(f"    {row.get('url')}", as_json=False)
+
+
+def _run_atlassian_quick_read(
+    *,
+    product: str,
+    fetcher,
+    limit: int,
+    hint_cmd: str = "potpie auth jira use",
+    display_name: str | None = None,
+) -> None:
+    load_cli_env()
+    j, v = _flags()
+    name = display_name or ("Confluence" if product == "wiki" else product.capitalize())
+    try:
+        rows = fetcher(limit=limit)
+    except AtlassianReadError as exc:
+        emit_error(f"{name} read failed", str(exc), verbose=v)
+        raise typer.Exit(code=1) from exc
+
+    if j:
+        print_json_blob(
+            {
+                "ok": True,
+                "provider": "jira" if product == "jira" else "confluence",
+                "product": product,
+                "count": len(rows),
+                "items": rows,
+            },
+            as_json=True,
+        )
+        return
+
+    pages = product == "wiki" and rows and "title" in (rows[0] or {})
+    row_label = "pages" if pages else ("issues" if product == "jira" else "spaces")
+    print_plain_line(f"{name} ({len(rows)} {row_label}):", as_json=False)
+    if not rows:
+        print_plain_line(f"  (no results — run: {hint_cmd})", as_json=False)
+        return
+    for row in rows:
+        if product == "jira":
+            if row.get("description") or row.get("url"):
+                _print_jira_issue_row(row)
+            else:
+                print_plain_line(
+                    f"  {row.get('key')}\t{row.get('status')}\t{row.get('project')}\t{row.get('summary')}",
+                    as_json=False,
+                )
+        else:
+            _print_wiki_row(row, pages=pages)
+
+
+def _run_product_use_result(
+    result: dict[str, Any],
+    *,
+    product_label: str,
+) -> None:
+    load_cli_env()
+    j, _ = _flags()
+    if j:
+        print_json_blob(
+            {"ok": True, "provider": result["product"], **result},
+            as_json=True,
+        )
+        return
+    print_plain_line(
+        f"{product_label} workspace: {result.get('workspace_key')} ({result.get('workspace_name')})",
+        as_json=False,
+    )
+    rows = result.get("items") or []
+    print_plain_line(f"{len(rows)} item(s):", as_json=False)
+    for row in rows:
+        if result["product"] == "jira":
+            _print_jira_issue_row(row)
+        else:
+            _print_wiki_row(row, pages=True)
+
+
+@jira_app.command("login")
+def jira_login(
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Re-authenticate even if Jira is already connected.",
+    ),
+) -> None:
+    """Connect Jira with an Atlassian API token (Jira access only)."""
+    load_cli_env()
+    j, v = _flags()
+    run_atlassian_api_token_auth("jira", force=force, as_json=j, verbose=v)
+
+
+@jira_app.command("logout")
+def jira_logout() -> None:
+    """Remove stored Jira credentials."""
+    auth_logout("jira")
+
+
+@jira_app.command("ls")
+def jira_ls(
+    limit: int = typer.Option(50, "--limit", "-n", min=1, max=50),
+) -> None:
+    """List Jira projects you can access."""
+    load_cli_env()
+    j, v = _flags()
+    try:
+        rows = fetch_jira_projects(limit=limit)
+    except AtlassianReadError as exc:
+        emit_error("Jira workspace list failed", str(exc), verbose=v)
+        raise typer.Exit(code=1) from exc
+    if j:
+        print_json_blob({"ok": True, "provider": "jira", "projects": rows}, as_json=True)
+        return
+    print_plain_line("Jira projects:", as_json=False)
+    if not rows:
+        print_plain_line("  (none)", as_json=False)
+    for row in rows:
+        print_plain_line(
+            f"  {row.get('key')}\t{row.get('name')}\t{row.get('type') or ''}",
+            as_json=False,
+        )
+        if row.get("url"):
+            print_plain_line(f"    {row.get('url')}", as_json=False)
+    print_plain_line("\nFetch issues: potpie auth jira use", as_json=False)
+
+
+@jira_app.command("use")
+def jira_use(
+    key: str | None = typer.Option(None, "--key", "-k", help="Jira project key."),
+    limit: int = typer.Option(10, "--limit", "-n", min=1, max=50),
+) -> None:
+    """Select a Jira project and fetch issues in the terminal."""
+    load_cli_env()
+    j, v = _flags()
+    try:
+        result = run_jira_use_flow(workspace_key=key, limit=limit)
+    except AtlassianReadError as exc:
+        emit_error("Jira fetch failed", str(exc), verbose=v)
+        raise typer.Exit(code=1) from exc
+    _run_product_use_result(result, product_label="Jira")
+
+
+@jira_app.command("issues")
+def jira_issues(
+    limit: int = typer.Option(10, "--limit", "-n", min=1, max=50),
+) -> None:
+    """Fetch recent Jira issues (saved project, or first project)."""
+    _run_atlassian_quick_read(
+        product="jira",
+        fetcher=fetch_jira_issues_sample,
+        limit=limit,
+        hint_cmd="potpie auth jira use",
+        display_name="Jira",
+    )
+
+
+@confluence_app.command("login")
+def confluence_login(
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Re-authenticate even if Confluence is already connected.",
+    ),
+) -> None:
+    """Connect Confluence with an Atlassian API token (Confluence access only)."""
+    load_cli_env()
+    j, v = _flags()
+    run_atlassian_api_token_auth("confluence", force=force, as_json=j, verbose=v)
+
+
+@confluence_app.command("logout")
+def confluence_logout() -> None:
+    """Remove stored Confluence credentials."""
+    auth_logout("confluence")
+
+
+@confluence_app.command("ls")
+def confluence_ls(
+    limit: int = typer.Option(50, "--limit", "-n", min=1, max=50),
+) -> None:
+    """List Confluence spaces you can access."""
+    load_cli_env()
+    j, v = _flags()
+    try:
+        rows = fetch_confluence_spaces_sample(limit=limit)
+    except AtlassianReadError as exc:
+        emit_error("Confluence workspace list failed", str(exc), verbose=v)
+        raise typer.Exit(code=1) from exc
+    if j:
+        print_json_blob({"ok": True, "provider": "confluence", "spaces": rows}, as_json=True)
+        return
+    print_plain_line("Confluence spaces:", as_json=False)
+    if not rows:
+        print_plain_line("  (none)", as_json=False)
+    for row in rows:
+        print_plain_line(
+            f"  {row.get('key')}\t{row.get('name')}\t{row.get('type') or ''}",
+            as_json=False,
+        )
+    print_plain_line("\nFetch pages: potpie auth confluence use", as_json=False)
+
+
+@confluence_app.command("use")
+def confluence_use(
+    key: str | None = typer.Option(None, "--key", "-k", help="Confluence space key."),
+    limit: int = typer.Option(10, "--limit", "-n", min=1, max=50),
+) -> None:
+    """Select a Confluence space and fetch pages in the terminal."""
+    load_cli_env()
+    j, v = _flags()
+    try:
+        result = run_confluence_use_flow(workspace_key=key, limit=limit)
+    except AtlassianReadError as exc:
+        emit_error("Confluence fetch failed", str(exc), verbose=v)
+        raise typer.Exit(code=1) from exc
+    _run_product_use_result(result, product_label="Confluence")
+
+
+@confluence_app.command("pages")
+def confluence_pages(
+    limit: int = typer.Option(10, "--limit", "-n", min=1, max=50),
+) -> None:
+    """Fetch Confluence pages (saved space) or list spaces if none saved."""
+    _run_atlassian_quick_read(
+        product="wiki",
+        fetcher=fetch_confluence_content_sample,
+        limit=limit,
+        hint_cmd="potpie auth confluence use",
+        display_name="Confluence",
+    )
+
+
+@linear_app.command("login")
+def linear_login(
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Re-authenticate even if Linear is already connected.",
+    ),
+) -> None:
+    """Authenticate with Linear via OAuth (PKCE)."""
+    _run_linear_oauth_flow(force=force)
+
+
+@linear_app.command("logout")
+def linear_logout() -> None:
+    """Remove stored Linear credentials."""
+    auth_logout("linear")
+
+
+register_provider_app("linear", linear_app)
+register_provider_app("jira", jira_app)
+register_provider_app("confluence", confluence_app)

--- a/app/src/context-engine/adapters/inbound/cli/callback_server.py
+++ b/app/src/context-engine/adapters/inbound/cli/callback_server.py
@@ -1,0 +1,94 @@
+"""Local HTTP server that captures OAuth redirect query parameters."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+
+@dataclass
+class OAuthCallbackResult:
+    code: str | None = None
+    state: str | None = None
+    error: str | None = None
+    error_description: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return bool(self.code) and not self.error
+
+
+def wait_for_oauth_callback(
+    *,
+    host: str = "localhost",
+    port: int,
+    path: str = "/callback",
+    timeout: float = 300.0,
+) -> OAuthCallbackResult:
+    """Block until the provider redirects to the local callback URL."""
+    result = OAuthCallbackResult()
+    done = threading.Event()
+    expected_path = path if path.startswith("/") else f"/{path}"
+
+    class _Handler(BaseHTTPRequestHandler):
+        def log_message(self, fmt: str, *args: Any) -> None:  # noqa: ARG002
+            return
+
+        def do_GET(self) -> None:  # noqa: N802
+            parsed = urlparse(self.path)
+            if parsed.path != expected_path:
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(b"Not found")
+                return
+
+            params = parse_qs(parsed.query, keep_blank_values=True)
+            result.code = _first(params, "code")
+            result.state = _first(params, "state")
+            result.error = _first(params, "error")
+            result.error_description = _first(params, "error_description")
+
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            if result.ok:
+                body = (
+                    "<html><body><h1>Authentication successful</h1>"
+                    "<p>You can close this tab and return to the terminal.</p>"
+                    "</body></html>"
+                )
+            else:
+                body = (
+                    "<html><body><h1>Authentication failed</h1>"
+                    f"<p>{result.error or 'No authorization code received'}</p>"
+                    "</body></html>"
+                )
+            self.wfile.write(body.encode("utf-8"))
+            done.set()
+
+    server = HTTPServer((host, port), _Handler)
+    server.timeout = 1.0
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        if not done.wait(timeout=timeout):
+            raise TimeoutError(
+                f"Timed out after {timeout:.0f}s waiting for OAuth callback on "
+                f"http://{host}:{port}{expected_path}"
+            )
+        return result
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2.0)
+
+
+def _first(params: dict[str, list[str]], key: str) -> str | None:
+    values = params.get(key)
+    if not values:
+        return None
+    value = values[0]
+    return value if value else None

--- a/app/src/context-engine/adapters/inbound/cli/credentials_store.py
+++ b/app/src/context-engine/adapters/inbound/cli/credentials_store.py
@@ -16,10 +16,23 @@ _CREDENTIALS_FILENAME = "credentials.json"
 _CONFIG_DIR_NAME = "potpie"
 _LEGACY_CONFIG_DIR_NAME = "context-engine"
 _KEYRING_SERVICE = "potpie"
+_LINEAR_ACCESS_TOKEN_SECRET = "linear_access_token"
+_LINEAR_REFRESH_TOKEN_SECRET = "linear_refresh_token"
+_ATLASSIAN_LEGACY_TOKEN_SECRET = "atlassian_api_token"
+_JIRA_TOKEN_SECRET = "jira_api_token"
+_CONFLUENCE_TOKEN_SECRET = "confluence_api_token"
+_ATLASSIAN_CREDENTIALS_KEY = "atlassian"
+_JIRA_CREDENTIALS_KEY = "jira"
+_CONFLUENCE_CREDENTIALS_KEY = "confluence"
+_LINEAR_CREDENTIALS_KEY = "linear"
 
 
 class CredentialStoreError(Exception):
     """Credential metadata or secure secret storage failure."""
+
+
+class ProviderCredentialError(CredentialStoreError):
+    """Provider credential storage or retrieval failure."""
 
 
 def config_dir() -> Path:
@@ -303,6 +316,411 @@ def register_pot_alias(name: str, pot_id: str) -> None:
     aliases[key] = str(uid)
     payload["pot_aliases"] = aliases
     _write_payload(payload)
+
+
+def _get_secret_or_empty(name: str, *, label: str) -> str:
+    try:
+        return load_secure_secret(name, label=label)
+    except CredentialStoreError as exc:
+        raise ProviderCredentialError(str(exc)) from exc
+
+
+def _store_secret(name: str, secret: str, *, label: str) -> None:
+    try:
+        store_secure_secret(name, secret, label=label)
+    except CredentialStoreError as exc:
+        raise ProviderCredentialError(str(exc)) from exc
+
+
+def _delete_secret(name: str, *, label: str) -> None:
+    try:
+        delete_secure_secret(name, label=label)
+    except CredentialStoreError as exc:
+        raise ProviderCredentialError(str(exc)) from exc
+
+
+def _store_keychain_secret(label: str, username: str, secret: str) -> None:
+    _store_secret(username, secret, label=label)
+
+
+def _load_keychain_secret(label: str, username: str) -> str:
+    return _get_secret_or_empty(username, label=label)
+
+
+def _delete_keychain_secret(label: str, username: str) -> None:
+    _delete_secret(username, label=label)
+
+
+def _read_metadata_entry(key: str) -> dict[str, Any]:
+    return get_integration_metadata(key)
+
+
+def _write_metadata_entry(key: str, metadata: dict[str, Any]) -> None:
+    write_integration_metadata(key, metadata)
+
+
+def _clear_metadata_entries(*keys: str) -> None:
+    for key in keys:
+        clear_integration_metadata(key)
+
+
+def _norm_atlassian_product(product: str) -> str:
+    key = str(product or "").strip().lower()
+    if key in {"wiki", "conf"}:
+        return "confluence"
+    if key not in {"jira", "confluence"}:
+        raise ValueError(
+            f"Unknown Atlassian product {product!r} (expected 'jira' or 'confluence')."
+        )
+    return key
+
+
+def _legacy_atlassian_metadata() -> dict[str, Any]:
+    return _read_metadata_entry(_ATLASSIAN_CREDENTIALS_KEY)
+
+
+def _product_metadata_key(product: str) -> str:
+    key = _norm_atlassian_product(product)
+    return _JIRA_CREDENTIALS_KEY if key == "jira" else _CONFLUENCE_CREDENTIALS_KEY
+
+
+def _product_secret_name(product: str) -> tuple[str, str]:
+    key = _norm_atlassian_product(product)
+    if key == "jira":
+        return _JIRA_TOKEN_SECRET, "Jira API token"
+    return _CONFLUENCE_TOKEN_SECRET, "Confluence API token"
+
+
+def save_integration_tokens(provider: str, tokens: dict[str, Any]) -> None:
+    """Store Linear OAuth tokens in keychain and metadata on disk."""
+    key = _norm_integration_key(provider)
+    if key != _LINEAR_CREDENTIALS_KEY:
+        raise ValueError(f"{provider!r} does not use OAuth token storage.")
+
+    from adapters.inbound.cli.integration_profile import build_linear_integration_record
+
+    access_token = str(tokens.get("access_token") or "").strip()
+    if access_token:
+        _store_keychain_secret(
+            "Linear access token",
+            _LINEAR_ACCESS_TOKEN_SECRET,
+            access_token,
+        )
+    refresh_token = str(tokens.get("refresh_token") or "").strip()
+    if refresh_token:
+        _store_keychain_secret(
+            "Linear refresh token",
+            _LINEAR_REFRESH_TOKEN_SECRET,
+            refresh_token,
+        )
+
+    prior = _read_metadata_entry(_LINEAR_CREDENTIALS_KEY)
+    _write_metadata_entry(
+        _LINEAR_CREDENTIALS_KEY,
+        build_linear_integration_record(tokens, existing=prior),
+    )
+
+
+def write_integration_tokens(provider: str, tokens: dict[str, Any]) -> None:
+    save_integration_tokens(provider, tokens)
+
+
+def get_integration_tokens(provider: str) -> dict[str, Any]:
+    """Return integration credentials with secrets loaded from keychain."""
+    key = _norm_integration_key(provider)
+    if key == _LINEAR_CREDENTIALS_KEY:
+        metadata = _read_metadata_entry(key)
+        if not metadata:
+            return {}
+        access_token = _load_keychain_secret(
+            "Linear access token",
+            _LINEAR_ACCESS_TOKEN_SECRET,
+        )
+        if not access_token:
+            return {}
+        refresh_token = _load_keychain_secret(
+            "Linear refresh token",
+            _LINEAR_REFRESH_TOKEN_SECRET,
+        )
+        payload = {**metadata, "access_token": access_token}
+        if refresh_token:
+            payload["refresh_token"] = refresh_token
+        return payload
+
+    if key in {_ATLASSIAN_CREDENTIALS_KEY, _JIRA_CREDENTIALS_KEY, _CONFLUENCE_CREDENTIALS_KEY}:
+        if key == _ATLASSIAN_CREDENTIALS_KEY:
+            creds = get_atlassian_credentials()
+        elif key == _JIRA_CREDENTIALS_KEY:
+            creds = get_jira_credentials()
+        else:
+            creds = get_confluence_credentials()
+        return {"auth_type": "api_token", **creds} if creds else {}
+
+    raise ValueError(f"Unknown integration provider {provider!r}.")
+
+
+def clear_integration_tokens(provider: str) -> None:
+    """Remove stored credentials for an integration provider."""
+    key = _norm_integration_key(provider)
+    if key == _LINEAR_CREDENTIALS_KEY:
+        _delete_keychain_secret("Linear access token", _LINEAR_ACCESS_TOKEN_SECRET)
+        _delete_keychain_secret("Linear refresh token", _LINEAR_REFRESH_TOKEN_SECRET)
+        _clear_metadata_entries(_LINEAR_CREDENTIALS_KEY)
+        return
+    if key == _JIRA_CREDENTIALS_KEY:
+        clear_jira_credentials()
+        return
+    if key == _CONFLUENCE_CREDENTIALS_KEY:
+        clear_confluence_credentials()
+        return
+    if key == _ATLASSIAN_CREDENTIALS_KEY:
+        clear_atlassian_credentials()
+        return
+    raise ValueError(f"Unknown integration provider {provider!r}.")
+
+
+def save_jira_credentials(credentials: dict[str, Any]) -> None:
+    _save_atlassian_product_credentials("jira", credentials)
+
+
+def get_jira_credentials() -> dict[str, Any]:
+    return _get_atlassian_product_credentials("jira")
+
+
+def clear_jira_credentials() -> None:
+    _clear_atlassian_product_credentials("jira")
+
+
+def save_confluence_credentials(credentials: dict[str, Any]) -> None:
+    _save_atlassian_product_credentials("confluence", credentials)
+
+
+def get_confluence_credentials() -> dict[str, Any]:
+    return _get_atlassian_product_credentials("confluence")
+
+
+def clear_confluence_credentials() -> None:
+    _clear_atlassian_product_credentials("confluence")
+
+
+def _save_atlassian_product_credentials(product: str, credentials: dict[str, Any]) -> None:
+    from adapters.inbound.cli.integration_profile import (
+        atlassian_site_from_entry,
+        build_product_integration_record,
+    )
+
+    key = _norm_atlassian_product(product)
+    secret_name, label = _product_secret_name(key)
+    api_token = str(credentials.get("api_token") or "").strip()
+    if not api_token:
+        raise ProviderCredentialError(f"{key.capitalize()} API token is required.")
+
+    _store_keychain_secret(label, secret_name, api_token)
+    prior = _read_metadata_entry(_product_metadata_key(key))
+    merged = {**prior, **credentials}
+    site = atlassian_site_from_entry(merged)
+    if site.get("site_url") and not merged.get("site_url"):
+        merged["site_url"] = site["site_url"]
+    _write_metadata_entry(
+        _product_metadata_key(key),
+        build_product_integration_record(key, merged),
+    )
+
+
+def _get_atlassian_product_credentials(product: str) -> dict[str, Any]:
+    key = _norm_atlassian_product(product)
+    metadata = _read_metadata_entry(_product_metadata_key(key))
+    if not metadata:
+        legacy = _legacy_atlassian_metadata()
+        if legacy:
+            metadata = dict(legacy)
+    if not metadata:
+        return {}
+
+    secret_name, label = _product_secret_name(key)
+    api_token = _load_keychain_secret(label, secret_name)
+    if not api_token:
+        api_token = _load_keychain_secret(
+            "Atlassian API token",
+            _ATLASSIAN_LEGACY_TOKEN_SECRET,
+        )
+    if not api_token:
+        return {}
+    return {**metadata, "api_token": api_token}
+
+
+def _clear_atlassian_product_credentials(product: str) -> None:
+    key = _norm_atlassian_product(product)
+    secret_name, label = _product_secret_name(key)
+    _delete_keychain_secret(label, secret_name)
+    _clear_metadata_entries(_product_metadata_key(key))
+
+
+def save_atlassian_credentials(credentials: dict[str, Any]) -> None:
+    """Legacy combined Atlassian record retained for compatibility."""
+    from adapters.inbound.cli.integration_profile import (
+        atlassian_site_from_entry,
+        build_atlassian_integration_record,
+    )
+
+    api_token = str(credentials.get("api_token") or "").strip()
+    if not api_token:
+        raise ProviderCredentialError("Atlassian API token is required.")
+    _store_keychain_secret(
+        "Atlassian API token",
+        _ATLASSIAN_LEGACY_TOKEN_SECRET,
+        api_token,
+    )
+    prior = _legacy_atlassian_metadata()
+    merged = {**prior, **credentials}
+    site = atlassian_site_from_entry(merged)
+    if site.get("site_url") and not merged.get("site_url"):
+        merged["site_url"] = site["site_url"]
+    _write_metadata_entry(
+        _ATLASSIAN_CREDENTIALS_KEY,
+        build_atlassian_integration_record(merged),
+    )
+
+
+def get_atlassian_credentials() -> dict[str, Any]:
+    jira = get_jira_credentials()
+    if jira:
+        return jira
+    confluence = get_confluence_credentials()
+    if confluence:
+        return confluence
+
+    metadata = _legacy_atlassian_metadata()
+    if not metadata:
+        return {}
+    api_token = _load_keychain_secret(
+        "Atlassian API token",
+        _ATLASSIAN_LEGACY_TOKEN_SECRET,
+    )
+    if not api_token:
+        return {}
+    return {**metadata, "api_token": api_token}
+
+
+def clear_atlassian_credentials() -> None:
+    _delete_keychain_secret("Atlassian API token", _ATLASSIAN_LEGACY_TOKEN_SECRET)
+    _delete_keychain_secret("Jira API token", _JIRA_TOKEN_SECRET)
+    _delete_keychain_secret("Confluence API token", _CONFLUENCE_TOKEN_SECRET)
+    _clear_metadata_entries(
+        _ATLASSIAN_CREDENTIALS_KEY,
+        _JIRA_CREDENTIALS_KEY,
+        _CONFLUENCE_CREDENTIALS_KEY,
+    )
+
+
+def save_jira_workspace_prefs(*, project_key: str) -> None:
+    prior = get_jira_credentials()
+    if not prior.get("api_token"):
+        raise ProviderCredentialError("Jira is not connected. Run: potpie auth jira login")
+    workspaces = dict(prior.get("workspaces") or {})
+    workspaces["jira_project"] = project_key.strip().upper()
+    save_jira_credentials({**prior, "workspaces": workspaces})
+
+
+def save_confluence_workspace_prefs(*, space_key: str) -> None:
+    prior = get_confluence_credentials()
+    if not prior.get("api_token"):
+        raise ProviderCredentialError(
+            "Confluence is not connected. Run: potpie auth confluence login"
+        )
+    workspaces = dict(prior.get("workspaces") or {})
+    workspaces["confluence_space"] = space_key.strip().upper()
+    save_confluence_credentials({**prior, "workspaces": workspaces})
+
+
+def save_atlassian_workspace_prefs(
+    *,
+    jira_project: str | None = None,
+    confluence_space: str | None = None,
+) -> None:
+    if jira_project:
+        save_jira_workspace_prefs(project_key=jira_project)
+    if confluence_space:
+        save_confluence_workspace_prefs(space_key=confluence_space)
+
+
+def list_integration_providers() -> list[str]:
+    integrations = list_integration_metadata()
+    found: list[str] = []
+    for key in (
+        _JIRA_CREDENTIALS_KEY,
+        _CONFLUENCE_CREDENTIALS_KEY,
+        _ATLASSIAN_CREDENTIALS_KEY,
+        _LINEAR_CREDENTIALS_KEY,
+    ):
+        if isinstance(integrations.get(key), dict):
+            found.append(key)
+    return found
+
+
+def get_integration_status(provider: str) -> dict[str, Any]:
+    from adapters.inbound.cli.integration_profile import (
+        atlassian_account_from_entry,
+        atlassian_site_from_entry,
+        linear_account_from_entry,
+    )
+
+    key = _norm_integration_key(provider)
+
+    if key in {_ATLASSIAN_CREDENTIALS_KEY, _JIRA_CREDENTIALS_KEY, _CONFLUENCE_CREDENTIALS_KEY}:
+        if key == _ATLASSIAN_CREDENTIALS_KEY:
+            creds = get_atlassian_credentials()
+            entry = _legacy_atlassian_metadata() or creds
+        elif key == _JIRA_CREDENTIALS_KEY:
+            creds = get_jira_credentials()
+            entry = _read_metadata_entry(_JIRA_CREDENTIALS_KEY) or _legacy_atlassian_metadata()
+        else:
+            creds = get_confluence_credentials()
+            entry = _read_metadata_entry(_CONFLUENCE_CREDENTIALS_KEY) or _legacy_atlassian_metadata()
+
+        site = atlassian_site_from_entry(entry or creds)
+        if not creds or not site.get("site_url"):
+            return {"provider": key, "authenticated": False, "auth_type": "api_token"}
+
+        account = atlassian_account_from_entry(entry or creds)
+        return {
+            "provider": key,
+            "authenticated": True,
+            "auth_type": "api_token",
+            "email": account.get("email") or (entry or creds).get("email"),
+            "site_url": site.get("site_url") or (entry or creds).get("site_url"),
+            "site_name": site.get("site_name") or (entry or creds).get("site_name"),
+            "cloud_id": site.get("cloud_id") or (entry or creds).get("cloud_id"),
+            "stored_at": (entry or creds).get("stored_at"),
+            "token_storage": (entry or creds).get("token_storage"),
+        }
+
+    if key == _LINEAR_CREDENTIALS_KEY:
+        entry = _read_metadata_entry(_LINEAR_CREDENTIALS_KEY)
+        if not entry:
+            return {"provider": key, "authenticated": False, "auth_type": "oauth"}
+        account = linear_account_from_entry(entry)
+        organization = entry.get("organization")
+        org_name = organization.get("name") if isinstance(organization, dict) else None
+        scopes = entry.get("scopes")
+        scope = entry.get("scope")
+        if scopes is None and scope is not None:
+            scopes = scope
+        return {
+            "provider": key,
+            "authenticated": True,
+            "auth_type": "oauth",
+            "login": account.get("name") or account.get("email"),
+            "email": account.get("email"),
+            "site_name": org_name,
+            "expires_at": entry.get("expires_at"),
+            "scope": scopes,
+            "cloud_id": entry.get("cloud_id"),
+            "stored_at": entry.get("stored_at"),
+            "token_storage": entry.get("token_storage"),
+        }
+
+    raise ValueError(f"Unknown integration provider {provider!r}.")
 
 
 def resolve_cli_pot_ref(ref: str) -> tuple[str | None, str]:

--- a/app/src/context-engine/adapters/inbound/cli/integration_profile.py
+++ b/app/src/context-engine/adapters/inbound/cli/integration_profile.py
@@ -1,0 +1,278 @@
+"""Fetch and normalize integration identity metadata for credentials.json."""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+_LINEAR_VIEWER_QUERY = "query { viewer { id name email organization { id name } } }"
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def fetch_linear_viewer(access_token: str) -> dict[str, Any]:
+    """Return ``account`` and ``organization`` dicts from Linear's GraphQL API."""
+    token = access_token.strip()
+    if not token:
+        return {}
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    try:
+        with httpx.Client(timeout=15.0) as client:
+            response = client.post(
+                "https://api.linear.app/graphql",
+                headers=headers,
+                json={"query": _LINEAR_VIEWER_QUERY},
+            )
+    except httpx.HTTPError:
+        return {}
+    if response.status_code != 200:
+        return {}
+    data = response.json()
+    viewer = (data.get("data") or {}).get("viewer") if isinstance(data, dict) else None
+    if not isinstance(viewer, dict):
+        return {}
+
+    account: dict[str, Any] = {}
+    viewer_id = viewer.get("id")
+    if viewer_id is not None:
+        account["id"] = str(viewer_id)
+    name = viewer.get("name")
+    if name:
+        account["name"] = str(name)
+    email = viewer.get("email")
+    if email:
+        account["email"] = str(email)
+
+    organization: dict[str, Any] = {}
+    org_payload = viewer.get("organization")
+    if isinstance(org_payload, dict):
+        org_id = org_payload.get("id")
+        if org_id is not None:
+            organization["id"] = str(org_id)
+        org_name = org_payload.get("name")
+        if org_name:
+            organization["name"] = str(org_name)
+
+    out: dict[str, Any] = {}
+    if account:
+        out["account"] = account
+    if organization:
+        out["organization"] = organization
+    return out
+
+
+def _normalize_scopes(scope: Any) -> list[str]:
+    if isinstance(scope, list):
+        return [str(s).strip() for s in scope if str(s).strip()]
+    if isinstance(scope, str) and scope.strip():
+        return [part.strip() for part in scope.split(",") if part.strip()]
+    return []
+
+
+def _profile_section(
+    profile: dict[str, Any],
+    prior: dict[str, Any],
+    key: str,
+) -> dict[str, Any]:
+    """Prefer a profile subsection, then fall back to prior stored metadata."""
+    section = profile.get(key)
+    if isinstance(section, dict) and section:
+        return dict(section)
+    prior_section = prior.get(key)
+    if isinstance(prior_section, dict):
+        return dict(prior_section)
+    return {}
+
+
+def _resolve_stored_at(tokens: dict[str, Any], prior: dict[str, Any]) -> Any:
+    stored_at = tokens.get("stored_at")
+    if stored_at is None:
+        stored_at = prior.get("stored_at")
+    if stored_at is None:
+        stored_at = time.time()
+    return stored_at
+
+
+def _apply_optional_fields(
+    record: dict[str, Any],
+    tokens: dict[str, Any],
+    prior: dict[str, Any],
+    fields: tuple[str, ...],
+) -> None:
+    for field in fields:
+        value = tokens.get(field)
+        if value is None:
+            value = prior.get(field)
+        if value is not None:
+            record[field] = value
+
+
+def build_linear_integration_record(
+    tokens: dict[str, Any],
+    *,
+    existing: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build non-secret Linear metadata aligned with GitHub's credentials shape."""
+    prior = dict(existing or {})
+    now = utc_now_iso()
+    access_token = str(tokens.get("access_token") or "").strip()
+
+    profile = fetch_linear_viewer(access_token) if access_token else {}
+    account = _profile_section(profile, prior, "account")
+    organization = _profile_section(profile, prior, "organization")
+    scopes = _normalize_scopes(tokens.get("scope") or prior.get("scopes") or prior.get("scope"))
+    stored_at = _resolve_stored_at(tokens, prior)
+
+    record: dict[str, Any] = {
+        "provider": "linear",
+        "provider_host": "linear.app",
+        "auth_type": "oauth",
+        "token_storage": "keychain",
+        "token_type": tokens.get("token_type") or prior.get("token_type") or "Bearer",
+        "stored_at": stored_at,
+        "created_at": prior.get("created_at") or now,
+        "updated_at": now,
+        "metadata": {"auth_flow": "pkce"},
+    }
+    if account:
+        record["account"] = account
+    if organization:
+        record["organization"] = organization
+    if scopes:
+        record["scopes"] = scopes
+    _apply_optional_fields(record, tokens, prior, ("expires_at", "expires_in", "cloud_id"))
+    return record
+
+
+def build_product_integration_record(
+    product: str, credentials: dict[str, Any]
+) -> dict[str, Any]:
+    """Build metadata for a single Atlassian product (jira or confluence)."""
+    record = build_atlassian_integration_record(credentials)
+    record["provider"] = product.strip().lower()
+    return record
+
+
+def _stored_at_from_credentials(credentials: dict[str, Any]) -> Any:
+    stored_at = credentials.get("stored_at")
+    return time.time() if stored_at is None else stored_at
+
+
+def _atlassian_site_metadata(
+    cloud_id: str,
+    site_url: str,
+    site_name: str,
+) -> dict[str, Any]:
+    site: dict[str, Any] = {}
+    if cloud_id:
+        site["cloud_id"] = cloud_id
+    if site_url:
+        site["site_url"] = site_url
+    if site_name:
+        site["site_name"] = site_name
+    return site
+
+
+def _apply_atlassian_identity_fields(
+    record: dict[str, Any],
+    *,
+    email: str,
+    cloud_id: str,
+    site_url: str,
+    site_name: str,
+    account: dict[str, Any],
+    site: dict[str, Any],
+) -> None:
+    if account:
+        record["account"] = account
+    if site:
+        record["site"] = site
+    for key, value in (
+        ("email", email),
+        ("cloud_id", cloud_id),
+        ("site_url", site_url),
+        ("site_name", site_name),
+    ):
+        if value:
+            record[key] = value
+
+
+def build_atlassian_integration_record(credentials: dict[str, Any]) -> dict[str, Any]:
+    """Build non-secret Atlassian metadata with nested account/site plus flat fields."""
+    now = utc_now_iso()
+    email = str(credentials.get("email") or "").strip()
+    cloud_id = str(credentials.get("cloud_id") or "").strip()
+    site_url = str(credentials.get("site_url") or "").strip()
+    site_name = str(credentials.get("site_name") or "").strip()
+    account = {"email": email} if email else {}
+    site = _atlassian_site_metadata(cloud_id, site_url, site_name)
+    token_style = str(credentials.get("token_style") or "classic").strip() or "classic"
+
+    record: dict[str, Any] = {
+        "provider": "atlassian",
+        "provider_host": "atlassian.net",
+        "auth_type": "api_token",
+        "token_style": token_style,
+        "token_storage": "keychain",
+        "stored_at": _stored_at_from_credentials(credentials),
+        "created_at": credentials.get("created_at") or now,
+        "updated_at": now,
+        "metadata": {"auth_flow": "classic_api_token"},
+    }
+    _apply_atlassian_identity_fields(
+        record,
+        email=email,
+        cloud_id=cloud_id,
+        site_url=site_url,
+        site_name=site_name,
+        account=account,
+        site=site,
+    )
+    workspaces = credentials.get("workspaces")
+    if isinstance(workspaces, dict) and workspaces:
+        record["workspaces"] = workspaces
+    return record
+
+
+def atlassian_workspaces_from_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    workspaces = entry.get("workspaces")
+    if isinstance(workspaces, dict):
+        return workspaces
+    return {}
+
+
+def linear_account_from_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    account = entry.get("account")
+    if isinstance(account, dict):
+        return account
+    return {}
+
+
+def atlassian_account_from_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    account = entry.get("account")
+    if isinstance(account, dict):
+        return account
+    email = entry.get("email")
+    if email:
+        return {"email": email}
+    return {}
+
+
+def atlassian_site_from_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    site = entry.get("site")
+    if isinstance(site, dict):
+        return site
+    out: dict[str, Any] = {}
+    for key in ("cloud_id", "site_url", "site_name"):
+        value = entry.get(key)
+        if value:
+            out[key] = value
+    return out

--- a/app/src/context-engine/adapters/inbound/cli/integration_session.py
+++ b/app/src/context-engine/adapters/inbound/cli/integration_session.py
@@ -1,0 +1,57 @@
+"""Ensure integration OAuth tokens are valid, refreshing access tokens when needed."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from adapters.inbound.cli.credentials_store import (
+    get_integration_tokens,
+    save_integration_tokens,
+)
+from adapters.inbound.cli.provider_config import Provider
+from adapters.inbound.cli.token_exchange import refresh_access_token
+
+REFRESH_BUFFER_SECONDS = 300
+
+
+def token_needs_refresh(
+    expires_at: Any,
+    *,
+    buffer_seconds: int = REFRESH_BUFFER_SECONDS,
+) -> bool:
+    """True when the access token is expired or within the refresh buffer."""
+    if expires_at is None:
+        return False
+    try:
+        return time.time() >= float(expires_at) - buffer_seconds
+    except (TypeError, ValueError):
+        return False
+
+
+def ensure_valid_integration_tokens(provider: Provider) -> dict[str, Any]:
+    """Return stored tokens, refreshing OAuth access tokens for Linear when near expiry."""
+    if provider in ("jira", "confluence"):
+        return get_integration_tokens(provider)
+
+    if provider != "linear":
+        return get_integration_tokens(provider)
+
+    tokens = get_integration_tokens("linear")
+    access_token = str(tokens.get("access_token") or "").strip()
+    if not access_token:
+        return tokens
+    if not token_needs_refresh(tokens.get("expires_at")):
+        return tokens
+
+    refresh_token = str(tokens.get("refresh_token") or "").strip()
+    if not refresh_token:
+        return tokens
+
+    refreshed = refresh_access_token("linear", refresh_token=refresh_token)
+    merged: dict[str, Any] = {**tokens, **refreshed}
+    for field in ("cloud_id", "scope"):
+        if not merged.get(field) and tokens.get(field):
+            merged[field] = tokens[field]
+    save_integration_tokens(provider, merged)
+    return merged

--- a/app/src/context-engine/adapters/inbound/cli/integration_verify.py
+++ b/app/src/context-engine/adapters/inbound/cli/integration_verify.py
@@ -1,0 +1,118 @@
+"""Lightweight read-only API probes for stored integration credentials."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import httpx
+
+from adapters.inbound.cli.atlassian_auth import (
+    AtlassianAuthErrorKind,
+    fetch_cloud_id_for_site,
+    normalize_site_url,
+    verify_gateway_product,
+)
+from adapters.inbound.cli.provider_config import Provider
+
+
+def verify_integration_access(
+    provider: Provider,
+    credentials: dict[str, Any],
+) -> tuple[bool, str]:
+    """Return ``(ok, message)`` after a minimal read-only API check."""
+    if provider == "atlassian":
+        jira_ok, jira_message = _verify_atlassian_product("jira", credentials)
+        if jira_ok:
+            return jira_ok, jira_message
+        confluence_ok, confluence_message = _verify_atlassian_product(
+            "confluence",
+            credentials,
+        )
+        if confluence_ok:
+            return confluence_ok, confluence_message
+        return False, f"jira: {jira_message}; confluence: {confluence_message}"
+    if provider in ("jira", "confluence"):
+        return _verify_atlassian_product(provider, credentials)
+    if provider == "linear":
+        access_token = str(credentials.get("access_token") or "").strip()
+        if not access_token:
+            return False, "not authenticated"
+        expires_at = credentials.get("expires_at")
+        if expires_at is not None:
+            try:
+                if time.time() > float(expires_at):
+                    return False, "access token expired"
+            except (TypeError, ValueError):
+                pass
+        return _verify_linear(access_token)
+    return False, f"unknown provider {provider!r}"
+
+
+def _verify_message_for_kind(
+    provider: Provider,
+    kind: AtlassianAuthErrorKind | None,
+) -> str:
+    if kind == AtlassianAuthErrorKind.INVALID_CREDENTIALS:
+        return "invalid Atlassian email or API token"
+    if kind == AtlassianAuthErrorKind.INSUFFICIENT_SCOPES:
+        return f"{provider} API token missing required read scopes"
+    if kind == AtlassianAuthErrorKind.SITE_DISCOVERY_FAILED:
+        return "could not resolve Atlassian cloud ID for site"
+    if kind == AtlassianAuthErrorKind.PRODUCT_ACCESS_DENIED:
+        return f"no {provider} access on this site (license or scope)"
+    return f"{provider} gateway verification failed"
+
+
+def _verify_atlassian_product(
+    provider: Provider,
+    credentials: dict[str, Any],
+) -> tuple[bool, str]:
+    email = str(credentials.get("email") or "").strip()
+    api_token = str(credentials.get("api_token") or "").strip()
+    site_url = normalize_site_url(str(credentials.get("site_url") or ""))
+    if not email or not api_token or not site_url:
+        return False, "not authenticated"
+
+    cloud_id = str(credentials.get("cloud_id") or "").strip()
+    if not cloud_id:
+        cloud_id = fetch_cloud_id_for_site(site_url)
+    if not cloud_id:
+        return False, "could not resolve Atlassian cloud ID for site"
+
+    result = verify_gateway_product(email, api_token, cloud_id, provider)
+    if not result.ok:
+        return False, _verify_message_for_kind(provider, result.error_kind)
+
+    site_name = credentials.get("site_name") or site_url
+    name = result.display_name or "user"
+    return True, f"ok ({name} @ {site_name})"
+
+
+def _verify_linear(access_token: str) -> tuple[bool, str]:
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+    }
+    query = "query { viewer { id name email organization { name } } }"
+    with httpx.Client(timeout=15.0) as client:
+        response = client.post(
+            "https://api.linear.app/graphql",
+            headers=headers,
+            json={"query": query},
+        )
+    if response.status_code != 200:
+        return False, f"Linear API HTTP {response.status_code}"
+    data = response.json()
+    viewer = (data.get("data") or {}).get("viewer") if isinstance(data, dict) else None
+    if not isinstance(viewer, dict):
+        errors = data.get("errors") if isinstance(data, dict) else None
+        if errors:
+            return False, "Linear API rejected token"
+        return False, "Linear viewer unavailable"
+    name = viewer.get("name") or viewer.get("email") or viewer.get("id") or "user"
+    org_payload = viewer.get("organization")
+    org = org_payload.get("name") if isinstance(org_payload, dict) else None
+    if org:
+        return True, f"ok ({name} @ {org})"
+    return True, f"ok ({name})"

--- a/app/src/context-engine/adapters/inbound/cli/output.py
+++ b/app/src/context-engine/adapters/inbound/cli/output.py
@@ -29,7 +29,7 @@ def configure_error_output(*, as_json: bool) -> None:
 
 
 def configure_cli_logging(verbose: bool) -> None:
-    """Reduce graph driver noise unless verbose or graph-driver debug is enabled."""
+    """Reduce driver and HTTP client noise unless verbose or debug env is enabled."""
     env_verbose = os.getenv(
         "CONTEXT_ENGINE_GRAPH_DRIVER_DEBUG", ""
     ).strip().lower() in (
@@ -41,6 +41,10 @@ def configure_cli_logging(verbose: bool) -> None:
     level = logging.DEBUG if noisy else logging.ERROR
     for name in ("neo4j", "neo4j.io", "neo4j.notifications"):
         logging.getLogger(name).setLevel(level)
+    # httpx logs every request at INFO; keep CLI auth/read output clean.
+    http_level = logging.DEBUG if noisy else logging.WARNING
+    for name in ("httpx", "httpcore"):
+        logging.getLogger(name).setLevel(http_level)
 
 
 @dataclass

--- a/app/src/context-engine/adapters/inbound/cli/pkce.py
+++ b/app/src/context-engine/adapters/inbound/cli/pkce.py
@@ -1,0 +1,18 @@
+"""PKCE helpers for OAuth flows that require code challenge verification."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+
+
+def generate_pkce_pair() -> tuple[str, str]:
+    """Return ``(code_verifier, code_challenge)`` for S256 PKCE."""
+    verifier = secrets.token_urlsafe(64)[:64]
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+        .rstrip(b"=")
+        .decode()
+    )
+    return verifier, challenge

--- a/app/src/context-engine/adapters/inbound/cli/provider_config.py
+++ b/app/src/context-engine/adapters/inbound/cli/provider_config.py
@@ -1,0 +1,103 @@
+"""OAuth provider constants and env-backed configuration for CLI integration auth."""
+
+from __future__ import annotations
+
+import os
+from typing import Literal
+from urllib.parse import urlparse
+
+Provider = Literal["github", "atlassian", "jira", "confluence", "linear"]
+OAuthProvider = Literal["linear"]
+AtlassianProduct = Literal["jira", "confluence"]
+
+DEFAULT_CALLBACK_PORT = 8080
+DEFAULT_CALLBACK_PATH = "/callback"
+DEFAULT_REDIRECT_URI = f"http://localhost:{DEFAULT_CALLBACK_PORT}{DEFAULT_CALLBACK_PATH}"
+DEFAULT_CALLBACK_HOST = "localhost"
+
+ATLASSIAN_API_TOKEN_PAGE = "https://id.atlassian.com/manage-profile/security/api-tokens"
+ATLASSIAN_API_GATEWAY = "https://api.atlassian.com"
+ATLASSIAN_ACCESSIBLE_RESOURCES_URL = (
+    f"{ATLASSIAN_API_GATEWAY}/oauth/token/accessible-resources"
+)
+
+
+def atlassian_jira_gateway_url(cloud_id: str) -> str:
+    return f"{ATLASSIAN_API_GATEWAY}/ex/jira/{cloud_id.strip()}"
+
+
+def atlassian_confluence_gateway_url(cloud_id: str) -> str:
+    return f"{ATLASSIAN_API_GATEWAY}/ex/confluence/{cloud_id.strip()}"
+
+
+LINEAR_AUTH_URL = "https://linear.app/oauth/authorize"
+LINEAR_TOKEN_URL = "https://api.linear.app/oauth/token"
+LINEAR_DEFAULT_SCOPE = "read"
+
+# Public OAuth client id for Potpie CLI (PKCE; not a secret). Override with LINEAR_CLIENT_ID.
+DEFAULT_LINEAR_CLI_CLIENT_ID = "de23ba9b818dc7a352a837c734aca1d2"
+
+
+def get_redirect_uri() -> str:
+    return os.getenv("POTPIE_CLI_OAUTH_REDIRECT_URI", DEFAULT_REDIRECT_URI).strip()
+
+
+def _parsed_redirect_uri():
+    parsed = urlparse(get_redirect_uri())
+    if parsed.scheme != "http" or not parsed.hostname or not parsed.port:
+        raise ValueError(
+            "POTPIE_CLI_OAUTH_REDIRECT_URI must be an http localhost URL with a port, "
+            "for example http://localhost:8001/api/v1/integrations/linear/callback."
+        )
+    if parsed.hostname not in {"localhost", "127.0.0.1"}:
+        raise ValueError("POTPIE_CLI_OAUTH_REDIRECT_URI must use localhost or 127.0.0.1.")
+    return parsed
+
+
+def get_callback_port() -> int:
+    raw = os.getenv("POTPIE_CLI_OAUTH_CALLBACK_PORT", "").strip()
+    if raw:
+        try:
+            return int(raw)
+        except ValueError:
+            pass
+    return int(_parsed_redirect_uri().port or DEFAULT_CALLBACK_PORT)
+
+
+def get_client_id(provider: OAuthProvider) -> str:
+    if provider != "linear":
+        return ""
+    return (
+        os.getenv("LINEAR_CLIENT_ID", "").strip() or DEFAULT_LINEAR_CLI_CLIENT_ID
+    )
+
+
+def get_client_secret(provider: OAuthProvider) -> str:
+    return ""
+
+
+def get_callback_host() -> str:
+    return _parsed_redirect_uri().hostname or DEFAULT_CALLBACK_HOST
+
+
+def get_callback_path() -> str:
+    path = _parsed_redirect_uri().path or DEFAULT_CALLBACK_PATH
+    return path if path.startswith("/") else f"/{path}"
+
+
+def get_scopes(provider: OAuthProvider) -> str:
+    if provider != "linear":
+        return ""
+    return os.getenv("LINEAR_OAUTH_SCOPE", LINEAR_DEFAULT_SCOPE).strip()
+
+
+def authorization_url(provider: OAuthProvider) -> str:
+    if provider != "linear":
+        raise ValueError(f"Unsupported OAuth provider: {provider!r}")
+    return LINEAR_AUTH_URL
+
+
+def token_url(provider: OAuthProvider) -> str:
+    if provider != "linear":
+        raise ValueError(f"Unsupported OAuth provider: {provider!r}")
+    return LINEAR_TOKEN_URL

--- a/app/src/context-engine/adapters/inbound/cli/token_exchange.py
+++ b/app/src/context-engine/adapters/inbound/cli/token_exchange.py
@@ -1,0 +1,115 @@
+"""Exchange OAuth authorization codes for access tokens (Linear CLI integration)."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import httpx
+
+from adapters.inbound.cli.provider_config import (
+    OAuthProvider,
+    get_client_id,
+    get_redirect_uri,
+    token_url,
+)
+
+
+def exchange_authorization_code(
+    provider: OAuthProvider,
+    *,
+    code: str,
+    code_verifier: str,
+    redirect_uri: str | None = None,
+) -> dict[str, Any]:
+    """Exchange an authorization code (PKCE) for Linear OAuth tokens."""
+    if provider != "linear":
+        raise ValueError(f"OAuth exchange is only supported for Linear, not {provider!r}.")
+
+    client_id = get_client_id(provider)
+    if not client_id:
+        raise ValueError(
+            "Linear OAuth client id is not configured "
+            "(set LINEAR_CLIENT_ID to override the built-in CLI default)."
+        )
+    if not code_verifier:
+        raise ValueError("code_verifier is required for PKCE token exchange.")
+
+    payload: dict[str, Any] = {
+        "grant_type": "authorization_code",
+        "client_id": client_id,
+        "code": code,
+        "redirect_uri": redirect_uri or get_redirect_uri(),
+        "code_verifier": code_verifier,
+    }
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.post(
+            token_url(provider),
+            data=payload,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"Token exchange failed ({response.status_code}): {response.text}"
+        )
+
+    return _tokens_from_oauth_response(response.json())
+
+
+def refresh_access_token(
+    provider: OAuthProvider,
+    *,
+    refresh_token: str,
+) -> dict[str, Any]:
+    """Exchange a refresh token for a new Linear access token."""
+    if provider != "linear":
+        raise ValueError(f"OAuth refresh is only supported for Linear, not {provider!r}.")
+
+    refresh_token = refresh_token.strip()
+    if not refresh_token:
+        raise ValueError("refresh_token is required.")
+
+    client_id = get_client_id(provider)
+    if not client_id:
+        raise ValueError(
+            "Linear OAuth client id is not configured "
+            "(set LINEAR_CLIENT_ID to override the built-in CLI default)."
+        )
+
+    payload: dict[str, Any] = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": client_id,
+    }
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.post(
+            token_url(provider),
+            data=payload,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"Token refresh failed ({response.status_code}): {response.text}"
+        )
+
+    tokens = _tokens_from_oauth_response(response.json())
+    if not tokens.get("refresh_token"):
+        tokens["refresh_token"] = refresh_token
+    return tokens
+
+
+def _tokens_from_oauth_response(data: dict[str, Any]) -> dict[str, Any]:
+    expires_in = int(data.get("expires_in") or 3600)
+    return {
+        "access_token": data.get("access_token"),
+        "refresh_token": data.get("refresh_token"),
+        "token_type": data.get("token_type", "Bearer"),
+        "scope": data.get("scope"),
+        "expires_in": expires_in,
+        "expires_at": time.time() + expires_in,
+        "stored_at": time.time(),
+    }

--- a/app/src/context-engine/tests/unit/test_atlassian_auth_headers.py
+++ b/app/src/context-engine/tests/unit/test_atlassian_auth_headers.py
@@ -1,0 +1,26 @@
+"""Auth header selection for Atlassian tenant vs gateway URLs."""
+
+from __future__ import annotations
+
+from adapters.inbound.cli.atlassian_read import _auth_header_variants
+
+
+def test_tenant_base_uses_basic_only() -> None:
+    headers = _auth_header_variants(
+        "user@example.com",
+        "secret-token",
+        base="https://potpie-team.atlassian.net",
+    )
+    assert len(headers) == 1
+    assert headers[0]["Authorization"].startswith("Basic ")
+
+
+def test_gateway_base_allows_bearer_fallback() -> None:
+    headers = _auth_header_variants(
+        "user@example.com",
+        "secret-token",
+        base="https://api.atlassian.com/ex/jira/cloud-id",
+    )
+    assert len(headers) == 2
+    assert headers[0]["Authorization"].startswith("Basic ")
+    assert headers[1]["Authorization"].startswith("Bearer ")

--- a/app/src/context-engine/tests/unit/test_atlassian_read.py
+++ b/app/src/context-engine/tests/unit/test_atlassian_read.py
@@ -1,0 +1,151 @@
+"""Tests for Atlassian CLI read commands."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from adapters.inbound.cli import credentials_store as cs
+from adapters.inbound.cli.atlassian_read import (
+    AtlassianReadError,
+    fetch_confluence_spaces_sample,
+    fetch_jira_issues_sample,
+)
+
+
+def _mock_keychain(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    secrets: dict[str, str] = {}
+
+    def _store(_label: str, username: str, value: str) -> None:
+        secrets[username] = value
+
+    def _load(_label: str, username: str) -> str | None:
+        return secrets.get(username)
+
+    monkeypatch.setattr(cs, "_store_keychain_secret", _store)
+    monkeypatch.setattr(cs, "_load_keychain_secret", _load)
+    return secrets
+
+
+def test_fetch_jira_issues_sample(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    cred_path = tmp_path / "credentials.json"
+    monkeypatch.setattr(cs, "credentials_path", lambda: cred_path)
+    _mock_keychain(monkeypatch)
+    cs.save_jira_credentials(
+        {
+            "email": "user@example.com",
+            "api_token": "secret",
+            "cloud_id": "cid-1",
+            "site_url": "https://team.atlassian.net",
+            "site_name": "team",
+            "workspaces": {"jira_project": "ENG"},
+        }
+    )
+
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {
+        "issues": [
+            {
+                "key": "ENG-1",
+                "fields": {
+                    "summary": "Fix bug",
+                    "status": {"name": "Done"},
+                    "project": {"key": "ENG"},
+                    "updated": "2026-01-01T00:00:00.000+0000",
+                    "description": "Done",
+                },
+            }
+        ]
+    }
+    client = MagicMock()
+    client.__enter__.return_value = client
+    client.__exit__.return_value = None
+    client.get.return_value = response
+    client.post.return_value = response
+
+    with patch("adapters.inbound.cli.atlassian_read.httpx.Client", return_value=client):
+        issues = fetch_jira_issues_sample(limit=5)
+
+    assert len(issues) == 1
+    assert issues[0]["key"] == "ENG-1"
+    assert issues[0]["summary"] == "Fix bug"
+
+
+def test_fetch_confluence_spaces_sample(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    cred_path = tmp_path / "credentials.json"
+    monkeypatch.setattr(cs, "credentials_path", lambda: cred_path)
+    _mock_keychain(monkeypatch)
+    cs.save_confluence_credentials(
+        {
+            "email": "user@example.com",
+            "api_token": "secret",
+            "cloud_id": "cid-1",
+            "site_url": "https://team.atlassian.net",
+            "site_name": "team",
+        }
+    )
+
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {
+        "results": [
+            {
+                "key": "ENG",
+                "name": "Engineering",
+                "type": "global",
+                "_links": {"webui": "/spaces/ENG"},
+            }
+        ]
+    }
+    client = MagicMock()
+    client.__enter__.return_value = client
+    client.__exit__.return_value = None
+    client.get.return_value = response
+
+    with patch("adapters.inbound.cli.atlassian_read.httpx.Client", return_value=client):
+        spaces = fetch_confluence_spaces_sample(limit=5)
+
+    assert len(spaces) == 1
+    assert spaces[0]["key"] == "ENG"
+    assert "spaces/ENG" in (spaces[0].get("url") or "")
+
+
+def test_fetch_jira_requires_login(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    cred_path = tmp_path / "credentials.json"
+    monkeypatch.setattr(cs, "credentials_path", lambda: cred_path)
+    with pytest.raises(AtlassianReadError, match="not connected"):
+        fetch_jira_issues_sample()
+
+
+def test_jira_and_confluence_credentials_are_independent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    cred_path = tmp_path / "credentials.json"
+    monkeypatch.setattr(cs, "credentials_path", lambda: cred_path)
+    _mock_keychain(monkeypatch)
+    cs.save_jira_credentials(
+        {
+            "email": "jira@example.com",
+            "api_token": "jira-secret",
+            "cloud_id": "cid-j",
+            "site_url": "https://team.atlassian.net",
+            "site_name": "team",
+        }
+    )
+    assert cs.get_jira_credentials()["email"] == "jira@example.com"
+    assert not cs.get_confluence_credentials()
+    cs.save_confluence_credentials(
+        {
+            "email": "wiki@example.com",
+            "api_token": "wiki-secret",
+            "cloud_id": "cid-c",
+            "site_url": "https://team.atlassian.net",
+            "site_name": "team",
+        }
+    )
+    assert cs.get_confluence_credentials()["email"] == "wiki@example.com"
+    cs.clear_jira_credentials()
+    assert not cs.get_jira_credentials()
+    assert cs.get_confluence_credentials()["email"] == "wiki@example.com"

--- a/app/src/context-engine/tests/unit/test_atlassian_workspaces.py
+++ b/app/src/context-engine/tests/unit/test_atlassian_workspaces.py
@@ -1,0 +1,164 @@
+"""Tests for Atlassian workspace list/use helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from adapters.inbound.cli import credentials_store as cs
+from adapters.inbound.cli.atlassian_read import (
+    fetch_confluence_pages_in_space,
+    fetch_jira_issues_in_project,
+    fetch_jira_projects,
+)
+
+
+def _save_creds(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    cred_path = tmp_path / "credentials.json"
+    secrets: dict[str, str] = {}
+
+    def _store(_label: str, username: str, value: str) -> None:
+        secrets[username] = value
+
+    def _load(_label: str, username: str) -> str | None:
+        return secrets.get(username)
+
+    monkeypatch.setattr(cs, "credentials_path", lambda: cred_path)
+    monkeypatch.setattr(cs, "_store_keychain_secret", _store)
+    monkeypatch.setattr(cs, "_load_keychain_secret", _load)
+    cs.save_jira_credentials(
+        {
+            "email": "user@example.com",
+            "api_token": "secret",
+            "cloud_id": "cid-1",
+            "site_url": "https://team.atlassian.net",
+            "site_name": "team",
+        }
+    )
+
+
+def test_fetch_jira_issues_in_project(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    _save_creds(monkeypatch, tmp_path)
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {
+        "issues": [
+            {
+                "key": "ENG-9",
+                "fields": {
+                    "summary": "Ship CLI",
+                    "status": {"name": "In Progress"},
+                    "project": {"key": "ENG"},
+                    "description": {"type": "doc", "content": [{"type": "text", "text": "Details"}]},
+                "assignee": {"displayName": "Ada"},
+                "priority": {"name": "High"},
+                "issuetype": {"name": "Task"},
+                "created": "2026-04-01T09:00:00.000+0000",
+                "updated": "2026-05-01T12:30:00.000+0000",
+                },
+            }
+        ]
+    }
+    client = MagicMock()
+    client.__enter__.return_value = client
+    client.__exit__.return_value = None
+    client.get.return_value = response
+    client.post.return_value = response
+
+    with patch("adapters.inbound.cli.atlassian_read.httpx.Client", return_value=client):
+        issues = fetch_jira_issues_in_project("ENG", limit=5)
+
+    assert issues[0]["key"] == "ENG-9"
+    assert issues[0]["created"] == "2026-04-01 09:00:00"
+    assert issues[0]["updated"] == "2026-05-01 12:30:00"
+    assert issues[0]["description"] == "Details"
+    assert "browse/ENG-9" in (issues[0].get("url") or "")
+
+
+def test_save_workspace_prefs(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    _save_creds(monkeypatch, tmp_path)
+    cs.save_confluence_credentials(
+        {
+            "email": "user@example.com",
+            "api_token": "secret2",
+            "cloud_id": "cid-1",
+            "site_url": "https://team.atlassian.net",
+            "site_name": "team",
+        }
+    )
+    cs.save_jira_workspace_prefs(project_key="ENG")
+    cs.save_confluence_workspace_prefs(space_key="DOCS")
+    jira = cs.get_jira_credentials()
+    conf = cs.get_confluence_credentials()
+    assert jira.get("workspaces", {}).get("jira_project") == "ENG"
+    assert conf.get("workspaces", {}).get("confluence_space") == "DOCS"
+
+
+def test_fetch_confluence_pages_in_space(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    _save_creds(monkeypatch, tmp_path)
+    cs.save_confluence_credentials(
+        {
+            "email": "user@example.com",
+            "api_token": "secret",
+            "cloud_id": "cid-1",
+            "site_url": "https://team.atlassian.net",
+            "site_name": "team",
+        }
+    )
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {
+        "results": [
+            {
+                "id": "1",
+                "title": "Runbook",
+                "status": "current",
+                "body": {"storage": {"value": "<p>Steps here</p>"}},
+                "history": {
+                    "createdDate": "2026-04-01T10:00:00.000Z",
+                    "createdBy": {"displayName": "Ada"},
+                    "lastUpdated": {
+                        "when": "2026-05-22T08:45:40.682Z",
+                        "friendlyWhen": "May 22, 2026",
+                        "by": {"displayName": "Nihit"},
+                    },
+                },
+                "version": {"when": "2026-05-01"},
+                "_links": {"webui": "/spaces/DOCS/pages/1"},
+            }
+        ]
+    }
+    client = MagicMock()
+    client.__enter__.return_value = client
+    client.__exit__.return_value = None
+    client.get.return_value = response
+
+    with patch("adapters.inbound.cli.atlassian_read.httpx.Client", return_value=client):
+        pages = fetch_confluence_pages_in_space("DOCS", limit=5)
+
+    assert pages[0]["title"] == "Runbook"
+    assert pages[0]["updated"] == "May 22, 2026"
+    assert pages[0]["updated_by"] == "Nihit"
+    assert pages[0]["created"] == "2026-04-01T10:00:00.000Z"
+    assert pages[0]["created_by"] == "Ada"
+    assert "Steps here" in (pages[0].get("excerpt") or "")
+
+
+def test_fetch_jira_projects(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    _save_creds(monkeypatch, tmp_path)
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {
+        "values": [{"key": "ENG", "name": "Engineering", "projectTypeKey": "software"}]
+    }
+    client = MagicMock()
+    client.__enter__.return_value = client
+    client.__exit__.return_value = None
+    client.get.return_value = response
+
+    with patch("adapters.inbound.cli.atlassian_read.httpx.Client", return_value=client):
+        projects = fetch_jira_projects(limit=5)
+
+    assert projects[0]["key"] == "ENG"
+    assert "browse/ENG" in (projects[0].get("url") or "")

--- a/app/src/context-engine/tests/unit/test_integration_profile.py
+++ b/app/src/context-engine/tests/unit/test_integration_profile.py
@@ -1,0 +1,147 @@
+"""Integration profile metadata for credentials.json."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from adapters.inbound.cli import credentials_store as cs
+from adapters.inbound.cli.integration_profile import (
+    build_atlassian_integration_record,
+    build_linear_integration_record,
+    fetch_linear_viewer,
+)
+
+
+def test_build_linear_integration_record_includes_account_and_scopes() -> None:
+    tokens = {
+        "access_token": "lin-token",
+        "refresh_token": "lin-refresh",
+        "scope": "read,write",
+        "expires_at": 999.0,
+        "token_type": "Bearer",
+    }
+    viewer = {
+        "account": {"id": "u1", "name": "Ada", "email": "ada@example.com"},
+        "organization": {"id": "o1", "name": "Acme"},
+    }
+    with patch(
+        "adapters.inbound.cli.integration_profile.fetch_linear_viewer",
+        return_value=viewer,
+    ):
+        record = build_linear_integration_record(tokens)
+    assert record["account"]["email"] == "ada@example.com"
+    assert record["organization"]["name"] == "Acme"
+    assert record["scopes"] == ["read", "write"]
+    assert record["metadata"]["auth_flow"] == "pkce"
+    assert record["created_at"]
+    assert record["updated_at"]
+
+
+def test_build_linear_integration_record_preserves_account_on_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prior = {
+        "account": {"id": "u1", "name": "Ada", "email": "ada@example.com"},
+        "created_at": "2020-01-01T00:00:00+00:00",
+    }
+    tokens = {"access_token": "new-token", "expires_at": 123.0}
+    with patch(
+        "adapters.inbound.cli.integration_profile.fetch_linear_viewer",
+        return_value={},
+    ):
+        record = build_linear_integration_record(tokens, existing=prior)
+    assert record["account"]["email"] == "ada@example.com"
+    assert record["created_at"] == "2020-01-01T00:00:00+00:00"
+
+
+def test_build_atlassian_integration_record_nested_and_flat() -> None:
+    record = build_atlassian_integration_record(
+        {
+            "email": "user@example.com",
+            "cloud_id": "cid",
+            "site_url": "https://acme.atlassian.net",
+            "site_name": "acme",
+        }
+    )
+    assert record["account"]["email"] == "user@example.com"
+    assert record["site"]["site_url"] == "https://acme.atlassian.net"
+    assert record["email"] == "user@example.com"
+    assert record["site_url"] == "https://acme.atlassian.net"
+
+
+def test_save_integration_tokens_writes_account_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    cred_path = tmp_path / "credentials.json"
+    monkeypatch.setattr(cs, "credentials_path", lambda: cred_path)
+    monkeypatch.setattr(cs, "_store_keychain_secret", lambda *a, **k: None)
+    viewer = {
+        "account": {"id": "u1", "name": "Ada", "email": "ada@example.com"},
+        "organization": {"name": "Acme"},
+    }
+    with patch(
+        "adapters.inbound.cli.integration_profile.fetch_linear_viewer",
+        return_value=viewer,
+    ):
+        cs.save_integration_tokens(
+            "linear",
+            {"access_token": "tok", "scope": "read", "expires_at": 1.0},
+        )
+    payload = cs.read_credentials()
+    linear = payload["integrations"]["linear"]
+    assert linear["account"]["email"] == "ada@example.com"
+    assert linear["organization"]["name"] == "Acme"
+
+
+def test_get_integration_status_reads_legacy_atlassian_flat_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    cred_path = tmp_path / "credentials.json"
+    monkeypatch.setattr(cs, "credentials_path", lambda: cred_path)
+    monkeypatch.setattr(cs, "_load_keychain_secret", lambda *a, **k: "legacy-token")
+    monkeypatch.setattr(cs, "_store_keychain_secret", lambda *a, **k: None)
+    cs._write_payload(
+        {
+            "integrations": {
+                "atlassian": {
+                    "provider": "atlassian",
+                    "auth_type": "api_token",
+                    "email": "legacy@example.com",
+                    "site_url": "https://legacy.atlassian.net",
+                    "site_name": "legacy",
+                    "cloud_id": "cloud-1",
+                }
+            }
+        }
+    )
+    status = cs.get_integration_status("atlassian")
+    assert status["authenticated"] is True
+    assert status["email"] == "legacy@example.com"
+    assert status["site_url"] == "https://legacy.atlassian.net"
+
+
+def test_fetch_linear_viewer_parses_graphql_response() -> None:
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {
+        "data": {
+            "viewer": {
+                "id": "v1",
+                "name": "Nihit",
+                "email": "n@example.com",
+                "organization": {"id": "org1", "name": "Potpie"},
+            }
+        }
+    }
+    client = MagicMock()
+    client.__enter__.return_value = client
+    client.__exit__.return_value = None
+    client.post.return_value = response
+    with patch("adapters.inbound.cli.integration_profile.httpx.Client", return_value=client):
+        profile = fetch_linear_viewer("token")
+    assert profile["account"]["name"] == "Nihit"
+    assert profile["organization"]["name"] == "Potpie"

--- a/app/src/context-engine/tests/unit/test_provider_config.py
+++ b/app/src/context-engine/tests/unit/test_provider_config.py
@@ -1,0 +1,20 @@
+"""Tests for CLI OAuth provider configuration."""
+
+from __future__ import annotations
+
+import pytest
+
+from adapters.inbound.cli.provider_config import (
+    DEFAULT_LINEAR_CLI_CLIENT_ID,
+    get_client_id,
+)
+
+
+def test_get_client_id_uses_builtin_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LINEAR_CLIENT_ID", raising=False)
+    assert get_client_id("linear") == DEFAULT_LINEAR_CLI_CLIENT_ID
+
+
+def test_get_client_id_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LINEAR_CLIENT_ID", "override-client-id")
+    assert get_client_id("linear") == "override-client-id"


### PR DESCRIPTION
## Summary
Base: `feat/cli-integrations-foundation`. Adds `potpie auth` integration login for **Linear** (OAuth + PKCE) and **Jira / Confluence** (Atlassian API tokens). Secrets → OS keychain; metadata → `credentials.json`. Linear CLI client id is built into `provider_config.py` (no `.env` required for CLI).

## CLI (`potpie auth …`)
| Group | Commands |
|-------|----------|
| **Shared** | `potpie auth status` · `potpie auth logout <linear\|jira\|confluence>` |
| **linear** | `potpie auth linear login` · `potpie auth linear logout` |
| **jira** | `potpie auth jira login` · `logout` · `ls` · `use` · `issues` |
| **confluence** | `potpie auth confluence login` · `logout` · `ls` · `use` · `pages` |

## Setup (review / manual test)
```bash
cd potpie
uv sync
source .venv/bin/activate   # or: uv run potpie …


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Atlassian Jira and Confluence authentication via API tokens
  * Added Linear OAuth PKCE authentication flow
  * Added CLI commands for managing integrations (login, logout, status)
  * Added ability to browse Jira projects/issues and Confluence spaces/pages
  * Added automatic token refresh for OAuth integrations

* **Tests**
  * Added comprehensive unit tests for authentication and integration flows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->