### PR TITLE
feat(cli): potpie skills manager (fixes POT-1397)

### DIFF
--- a/app/src/context-engine/adapters/inbound/cli/agent_installer.py
+++ b/app/src/context-engine/adapters/inbound/cli/agent_installer.py
@@ -7,6 +7,8 @@ from dataclasses import asdict, dataclass, field
 from importlib import resources
 from pathlib import Path
 
+from adapters.inbound.cli.skill_manager import SkillManager, SkillManagerError
+
 _CLAUDE_MARKER_RE = re.compile(
     r"<!-- (?:context-engine|potpie)-start -->.*?<!-- (?:context-engine|potpie)-end -->",
     re.DOTALL,
@@ -82,8 +84,11 @@ def _install_bundle(
     result: InstallResult,
     *,
     force: bool,
+    skip_skill_files: bool = False,
 ) -> None:
     for rel_path, content in _iter_bundle_files(bundle_name):
+        if skip_skill_files and rel_path.parts[:2] == (".agents", "skills"):
+            continue
         target = install_root / rel_path
 
         # Special handling: merge CLAUDE.md section instead of overwriting
@@ -146,6 +151,33 @@ def install_agent_bundle(
     if normalized == "claude":
         _install_bundle(root, "claude_bundle", result, force=force)
     else:
-        _install_bundle(root, "agent_bundle", result, force=force)
+        _install_bundle(
+            root, "agent_bundle", result, force=force, skip_skill_files=True
+        )
+        manager = SkillManager(root, agent=normalized)
+        available = manager.list_skills(mode="available")["skills"]
+        installed: list[dict[str, object]] = []
+        skipped_ids: list[str] = []
+        for row in available:
+            skill_id = str(row["id"])
+            try:
+                payload = manager.install(skill_id, yes=force, force=force)
+            except SkillManagerError:
+                skipped_ids.append(skill_id)
+                continue
+            installed.extend(payload.get("installed", []))
+        for item in installed:
+            if not isinstance(item, dict) or not item.get("id"):
+                continue
+            sid = str(item["id"])
+            rel_dir = f".agents/skills/{sid}"
+            if item.get("status") == "updated":
+                result.updated.append(rel_dir)
+            elif item.get("status") == "unchanged":
+                result.unchanged.append(rel_dir)
+            else:
+                result.created.append(rel_dir)
+        for sid in skipped_ids:
+            result.skipped.append(f".agents/skills/{sid}")
 
     return result

--- a/app/src/context-engine/adapters/inbound/cli/main.py
+++ b/app/src/context-engine/adapters/inbound/cli/main.py
@@ -51,6 +51,7 @@ from adapters.inbound.cli.potpie_api_config import (
     resolve_potpie_api_base_url,
     resolve_potpie_api_key,
 )
+from adapters.inbound.cli.skill_manager import SkillManager, SkillManagerError
 from adapters.outbound.http.potpie_context_api_client import (
     IngestRejectedError,
     PotpieContextApiClient,
@@ -74,7 +75,7 @@ app = typer.Typer(
 pot_app = typer.Typer(help="Active pot and local pot helpers.")
 pot_repo_app = typer.Typer(help="Repositories attached to a context pot (Potpie API).")
 event_app = typer.Typer(help="Inspect and wait for ingestion events.")
-conflict_app = typer.Typer(help="Predicate-family conflicts (QualityIssue).")
+skills_app = typer.Typer(help="Manage repo-local Potpie agent skills.")
 
 # Set by root callback; read by all subcommands (including nested `pot`).
 _cli_state: dict[str, Any] = {"json": False, "verbose": False, "source": None}
@@ -142,7 +143,7 @@ def _ingest_result_from_http(status_code: int, data: dict[str, Any]) -> dict[str
     if status_code == 202:
         return {
             "status": "queued",
-            "episode_uuid": data.get("episode_uuid"),
+            "mutation_id": data.get("mutation_id"),
             "event_id": data.get("event_id"),
             "job_id": data.get("job_id"),
             "downgrades": list(data.get("downgrades") or []),
@@ -150,7 +151,7 @@ def _ingest_result_from_http(status_code: int, data: dict[str, Any]) -> dict[str
     if "event_id" in data or "job_id" in data:
         return {
             "status": data.get("status") or "applied",
-            "episode_uuid": data.get("episode_uuid"),
+            "mutation_id": data.get("mutation_id"),
             "event_id": data.get("event_id"),
             "job_id": data.get("job_id"),
             "downgrades": list(data.get("downgrades") or []),
@@ -158,7 +159,7 @@ def _ingest_result_from_http(status_code: int, data: dict[str, Any]) -> dict[str
         }
     return {
         "status": "applied",
-        "episode_uuid": data.get("episode_uuid"),
+        "mutation_id": data.get("mutation_id"),
         "event_id": data.get("event_id"),
         "job_id": data.get("job_id"),
         "downgrades": list(data.get("downgrades") or []),
@@ -248,16 +249,6 @@ def doctor_cmd() -> None:
     s = EnvContextEngineSettings()
     cg = s.is_enabled()
     neo = bool(s.neo4j_uri())
-    ce_neo = bool(
-        os.getenv("CONTEXT_ENGINE_NEO4J_URI") or os.getenv("CONTEXT_ENGINE_NEO4J_URL")
-    )
-    legacy_neo = bool(os.getenv("NEO4J_URI") or os.getenv("NEO4J_URL"))
-    if ce_neo:
-        neo_src = "context_engine"
-    elif legacy_neo:
-        neo_src = "legacy"
-    else:
-        neo_src = "missing"
 
     has_potpie_key_env = bool(os.getenv("POTPIE_API_KEY"))
     has_stored_key = bool(get_stored_api_key())
@@ -306,7 +297,7 @@ def doctor_cmd() -> None:
 
     summary: list[str] = [
         "[dim]search / ingest / pot hard-reset call Potpie POST /api/v2/context/* with X-API-Key.[/dim]",
-        "[dim]Local Neo4j/Graphiti is not required on this machine.[/dim]",
+        "[dim]Local Neo4j is not required on this machine.[/dim]",
     ]
     if health_ok is True:
         summary.append("[green]GET /health on Potpie base URL succeeded.[/green]")
@@ -320,7 +311,6 @@ def doctor_cmd() -> None:
     snap = DoctorSnapshot(
         context_graph_enabled=cg,
         neo4j_effective_set=neo,
-        neo4j_source=neo_src,
         pot_maps_set=maps_set,
         active_pot_id=get_active_pot_id() or None,
         potpie_api_key_env=has_potpie_key_env,
@@ -409,6 +399,215 @@ def init_agent_cmd(
         print_plain_line(
             f"skipped {rel_path} (use --force to overwrite)", as_json=False
         )
+
+
+def _skill_manager_or_exit(path: str, agent: str) -> SkillManager:
+    j, _ = _flags()
+    try:
+        return SkillManager(path, agent=agent)
+    except SkillManagerError as exc:
+        _emit_skill_error(exc, as_json=j)
+        raise typer.Exit(code=1) from exc
+
+
+def _emit_skill_error(exc: SkillManagerError, *, as_json: bool) -> None:
+    if as_json:
+        print_json_blob(exc.to_payload(), as_json=True)
+        return
+    hint = f"Try: {exc.recommended_command}" if exc.recommended_command else None
+    emit_error(exc.code, exc.message, hint=hint)
+
+
+def _skill_payload_or_exit(action: Any, *, success_exit: int = 0) -> dict[str, Any]:
+    j, _ = _flags()
+    try:
+        return action()
+    except SkillManagerError as exc:
+        _emit_skill_error(exc, as_json=j)
+        raise typer.Exit(code=1) from exc
+
+
+def _print_skills_status(payload: dict[str, Any], *, as_json: bool) -> None:
+    if as_json:
+        print_json_blob(payload, as_json=True)
+        return
+    print_plain_line(f"Skills root: {payload['root']}", as_json=False)
+    print_plain_line(f"Agent: {payload['agent']}", as_json=False)
+    print_plain_line(
+        "Installed: "
+        f"{len(payload['installed'])}; missing: {len(payload['missing'])}; "
+        f"outdated: {len(payload['outdated'])}; "
+        f"locally modified: {len(payload['locallyModified'])}",
+        as_json=False,
+    )
+    actions = payload.get("nextActions") or []
+    if actions:
+        print_plain_line("Next actions:", as_json=False)
+        for action in actions:
+            print_plain_line(f"  {action['recommendedCommand']}", as_json=False)
+    else:
+        print_plain_line("Skills are up to date for this agent.", as_json=False)
+
+
+def _print_skills_list(payload: dict[str, Any], *, as_json: bool) -> None:
+    if as_json:
+        print_json_blob(payload, as_json=True)
+        return
+    print_plain_line(
+        f"{payload['mode']} skills for {payload['agent']} at {payload['root']}:",
+        as_json=False,
+    )
+    for row in payload["skills"]:
+        desc = row.get("description") or ""
+        print_plain_line(f"  {row['id']} - {desc}", as_json=False)
+
+
+def _print_skills_mutation(payload: dict[str, Any], *, as_json: bool) -> None:
+    if as_json:
+        print_json_blob(payload, as_json=True)
+        return
+    for key in ("installed", "updated", "removed", "skipped"):
+        for row in payload.get(key, []) or []:
+            status = row.get("status", key.rstrip("d"))
+            suffix = f" ({row['reason']})" if row.get("reason") else ""
+            print_plain_line(f"{status} {row['id']}{suffix}", as_json=False)
+            command = row.get("recommendedCommand")
+            if command:
+                print_plain_line(f"  next: {command}", as_json=False)
+
+
+def _print_skills_doctor(payload: dict[str, Any], *, as_json: bool) -> None:
+    if as_json:
+        print_json_blob(payload, as_json=True)
+        return
+    print_plain_line(
+        f"Skill doctor: {'ok' if payload['ok'] else 'issues found'}",
+        as_json=False,
+    )
+    for diag in payload.get("diagnostics", []):
+        skill = f" {diag['skillId']}" if diag.get("skillId") else ""
+        print_plain_line(
+            f"  {diag['code']}{skill}: {diag.get('message', '')}", as_json=False
+        )
+    if payload.get("recommendedCommand"):
+        print_plain_line(f"Next: {payload['recommendedCommand']}", as_json=False)
+
+
+@skills_app.command("status")
+def skills_status_cmd(
+    agent: str = typer.Option(
+        "default",
+        "--agent",
+        help="Agent harness: default, codex, claude, claude-code, or cursor.",
+    ),
+    path: str = typer.Option(".", "--path", help="Repository path."),
+) -> None:
+    """Read skill health without mutating files."""
+    j, _ = _flags()
+    manager = _skill_manager_or_exit(path, agent)
+    payload = _skill_payload_or_exit(manager.status)
+    _print_skills_status(payload, as_json=j)
+
+
+@skills_app.command("list")
+def skills_list_cmd(
+    available: bool = typer.Option(False, "--available", help="List bundled skills."),
+    installed: bool = typer.Option(
+        False, "--installed", help="List installed repo-local skills."
+    ),
+    recommended: bool = typer.Option(
+        False, "--recommended", help="List recommended skills for the agent."
+    ),
+    agent: str = typer.Option("default", "--agent"),
+    path: str = typer.Option(".", "--path", help="Repository path."),
+) -> None:
+    """List available, installed, or recommended skills."""
+    j, _ = _flags()
+    selected = [available, installed, recommended]
+    if sum(1 for flag in selected if flag) > 1:
+        exc = SkillManagerError(
+            "INVALID_ARGUMENTS",
+            "Choose only one of --available, --installed, or --recommended.",
+        )
+        _emit_skill_error(exc, as_json=j)
+        raise typer.Exit(code=1)
+    mode = "available" if available else "recommended" if recommended else "installed"
+    manager = _skill_manager_or_exit(path, agent)
+    payload = _skill_payload_or_exit(lambda: manager.list_skills(mode=mode))
+    _print_skills_list(payload, as_json=j)
+
+
+@skills_app.command("install")
+def skills_install_cmd(
+    skill_id: str | None = typer.Argument(
+        None, help="Bundled skill id. Omit to install the recommended set."
+    ),
+    agent: str = typer.Option("default", "--agent"),
+    path: str = typer.Option(".", "--path", help="Repository path."),
+    yes: bool = typer.Option(False, "--yes", help="Confirm overwrites."),
+    force: bool = typer.Option(
+        False, "--force", help="Overwrite locally modified owned skills."
+    ),
+) -> None:
+    """Install bundled Potpie skills into `.agents/skills`."""
+    j, _ = _flags()
+    manager = _skill_manager_or_exit(path, agent)
+    payload = _skill_payload_or_exit(
+        lambda: manager.install(skill_id, yes=yes, force=force)
+    )
+    _print_skills_mutation(payload, as_json=j)
+
+
+@skills_app.command("update")
+def skills_update_cmd(
+    skill_id: str | None = typer.Argument(
+        None, help="Installed skill id. Omit to update outdated skills."
+    ),
+    all_: bool = typer.Option(
+        False, "--all", help="Check every installed bundled skill."
+    ),
+    agent: str = typer.Option("default", "--agent"),
+    path: str = typer.Option(".", "--path", help="Repository path."),
+    yes: bool = typer.Option(False, "--yes", help="Confirm updates."),
+) -> None:
+    """Update installed bundled skills when templates changed."""
+    j, _ = _flags()
+    manager = _skill_manager_or_exit(path, agent)
+    payload = _skill_payload_or_exit(
+        lambda: manager.update(skill_id, all_=all_, yes=yes)
+    )
+    _print_skills_mutation(payload, as_json=j)
+
+
+@skills_app.command("remove")
+def skills_remove_cmd(
+    skill_id: str = typer.Argument(..., help="Installed skill id to remove."),
+    agent: str = typer.Option("default", "--agent"),
+    path: str = typer.Option(".", "--path", help="Repository path."),
+    yes: bool = typer.Option(False, "--yes", help="Confirm removal."),
+) -> None:
+    """Remove a Potpie-owned installed skill."""
+    j, _ = _flags()
+    manager = _skill_manager_or_exit(path, agent)
+    payload = _skill_payload_or_exit(lambda: manager.remove(skill_id, yes=yes))
+    _print_skills_mutation(payload, as_json=j)
+
+
+@skills_app.command("doctor")
+def skills_doctor_cmd(
+    agent: str = typer.Option("default", "--agent"),
+    path: str = typer.Option(".", "--path", help="Repository path."),
+) -> None:
+    """Run read-only skill diagnostics."""
+    j, _ = _flags()
+    manager = _skill_manager_or_exit(path, agent)
+    payload = _skill_payload_or_exit(manager.doctor)
+    _print_skills_doctor(payload, as_json=j)
+    if not payload.get("ok", False):
+        raise typer.Exit(code=1)
+
+
+app.add_typer(skills_app, name="skills")
 
 
 def _pot_id_or_git(explicit: str | None, *, cwd: str | None = None) -> str:
@@ -1026,60 +1225,6 @@ def event_wait_cmd(
 app.add_typer(event_app, name="event")
 
 
-@conflict_app.command("list")
-def conflict_list_cmd(
-    cwd: str = typer.Option(
-        ".",
-        "--cwd",
-        help="Git working tree used when inferring pot from remote / env",
-    ),
-) -> None:
-    """List open predicate-family conflicts for the active pot."""
-    load_cli_env()
-    j, v = _flags()
-    cwd_resolved = str(Path(cwd).resolve())
-    pot_id = _pot_id_or_git(None, cwd=cwd_resolved)
-    client = _cli_client_or_exit(v)
-    try:
-        out = client.conflicts_list(pot_id)
-    except PotpieContextApiError as exc:
-        emit_error("Could not list conflicts", _format_api_error(exc), verbose=v)
-        raise typer.Exit(code=1) from exc
-    print_json_blob(out, as_json=j)
-
-
-@conflict_app.command("resolve")
-def conflict_resolve_cmd(
-    issue_uuid: str = typer.Argument(..., help="QualityIssue uuid"),
-    action: str = typer.Option(
-        "supersede_older",
-        "--action",
-        "-a",
-        help="Resolution strategy (supersede_older stamps invalid_at on the older edge)",
-    ),
-    cwd: str = typer.Option(
-        ".",
-        "--cwd",
-        help="Git working tree used when inferring pot from remote / env",
-    ),
-) -> None:
-    """Resolve one open conflict (default: supersede the older episodic edge)."""
-    load_cli_env()
-    j, v = _flags()
-    cwd_resolved = str(Path(cwd).resolve())
-    pot_id = _pot_id_or_git(None, cwd=cwd_resolved)
-    client = _cli_client_or_exit(v)
-    try:
-        out = client.conflicts_resolve(pot_id, issue_uuid, action=action)
-    except PotpieContextApiError as exc:
-        emit_error("Could not resolve conflict", _format_api_error(exc), verbose=v)
-        raise typer.Exit(code=1) from exc
-    print_json_blob(out, as_json=j)
-
-
-app.add_typer(conflict_app, name="conflict")
-
-
 @app.command("add")
 def add_repo_cmd(
     path: str = typer.Argument(
@@ -1130,7 +1275,7 @@ def search(
     node_labels: str | None = typer.Option(
         None,
         "--node-labels",
-        help="Optional comma-separated Graphiti labels, e.g. PullRequest,Decision",
+        help="Optional comma-separated entity labels, e.g. PullRequest,Decision",
     ),
     repo_name: str | None = typer.Option(
         None,
@@ -1147,7 +1292,7 @@ def search(
     include_invalidated: bool = typer.Option(
         False,
         "--include-invalidated",
-        help="Return superseded facts too (Graphiti edges with invalid_at set). Ignored when --as-of is set.",
+        help="Return superseded facts too (edges with invalid_at set). Ignored when --as-of is set.",
     ),
     with_temporal: bool = typer.Option(
         False,
@@ -1159,16 +1304,16 @@ def search(
         "--as-of",
         help="ISO 8601 instant; restrict results to edges valid at that time (valid_at/invalid_at window).",
     ),
-    episode_uuid: str | None = typer.Option(
+    mutation_id: str | None = typer.Option(
         None,
-        "--episode",
-        "-e",
-        help="Only facts linked to this ingested episode UUID (server-side filter).",
+        "--mutation-id",
+        "-m",
+        help="Only facts written by this apply-plan mutation UUID (server-side filter).",
     ),
     no_provenance: bool = typer.Option(
         False,
         "--no-provenance",
-        help="Hide source / reference_time / episode line in plain (non-JSON) output.",
+        help="Hide source / reference_time / mutation_id line in plain (non-JSON) output.",
     ),
     cwd: str = typer.Option(
         ".",
@@ -1206,8 +1351,8 @@ def search(
         "source_descriptions": [_resolved_source_label(source_description)]
         if _resolved_source_label(source_description)
         else [],
-        "episode_uuids": [episode_uuid.strip()]
-        if episode_uuid and episode_uuid.strip()
+        "mutation_ids": [mutation_id.strip()]
+        if mutation_id and mutation_id.strip()
         else [],
         "include_invalidated": include_invalidated,
         "as_of": as_of_dt,
@@ -1292,7 +1437,8 @@ def status_cmd(
 ) -> None:
     """Fetch readiness / capability envelope (POST /status)."""
     j, v = _flags()
-    pot_id = _pot_id_or_git(pot, cwd=str(Path(cwd).resolve()))
+    cwd_resolved = str(Path(cwd).resolve())
+    pot_id = _pot_id_or_git(pot, cwd=cwd_resolved)
     body: dict[str, Any] = {
         "pot_id": pot_id,
         "scope": _resolve_scope_body(
@@ -1309,6 +1455,15 @@ def status_cmd(
             "Status failed", _format_api_error(exc), verbose=v, exc=exc if v else None
         )
         raise typer.Exit(code=1) from exc
+    if isinstance(response, dict):
+        try:
+            response["skills"] = SkillManager(cwd_resolved).context_status_advisory()
+        except SkillManagerError as exc:
+            response["skills"] = {
+                "ok": False,
+                "error": exc.to_payload()["error"],
+                "doNotEditInstalledSkillsDirectly": True,
+            }
     print_json_blob(response, as_json=j)
 
 
@@ -1399,14 +1554,14 @@ def overview_cmd(
     limit: int = typer.Option(12, "--limit", "-n"),
     cwd: str = typer.Option(".", "--cwd"),
 ) -> None:
-    """Fetch graph-wide readiness / activity snapshot (goal=aggregate, include=[graph_overview])."""
+    """Fetch the project's infra/topology snapshot (services, datastores, deps)."""
     j, v = _flags()
     pot_id = _pot_id_or_git(pot, cwd=str(Path(cwd).resolve()))
     body: dict[str, Any] = {
         "pot_id": pot_id,
-        "goal": "aggregate",
+        "goal": "retrieve",
         "strategy": "auto",
-        "include": ["graph_overview"],
+        "include": ["infra_topology"],
         "limit": limit,
         "scope": _resolve_scope_body(repo_name=repo_name),
     }
@@ -1714,7 +1869,7 @@ def ingest_cmd(
         raise typer.Exit(code=2)
     if (
         out["status"] == "applied"
-        and not out.get("episode_uuid")
+        and not out.get("mutation_id")
         and not out.get("event_id")
     ):
         emit_error(
@@ -1728,6 +1883,9 @@ def ingest_cmd(
 
 
 def main() -> None:
+    from bootstrap.logging_setup import configure_logging
+
+    configure_logging()
     app()
 
 

--- a/app/src/context-engine/adapters/inbound/cli/main.py
+++ b/app/src/context-engine/adapters/inbound/cli/main.py
@@ -75,6 +75,7 @@ app = typer.Typer(
 pot_app = typer.Typer(help="Active pot and local pot helpers.")
 pot_repo_app = typer.Typer(help="Repositories attached to a context pot (Potpie API).")
 event_app = typer.Typer(help="Inspect and wait for ingestion events.")
+conflict_app = typer.Typer(help="Predicate-family conflicts (QualityIssue).")
 skills_app = typer.Typer(help="Manage repo-local Potpie agent skills.")
 
 # Set by root callback; read by all subcommands (including nested `pot`).
@@ -143,7 +144,7 @@ def _ingest_result_from_http(status_code: int, data: dict[str, Any]) -> dict[str
     if status_code == 202:
         return {
             "status": "queued",
-            "mutation_id": data.get("mutation_id"),
+            "episode_uuid": data.get("episode_uuid"),
             "event_id": data.get("event_id"),
             "job_id": data.get("job_id"),
             "downgrades": list(data.get("downgrades") or []),
@@ -151,7 +152,7 @@ def _ingest_result_from_http(status_code: int, data: dict[str, Any]) -> dict[str
     if "event_id" in data or "job_id" in data:
         return {
             "status": data.get("status") or "applied",
-            "mutation_id": data.get("mutation_id"),
+            "episode_uuid": data.get("episode_uuid"),
             "event_id": data.get("event_id"),
             "job_id": data.get("job_id"),
             "downgrades": list(data.get("downgrades") or []),
@@ -159,7 +160,7 @@ def _ingest_result_from_http(status_code: int, data: dict[str, Any]) -> dict[str
         }
     return {
         "status": "applied",
-        "mutation_id": data.get("mutation_id"),
+        "episode_uuid": data.get("episode_uuid"),
         "event_id": data.get("event_id"),
         "job_id": data.get("job_id"),
         "downgrades": list(data.get("downgrades") or []),
@@ -249,6 +250,16 @@ def doctor_cmd() -> None:
     s = EnvContextEngineSettings()
     cg = s.is_enabled()
     neo = bool(s.neo4j_uri())
+    ce_neo = bool(
+        os.getenv("CONTEXT_ENGINE_NEO4J_URI") or os.getenv("CONTEXT_ENGINE_NEO4J_URL")
+    )
+    legacy_neo = bool(os.getenv("NEO4J_URI") or os.getenv("NEO4J_URL"))
+    if ce_neo:
+        neo_src = "context_engine"
+    elif legacy_neo:
+        neo_src = "legacy"
+    else:
+        neo_src = "missing"
 
     has_potpie_key_env = bool(os.getenv("POTPIE_API_KEY"))
     has_stored_key = bool(get_stored_api_key())
@@ -297,7 +308,7 @@ def doctor_cmd() -> None:
 
     summary: list[str] = [
         "[dim]search / ingest / pot hard-reset call Potpie POST /api/v2/context/* with X-API-Key.[/dim]",
-        "[dim]Local Neo4j is not required on this machine.[/dim]",
+        "[dim]Local Neo4j/Graphiti is not required on this machine.[/dim]",
     ]
     if health_ok is True:
         summary.append("[green]GET /health on Potpie base URL succeeded.[/green]")
@@ -311,6 +322,7 @@ def doctor_cmd() -> None:
     snap = DoctorSnapshot(
         context_graph_enabled=cg,
         neo4j_effective_set=neo,
+        neo4j_source=neo_src,
         pot_maps_set=maps_set,
         active_pot_id=get_active_pot_id() or None,
         potpie_api_key_env=has_potpie_key_env,
@@ -466,9 +478,15 @@ def _print_skills_mutation(payload: dict[str, Any], *, as_json: bool) -> None:
     if as_json:
         print_json_blob(payload, as_json=True)
         return
+    default_status = {
+        "installed": "installed",
+        "updated": "updated",
+        "removed": "removed",
+        "skipped": "skipped",
+    }
     for key in ("installed", "updated", "removed", "skipped"):
         for row in payload.get(key, []) or []:
-            status = row.get("status", key.rstrip("d"))
+            status = row.get("status", default_status[key])
             suffix = f" ({row['reason']})" if row.get("reason") else ""
             print_plain_line(f"{status} {row['id']}{suffix}", as_json=False)
             command = row.get("recommendedCommand")
@@ -1225,6 +1243,60 @@ def event_wait_cmd(
 app.add_typer(event_app, name="event")
 
 
+@conflict_app.command("list")
+def conflict_list_cmd(
+    cwd: str = typer.Option(
+        ".",
+        "--cwd",
+        help="Git working tree used when inferring pot from remote / env",
+    ),
+) -> None:
+    """List open predicate-family conflicts for the active pot."""
+    load_cli_env()
+    j, v = _flags()
+    cwd_resolved = str(Path(cwd).resolve())
+    pot_id = _pot_id_or_git(None, cwd=cwd_resolved)
+    client = _cli_client_or_exit(v)
+    try:
+        out = client.conflicts_list(pot_id)
+    except PotpieContextApiError as exc:
+        emit_error("Could not list conflicts", _format_api_error(exc), verbose=v)
+        raise typer.Exit(code=1) from exc
+    print_json_blob(out, as_json=j)
+
+
+@conflict_app.command("resolve")
+def conflict_resolve_cmd(
+    issue_uuid: str = typer.Argument(..., help="QualityIssue uuid"),
+    action: str = typer.Option(
+        "supersede_older",
+        "--action",
+        "-a",
+        help="Resolution strategy (supersede_older stamps invalid_at on the older edge)",
+    ),
+    cwd: str = typer.Option(
+        ".",
+        "--cwd",
+        help="Git working tree used when inferring pot from remote / env",
+    ),
+) -> None:
+    """Resolve one open conflict (default: supersede the older episodic edge)."""
+    load_cli_env()
+    j, v = _flags()
+    cwd_resolved = str(Path(cwd).resolve())
+    pot_id = _pot_id_or_git(None, cwd=cwd_resolved)
+    client = _cli_client_or_exit(v)
+    try:
+        out = client.conflicts_resolve(pot_id, issue_uuid, action=action)
+    except PotpieContextApiError as exc:
+        emit_error("Could not resolve conflict", _format_api_error(exc), verbose=v)
+        raise typer.Exit(code=1) from exc
+    print_json_blob(out, as_json=j)
+
+
+app.add_typer(conflict_app, name="conflict")
+
+
 @app.command("add")
 def add_repo_cmd(
     path: str = typer.Argument(
@@ -1275,7 +1347,7 @@ def search(
     node_labels: str | None = typer.Option(
         None,
         "--node-labels",
-        help="Optional comma-separated entity labels, e.g. PullRequest,Decision",
+        help="Optional comma-separated Graphiti labels, e.g. PullRequest,Decision",
     ),
     repo_name: str | None = typer.Option(
         None,
@@ -1292,7 +1364,7 @@ def search(
     include_invalidated: bool = typer.Option(
         False,
         "--include-invalidated",
-        help="Return superseded facts too (edges with invalid_at set). Ignored when --as-of is set.",
+        help="Return superseded facts too (Graphiti edges with invalid_at set). Ignored when --as-of is set.",
     ),
     with_temporal: bool = typer.Option(
         False,
@@ -1304,16 +1376,16 @@ def search(
         "--as-of",
         help="ISO 8601 instant; restrict results to edges valid at that time (valid_at/invalid_at window).",
     ),
-    mutation_id: str | None = typer.Option(
+    episode_uuid: str | None = typer.Option(
         None,
-        "--mutation-id",
-        "-m",
-        help="Only facts written by this apply-plan mutation UUID (server-side filter).",
+        "--episode",
+        "-e",
+        help="Only facts linked to this ingested episode UUID (server-side filter).",
     ),
     no_provenance: bool = typer.Option(
         False,
         "--no-provenance",
-        help="Hide source / reference_time / mutation_id line in plain (non-JSON) output.",
+        help="Hide source / reference_time / episode line in plain (non-JSON) output.",
     ),
     cwd: str = typer.Option(
         ".",
@@ -1351,8 +1423,8 @@ def search(
         "source_descriptions": [_resolved_source_label(source_description)]
         if _resolved_source_label(source_description)
         else [],
-        "mutation_ids": [mutation_id.strip()]
-        if mutation_id and mutation_id.strip()
+        "episode_uuids": [episode_uuid.strip()]
+        if episode_uuid and episode_uuid.strip()
         else [],
         "include_invalidated": include_invalidated,
         "as_of": as_of_dt,
@@ -1437,8 +1509,7 @@ def status_cmd(
 ) -> None:
     """Fetch readiness / capability envelope (POST /status)."""
     j, v = _flags()
-    cwd_resolved = str(Path(cwd).resolve())
-    pot_id = _pot_id_or_git(pot, cwd=cwd_resolved)
+    pot_id = _pot_id_or_git(pot, cwd=str(Path(cwd).resolve()))
     body: dict[str, Any] = {
         "pot_id": pot_id,
         "scope": _resolve_scope_body(
@@ -1455,15 +1526,6 @@ def status_cmd(
             "Status failed", _format_api_error(exc), verbose=v, exc=exc if v else None
         )
         raise typer.Exit(code=1) from exc
-    if isinstance(response, dict):
-        try:
-            response["skills"] = SkillManager(cwd_resolved).context_status_advisory()
-        except SkillManagerError as exc:
-            response["skills"] = {
-                "ok": False,
-                "error": exc.to_payload()["error"],
-                "doNotEditInstalledSkillsDirectly": True,
-            }
     print_json_blob(response, as_json=j)
 
 
@@ -1554,14 +1616,14 @@ def overview_cmd(
     limit: int = typer.Option(12, "--limit", "-n"),
     cwd: str = typer.Option(".", "--cwd"),
 ) -> None:
-    """Fetch the project's infra/topology snapshot (services, datastores, deps)."""
+    """Fetch graph-wide readiness / activity snapshot (goal=aggregate, include=[graph_overview])."""
     j, v = _flags()
     pot_id = _pot_id_or_git(pot, cwd=str(Path(cwd).resolve()))
     body: dict[str, Any] = {
         "pot_id": pot_id,
-        "goal": "retrieve",
+        "goal": "aggregate",
         "strategy": "auto",
-        "include": ["infra_topology"],
+        "include": ["graph_overview"],
         "limit": limit,
         "scope": _resolve_scope_body(repo_name=repo_name),
     }
@@ -1869,7 +1931,7 @@ def ingest_cmd(
         raise typer.Exit(code=2)
     if (
         out["status"] == "applied"
-        and not out.get("mutation_id")
+        and not out.get("episode_uuid")
         and not out.get("event_id")
     ):
         emit_error(
@@ -1883,9 +1945,6 @@ def ingest_cmd(
 
 
 def main() -> None:
-    from bootstrap.logging_setup import configure_logging
-
-    configure_logging()
     app()
 
 

--- a/app/src/context-engine/adapters/inbound/cli/main.py
+++ b/app/src/context-engine/adapters/inbound/cli/main.py
@@ -430,7 +430,7 @@ def _emit_skill_error(exc: SkillManagerError, *, as_json: bool) -> None:
     emit_error(exc.code, exc.message, hint=hint)
 
 
-def _skill_payload_or_exit(action: Any, *, success_exit: int = 0) -> dict[str, Any]:
+def _skill_payload_or_exit(action: Any) -> dict[str, Any]:
     j, _ = _flags()
     try:
         return action()

--- a/app/src/context-engine/adapters/inbound/cli/skill_catalog.py
+++ b/app/src/context-engine/adapters/inbound/cli/skill_catalog.py
@@ -1,0 +1,361 @@
+"""Potpie skill catalog + filesystem helpers for `potpie skills`.
+
+Contract:
+- Canonical install dir: `.agents/skills/<skill-id>`
+- Bundled catalog: packaged templates at `templates/agent_bundle/.agents/skills/<skill-id>/SKILL.md`
+- Hashing: deterministic SHA-256 over sorted relative paths + bytes, ignoring:
+  `.git/`, `__pycache__/`, `__pypackages__/`, and `metadata.json`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import shutil
+import tempfile
+from dataclasses import dataclass, field
+from importlib import resources
+from importlib.abc import Traversable
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+CANONICAL_SKILLS_DIR = Path(".agents") / "skills"
+LOCK_PATH = Path(".agents") / "skills-lock.json"
+SKILL_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,254}$")
+IGNORED_HASH_PARTS = {".git", "__pycache__", "__pypackages__"}
+IGNORED_HASH_FILES = {"metadata.json"}
+
+
+class SkillCatalogError(ValueError):
+    """Catalog or skill metadata validation failure."""
+
+
+@dataclass(frozen=True)
+class SkillEntry:
+    """A first-party Potpie skill catalog entry."""
+
+    id: str
+    name: str
+    description: str
+    template_path: str  # repo-relative SKILL.md path
+    template_hash: str  # sha256:...
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_catalog_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "templatePath": self.template_path,
+            "templateHash": self.template_hash,
+            "metadata": self.metadata,
+        }
+
+
+def validate_skill_id(skill_id: str) -> str:
+    """Return a normalized skill id or raise ``SkillCatalogError``."""
+
+    value = (skill_id or "").strip()
+    if (
+        not SKILL_ID_RE.match(value)
+        or "/" in value
+        or "\\" in value
+        or ".." in value
+        or value.startswith(".")
+        or value.endswith(".")
+        or value.startswith("-")
+        or value.endswith("-")
+    ):
+        raise SkillCatalogError(f"Invalid skill id: {skill_id!r}")
+    return value
+
+
+def canonical_skills_dir(root: Path) -> Path:
+    return root / CANONICAL_SKILLS_DIR
+
+
+def lock_path(root: Path) -> Path:
+    return root / LOCK_PATH
+
+
+def skill_dir(root: Path, skill_id: str) -> Path:
+    """Resolve a skill directory and assert it remains in the canonical dir."""
+
+    safe_id = validate_skill_id(skill_id)
+    base = canonical_skills_dir(root).resolve()
+    target = (base / safe_id).resolve()
+    if target != base / safe_id or not _is_relative_to(target, base):
+        raise SkillCatalogError(f"Unsafe skill path for {skill_id!r}")
+    return target
+
+
+def relative_to_root(path: Path, root: Path) -> str:
+    return path.resolve().relative_to(root.resolve()).as_posix()
+
+
+def parse_skill_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+    """Parse simple YAML frontmatter without executing arbitrary tags.
+
+    The MVP only needs scalar keys. Dotted keys such as ``metadata.internal`` are
+    expanded into nested dictionaries for compatibility with reference skills.
+    """
+
+    if not text.startswith("---\n"):
+        raise SkillCatalogError("SKILL.md is missing YAML frontmatter")
+    end = text.find("\n---", 4)
+    if end == -1:
+        raise SkillCatalogError("SKILL.md frontmatter is not closed")
+    raw = text[4:end]
+    body = text[end + len("\n---") :].lstrip("\n")
+    data: dict[str, Any] = {}
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if ":" not in stripped:
+            raise SkillCatalogError(f"Invalid frontmatter line: {line!r}")
+        key, value = stripped.split(":", 1)
+        key = key.strip()
+        parsed = _parse_scalar(value.strip())
+        _assign_dotted_key(data, key, parsed)
+    name = data.get("name")
+    description = data.get("description")
+    if not isinstance(name, str) or not name.strip():
+        raise SkillCatalogError("SKILL.md frontmatter requires string name")
+    if not isinstance(description, str) or not description.strip():
+        raise SkillCatalogError("SKILL.md frontmatter requires string description")
+    data["name"] = name.strip()
+    data["description"] = description.strip()
+    return data, body
+
+
+def discover_bundled_skills() -> tuple[list[SkillEntry], list[dict[str, Any]]]:
+    """Discover first-party bundled skills from packaged templates."""
+
+    templates_root = _packaged_skills_root()
+    entries: list[SkillEntry] = []
+    diagnostics: list[dict[str, Any]] = []
+
+    for child in sorted(templates_root.iterdir(), key=lambda item: item.name):
+        if not child.is_dir():
+            continue
+        try:
+            skill_id = validate_skill_id(child.name)
+            skill_md = child / "SKILL.md"
+            if not skill_md.is_file():
+                continue
+            metadata, _ = parse_skill_frontmatter(skill_md.read_text(encoding="utf-8"))
+            if _is_internal(metadata):
+                continue
+            entries.append(
+                SkillEntry(
+                    id=skill_id,
+                    name=str(metadata["name"]),
+                    description=str(metadata["description"]),
+                    template_path=f"templates/agent_bundle/.agents/skills/{skill_id}/SKILL.md",
+                    template_hash=hash_traversable_dir(child),
+                    metadata={
+                        k: v
+                        for k, v in metadata.items()
+                        if k not in {"name", "description"}
+                    },
+                )
+            )
+        except Exception as exc:
+            diagnostics.append(
+                {
+                    "code": "INVALID_CATALOG_SKILL",
+                    "skillId": child.name,
+                    "message": str(exc),
+                }
+            )
+    return sorted(entries, key=lambda entry: entry.id), diagnostics
+
+
+def discover_installed_skills(
+    root: Path,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Read installed repo-local skills from ``.agents/skills``."""
+
+    skills_root = canonical_skills_dir(root)
+    if not skills_root.exists():
+        return [], []
+    installed: list[dict[str, Any]] = []
+    diagnostics: list[dict[str, Any]] = []
+    for child in sorted(skills_root.iterdir(), key=lambda item: item.name):
+        if not child.is_dir():
+            continue
+        try:
+            skill_id = validate_skill_id(child.name)
+            skill_md = child / "SKILL.md"
+            if not skill_md.is_file():
+                continue
+            metadata, _ = parse_skill_frontmatter(skill_md.read_text(encoding="utf-8"))
+            installed.append(
+                {
+                    "id": skill_id,
+                    "name": metadata["name"],
+                    "description": metadata["description"],
+                    "installedPath": relative_to_root(skill_md, root),
+                    "installedHash": hash_path_dir(child),
+                    "metadata": {
+                        k: v
+                        for k, v in metadata.items()
+                        if k not in {"name", "description"}
+                    },
+                }
+            )
+        except Exception as exc:
+            diagnostics.append(
+                {
+                    "code": "INVALID_INSTALLED_SKILL",
+                    "skillId": child.name,
+                    "message": str(exc),
+                }
+            )
+    return installed, diagnostics
+
+
+def copy_bundled_skill_atomic(skill_id: str, root: Path) -> str:
+    """Copy one bundled (packaged) skill into the canonical project directory atomically."""
+
+    safe_id = validate_skill_id(skill_id)
+    source = _packaged_skills_root().joinpath(safe_id)
+    if not source.is_dir() or not source.joinpath("SKILL.md").is_file():
+        raise SkillCatalogError(f"Unknown bundled skill: {skill_id!r}")
+    target = skill_dir(root, safe_id)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = Path(
+        tempfile.mkdtemp(prefix=f".{safe_id}.tmp-", dir=str(target.parent.resolve()))
+    )
+    try:
+        _copy_traversable_dir(source, tmp)
+        installed_hash = hash_path_dir(tmp)
+        if target.exists():
+            shutil.rmtree(target)
+        tmp.replace(target)
+        return installed_hash
+    except Exception:
+        if tmp.exists():
+            shutil.rmtree(tmp, ignore_errors=True)
+        raise
+
+
+def hash_path_dir(path: Path) -> str:
+    digest = hashlib.sha256()
+    for file_path in _iter_hashable_paths(path):
+        rel = file_path.relative_to(path).as_posix()
+        digest.update(rel.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(file_path.read_bytes())
+        digest.update(b"\0")
+    return f"sha256:{digest.hexdigest()}"
+
+
+def hash_traversable_dir(path: Traversable) -> str:
+    digest = hashlib.sha256()
+    for rel, file_obj in _iter_hashable_traversables(path):
+        digest.update(rel.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(file_obj.read_bytes())
+        digest.update(b"\0")
+    return f"sha256:{digest.hexdigest()}"
+
+
+def packaged_skill_hash(skill_id: str) -> str:
+    return hash_traversable_dir(
+        _packaged_skills_root().joinpath(validate_skill_id(skill_id))
+    )
+
+
+def _packaged_skills_root() -> Traversable:
+    return resources.files("adapters.inbound.cli").joinpath(
+        "templates", "agent_bundle", ".agents", "skills"
+    )
+
+
+def _parse_scalar(value: str) -> Any:
+    if value in {"true", "True"}:
+        return True
+    if value in {"false", "False"}:
+        return False
+    if value in {"null", "Null", "~"}:
+        return None
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def _assign_dotted_key(data: dict[str, Any], key: str, value: Any) -> None:
+    if "." not in key:
+        data[key] = value
+        return
+    current = data
+    parts = [part.strip() for part in key.split(".") if part.strip()]
+    for part in parts[:-1]:
+        nested = current.setdefault(part, {})
+        if not isinstance(nested, dict):
+            raise SkillCatalogError(f"Conflicting frontmatter key: {key!r}")
+        current = nested
+    current[parts[-1]] = value
+
+
+def _is_internal(metadata: dict[str, Any]) -> bool:
+    internal = False
+    meta = metadata.get("metadata")
+    if isinstance(meta, dict):
+        internal = meta.get("internal") is True
+    if not internal:
+        return False
+    return os.getenv("INSTALL_INTERNAL_SKILLS", "").strip().lower() not in {
+        "1",
+        "true",
+    }
+
+
+def _iter_hashable_paths(path: Path) -> list[Path]:
+    files: list[Path] = []
+    for file_path in path.rglob("*"):
+        rel_parts = set(file_path.relative_to(path).parts)
+        if rel_parts & IGNORED_HASH_PARTS:
+            continue
+        if file_path.name in IGNORED_HASH_FILES:
+            continue
+        if file_path.is_file() and not file_path.is_symlink():
+            files.append(file_path)
+    return sorted(files, key=lambda item: item.relative_to(path).as_posix())
+
+
+def _iter_hashable_traversables(
+    root: Traversable, prefix: Path = Path(".")
+) -> list[tuple[str, Traversable]]:
+    files: list[tuple[str, Traversable]] = []
+    for child in root.iterdir():
+        rel = prefix / child.name
+        if set(rel.parts) & IGNORED_HASH_PARTS or child.name in IGNORED_HASH_FILES:
+            continue
+        if child.is_dir():
+            files.extend(_iter_hashable_traversables(child, rel))
+        elif child.is_file():
+            files.append((rel.as_posix(), child))
+    return sorted(files, key=lambda item: item[0])
+
+
+def _copy_traversable_dir(source: Traversable, target: Path) -> None:
+    target.mkdir(parents=True, exist_ok=True)
+    for child in source.iterdir():
+        dest = target / child.name
+        if child.is_dir():
+            _copy_traversable_dir(child, dest)
+        elif child.is_file():
+            dest.write_bytes(child.read_bytes())
+
+
+def _is_relative_to(path: Path, base: Path) -> bool:
+    try:
+        path.relative_to(base)
+        return True
+    except ValueError:
+        return False

--- a/app/src/context-engine/adapters/inbound/cli/skill_lock.py
+++ b/app/src/context-engine/adapters/inbound/cli/skill_lock.py
@@ -1,0 +1,121 @@
+"""Deterministic Potpie skill lockfile handling.
+
+Contract lockfile: `.agents/skills-lock.json`
+
+Shape (v1):
+{
+  "version": 1,
+  "skills": {
+    "<skill-id>": {
+      "sourceType": "bundled",
+      "source": "templates/agent_bundle",
+      "templateHash": "sha256:...",
+      "installedHash": "sha256:...",
+      "installedAt": "...Z",
+      "updatedAt": "...Z"
+    }
+  }
+}
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from adapters.inbound.cli.skill_catalog import LOCK_PATH, lock_path
+
+LOCK_VERSION = 1
+
+
+class SkillLockError(ValueError):
+    """Lockfile parse or version error."""
+
+
+def utc_now() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def empty_lock() -> dict[str, Any]:
+    return {"version": LOCK_VERSION, "skills": {}}
+
+
+def read_lock(root: Path) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    """Read lockfile. Returns an empty lock plus diagnostic on parse failures."""
+
+    path = lock_path(root)
+    if not path.exists():
+        return empty_lock(), None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise SkillLockError("Lockfile must contain a JSON object")
+        if data.get("version") != LOCK_VERSION:
+            raise SkillLockError(
+                f"Unsupported lockfile version {data.get('version')!r}"
+            )
+        skills = data.get("skills")
+        if not isinstance(skills, dict):
+            raise SkillLockError("Lockfile field 'skills' must be an object")
+        return {"version": LOCK_VERSION, "skills": dict(skills)}, None
+    except Exception as exc:
+        return empty_lock(), {
+            "code": "INVALID_LOCKFILE",
+            "path": LOCK_PATH.as_posix(),
+            "message": str(exc),
+        }
+
+
+def write_lock(root: Path, data: dict[str, Any]) -> None:
+    path = lock_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    normalized = {
+        "version": LOCK_VERSION,
+        "skills": {
+            skill_id: data.get("skills", {})[skill_id]
+            for skill_id in sorted(data.get("skills", {}))
+        },
+    }
+    path.write_text(
+        json.dumps(normalized, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def upsert_lock_entry(
+    lock: dict[str, Any],
+    *,
+    skill_id: str,
+    source: str,
+    skill_path: str,
+    template_hash: str,
+    installed_hash: str,
+) -> None:
+    now = utc_now()
+    skills = lock.setdefault("skills", {})
+    previous = skills.get(skill_id)
+    installed_at = (
+        previous.get("installedAt")
+        if isinstance(previous, dict) and previous.get("installedAt")
+        else now
+    )
+    skills[skill_id] = {
+        "sourceType": "bundled",
+        "source": source,
+        "skillPath": skill_path,
+        "templateHash": template_hash,
+        "installedHash": installed_hash,
+        "installedAt": installed_at,
+        "updatedAt": now,
+    }
+
+
+def remove_lock_entry(lock: dict[str, Any], skill_id: str) -> None:
+    skills = lock.setdefault("skills", {})
+    if isinstance(skills, dict):
+        skills.pop(skill_id, None)

--- a/app/src/context-engine/adapters/inbound/cli/skill_manager.py
+++ b/app/src/context-engine/adapters/inbound/cli/skill_manager.py
@@ -1,0 +1,538 @@
+"""Potpie repo-local skill lifecycle service."""
+
+from __future__ import annotations
+
+import shlex
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from adapters.inbound.cli.skill_catalog import (
+    CANONICAL_SKILLS_DIR,
+    LOCK_PATH,
+    SCHEMA_VERSION,
+    SkillCatalogError,
+    canonical_skills_dir,
+    copy_bundled_skill_atomic,
+    discover_installed_skills,
+    discover_bundled_skills,
+    hash_path_dir,
+    relative_to_root,
+    skill_dir,
+    validate_skill_id,
+)
+from adapters.inbound.cli.skill_lock import (
+    read_lock,
+    remove_lock_entry,
+    upsert_lock_entry,
+    write_lock,
+)
+from adapters.inbound.cli.skill_targets import (
+    InvalidAgentError,
+    llm_guidance,
+    normalize_agent,
+    recommended_skill_ids,
+)
+
+
+@dataclass
+class SkillManagerError(Exception):
+    code: str
+    message: str
+    recommended_command: str | None = None
+    detail: Any = None
+
+    def to_payload(self) -> dict[str, Any]:
+        error: dict[str, Any] = {"code": self.code, "message": self.message}
+        if self.recommended_command:
+            error["recommendedCommand"] = self.recommended_command
+        if self.detail is not None:
+            error["detail"] = self.detail
+        return {"ok": False, "schemaVersion": SCHEMA_VERSION, "error": error}
+
+
+class SkillManager:
+    """Service object used by CLI commands and context-status advisory."""
+
+    def __init__(self, root: str | Path = ".", *, agent: str = "default") -> None:
+        self.root = Path(root).expanduser().resolve()
+        try:
+            self.agent = normalize_agent(agent)
+        except InvalidAgentError as exc:
+            raise SkillManagerError(
+                "INVALID_AGENT",
+                str(exc),
+                detail={"validAgents": ["default", "codex", "claude", "cursor"]},
+            ) from exc
+
+    def status(self) -> dict[str, Any]:
+        available_entries, catalog_diagnostics = discover_bundled_skills()
+        available = [entry.to_catalog_dict() for entry in available_entries]
+        catalog = {entry.id: entry for entry in available_entries}
+        installed_rows, installed_diagnostics = discover_installed_skills(self.root)
+        installed_by_id = {row["id"]: row for row in installed_rows}
+        lock, lock_diagnostic = read_lock(self.root)
+        lock_skills = lock.get("skills", {})
+
+        installed: list[dict[str, Any]] = []
+        outdated: list[dict[str, Any]] = []
+        locally_modified: list[dict[str, Any]] = []
+        for row in sorted(installed_rows, key=lambda item: str(item["id"])):
+            skill_id = str(row["id"])
+            catalog_entry = catalog.get(skill_id)
+            lock_entry = lock_skills.get(skill_id)
+            lock_payload = {"present": isinstance(lock_entry, dict)}
+            if isinstance(lock_entry, dict):
+                lock_payload.update(
+                    {
+                        "sourceType": lock_entry.get("sourceType"),
+                        "templateHash": lock_entry.get("templateHash"),
+                        "installedHash": lock_entry.get("installedHash"),
+                    }
+                )
+            output_row = {**row, "status": "installed", "lock": lock_payload}
+            if catalog_entry:
+                output_row["templateHash"] = catalog_entry.template_hash
+            installed.append(output_row)
+
+            installed_hash = str(row["installedHash"])
+            template_hash = catalog_entry.template_hash if catalog_entry else None
+            if isinstance(lock_entry, dict) and installed_hash != lock_entry.get(
+                "installedHash"
+            ):
+                locally_modified.append(
+                    {
+                        "id": skill_id,
+                        "installedHash": installed_hash,
+                        "lockedHash": lock_entry.get("installedHash"),
+                    }
+                )
+            if catalog_entry and isinstance(lock_entry, dict):
+                if catalog_entry.template_hash != lock_entry.get("templateHash"):
+                    outdated.append(
+                        {
+                            "id": skill_id,
+                            "installedHash": installed_hash,
+                            "templateHash": catalog_entry.template_hash,
+                            "lockedTemplateHash": lock_entry.get("templateHash"),
+                        }
+                    )
+            elif catalog_entry and template_hash != installed_hash:
+                outdated.append(
+                    {
+                        "id": skill_id,
+                        "installedHash": installed_hash,
+                        "templateHash": template_hash,
+                        "lockedTemplateHash": None,
+                    }
+                )
+
+        recommended = [
+            skill_id
+            for skill_id in recommended_skill_ids(self.agent)
+            if skill_id in catalog
+        ]
+        missing = [
+            skill_id for skill_id in recommended if skill_id not in installed_by_id
+        ]
+        diagnostics = [*catalog_diagnostics, *installed_diagnostics]
+        if lock_diagnostic:
+            diagnostics.append(lock_diagnostic)
+        next_actions = self._next_actions(missing, outdated, locally_modified)
+        return {
+            "ok": True,
+            "schemaVersion": SCHEMA_VERSION,
+            "root": str(self.root),
+            "agent": self.agent,
+            "canonicalDir": CANONICAL_SKILLS_DIR.as_posix(),
+            "lockPath": LOCK_PATH.as_posix(),
+            "available": available,
+            "installed": installed,
+            "recommended": recommended,
+            "missing": missing,
+            "outdated": outdated,
+            "locallyModified": locally_modified,
+            "diagnostics": diagnostics,
+            "next_actions": next_actions,
+            "nextActions": next_actions,
+            "llmGuidance": llm_guidance(self.agent),
+        }
+
+    def list_skills(self, *, mode: str) -> dict[str, Any]:
+        status = self.status()
+        if mode == "available":
+            skills = status["available"]
+        elif mode == "installed":
+            skills = status["installed"]
+        elif mode == "recommended":
+            available = {row["id"]: row for row in status["available"]}
+            skills = [
+                available[skill_id]
+                for skill_id in status["recommended"]
+                if skill_id in available
+            ]
+        else:
+            raise SkillManagerError("INVALID_ARGUMENTS", f"Unknown list mode {mode!r}")
+        return {
+            "ok": True,
+            "schemaVersion": SCHEMA_VERSION,
+            "root": str(self.root),
+            "agent": self.agent,
+            "mode": mode,
+            "skills": skills,
+        }
+
+    def install(
+        self, skill_id: str | None = None, *, yes: bool = False, force: bool = False
+    ) -> dict[str, Any]:
+        status = self.status()
+        catalog = {row["id"]: row for row in status["available"]}
+        targets = [skill_id] if skill_id else list(status["recommended"])
+        if not targets:
+            targets = list(catalog)
+        results = []
+        lock, lock_error = read_lock(self.root)
+        if lock_error:
+            raise SkillManagerError(
+                "INVALID_LOCKFILE",
+                lock_error["message"],
+                recommended_command="Fix or remove .agents/skills-lock.json, then retry.",
+            )
+        for target_id in targets:
+            safe_id = self._known_skill_or_error(str(target_id), catalog)
+            results.append(
+                self._install_one(safe_id, catalog[safe_id], lock, yes=yes, force=force)
+            )
+        write_lock(self.root, lock)
+        return {
+            "ok": True,
+            "schemaVersion": SCHEMA_VERSION,
+            "root": str(self.root),
+            "agent": self.agent,
+            "installed": results,
+        }
+
+    def update(
+        self, skill_id: str | None = None, *, all_: bool = False, yes: bool = False
+    ) -> dict[str, Any]:
+        if skill_id and all_:
+            raise SkillManagerError(
+                "INVALID_ARGUMENTS", "Pass either <skill-id> or --all, not both."
+            )
+        status = self.status()
+        catalog = {row["id"]: row for row in status["available"]}
+        installed_ids = {row["id"] for row in status["installed"]}
+        modified_ids = {row["id"] for row in status["locallyModified"]}
+        if skill_id:
+            safe_id = validate_skill_id(skill_id)
+            if safe_id not in installed_ids:
+                raise SkillManagerError("NOT_INSTALLED", f"{safe_id} is not installed.")
+            if safe_id not in catalog:
+                raise SkillManagerError("NOT_IN_CATALOG", f"{safe_id} is not bundled.")
+            targets = [safe_id]
+        elif all_:
+            targets = sorted(sid for sid in installed_ids if sid in catalog)
+        else:
+            targets = [row["id"] for row in status["outdated"]]
+
+        if not targets:
+            return {
+                "ok": True,
+                "schemaVersion": SCHEMA_VERSION,
+                "root": str(self.root),
+                "agent": self.agent,
+                "updated": [],
+                "skipped": [],
+            }
+        if not yes:
+            raise SkillManagerError(
+                "NEEDS_YES",
+                "Refusing to update skills without --yes.",
+                recommended_command=(
+                    f"potpie skills update --path {self._quoted_root()} --yes"
+                ),
+            )
+
+        lock, lock_error = read_lock(self.root)
+        if lock_error:
+            raise SkillManagerError("INVALID_LOCKFILE", lock_error["message"])
+        updated: list[dict[str, Any]] = []
+        skipped: list[dict[str, Any]] = []
+        for target_id in targets:
+            if target_id in modified_ids:
+                item = {
+                    "id": target_id,
+                    "status": "skipped",
+                    "reason": "locally_modified",
+                    "recommendedCommand": (
+                        f"potpie skills install {target_id} "
+                        f"--path {self._quoted_root()} --yes --force"
+                    ),
+                }
+                skipped.append(item)
+                if skill_id:
+                    raise SkillManagerError(
+                        "LOCALLY_MODIFIED_REFUSED",
+                        f"{target_id} has local modifications.",
+                        recommended_command=item["recommendedCommand"],
+                    )
+                continue
+            updated.append(
+                self._install_one(
+                    target_id, catalog[target_id], lock, yes=True, force=False
+                )
+            )
+        write_lock(self.root, lock)
+        return {
+            "ok": True,
+            "schemaVersion": SCHEMA_VERSION,
+            "root": str(self.root),
+            "agent": self.agent,
+            "updated": updated,
+            "skipped": skipped,
+        }
+
+    def remove(self, skill_id: str, *, yes: bool = False) -> dict[str, Any]:
+        safe_id = validate_skill_id(skill_id)
+        target = skill_dir(self.root, safe_id)
+        if not target.exists():
+            raise SkillManagerError("NOT_INSTALLED", f"{safe_id} is not installed.")
+        lock, lock_error = read_lock(self.root)
+        if lock_error:
+            raise SkillManagerError("INVALID_LOCKFILE", lock_error["message"])
+        if safe_id not in lock.get("skills", {}):
+            raise SkillManagerError(
+                "UNOWNED_SKILL_REFUSED",
+                f"{safe_id} is not owned by Potpie lockfile.",
+            )
+        if not yes:
+            raise SkillManagerError(
+                "NEEDS_YES",
+                "Refusing to remove a skill without --yes.",
+                recommended_command=(
+                    f"potpie skills remove {safe_id} "
+                    f"--path {self._quoted_root()} --yes"
+                ),
+            )
+        shutil.rmtree(target)
+        remove_lock_entry(lock, safe_id)
+        write_lock(self.root, lock)
+        return {
+            "ok": True,
+            "schemaVersion": SCHEMA_VERSION,
+            "root": str(self.root),
+            "agent": self.agent,
+            "removed": [{"id": safe_id, "status": "removed"}],
+        }
+
+    def doctor(self) -> dict[str, Any]:
+        status = self.status()
+        lock, lock_error = read_lock(self.root)
+        installed_ids = {row["id"] for row in status["installed"]}
+        catalog_ids = {row["id"] for row in status["available"]}
+        lock_skills = lock.get("skills", {})
+        diagnostics = list(status["diagnostics"])
+        for skill_id in sorted(installed_ids - catalog_ids):
+            diagnostics.append(
+                {
+                    "code": "UNKNOWN_INSTALLED_SKILL",
+                    "skillId": skill_id,
+                    "message": f"{skill_id} is installed but not in the bundled catalog.",
+                }
+            )
+        for skill_id in sorted(set(lock_skills) - installed_ids):
+            diagnostics.append(
+                {
+                    "code": "LOCK_ENTRY_WITHOUT_INSTALL",
+                    "skillId": skill_id,
+                    "message": f"{skill_id} has a lock entry but no installed directory.",
+                }
+            )
+        for skill_id in sorted(installed_ids - set(lock_skills)):
+            diagnostics.append(
+                {
+                    "code": "INSTALLED_WITHOUT_LOCK",
+                    "skillId": skill_id,
+                    "message": f"{skill_id} is installed but not owned by the lockfile.",
+                }
+            )
+        if lock_error:
+            diagnostics.append(lock_error)
+        ok = not diagnostics
+        return {
+            "ok": ok,
+            "schemaVersion": SCHEMA_VERSION,
+            "root": str(self.root),
+            "agent": self.agent,
+            "canonicalDir": CANONICAL_SKILLS_DIR.as_posix(),
+            "lockPath": LOCK_PATH.as_posix(),
+            "checks": {
+                "catalogReadable": bool(status["available"]),
+                "canonicalDirExists": canonical_skills_dir(self.root).exists(),
+                "lockfileValid": lock_error is None,
+            },
+            "diagnostics": diagnostics,
+            "recommendedCommand": None
+            if ok
+            else f"potpie skills status --path {self._quoted_root()}",
+        }
+
+    def context_status_advisory(self) -> dict[str, Any]:
+        status = self.status()
+        return {
+            "agent": status["agent"],
+            "recommended": status["recommended"],
+            "installed": [
+                {
+                    "id": row["id"],
+                    "path": row["installedPath"],
+                    "installedHash": row["installedHash"],
+                }
+                for row in status["installed"]
+            ],
+            "missing": status["missing"],
+            "outdated": status["outdated"],
+            "locallyModified": status["locallyModified"],
+            "nextActions": status["nextActions"],
+            "doNotEditInstalledSkillsDirectly": True,
+        }
+
+    def _install_one(
+        self,
+        skill_id: str,
+        catalog_entry: dict[str, Any],
+        lock: dict[str, Any],
+        *,
+        yes: bool,
+        force: bool,
+    ) -> dict[str, Any]:
+        target = skill_dir(self.root, skill_id)
+        existing_hash = hash_path_dir(target) if target.exists() else None
+        lock_entry = lock.get("skills", {}).get(skill_id)
+        if existing_hash == catalog_entry["templateHash"]:
+            upsert_lock_entry(
+                lock,
+                skill_id=skill_id,
+                source=catalog_entry["templatePath"].removesuffix("/SKILL.md"),
+                skill_path=relative_to_root(target / "SKILL.md", self.root),
+                template_hash=catalog_entry["templateHash"],
+                installed_hash=existing_hash,
+            )
+            return {
+                "id": skill_id,
+                "status": "unchanged",
+                "installedHash": existing_hash,
+            }
+        if (
+            target.exists()
+            and isinstance(lock_entry, dict)
+            and existing_hash != lock_entry.get("installedHash")
+            and not force
+        ):
+            raise SkillManagerError(
+                "LOCALLY_MODIFIED_REFUSED",
+                f"{skill_id} has local modifications.",
+                recommended_command=(
+                    f"potpie skills install {skill_id} "
+                    f"--path {self._quoted_root()} --yes --force"
+                ),
+            )
+        if target.exists() and not yes:
+            raise SkillManagerError(
+                "NEEDS_YES",
+                "Refusing to overwrite existing skill without --yes.",
+                recommended_command=(
+                    f"potpie skills install {skill_id} "
+                    f"--path {self._quoted_root()} --yes"
+                ),
+            )
+        try:
+            installed_hash = copy_bundled_skill_atomic(skill_id, self.root)
+        except SkillCatalogError as exc:
+            raise SkillManagerError("UNKNOWN_SKILL", str(exc)) from exc
+        upsert_lock_entry(
+            lock,
+            skill_id=skill_id,
+            source=catalog_entry["templatePath"].removesuffix("/SKILL.md"),
+            skill_path=relative_to_root(target / "SKILL.md", self.root),
+            template_hash=catalog_entry["templateHash"],
+            installed_hash=installed_hash,
+        )
+        return {
+            "id": skill_id,
+            "status": "installed" if existing_hash is None else "updated",
+            "installedPath": relative_to_root(target / "SKILL.md", self.root),
+            "installedHash": installed_hash,
+        }
+
+    def _known_skill_or_error(
+        self, skill_id: str, catalog: dict[str, dict[str, Any]]
+    ) -> str:
+        try:
+            safe_id = validate_skill_id(skill_id)
+        except SkillCatalogError as exc:
+            raise SkillManagerError("INVALID_SKILL_ID", str(exc)) from exc
+        if safe_id not in catalog:
+            raise SkillManagerError(
+                "UNKNOWN_SKILL",
+                f"{safe_id} is not in the bundled Potpie skill catalog.",
+                recommended_command="potpie skills list --available",
+            )
+        return safe_id
+
+    def _next_actions(
+        self,
+        missing: list[str],
+        outdated: list[dict[str, Any]],
+        locally_modified: list[dict[str, Any]],
+    ) -> list[dict[str, str]]:
+        actions: list[dict[str, str]] = []
+        for skill_id in missing:
+            command = (
+                f"potpie skills install {skill_id} "
+                f"--path {self._quoted_root()} --yes"
+            )
+            actions.append(
+                {
+                    "action": "install",
+                    "skillId": skill_id,
+                    "reason": "missing",
+                    "command": command,
+                    "recommendedCommand": command,
+                }
+            )
+        for row in outdated:
+            skill_id = str(row["id"])
+            command = (
+                f"potpie skills update {skill_id} "
+                f"--path {self._quoted_root()} --yes"
+            )
+            actions.append(
+                {
+                    "action": "update",
+                    "skillId": skill_id,
+                    "reason": "outdated",
+                    "command": command,
+                    "recommendedCommand": command,
+                }
+            )
+        for row in locally_modified:
+            skill_id = str(row["id"])
+            command = (
+                f"potpie skills install {skill_id} "
+                f"--path {self._quoted_root()} --yes --force"
+            )
+            actions.append(
+                {
+                    "action": "force-install",
+                    "skillId": skill_id,
+                    "reason": "locally_modified",
+                    "command": command,
+                    "recommendedCommand": command,
+                }
+            )
+        return actions
+
+    def _quoted_root(self) -> str:
+        return shlex.quote(str(self.root))

--- a/app/src/context-engine/adapters/inbound/cli/skill_manager.py
+++ b/app/src/context-engine/adapters/inbound/cli/skill_manager.py
@@ -82,7 +82,7 @@ class SkillManager:
             skill_id = str(row["id"])
             catalog_entry = catalog.get(skill_id)
             lock_entry = lock_skills.get(skill_id)
-            lock_payload = {"present": isinstance(lock_entry, dict)}
+            lock_payload: dict[str, Any] = {"present": isinstance(lock_entry, dict)}
             if isinstance(lock_entry, dict):
                 lock_payload.update(
                     {
@@ -410,13 +410,15 @@ class SkillManager:
         target = skill_dir(self.root, skill_id)
         existing_hash = hash_path_dir(target) if target.exists() else None
         lock_entry = lock.get("skills", {}).get(skill_id)
-        if existing_hash == catalog_entry["templateHash"]:
+        template_hash = str(catalog_entry["templateHash"])
+        template_path = str(catalog_entry["templatePath"])
+        if existing_hash is not None and existing_hash == template_hash:
             upsert_lock_entry(
                 lock,
                 skill_id=skill_id,
-                source=catalog_entry["templatePath"].removesuffix("/SKILL.md"),
+                source=template_path.removesuffix("/SKILL.md"),
                 skill_path=relative_to_root(target / "SKILL.md", self.root),
-                template_hash=catalog_entry["templateHash"],
+                template_hash=template_hash,
                 installed_hash=existing_hash,
             )
             return {
@@ -454,9 +456,9 @@ class SkillManager:
         upsert_lock_entry(
             lock,
             skill_id=skill_id,
-            source=catalog_entry["templatePath"].removesuffix("/SKILL.md"),
+            source=template_path.removesuffix("/SKILL.md"),
             skill_path=relative_to_root(target / "SKILL.md", self.root),
-            template_hash=catalog_entry["templateHash"],
+            template_hash=template_hash,
             installed_hash=installed_hash,
         )
         return {

--- a/app/src/context-engine/adapters/inbound/cli/skill_manager.py
+++ b/app/src/context-engine/adapters/inbound/cli/skill_manager.py
@@ -357,7 +357,7 @@ class SkillManager:
                     "message": f"{skill_id} is installed but not owned by the lockfile.",
                 }
             )
-        if lock_error:
+        if lock_error and lock_error not in diagnostics:
             diagnostics.append(lock_error)
         ok = not diagnostics
         return {

--- a/app/src/context-engine/adapters/inbound/cli/skill_targets.py
+++ b/app/src/context-engine/adapters/inbound/cli/skill_targets.py
@@ -1,0 +1,50 @@
+"""Agent harness recommendations for Potpie skills."""
+
+from __future__ import annotations
+
+VALID_AGENTS = ("default", "codex", "claude", "cursor")
+AGENT_ALIASES = {"claude-code": "claude"}
+
+RECOMMENDED_BY_AGENT: dict[str, list[str]] = {
+    "default": ["potpie-agent-context", "potpie-pot-scope"],
+    "cursor": [
+        "potpie-agent-context",
+        "potpie-pot-scope",
+        "potpie-cli",
+        "potpie-cli-troubleshooting",
+    ],
+    "claude": ["potpie-agent-context", "potpie-pot-scope", "potpie-cli"],
+    "codex": ["potpie-agent-context", "potpie-pot-scope", "potpie-cli"],
+}
+
+
+class InvalidAgentError(ValueError):
+    """Raised when the CLI receives an unknown agent harness."""
+
+
+def normalize_agent(agent: str | None) -> str:
+    value = (agent or "default").strip().lower()
+    value = AGENT_ALIASES.get(value, value)
+    if value not in VALID_AGENTS:
+        raise InvalidAgentError(
+            f"Unknown agent {agent!r}. Choose one of: {', '.join(VALID_AGENTS)}."
+        )
+    return value
+
+
+def recommended_skill_ids(agent: str | None) -> list[str]:
+    return list(RECOMMENDED_BY_AGENT[normalize_agent(agent)])
+
+
+def llm_guidance(agent: str) -> dict[str, object]:
+    normalized = normalize_agent(agent)
+    read_for_cli = ["potpie-cli"]
+    if normalized == "cursor":
+        read_for_cli.append("potpie-cli-troubleshooting")
+    return {
+        "agent": normalized,
+        "readBeforeWork": ["potpie-agent-context"],
+        "readForCliTasks": read_for_cli,
+        "readForPotScopeTasks": ["potpie-pot-scope"],
+        "doNotEditInstalledSkillsDirectly": True,
+    }

--- a/tests/unit/cli/test_potpie_skills.py
+++ b/tests/unit/cli/test_potpie_skills.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from adapters.inbound.cli import main as cli_main
+from adapters.inbound.cli import skill_catalog, skill_lock, skill_targets
+from adapters.inbound.cli.skill_manager import SkillManager
+
+pytestmark = pytest.mark.unit
+
+
+def _write_skill_md(path: Path, *, name: str, description: str) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "---",
+                f"name: {name}",
+                f"description: {description}",
+                "---",
+                "",
+                "Body",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _make_packaged_catalog(root: Path, skill_ids: list[str]) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    for sid in skill_ids:
+        d = root / sid
+        d.mkdir(parents=True, exist_ok=True)
+        _write_skill_md(d / "SKILL.md", name=f"Skill {sid}", description=f"Desc {sid}")
+        # Add a file that participates in hashing.
+        (d / "extra.txt").write_text(f"extra {sid}\n", encoding="utf-8")
+        # Add ignored hash files/dirs.
+        (d / "metadata.json").write_text('{"ignored": true}\n', encoding="utf-8")
+        (d / ".git").mkdir(exist_ok=True)
+        (d / ".git" / "config").write_text("[core]\nignored = true\n", encoding="utf-8")
+    return root
+
+
+def _invoke_skills(args: list[str]) -> tuple[int, dict]:
+    runner = CliRunner()
+    result = runner.invoke(cli_main.app, ["--json", "skills", *args])
+    stdout = result.stdout.strip()
+    payload = json.loads(stdout) if stdout else {}
+    return result.exit_code, payload
+
+
+@pytest.fixture()
+def packaged_catalog(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    # Provide a deterministic bundled catalog for all tests in this module.
+    skills = [
+        "potpie-agent-context",
+        "potpie-pot-scope",
+        "potpie-cli",
+        "potpie-cli-troubleshooting",
+        "alpha",
+        "beta",
+    ]
+    root = _make_packaged_catalog(tmp_path / "bundled_skills", skills)
+    monkeypatch.setattr(skill_catalog, "_packaged_skills_root", lambda: root)
+    return root
+
+
+def test_catalog_discovery_only_immediate_children(packaged_catalog: Path) -> None:
+    # Nested SKILL.md must not be discovered as its own skill.
+    nested = packaged_catalog / "alpha" / "nested-child"
+    nested.mkdir(parents=True, exist_ok=True)
+    _write_skill_md(nested / "SKILL.md", name="Nested", description="Nested")
+
+    entries, diagnostics = skill_catalog.discover_bundled_skills()
+    assert diagnostics == []
+    ids = [e.id for e in entries]
+    assert "alpha" in ids
+    assert "nested-child" not in ids
+
+
+def test_hash_path_dir_is_deterministic_and_ignores_rules(tmp_path: Path) -> None:
+    root = tmp_path / "dir"
+    root.mkdir()
+    (root / "b.txt").write_text("b", encoding="utf-8")
+    (root / "a.txt").write_text("a", encoding="utf-8")
+
+    # Ignored artifacts
+    (root / "metadata.json").write_text("ignored", encoding="utf-8")
+    (root / ".git").mkdir()
+    (root / ".git" / "HEAD").write_text("ignored", encoding="utf-8")
+    (root / "__pycache__").mkdir()
+    (root / "__pycache__" / "x.pyc").write_bytes(b"\0\1")
+
+    h1 = skill_catalog.hash_path_dir(root)
+    # Touching ignored files must not change hash.
+    (root / "metadata.json").write_text("ignored but changed", encoding="utf-8")
+    (root / ".git" / "HEAD").write_text("ignored2", encoding="utf-8")
+    h2 = skill_catalog.hash_path_dir(root)
+    assert h1 == h2
+
+    # Changing a tracked file must change hash.
+    (root / "a.txt").write_text("a2", encoding="utf-8")
+    h3 = skill_catalog.hash_path_dir(root)
+    assert h3 != h1
+
+
+def test_lockfile_read_write_sorted_keys_and_version_checks(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    lock = skill_lock.empty_lock()
+    lock["skills"] = {
+        "zeta": {"installedHash": "sha256:z", "templateHash": "sha256:z"},
+        "alpha": {"installedHash": "sha256:a", "templateHash": "sha256:a"},
+    }
+    skill_lock.write_lock(repo, lock)
+
+    raw = (repo / ".agents" / "skills-lock.json").read_text(encoding="utf-8")
+    parsed = json.loads(raw)
+    assert parsed["version"] == skill_lock.LOCK_VERSION
+    assert list(parsed["skills"].keys()) == ["alpha", "zeta"]
+
+    # Unsupported version yields diagnostic and empty lock.
+    (repo / ".agents" / "skills-lock.json").write_text(
+        json.dumps({"version": 999, "skills": {}}), encoding="utf-8"
+    )
+    lock2, diag = skill_lock.read_lock(repo)
+    assert lock2["version"] == skill_lock.LOCK_VERSION
+    assert diag and diag["code"] == "INVALID_LOCKFILE"
+
+
+def test_agent_recommendation_matrix_matches_spec() -> None:
+    assert skill_targets.recommended_skill_ids("default") == [
+        "potpie-agent-context",
+        "potpie-pot-scope",
+    ]
+    assert skill_targets.recommended_skill_ids("cursor") == [
+        "potpie-agent-context",
+        "potpie-pot-scope",
+        "potpie-cli",
+        "potpie-cli-troubleshooting",
+    ]
+    assert skill_targets.recommended_skill_ids("claude") == [
+        "potpie-agent-context",
+        "potpie-pot-scope",
+        "potpie-cli",
+    ]
+    assert skill_targets.recommended_skill_ids("codex") == [
+        "potpie-agent-context",
+        "potpie-pot-scope",
+        "potpie-cli",
+    ]
+
+
+def test_cli_list_available_json_contract(packaged_catalog: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    code, payload = _invoke_skills(["list", "--available", "--path", str(repo)])
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["schemaVersion"] == skill_catalog.SCHEMA_VERSION
+    assert payload["mode"] == "available"
+    assert isinstance(payload["skills"], list)
+
+
+def test_cli_status_install_update_remove_doctor_end_to_end(
+    packaged_catalog: Path, tmp_path: Path
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    # status --agent cursor --json
+    code, payload = _invoke_skills(["status", "--agent", "cursor", "--path", str(repo)])
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["schemaVersion"] == skill_catalog.SCHEMA_VERSION
+    assert payload["agent"] == "cursor"
+    assert payload["missing"]  # recommended set not installed yet
+
+    # install <id> --yes
+    code, payload = _invoke_skills(
+        ["install", "alpha", "--yes", "--path", str(repo), "--agent", "default"]
+    )
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["schemaVersion"] == skill_catalog.SCHEMA_VERSION
+    assert [row["id"] for row in payload["installed"]] == ["alpha"]
+    assert (repo / ".agents" / "skills" / "alpha" / "SKILL.md").exists()
+    assert (repo / ".agents" / "skills-lock.json").exists()
+
+    # install --agent cursor --yes (installs recommended set)
+    code, payload = _invoke_skills(
+        ["install", "--agent", "cursor", "--yes", "--path", str(repo)]
+    )
+    assert code == 0
+    assert payload["ok"] is True
+    installed_ids = {row["id"] for row in payload["installed"]}
+    assert installed_ids.issuperset(set(skill_targets.recommended_skill_ids("cursor")))
+
+    # doctor --json
+    code, payload = _invoke_skills(["doctor", "--agent", "cursor", "--path", str(repo)])
+    assert code == 0
+    assert payload["schemaVersion"] == skill_catalog.SCHEMA_VERSION
+    assert "diagnostics" in payload
+
+    # mutate the packaged template for alpha to force "outdated"
+    (packaged_catalog / "alpha" / "extra.txt").write_text("changed\n", encoding="utf-8")
+
+    # update --yes should update outdated skills (alpha included)
+    code, payload = _invoke_skills(["update", "--yes", "--path", str(repo)])
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["schemaVersion"] == skill_catalog.SCHEMA_VERSION
+
+    # remove <id> --yes
+    code, payload = _invoke_skills(["remove", "alpha", "--yes", "--path", str(repo)])
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["schemaVersion"] == skill_catalog.SCHEMA_VERSION
+    assert not (repo / ".agents" / "skills" / "alpha").exists()
+
+
+def test_json_error_envelopes_unknown_skill_needs_yes_locally_modified_unowned(
+    packaged_catalog: Path, tmp_path: Path
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    # UNKNOWN_SKILL
+    code, payload = _invoke_skills(["install", "does-not-exist", "--yes", "--path", str(repo)])
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["schemaVersion"] == skill_catalog.SCHEMA_VERSION
+    assert payload["error"]["code"] == "UNKNOWN_SKILL"
+
+    # Install alpha once.
+    code, _ = _invoke_skills(["install", "alpha", "--yes", "--path", str(repo)])
+    assert code == 0
+
+    # NEEDS_YES when overwriting without --yes in non-interactive mode.
+    # (If nothing changed, install is a no-op; force an overwrite by changing
+    # the bundled template hash.)
+    (packaged_catalog / "alpha" / "extra.txt").write_text("template changed\n", encoding="utf-8")
+    code, payload = _invoke_skills(["install", "alpha", "--path", str(repo)])
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "NEEDS_YES"
+
+    # LOCALLY_MODIFIED_REFUSED for update of an owned locally modified skill.
+    alpha_md = repo / ".agents" / "skills" / "alpha" / "SKILL.md"
+    alpha_md.write_text(alpha_md.read_text(encoding="utf-8") + "\nlocal edit\n", encoding="utf-8")
+    code, payload = _invoke_skills(["update", "alpha", "--yes", "--path", str(repo)])
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "LOCALLY_MODIFIED_REFUSED"
+
+    # UNOWNED_SKILL_REFUSED: installed dir exists but lock entry missing.
+    unowned_dir = repo / ".agents" / "skills" / "beta"
+    unowned_dir.mkdir(parents=True, exist_ok=True)
+    _write_skill_md(unowned_dir / "SKILL.md", name="Beta", description="Beta")
+    lock_path = repo / ".agents" / "skills-lock.json"
+    lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    lock["skills"].pop("beta", None)
+    lock_path.write_text(json.dumps(lock, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    code, payload = _invoke_skills(["remove", "beta", "--yes", "--path", str(repo)])
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "UNOWNED_SKILL_REFUSED"
+
+
+def test_status_computation_missing_outdated_locally_modified_and_lock_diagnostics(
+    packaged_catalog: Path, tmp_path: Path
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    manager = SkillManager(repo, agent="cursor")
+    status = manager.status()
+    assert status["ok"] is True
+    assert status["schemaVersion"] == skill_catalog.SCHEMA_VERSION
+    assert status["missing"]  # recommended set not installed
+
+    # Install alpha to create lock ownership.
+    _invoke_skills(["install", "alpha", "--yes", "--path", str(repo)])
+
+    # Make it locally modified.
+    alpha_md = repo / ".agents" / "skills" / "alpha" / "SKILL.md"
+    alpha_md.write_text(alpha_md.read_text(encoding="utf-8") + "\nlocal edit\n", encoding="utf-8")
+    status2 = SkillManager(repo, agent="default").status()
+    assert any(row["id"] == "alpha" for row in status2["installed"])
+    assert any(row["id"] == "alpha" for row in status2["locallyModified"])
+
+    # Break lockfile -> diagnostics should include INVALID_LOCKFILE.
+    (repo / ".agents" / "skills-lock.json").write_text("{not json", encoding="utf-8")
+    status3 = SkillManager(repo, agent="default").status()
+    assert any(d.get("code") == "INVALID_LOCKFILE" for d in status3.get("diagnostics", []))


### PR DESCRIPTION
## Summary
- Add `potpie skills` CLI (status/list/install/update/remove/doctor) backed by deterministic hashing + `.agents/skills-lock.json` ownership.
- Route `init-agent` to install bundled skills via the new manager.
- Add focused unit/CLI tests for JSON contract, safety, and agent recommendation matrix.

## Test plan
- `uv run pytest -q tests/unit/cli/test_potpie_skills.py`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "potpie skills" command suite: status, list (available/installed/recommended), install, update, remove, and doctor diagnostics.
  * Added a skills catalog/lock system and lifecycle manager to discover, install, update, and remove bundled and repo-local skills.

* **Changes**
  * Agent bundle installation now skips packaged skill files during initial copy and records per-skill install outcomes; status output includes skill advisories.

* **Tests**
  * Added comprehensive unit tests for catalog discovery, hashing, lockfile handling, CLI flows, and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->