### PR TITLE
feat(daemon): daemon-shell contracts + runtime primitives (1/3)

### DIFF
--- a/app/src/context-engine/adapters/outbound/daemon_process/__init__.py
+++ b/app/src/context-engine/adapters/outbound/daemon_process/__init__.py
@@ -1,0 +1,4 @@
+"""``adapters.outbound.daemon_process`` — OS-level mechanisms the host drives to run
+the daemon as a detached process: pid/discovery files + signals (``pidfile``), the
+detached launcher (``launcher``), and the UDS/TCP IPC client (``ipc_client``).
+"""

--- a/app/src/context-engine/adapters/outbound/daemon_process/pidfile.py
+++ b/app/src/context-engine/adapters/outbound/daemon_process/pidfile.py
@@ -1,0 +1,64 @@
+"""PID file, discovery file, and signal-based shutdown helpers."""
+from __future__ import annotations
+import asyncio, json, os, pathlib, signal
+
+
+class AlreadyRunning(RuntimeError):
+    pass
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, PermissionError):
+        return False
+    except OSError:
+        return False
+
+
+def write_pid_file(path: pathlib.Path, pid: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        try:
+            existing = int(path.read_text().strip())
+        except ValueError:
+            existing = -1
+        if existing > 0 and _pid_alive(existing):
+            raise AlreadyRunning(f"daemon already running (pid={existing})")
+    path.write_text(f"{pid}\n")
+
+
+def read_pid_file(path: pathlib.Path) -> int | None:
+    if not path.exists():
+        return None
+    try:
+        return int(path.read_text().strip())
+    except ValueError:
+        return None
+
+
+def remove_pid_file(path: pathlib.Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def write_discovery(path: pathlib.Path, **fields) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(fields))
+
+
+def read_discovery(path: pathlib.Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def install_signal_handlers(shutdown: asyncio.Event) -> None:
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, shutdown.set)
+        except (NotImplementedError, RuntimeError):
+            # Windows/restricted: ignore; CLI 'stop' uses the PID kill path.
+            pass

--- a/app/src/context-engine/domain/ports/daemon/__init__.py
+++ b/app/src/context-engine/domain/ports/daemon/__init__.py
@@ -1,0 +1,6 @@
+"""Daemon-shell ports — transport-agnostic contracts for the local daemon host.
+
+These are the hexagonal ports the in-process daemon runtime (``host.daemon_runtime``)
+and its adapters bind to: the operation contract (``operations``), the three runtime
+ports + health (``shell``), and the managed-service value objects (``service``).
+"""

--- a/app/src/context-engine/domain/ports/daemon/operations.py
+++ b/app/src/context-engine/domain/ports/daemon/operations.py
@@ -1,0 +1,76 @@
+"""Operation contract — neutral, transport-agnostic ops served identically over any protocol."""
+from __future__ import annotations
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Awaitable, Callable
+from pydantic import BaseModel
+
+
+class AuthRequirement(Enum):
+    REQUIRED = "required"
+    OPTIONAL = "optional"
+    NONE = "none"
+
+
+class OpKind(Enum):
+    UNARY = "unary"
+    SERVER_STREAM = "server_stream"  # reserved; V1 ships UNARY only
+
+
+class OperationError(Exception):
+    """Uniform error for any operation handler. Transport adapters map ``code`` onto protocol-native error shapes."""
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        detail: dict[str, Any] | None = None,
+        recommended_next_action: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.detail = detail
+        self.recommended_next_action = recommended_next_action
+
+
+@dataclass(frozen=True)
+class Principal:
+    """Identity of the caller produced by transport auth."""
+    name: str
+    attrs: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class OperationContext:
+    principal: Principal
+    request_id: str
+    deadline: float | None = None
+    deps: Any = None  # opaque; component-supplied wired deps
+
+
+@dataclass(frozen=True)
+class OperationSpec:
+    name: str
+    input_model: type[BaseModel]
+    output_model: type[BaseModel]
+    handler: Callable[[BaseModel, OperationContext], Awaitable[BaseModel]]
+    summary: str
+    mutating: bool = False
+    auth: AuthRequirement = AuthRequirement.REQUIRED
+    kind: OpKind = OpKind.UNARY
+
+
+class OperationRegistry:
+    def __init__(self) -> None:
+        self._ops: dict[str, OperationSpec] = {}
+
+    def register(self, op: OperationSpec) -> None:
+        if op.name in self._ops:
+            raise ValueError(f"operation already registered: {op.name!r}")
+        self._ops[op.name] = op
+
+    def get(self, name: str) -> OperationSpec:
+        return self._ops[name]
+
+    def all(self) -> list[OperationSpec]:
+        return list(self._ops.values())

--- a/app/src/context-engine/domain/ports/daemon/service.py
+++ b/app/src/context-engine/domain/ports/daemon/service.py
@@ -1,0 +1,31 @@
+"""Managed-service value objects: how the daemon describes a service it supervises."""
+from __future__ import annotations
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ReadyProbe:
+    kind: str           # "tcp" | "http" | "cmd"
+    target: str         # "host:port" | url | shell argv (json-encoded)
+    interval_s: float = 0.5
+    timeout_s: float = 30.0
+
+
+class RestartPolicy(Enum):
+    NO = "no"
+    ON_FAILURE = "on_failure"
+    ALWAYS = "always"
+
+
+@dataclass
+class ServiceSpec:
+    name: str
+    backend: str                       # registry key
+    config: dict[str, Any]             # backend-specific
+    ready: ReadyProbe
+    endpoint: str                      # connection string consumers receive
+    restart: RestartPolicy = RestartPolicy.ON_FAILURE
+    depends_on: list[str] = field(default_factory=list)
+    data_dir: str | None = None        # optional per-service writable dir

--- a/app/src/context-engine/domain/ports/daemon/shell.py
+++ b/app/src/context-engine/domain/ports/daemon/shell.py
@@ -1,0 +1,46 @@
+"""The three ports of the hexagonal daemon shell: Transport, Component, ServiceBackend."""
+from __future__ import annotations
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+from domain.ports.daemon.operations import OperationRegistry
+from domain.ports.daemon.service import ServiceSpec, ReadyProbe, RestartPolicy
+
+
+class HealthStatus(Enum):
+    STARTING = "starting"
+    READY = "ready"
+    DEGRADED = "degraded"
+    STOPPED = "stopped"
+
+
+@runtime_checkable
+class Transport(Protocol):
+    def bind(self, ctx: "ShellContext") -> None: ...  # type: ignore[name-defined]  # noqa: F821
+    async def serve(self, ops: OperationRegistry) -> None: ...
+    async def stop(self) -> None: ...
+    def health(self) -> HealthStatus: ...
+
+
+@runtime_checkable
+class Component(Protocol):
+    name: str
+    async def on_start(self, ctx: "ShellContext") -> None: ...  # type: ignore[name-defined]  # noqa: F821
+    async def on_stop(self) -> None: ...
+    def health(self) -> HealthStatus: ...
+    def operations(self) -> list: ...  # list[OperationSpec]
+
+
+@runtime_checkable
+class ServiceBackend(Protocol):
+    async def start(self, spec: ServiceSpec, ctx: "ShellContext") -> None: ...  # type: ignore[name-defined]  # noqa: F821
+    async def stop(self, spec: ServiceSpec) -> None: ...
+    async def probe(self, spec: ServiceSpec) -> HealthStatus: ...
+
+
+# Convenience re-exports: the service value objects live in ``service`` but are commonly
+# imported alongside these ports.
+__all__ = [
+    "HealthStatus", "Transport", "Component", "ServiceBackend",
+    "ServiceSpec", "ReadyProbe", "RestartPolicy",
+]

--- a/app/src/context-engine/host/daemon_runtime/__init__.py
+++ b/app/src/context-engine/host/daemon_runtime/__init__.py
@@ -1,0 +1,8 @@
+"""``host.daemon_runtime`` — the in-daemon-process runtime.
+
+When the host runs detached (``host_mode = "daemon"``), this is what the background
+process executes: the async ``DaemonRuntime`` that binds transports, starts managed
+services, and serves the registered components' operations. Distinct from
+``host.shell.HostShell`` (the in-process service facade) — the runtime *hosts* a
+HostShell and exposes its surfaces over a transport.
+"""

--- a/app/src/context-engine/host/daemon_runtime/context.py
+++ b/app/src/context-engine/host/daemon_runtime/context.py
@@ -1,0 +1,40 @@
+"""ShellContext: cross-cutting services handed to every plugin instance."""
+from __future__ import annotations
+import asyncio, logging, pathlib
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class ServiceEndpoints:
+    """Registry of resolved managed-service endpoints (e.g. graph-db -> bolt://...)."""
+
+    def __init__(self) -> None:
+        self._eps: dict[str, str] = {}
+
+    def set(self, name: str, endpoint: str) -> None:
+        self._eps[name] = endpoint
+
+    def get(self, name: str) -> str:
+        return self._eps[name]
+
+    def remove(self, name: str) -> None:
+        self._eps.pop(name, None)
+
+    def resolve(self, value: str) -> str:
+        """``service:<name>`` -> resolved endpoint; any other value passes through."""
+        if value.startswith("service:"):
+            name = value.split(":", 1)[1]
+            try:
+                return self._eps[name]
+            except KeyError as exc:
+                raise KeyError(f"unknown service endpoint: {name!r}") from exc
+        return value
+
+
+@dataclass
+class ShellContext:
+    config: dict[str, Any]
+    data_dir: pathlib.Path
+    logger: logging.Logger
+    endpoints: ServiceEndpoints
+    shutdown: asyncio.Event = field(default_factory=asyncio.Event)

--- a/app/src/context-engine/host/daemon_runtime/health.py
+++ b/app/src/context-engine/host/daemon_runtime/health.py
@@ -1,0 +1,35 @@
+"""Aggregated health registrar for transports, components, and services."""
+from __future__ import annotations
+import threading
+from domain.ports.daemon.shell import HealthStatus
+
+
+class HealthRegistrar:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._states: dict[str, HealthStatus] = {}
+
+    def set(self, key: str, status: HealthStatus) -> None:
+        with self._lock:
+            self._states[key] = status
+
+    def get(self, key: str) -> HealthStatus:
+        with self._lock:
+            return self._states[key]
+
+    def snapshot(self) -> dict[str, HealthStatus]:
+        with self._lock:
+            return dict(self._states)
+
+    def aggregate(self) -> HealthStatus:
+        with self._lock:
+            states = list(self._states.values())
+        if not states:
+            return HealthStatus.STARTING
+        if any(s is HealthStatus.STARTING for s in states):
+            return HealthStatus.STARTING
+        if any(s is HealthStatus.DEGRADED for s in states):
+            return HealthStatus.DEGRADED
+        if all(s is HealthStatus.READY for s in states):
+            return HealthStatus.READY
+        return HealthStatus.STOPPED

--- a/app/src/context-engine/host/daemon_runtime/ipc_auth.py
+++ b/app/src/context-engine/host/daemon_runtime/ipc_auth.py
@@ -1,0 +1,45 @@
+"""Local IPC auth: token for loopback HTTP; OS-user/UDS perms for the socket.
+
+This is the daemon's *transport* gate (who may call the socket), distinct from
+``application.services.auth_service`` / ``domain.ports.services.auth`` which own the
+user's identity and credentials.
+"""
+from __future__ import annotations
+import os, pathlib, secrets
+from domain.ports.daemon.operations import Principal
+
+
+class AuthFailure(Exception):
+    pass
+
+
+class IpcAuthGate:
+    def __init__(self, token: str | None) -> None:
+        self._token = token
+
+    @property
+    def token_configured(self) -> bool:
+        return self._token is not None
+
+    def authenticate_token(self, presented: str) -> Principal:
+        if self._token is None:
+            raise AuthFailure("token auth not configured")
+        # constant-time compare
+        if not secrets.compare_digest(presented, self._token):
+            raise AuthFailure("invalid token")
+        return Principal(name="local")
+
+    def authenticate_uds(self, peer_uid: int) -> Principal:
+        return Principal(name="local", attrs={"uid": peer_uid})
+
+    @staticmethod
+    def generate_token_file(path: pathlib.Path) -> str:
+        tok = secrets.token_urlsafe(32)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            os.write(fd, tok.encode())
+        finally:
+            os.close(fd)
+        os.chmod(path, 0o600)  # ensure 0600 even if the file pre-existed with looser perms
+        return tok

--- a/app/src/context-engine/host/daemon_runtime/registry.py
+++ b/app/src/context-engine/host/daemon_runtime/registry.py
@@ -1,0 +1,32 @@
+"""Generic plugin registry used for transports, components, and service backends."""
+from __future__ import annotations
+from typing import Callable, Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class UnknownPlugin(KeyError):
+    """Raised when create() is called with a name not in the registry."""
+
+
+class Registry(Generic[T]):
+    def __init__(self) -> None:
+        self._factories: dict[str, Callable[..., T]] = {}
+
+    def register(self, name: str, factory: Callable[..., T]) -> None:
+        if name in self._factories:
+            raise ValueError(f"plugin already registered: {name!r}")
+        self._factories[name] = factory
+
+    def create(self, plugin_name: str, **cfg) -> T:
+        try:
+            factory = self._factories[plugin_name]
+        except KeyError as exc:
+            known = ", ".join(sorted(self._factories)) or "<none>"
+            raise UnknownPlugin(
+                f"unknown plugin {plugin_name!r}; known: {known}"
+            ) from exc
+        return factory(**cfg)
+
+    def names(self) -> list[str]:
+        return list(self._factories)

--- a/app/src/context-engine/tests/unit/test_daemon_context.py
+++ b/app/src/context-engine/tests/unit/test_daemon_context.py
@@ -1,0 +1,37 @@
+import logging, pathlib, pytest
+from host.daemon_runtime.context import ShellContext, ServiceEndpoints
+
+
+def test_service_endpoints_register_and_resolve():
+    se = ServiceEndpoints()
+    se.set("graph-db", "bolt://127.0.0.1:7687")
+    assert se.get("graph-db") == "bolt://127.0.0.1:7687"
+    assert se.resolve("service:graph-db") == "bolt://127.0.0.1:7687"
+    # passthrough for non-service URIs
+    assert se.resolve("sqlite:///x.db") == "sqlite:///x.db"
+
+
+def test_service_endpoints_unknown_raises():
+    se = ServiceEndpoints()
+    with pytest.raises(KeyError) as ei:
+        se.resolve("service:missing")
+    assert "missing" in str(ei.value)
+
+
+def test_service_endpoints_remove():
+    se = ServiceEndpoints()
+    se.set("a", "tcp://x")
+    se.remove("a")
+    with pytest.raises(KeyError):
+        se.get("a")
+    se.remove("a")  # idempotent — no error
+
+
+def test_shell_context_construct(tmp_path: pathlib.Path):
+    ctx = ShellContext(
+        config={"k": 1}, data_dir=tmp_path, logger=logging.getLogger("t"),
+        endpoints=ServiceEndpoints(),
+    )
+    assert ctx.config == {"k": 1}
+    assert ctx.data_dir == tmp_path
+    assert ctx.shutdown.is_set() is False

--- a/app/src/context-engine/tests/unit/test_daemon_health.py
+++ b/app/src/context-engine/tests/unit/test_daemon_health.py
@@ -1,0 +1,49 @@
+from host.daemon_runtime.health import HealthRegistrar
+from domain.ports.daemon.shell import HealthStatus
+
+
+def test_register_and_get():
+    h = HealthRegistrar()
+    h.set("transport:http", HealthStatus.STARTING)
+    h.set("transport:http", HealthStatus.READY)
+    assert h.get("transport:http") is HealthStatus.READY
+
+
+def test_aggregate_all_ready():
+    h = HealthRegistrar()
+    h.set("a", HealthStatus.READY)
+    h.set("b", HealthStatus.READY)
+    assert h.aggregate() is HealthStatus.READY
+
+
+def test_aggregate_degraded_dominates():
+    h = HealthRegistrar()
+    h.set("a", HealthStatus.READY)
+    h.set("b", HealthStatus.DEGRADED)
+    assert h.aggregate() is HealthStatus.DEGRADED
+
+
+def test_aggregate_starting_when_anything_starting():
+    h = HealthRegistrar()
+    h.set("a", HealthStatus.READY)
+    h.set("b", HealthStatus.STARTING)
+    assert h.aggregate() is HealthStatus.STARTING
+
+
+def test_snapshot_returns_copy():
+    h = HealthRegistrar()
+    h.set("a", HealthStatus.READY)
+    snap = h.snapshot()
+    snap["a"] = HealthStatus.DEGRADED
+    assert h.get("a") is HealthStatus.READY
+
+
+def test_aggregate_empty_is_starting():
+    h = HealthRegistrar()
+    assert h.aggregate() is HealthStatus.STARTING
+
+
+def test_aggregate_stopped_when_only_stopped():
+    h = HealthRegistrar()
+    h.set("a", HealthStatus.STOPPED)
+    assert h.aggregate() is HealthStatus.STOPPED

--- a/app/src/context-engine/tests/unit/test_daemon_ipc_auth.py
+++ b/app/src/context-engine/tests/unit/test_daemon_ipc_auth.py
@@ -1,0 +1,36 @@
+import pathlib, pytest
+from host.daemon_runtime.ipc_auth import IpcAuthGate, AuthFailure
+from domain.ports.daemon.operations import Principal
+
+
+def test_token_match():
+    g = IpcAuthGate(token="secret-1234")
+    p = g.authenticate_token("secret-1234")
+    assert isinstance(p, Principal)
+    assert p.name == "local"
+
+
+def test_token_mismatch():
+    g = IpcAuthGate(token="secret-1234")
+    with pytest.raises(AuthFailure):
+        g.authenticate_token("wrong")
+
+
+def test_uds_principal_from_peer_uid():
+    g = IpcAuthGate(token=None)
+    p = g.authenticate_uds(peer_uid=42)
+    assert p.name == "local"
+    assert p.attrs.get("uid") == 42
+
+
+def test_generate_token_creates_file(tmp_path: pathlib.Path):
+    f = tmp_path / "token"
+    tok = IpcAuthGate.generate_token_file(f)
+    assert f.read_text() == tok
+    # owner-only permissions enforced
+    assert oct(f.stat().st_mode & 0o777) == "0o600"
+
+
+def test_token_configured_flag():
+    assert IpcAuthGate(token="x").token_configured is True
+    assert IpcAuthGate(token=None).token_configured is False

--- a/app/src/context-engine/tests/unit/test_daemon_operations.py
+++ b/app/src/context-engine/tests/unit/test_daemon_operations.py
@@ -1,0 +1,53 @@
+import pytest
+from pydantic import BaseModel
+from domain.ports.daemon.operations import (
+    OperationSpec, OperationRegistry, OperationError, OperationContext,
+    AuthRequirement, OpKind,
+)
+
+
+class Echo(BaseModel):
+    msg: str
+
+class EchoOut(BaseModel):
+    echoed: str
+
+
+async def handler(inp: Echo, ctx: OperationContext) -> EchoOut:
+    return EchoOut(echoed=inp.msg)
+
+
+def test_register_and_lookup():
+    reg = OperationRegistry()
+    op = OperationSpec(
+        name="echo.say", input_model=Echo, output_model=EchoOut,
+        handler=handler, summary="echo", mutating=False,
+    )
+    reg.register(op)
+    assert reg.get("echo.say") is op
+    assert "echo.say" in [o.name for o in reg.all()]
+
+
+def test_duplicate_name_rejected():
+    reg = OperationRegistry()
+    op = OperationSpec(name="dup", input_model=Echo, output_model=EchoOut, handler=handler, summary="")
+    reg.register(op)
+    with pytest.raises(ValueError):
+        reg.register(op)
+
+
+def test_operation_error_fields():
+    err = OperationError(
+        code="not_found", message="x", detail={"k": 1},
+        recommended_next_action="try again",
+    )
+    assert err.code == "not_found"
+    assert err.detail == {"k": 1}
+    assert err.recommended_next_action == "try again"
+
+
+def test_defaults():
+    op = OperationSpec(name="d", input_model=Echo, output_model=EchoOut, handler=handler, summary="")
+    assert op.mutating is False
+    assert op.auth is AuthRequirement.REQUIRED
+    assert op.kind is OpKind.UNARY

--- a/app/src/context-engine/tests/unit/test_daemon_pidfile.py
+++ b/app/src/context-engine/tests/unit/test_daemon_pidfile.py
@@ -1,0 +1,36 @@
+import os, pathlib, signal, pytest
+from adapters.outbound.daemon_process.pidfile import (
+    write_pid_file, read_pid_file, remove_pid_file,
+    write_discovery, read_discovery, AlreadyRunning,
+)
+
+
+def test_pid_roundtrip(tmp_path: pathlib.Path):
+    p = tmp_path / "potpied.pid"
+    write_pid_file(p, 12345)
+    assert read_pid_file(p) == 12345
+    remove_pid_file(p)
+    assert not p.exists()
+
+
+def test_pid_already_running_when_live_pid(tmp_path: pathlib.Path):
+    p = tmp_path / "potpied.pid"
+    write_pid_file(p, os.getpid())          # use our own PID — guaranteed alive
+    with pytest.raises(AlreadyRunning):
+        write_pid_file(p, 99999)
+
+
+def test_pid_overwrites_stale(tmp_path: pathlib.Path):
+    p = tmp_path / "potpied.pid"
+    # write a PID we know isn't running
+    p.write_text("999999\n")
+    write_pid_file(p, 12345)
+    assert read_pid_file(p) == 12345
+
+
+def test_discovery_roundtrip(tmp_path: pathlib.Path):
+    f = tmp_path / "discovery.json"
+    write_discovery(f, transport="http", bind="unix:/tmp/x.sock")
+    d = read_discovery(f)
+    assert d["transport"] == "http"
+    assert d["bind"] == "unix:/tmp/x.sock"

--- a/app/src/context-engine/tests/unit/test_daemon_pidfile_extra.py
+++ b/app/src/context-engine/tests/unit/test_daemon_pidfile_extra.py
@@ -1,0 +1,38 @@
+"""Additional lifecycle coverage: install_signal_handlers and ValueError edge cases."""
+from __future__ import annotations
+import asyncio, pathlib, pytest
+from adapters.outbound.daemon_process.pidfile import (
+    write_pid_file, read_pid_file, remove_pid_file,
+    write_discovery, read_discovery, install_signal_handlers,
+)
+
+
+def test_read_pid_file_returns_none_when_missing(tmp_path: pathlib.Path):
+    assert read_pid_file(tmp_path / "nonexistent.pid") is None
+
+
+def test_read_pid_file_returns_none_on_value_error(tmp_path: pathlib.Path):
+    p = tmp_path / "bad.pid"
+    p.write_text("not-a-number\n")
+    assert read_pid_file(p) is None
+
+
+def test_write_pid_file_overwrites_invalid_existing(tmp_path: pathlib.Path):
+    p = tmp_path / "bad.pid"
+    p.write_text("not-a-number\n")
+    # existing = -1 branch — should not raise AlreadyRunning
+    write_pid_file(p, 42)
+    assert read_pid_file(p) == 42
+
+
+def test_remove_pid_file_silent_on_missing(tmp_path: pathlib.Path):
+    remove_pid_file(tmp_path / "ghost.pid")  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_install_signal_handlers_does_not_raise():
+    """install_signal_handlers should succeed or silently ignore NotImplementedError/RuntimeError."""
+    shutdown = asyncio.Event()
+    install_signal_handlers(shutdown)
+    # If we get here without exception, the function handled the platform gracefully.
+    assert not shutdown.is_set()

--- a/app/src/context-engine/tests/unit/test_daemon_ports.py
+++ b/app/src/context-engine/tests/unit/test_daemon_ports.py
@@ -1,0 +1,52 @@
+from dataclasses import is_dataclass
+from domain.ports.daemon.shell import (
+    Transport, Component, ServiceBackend,
+    ServiceSpec, ReadyProbe, RestartPolicy, HealthStatus,
+)
+
+
+def test_protocols_are_runtime_checkable():
+    class ConcreteTransport:
+        def bind(self, ctx): ...
+        async def serve(self, ops): ...
+        async def stop(self): ...
+        def health(self): ...
+
+    class ConcreteComponent:
+        name = "x"
+        async def on_start(self, ctx): ...
+        async def on_stop(self): ...
+        def health(self): ...
+        def operations(self): return []
+
+    class ConcreteBackend:
+        async def start(self, spec, ctx): ...
+        async def stop(self, spec): ...
+        async def probe(self, spec): ...
+
+    assert isinstance(ConcreteTransport(), Transport)
+    assert isinstance(ConcreteComponent(), Component)
+    assert isinstance(ConcreteBackend(), ServiceBackend)
+
+    class NotATransport:
+        pass
+    assert not isinstance(NotATransport(), Transport)
+
+
+def test_service_spec_is_dataclass():
+    spec = ServiceSpec(
+        name="g", backend="subprocess",
+        config={"command": ["echo", "hi"]},
+        ready=ReadyProbe(kind="tcp", target="127.0.0.1:1"),
+        endpoint="tcp://127.0.0.1:1",
+    )
+    assert is_dataclass(ServiceSpec)
+    assert spec.restart is RestartPolicy.ON_FAILURE
+    assert spec.depends_on == []
+
+
+def test_health_status_values():
+    assert HealthStatus.STARTING.value == "starting"
+    assert HealthStatus.READY.value == "ready"
+    assert HealthStatus.DEGRADED.value == "degraded"
+    assert HealthStatus.STOPPED.value == "stopped"

--- a/app/src/context-engine/tests/unit/test_daemon_registry.py
+++ b/app/src/context-engine/tests/unit/test_daemon_registry.py
@@ -1,0 +1,32 @@
+import pytest
+from host.daemon_runtime.registry import Registry, UnknownPlugin
+
+
+def test_register_and_create():
+    reg: Registry[dict] = Registry()
+    reg.register("greet", lambda **cfg: {"hello": cfg.get("name", "world")})
+    out = reg.create("greet", name="alice")
+    assert out == {"hello": "alice"}
+
+
+def test_unknown_raises_with_known_names():
+    reg: Registry[int] = Registry()
+    reg.register("one", lambda: 1)
+    with pytest.raises(UnknownPlugin) as ei:
+        reg.create("two")
+    assert "two" in str(ei.value)
+    assert "one" in str(ei.value)
+
+
+def test_duplicate_register_raises():
+    reg: Registry[int] = Registry()
+    reg.register("x", lambda: 1)
+    with pytest.raises(ValueError):
+        reg.register("x", lambda: 2)
+
+
+def test_names_listed():
+    reg: Registry[int] = Registry()
+    reg.register("a", lambda: 1)
+    reg.register("b", lambda: 2)
+    assert sorted(reg.names()) == ["a", "b"]


### PR DESCRIPTION
**Stack 1/3** · base `feat/local-context-engine` · 19 files

Dissolves our standalone `potpied` daemon shell into context-engine's hexagon — **no separate top-level package**. This first layer is pure contracts + primitives (net-new, no behavior change).

- `domain/ports/daemon/*` — operation contract; Transport/Component/ServiceBackend ports; managed-service value objects (`HealthStatus`, `ServiceSpec`, `ReadyProbe`, `RestartPolicy`)
- `host/daemon_runtime/*` — in-daemon-process primitives: health registrar, shell context, plugin registry, IPC auth gate
- `adapters/outbound/daemon_process/pidfile` — pid/discovery files + signal handlers

**Tests:** 8 files / 36 tests, all green on this branch alone.

> Replaces the previous `potpied`-package version of this PR (re-pointed from `feat/cli-setup` onto trunk). Merge order: **#842 → #843 → #844**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)