### PR TITLE
feat(daemon): runtime, managed services, detached lifecycle + CLI (2/3)

### DIFF
--- a/app/src/context-engine/adapters/inbound/cli/commands/bootstrap.py
+++ b/app/src/context-engine/adapters/inbound/cli/commands/bootstrap.py
@@ -31,6 +31,11 @@ def register(root: typer.Typer) -> None:
         scan: bool = typer.Option(False, "--scan"),
         dry_run: bool = typer.Option(False, "--dry-run", help="Show the steps without executing."),
         yes: bool = typer.Option(False, "--yes", "-y", help="Assume yes for prompts."),
+        daemon: bool = typer.Option(
+            None, "--daemon/--in-process",
+            help="Provision a real detached daemon (makes the daemon/installer steps hard). "
+                 "Defaults to $CONTEXT_ENGINE_HOST_MODE (in-process).",
+        ),
     ) -> None:
         """Idempotent first-run: provision config, storage, daemon, default pot, skills."""
         with contract():
@@ -44,6 +49,16 @@ def register(root: typer.Typer) -> None:
                 from bootstrap.host_wiring import build_host_shell
 
                 host = build_host_shell(backend=build_backend(backend), profile=host.profile)
+                set_host(host)
+            # --daemon/--in-process selects the host mode for this run. Like --backend it is
+            # a wiring-time choice, so rebuild the host with the matching Daemon when it differs.
+            if daemon is not None and getattr(host.daemon, "in_process", True) != (not daemon):
+                import os
+                from adapters.inbound.cli.commands._common import set_host
+                from bootstrap.host_wiring import build_host_shell
+
+                os.environ["CONTEXT_ENGINE_HOST_MODE"] = "daemon" if daemon else "in_process"
+                host = build_host_shell(backend=host.backend, profile=host.profile)
                 set_host(host)
             plan = SetupPlan(
                 mode=host.profile if host.profile in ("local", "managed") else "local",

--- a/app/src/context-engine/adapters/inbound/cli/commands/daemon.py
+++ b/app/src/context-engine/adapters/inbound/cli/commands/daemon.py
@@ -1,38 +1,78 @@
-"""Daemon admin commands → ``HostShell.daemon`` (local recovery tools)."""
+"""Daemon admin commands → ``HostShell.daemon`` (local recovery tools).
+
+These always target the *detached* daemon process: even when the wired host runs
+in-process (the default), ``potpie daemon start/stop/status`` operate on the background
+daemon, since asking for them is an explicit request to manage that process.
+"""
 
 from __future__ import annotations
 
 import typer
 
-from adapters.inbound.cli.commands._common import contract, emit, get_host
+from adapters.inbound.cli.commands._common import (
+    EXIT_UNAVAILABLE, contract, emit, fail, get_host,
+)
+from adapters.outbound.daemon_process.launcher import DaemonStartError
+from host.daemon import Daemon
 
 daemon_app = typer.Typer(help="Local daemon lifecycle (recovery tools).")
+
+
+def _detached_daemon() -> Daemon:
+    d = get_host().daemon
+    if not d.in_process:
+        return d
+    return Daemon(home=d.home, in_process=False)
+
+
+def _start(daemon: Daemon) -> dict:
+    try:
+        return daemon.start()
+    except DaemonStartError as exc:
+        fail(
+            code="daemon_start_failed",
+            message=str(exc),
+            detail=(str(exc.log_path) if exc.log_path else None),
+            next_action="inspect the daemon log with 'potpie daemon logs'",
+            exit_code=EXIT_UNAVAILABLE,
+        )
+
+
+@daemon_app.command("start")
+def daemon_start() -> None:
+    with contract():
+        info = _start(_detached_daemon())
+        emit(info, human=f"daemon started (pid={info.get('pid')})")
 
 
 @daemon_app.command("status")
 def daemon_status() -> None:
     with contract():
-        st = get_host().daemon.status()
+        st = _detached_daemon().status()
         emit(st, human=f"daemon: {st['mode']} (up={st['up']})")
 
 
 @daemon_app.command("logs")
 def daemon_logs(follow: bool = typer.Option(False, "--follow")) -> None:
     with contract():
-        lines = get_host().daemon.logs(follow=follow)
+        lines = _detached_daemon().logs(follow=follow)
         emit({"lines": lines}, human="\n".join(lines) or "(no logs)")
 
 
 @daemon_app.command("restart")
 def daemon_restart() -> None:
     with contract():
-        emit(get_host().daemon.restart(), human="restarted")
+        d = _detached_daemon()
+        d.stop()
+        info = _start(d)
+        emit(info, human=f"restarted (pid={info.get('pid')})")
 
 
 @daemon_app.command("stop")
 def daemon_stop() -> None:
     with contract():
-        emit(get_host().daemon.stop(), human="stopped")
+        res = _detached_daemon().stop()
+        emit(res, human=res.get("detail", "stopped"))
 
 
 __all__ = ["daemon_app"]

--- a/app/src/context-engine/adapters/inbound/cli/commands/service.py
+++ b/app/src/context-engine/adapters/inbound/cli/commands/service.py
@@ -1,0 +1,93 @@
+"""Service admin commands → the running daemon's ``/admin/services`` IPC (managed services).
+
+Only meaningful when a detached daemon is running (``potpie daemon start`` /
+``potpie setup --daemon``); the managed services live inside that process.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from adapters.inbound.cli.commands._common import (
+    EXIT_UNAVAILABLE, contract, emit, fail, get_host,
+)
+from adapters.outbound.daemon_process.ipc_client import client_for
+
+service_app = typer.Typer(help="Manage the daemon's supporting services.")
+
+
+def _home():
+    return get_host().daemon.home
+
+
+def _client():
+    """Open a client to the running daemon, or fail cleanly if it is not up."""
+    try:
+        return client_for(_home())
+    except RuntimeError as exc:
+        fail(
+            code="daemon_not_running",
+            message=str(exc),
+            next_action="start it with 'potpie daemon start' (or 'potpie setup --daemon')",
+            exit_code=EXIT_UNAVAILABLE,
+        )
+
+
+@service_app.command("up")
+def service_up(name: str) -> None:
+    with contract():
+        with _client() as c:
+            r = c.post(f"/admin/services/{name}/up")
+            r.raise_for_status()
+            ep = r.json().get("endpoint")
+            emit({"name": name, "endpoint": ep}, human=f"up: {ep}")
+
+
+@service_app.command("down")
+def service_down(name: str) -> None:
+    with contract():
+        with _client() as c:
+            r = c.post(f"/admin/services/{name}/down")
+            r.raise_for_status()
+            emit({"name": name, "ok": True}, human="down")
+
+
+@service_app.command("status")
+def service_status() -> None:
+    with contract():
+        with _client() as c:
+            r = c.get("/admin/services")
+            r.raise_for_status()
+            services = r.json()["services"]
+            emit(
+                {"services": services},
+                human="\n".join(
+                    f"{s['name']:<24} {s['status']:<10} {s['endpoint'] or ''}" for s in services
+                ) or "(no services)",
+            )
+
+
+@service_app.command("logs")
+def service_logs(name: str, follow: bool = typer.Option(False, "-f", "--follow")) -> None:
+    with contract():
+        log_path = _home() / "logs" / f"service-{name}.log"
+        if not log_path.exists():
+            emit({"lines": []}, human="no log file")
+            return
+        if not follow:
+            text = log_path.read_text(errors="replace")
+            emit({"lines": text.splitlines()}, human=text)
+            return
+        import time as _t
+
+        with log_path.open() as f:
+            f.seek(0, 2)
+            while True:
+                line = f.readline()
+                if not line:
+                    _t.sleep(0.2)
+                    continue
+                typer.echo(line.rstrip("\n"))
+
+
+__all__ = ["service_app"]

--- a/app/src/context-engine/adapters/inbound/cli/host_cli.py
+++ b/app/src/context-engine/adapters/inbound/cli/host_cli.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import typer
 
-from adapters.inbound.cli.commands import bootstrap, cloud, daemon, graph, ledger, pots
+from adapters.inbound.cli.commands import bootstrap, cloud, daemon, graph, ledger, pots, service
 from adapters.inbound.cli.commands import ingest as ingest_cmds
 from adapters.inbound.cli.commands import query as query_cmds
 from adapters.inbound.cli.commands import skills as skills_cmds
@@ -40,6 +40,7 @@ def build_app() -> typer.Typer:
     app.add_typer(pots.pot_app, name="pot")
     app.add_typer(pots.source_app, name="source")
     app.add_typer(daemon.daemon_app, name="daemon")
+    app.add_typer(service.service_app, name="service")
     app.add_typer(ingest_cmds.ingest_app, name="ingest")
     app.add_typer(ledger.ledger_app, name="ledger")
     app.add_typer(graph.graph_app, name="graph")

--- a/app/src/context-engine/adapters/inbound/daemon_http/__init__.py
+++ b/app/src/context-engine/adapters/inbound/daemon_http/__init__.py
@@ -1,0 +1,4 @@
+"""``adapters.inbound.daemon_http`` — the daemon's inbound HTTP transport, serving the
+``OperationRegistry`` over a Unix domain socket (or TCP) with generic ``/op/{name}``
+dispatch. Knows nothing about specific operations.
+"""

--- a/app/src/context-engine/adapters/inbound/daemon_http/transport.py
+++ b/app/src/context-engine/adapters/inbound/daemon_http/transport.py
@@ -1,0 +1,221 @@
+"""HTTP transport: serves OperationRegistry over UDS or TCP. Generic dispatch — knows nothing about specific operations."""
+from __future__ import annotations
+import asyncio
+import json
+import pathlib
+import socket
+import uvicorn
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from pydantic import ValidationError
+
+from domain.ports.daemon.operations import (
+    OperationRegistry, OperationContext, OperationError, AuthRequirement, Principal,
+)
+from host.daemon_runtime.context import ShellContext
+from host.daemon_runtime.health import HealthRegistrar
+from host.daemon_runtime.ipc_auth import IpcAuthGate, AuthFailure
+from domain.ports.daemon.shell import HealthStatus
+
+
+_STATUS_MAP = {
+    "invalid_input": 400,
+    "unauthorized": 401,
+    "forbidden": 403,
+    "not_found": 404,
+    "conflict": 409,
+    "unavailable": 503,
+    "degraded": 503,
+    "internal_error": 500,
+}
+
+
+def _error_envelope(e: OperationError) -> dict:
+    return {
+        "error": {
+            "code": e.code,
+            "message": e.message,
+            "detail": e.detail,
+            "recommended_next_action": e.recommended_next_action,
+        }
+    }
+
+
+class HttpTransport:
+    """Built-in transport. Serves operations over a UNIX domain socket (unix:/path) or TCP (tcp:host:port)."""
+
+    def __init__(self, bind: str, auth: IpcAuthGate, health: HealthRegistrar, health_key: str = "transport:http") -> None:
+        self._bind = bind
+        self._auth = auth
+        self._health = health
+        self._health_key = health_key
+        self._server: uvicorn.Server | None = None
+        self._ctx: ShellContext | None = None
+        self._sock: socket.socket | None = None
+        self._bound_port: int | None = None
+
+    def bind(self, ctx: ShellContext) -> None:
+        self._ctx = ctx
+        self._health.set(self._health_key, HealthStatus.STARTING)
+        if self._bind.startswith("tcp:"):
+            _, host, port = self._bind.split(":", 2)
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind((host, int(port)))
+            sock.listen()
+            sock.setblocking(False)
+            self._sock = sock
+            self._bound_port = sock.getsockname()[1]
+        elif not self._bind.startswith("unix:"):
+            raise ValueError(f"unsupported bind {self._bind!r}; use unix:/path or tcp:host:port")
+
+    def bound_port(self) -> int | None:
+        return self._bound_port
+
+    def health(self) -> HealthStatus:
+        return self._health.get(self._health_key)
+
+    async def serve(self, ops: OperationRegistry) -> None:
+        if self._ctx is None:
+            raise RuntimeError("bind() before serve()")
+        app = self._build_app(ops)
+        if self._bind.startswith("unix:"):
+            sockpath = pathlib.Path(self._bind[len("unix:"):]).expanduser()
+            sockpath.parent.mkdir(parents=True, exist_ok=True)
+            if sockpath.exists():
+                sockpath.unlink()
+            config = uvicorn.Config(app=app, uds=str(sockpath), log_level="warning", lifespan="off")
+            self._server = uvicorn.Server(config)
+            watcher = asyncio.create_task(self._mark_ready_when_started())
+            try:
+                await self._server.serve()
+            finally:
+                watcher.cancel()
+                if sockpath.exists():
+                    sockpath.unlink()
+                self._health.set(self._health_key, HealthStatus.STOPPED)
+        else:  # tcp
+            config = uvicorn.Config(app=app, log_level="warning", lifespan="off")
+            self._server = uvicorn.Server(config)
+            watcher = asyncio.create_task(self._mark_ready_when_started())
+            try:
+                await self._server.serve(sockets=[self._sock])
+            finally:
+                watcher.cancel()
+                if self._sock is not None:
+                    self._sock.close()
+                    self._sock = None
+                self._health.set(self._health_key, HealthStatus.STOPPED)
+
+    async def _mark_ready_when_started(self) -> None:
+        """Flip health to READY only once uvicorn reports the socket is bound and serving."""
+        try:
+            while self._server is None or not self._server.started:
+                await asyncio.sleep(0.01)
+            self._health.set(self._health_key, HealthStatus.READY)
+        except asyncio.CancelledError:
+            pass
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.should_exit = True
+        elif self._sock is not None:
+            # serve() was never called; release the listening socket bound in bind()
+            self._sock.close()
+            self._sock = None
+
+    def _resolve_principal(self, request: Request) -> Principal | None:
+        """UDS → trust loopback OS user. TCP → require token only when one is configured."""
+        if self._bind.startswith("unix:"):
+            return Principal(name="local")
+        if not self._auth.token_configured:
+            return Principal(name="local")
+        tok = request.headers.get("x-potpie-token", "")
+        try:
+            return self._auth.authenticate_token(tok)
+        except AuthFailure:
+            return None
+
+    def _build_app(self, ops: OperationRegistry) -> FastAPI:
+        app = FastAPI(title="potpied", version="0.1.0")
+        transport = self
+
+        @app.post("/op/{name}")
+        async def dispatch(name: str, request: Request):
+            try:
+                op = ops.get(name)
+            except KeyError:
+                return JSONResponse(status_code=404, content=_error_envelope(
+                    OperationError("not_found", f"unknown operation {name!r}")))
+            principal = transport._resolve_principal(request)
+            if op.auth == AuthRequirement.REQUIRED and principal is None:
+                return JSONResponse(status_code=401, content=_error_envelope(
+                    OperationError("unauthorized", "authentication required")))
+            if principal is None:
+                principal = Principal(name="anonymous")
+            try:
+                raw = await request.json()
+            except Exception:
+                raw = {}
+            try:
+                inp = op.input_model.model_validate(raw)
+            except ValidationError as ve:
+                return JSONResponse(status_code=400, content=_error_envelope(
+                    OperationError("invalid_input", "validation failed",
+                                   detail={"errors": json.loads(ve.json())})))
+            octx = OperationContext(
+                principal=principal,
+                request_id=request.headers.get("x-request-id", ""),
+                deps=(transport._ctx.config.get("deps") if transport._ctx else None),
+            )
+            try:
+                out = await op.handler(inp, octx)
+            except OperationError as oe:
+                return JSONResponse(status_code=_STATUS_MAP.get(oe.code, 500), content=_error_envelope(oe))
+            except Exception as ex:  # noqa: BLE001 — convert any handler error to a uniform envelope
+                return JSONResponse(status_code=500, content=_error_envelope(
+                    OperationError("internal_error", str(ex))))
+            return JSONResponse(status_code=200, content=out.model_dump())
+
+        @app.get("/op")
+        async def list_ops():
+            return {"operations": [o.name for o in ops.all()]}
+
+        @app.get("/admin/health")
+        async def admin_health():
+            st = transport._health.snapshot().get(transport._health_key)
+            return {"status": st.value if st else "unknown"}
+
+        @app.get("/admin/services")
+        async def admin_services():
+            mgr = (transport._ctx.config or {}).get("service_manager")
+            if mgr is None:
+                return {"services": []}
+            return {"services": [
+                {"name": s.name, "status": s.status.value, "endpoint": s.endpoint}
+                for s in mgr.status()
+            ]}
+
+        @app.post("/admin/services/{name}/up")
+        async def admin_service_up(name: str):
+            mgr = (transport._ctx.config or {}).get("service_manager")
+            if mgr is None:
+                return JSONResponse(status_code=503, content=_error_envelope(
+                    OperationError("unavailable", "service manager not available")))
+            try:
+                ep = await mgr.up(name)
+                return {"endpoint": ep}
+            except Exception as ex:  # noqa: BLE001 — surface any startup error as 400
+                return JSONResponse(status_code=400, content=_error_envelope(
+                    OperationError("invalid_input", str(ex))))
+
+        @app.post("/admin/services/{name}/down")
+        async def admin_service_down(name: str):
+            mgr = (transport._ctx.config or {}).get("service_manager")
+            if mgr is None:
+                return JSONResponse(status_code=503, content=_error_envelope(
+                    OperationError("unavailable", "service manager not available")))
+            await mgr.down(name)
+            return {"ok": True}
+
+        return app

--- a/app/src/context-engine/adapters/outbound/daemon_process/ipc_client.py
+++ b/app/src/context-engine/adapters/outbound/daemon_process/ipc_client.py
@@ -1,0 +1,30 @@
+"""HTTP client for the running daemon (UDS-preferred)."""
+from __future__ import annotations
+import json, pathlib, httpx
+
+
+def discovery_path(home: pathlib.Path) -> pathlib.Path:
+    return home / "discovery.json"
+
+
+def load_discovery(home: pathlib.Path) -> dict | None:
+    p = discovery_path(home)
+    if not p.exists():
+        return None
+    return json.loads(p.read_text())
+
+
+def client_for(home: pathlib.Path) -> httpx.Client:
+    """Return an httpx.Client connected to the running daemon. The caller owns and must close it
+    (use `with client_for(home) as c:`)."""
+    d = load_discovery(home)
+    if not d:
+        raise RuntimeError("daemon not running (no discovery file)")
+    bind = d["bind"]
+    if bind.startswith("unix:"):
+        sock = bind[len("unix:"):]
+        return httpx.Client(transport=httpx.HTTPTransport(uds=sock), base_url="http://localhost")
+    if bind.startswith("tcp:"):
+        _, host, port = bind.split(":", 2)
+        return httpx.Client(base_url=f"http://{host}:{port}")
+    raise RuntimeError(f"unknown bind {bind!r}")

--- a/app/src/context-engine/adapters/outbound/daemon_process/launcher.py
+++ b/app/src/context-engine/adapters/outbound/daemon_process/launcher.py
@@ -1,0 +1,109 @@
+"""Detached daemon launcher: start the daemon as a background process and block until ready, or stop it.
+
+This is the reliable, transport-agnostic start/stop mechanism the ``host.daemon.Daemon``
+seam drives. ``start_detached`` is QUIET — it returns ``{"pid","socket","bind"}`` once the
+daemon has signalled readiness (discovery file written) or raises ``DaemonStartError``; it
+never prints, so it is safe to call from inside a rich/live setup UI.
+"""
+from __future__ import annotations
+import json, os, pathlib, signal, subprocess, sys, time
+
+from adapters.outbound.daemon_process.pidfile import read_pid_file
+
+
+class DaemonStartError(Exception):
+    """Raised by start_detached() when the daemon does not come up.
+
+    Carries the daemon log path (when available) so callers can surface the cause.
+    """
+
+    def __init__(self, message: str, *, log_path: "pathlib.Path | None" = None) -> None:
+        super().__init__(message)
+        self.log_path = log_path
+
+
+def start_detached(home: pathlib.Path, *, ready_timeout_s: float = 60.0) -> dict:
+    """Start the daemon detached for ``home`` and block until it is fully serving.
+
+    Returns ``{"pid", "socket", "bind"}`` once the daemon signals readiness (discovery file
+    written), or raises :class:`DaemonStartError` on any failure (already running, child
+    crash, or readiness timeout).
+    """
+    home = pathlib.Path(home)
+    pid_file = home / "daemon.pid"
+    disc_file = home / "discovery.json"
+    log_path = home / "logs" / "potpied.log"
+    if pid_file.exists():
+        existing = read_pid_file(pid_file)
+        if existing:
+            try:
+                os.kill(existing, 0)
+                raise DaemonStartError(f"daemon already running (pid={existing})")
+            except ProcessLookupError:
+                pid_file.unlink()  # stale
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_fp = log_path.open("a")
+    try:
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "host.daemon_runtime", "run", "--home", str(home)],
+            stdout=log_fp, stderr=subprocess.STDOUT,
+            start_new_session=True, close_fds=True,
+            env={**os.environ, "CONTEXT_ENGINE_HOME": str(home)},
+        )
+    finally:
+        log_fp.close()
+    deadline = time.time() + ready_timeout_s
+    while time.time() < deadline:
+        if disc_file.exists():
+            try:
+                disc = json.loads(disc_file.read_text())
+            except (OSError, json.JSONDecodeError):
+                disc = {}
+            bind = disc.get("bind", "")
+            socket_path = bind[len("unix:"):] if bind.startswith("unix:") else bind
+            return {"pid": proc.pid, "socket": socket_path, "bind": bind}
+        if proc.poll() is not None:
+            raise DaemonStartError(
+                f"daemon failed to start (exit {proc.returncode})", log_path=log_path
+            )
+        time.sleep(0.1)
+    # Alive but never signalled ready — stop it so we don't leave a half-up daemon.
+    try:
+        os.kill(proc.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    raise DaemonStartError(
+        f"daemon did not become ready within {int(ready_timeout_s)}s", log_path=log_path
+    )
+
+
+def stop_daemon(home: pathlib.Path) -> str:
+    """Stop the daemon if running. Returns a human-readable message; never raises."""
+    home = pathlib.Path(home)
+    pid_file = home / "daemon.pid"
+    pid = read_pid_file(pid_file)
+    if not pid:
+        return "daemon not running"
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        _unlink(pid_file)
+        return "stale pid file removed"
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        if not pid_file.exists():
+            return "daemon stopped"
+        time.sleep(0.1)
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    _unlink(pid_file)
+    return "daemon killed (forced after timeout)"
+
+
+def _unlink(path: pathlib.Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass

--- a/app/src/context-engine/adapters/outbound/managed_services/__init__.py
+++ b/app/src/context-engine/adapters/outbound/managed_services/__init__.py
@@ -1,0 +1,4 @@
+"""``adapters.outbound.managed_services`` — ``ServiceBackend`` adapters the daemon's
+``ServiceManager`` drives to run supporting services: a local ``subprocess``, a docker
+``container``, or an already-running ``external`` endpoint (probe-only).
+"""

--- a/app/src/context-engine/adapters/outbound/managed_services/container_backend.py
+++ b/app/src/context-engine/adapters/outbound/managed_services/container_backend.py
@@ -1,0 +1,55 @@
+"""container ServiceBackend — runs services via the local docker CLI (no docker-py dep)."""
+from __future__ import annotations
+import asyncio
+from host.daemon_runtime.context import ShellContext
+from domain.ports.daemon.service import ServiceSpec
+from domain.ports.daemon.shell import HealthStatus
+
+
+class ContainerBackend:
+    name = "container"
+
+    def __init__(self, docker_cmd: str = "docker") -> None:
+        self._docker = docker_cmd
+        self._containers: dict[str, str] = {}        # service name -> container id
+
+    async def start(self, spec: ServiceSpec, ctx: ShellContext) -> None:
+        cfg = spec.config
+        image = cfg["image"]
+        argv = [self._docker, "run", "-d", "--rm", "--name", f"potpie_{spec.name}"]
+        for host, container in (cfg.get("ports") or {}).items():
+            argv += ["-p", f"{host}:{container}"]
+        for k, v in (cfg.get("env") or {}).items():
+            argv += ["-e", f"{k}={v}"]
+        for src, dst in (cfg.get("volumes") or {}).items():
+            argv += ["-v", f"{src}:{dst}"]
+        argv += [image]
+        if cfg.get("command"):
+            argv += list(cfg["command"])
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        )
+        out, err = await proc.communicate()
+        if proc.returncode != 0:
+            raise RuntimeError(f"docker run failed: {err.decode().strip() or out.decode().strip()}")
+        self._containers[spec.name] = out.decode().strip()
+
+    async def stop(self, spec: ServiceSpec) -> None:
+        cid = self._containers.pop(spec.name, None)
+        if cid is None:
+            return
+        for verb in ("stop", "rm"):
+            proc = await asyncio.create_subprocess_exec(
+                self._docker, verb, cid,
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+            )
+            await proc.communicate()  # ignore errors on stop/rm idempotency
+
+    async def probe(self, spec: ServiceSpec) -> HealthStatus:
+        from adapters.outbound.managed_services.subprocess_backend import _tcp_probe
+        rp = spec.ready
+        if rp.kind == "tcp":
+            host, port = rp.target.split(":")
+            return HealthStatus.READY if await _tcp_probe(host, int(port), rp.interval_s) else HealthStatus.STARTING
+        return HealthStatus.STARTING

--- a/app/src/context-engine/adapters/outbound/managed_services/external_backend.py
+++ b/app/src/context-engine/adapters/outbound/managed_services/external_backend.py
@@ -1,0 +1,23 @@
+"""external ServiceBackend — does not start anything; only probes an already-running endpoint."""
+from __future__ import annotations
+from host.daemon_runtime.context import ShellContext
+from domain.ports.daemon.service import ServiceSpec
+from domain.ports.daemon.shell import HealthStatus
+from adapters.outbound.managed_services.subprocess_backend import _tcp_probe
+
+
+class ExternalBackend:
+    name = "external"
+
+    async def start(self, spec: ServiceSpec, ctx: ShellContext) -> None:
+        return None
+
+    async def stop(self, spec: ServiceSpec) -> None:
+        return None
+
+    async def probe(self, spec: ServiceSpec) -> HealthStatus:
+        rp = spec.ready
+        if rp.kind == "tcp":
+            host, port = rp.target.split(":")
+            return HealthStatus.READY if await _tcp_probe(host, int(port), rp.interval_s) else HealthStatus.STARTING
+        return HealthStatus.STARTING

--- a/app/src/context-engine/adapters/outbound/managed_services/subprocess_backend.py
+++ b/app/src/context-engine/adapters/outbound/managed_services/subprocess_backend.py
@@ -1,0 +1,88 @@
+"""subprocess ServiceBackend — spawn any local binary, supervise it, probe readiness."""
+from __future__ import annotations
+import asyncio, contextlib, signal, subprocess
+from host.daemon_runtime.context import ShellContext
+from domain.ports.daemon.service import ServiceSpec
+from domain.ports.daemon.shell import HealthStatus
+
+
+class SubprocessBackend:
+    name = "subprocess"
+
+    def __init__(self) -> None:
+        self._procs: dict[str, asyncio.subprocess.Process] = {}
+
+    async def start(self, spec: ServiceSpec, ctx: ShellContext) -> None:
+        cmd = spec.config["command"]
+        env = spec.config.get("env")
+        cwd = spec.config.get("cwd")
+        log_path = ctx.data_dir / "logs" / f"service-{spec.name}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_fp = log_path.open("a")
+        proc = await asyncio.create_subprocess_exec(
+            *cmd, env=env, cwd=cwd,
+            stdout=log_fp, stderr=asyncio.subprocess.STDOUT,
+            start_new_session=True,
+        )
+        self._procs[spec.name] = proc
+
+    async def stop(self, spec: ServiceSpec) -> None:
+        proc = self._procs.pop(spec.name, None)
+        if proc is None or proc.returncode is not None:
+            return
+        proc.send_signal(signal.SIGTERM)
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=5.0)
+        except asyncio.TimeoutError:
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+            await proc.wait()
+
+    async def probe(self, spec: ServiceSpec) -> HealthStatus:
+        proc = self._procs.get(spec.name)
+        if proc is None:
+            return HealthStatus.STOPPED
+        if proc.returncode is not None:
+            return HealthStatus.DEGRADED
+        rp = spec.ready
+        if rp.kind == "tcp":
+            host, port = rp.target.split(":")
+            ok = await _tcp_probe(host, int(port), timeout_s=rp.interval_s)
+            return HealthStatus.READY if ok else HealthStatus.STARTING
+        if rp.kind == "http":
+            import httpx
+            try:
+                async with httpx.AsyncClient(timeout=rp.interval_s) as c:
+                    r = await c.get(rp.target)
+                return HealthStatus.READY if r.status_code < 500 else HealthStatus.STARTING
+            except Exception:
+                return HealthStatus.STARTING
+        if rp.kind == "cmd":
+            argv = rp.target.split()
+            proc = None
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    *argv, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+                )
+                rc = await asyncio.wait_for(proc.wait(), timeout=rp.interval_s)
+                return HealthStatus.READY if rc == 0 else HealthStatus.STARTING
+            except Exception:
+                if proc is not None and proc.returncode is None:
+                    with contextlib.suppress(ProcessLookupError):
+                        proc.kill()
+                    with contextlib.suppress(Exception):
+                        await proc.wait()
+                return HealthStatus.STARTING
+        return HealthStatus.DEGRADED
+
+
+async def _tcp_probe(host: str, port: int, timeout_s: float) -> bool:
+    try:
+        fut = asyncio.open_connection(host, port)
+        reader, writer = await asyncio.wait_for(fut, timeout=timeout_s)
+        writer.close()
+        with contextlib.suppress(Exception):
+            await writer.wait_closed()
+        return True
+    except Exception:
+        return False

--- a/app/src/context-engine/application/services/managed_service_manager.py
+++ b/app/src/context-engine/application/services/managed_service_manager.py
@@ -1,0 +1,123 @@
+"""ServiceManager — orchestrates managed services through ServiceBackend plugins."""
+from __future__ import annotations
+import asyncio
+import contextlib
+from dataclasses import dataclass
+from host.daemon_runtime.context import ShellContext
+from domain.ports.daemon.service import ServiceSpec
+from domain.ports.daemon.shell import HealthStatus, ServiceBackend
+from host.daemon_runtime.registry import Registry
+
+
+class ServiceNotFound(KeyError):
+    pass
+
+
+class DependencyCycle(RuntimeError):
+    pass
+
+
+class ReadyTimeout(RuntimeError):
+    pass
+
+
+@dataclass
+class ServiceStatus:
+    name: str
+    status: HealthStatus
+    endpoint: str | None
+
+
+class ServiceManager:
+    def __init__(
+        self,
+        specs: dict[str, ServiceSpec],
+        backends: Registry[ServiceBackend],
+        ctx: ShellContext,
+    ) -> None:
+        self._specs = specs
+        self._backends = backends
+        self._ctx = ctx
+        self._instances: dict[str, ServiceBackend] = {}
+        self._lock = asyncio.Lock()
+        self._statuses: dict[str, HealthStatus] = {}
+
+    async def up(self, name: str) -> str:
+        async with self._lock:
+            await self._up_resolving([name], stack=set())
+        return self._specs[name].endpoint
+
+    async def _up_resolving(self, names: list[str], stack: set[str]) -> None:
+        for name in names:
+            if name in self._instances and self._statuses.get(name) is HealthStatus.READY:
+                continue
+            if name not in self._specs:
+                raise ServiceNotFound(f"unknown service {name!r}")
+            if name in stack:
+                raise DependencyCycle(f"service dependency cycle through {name!r}")
+            stack.add(name)
+            spec = self._specs[name]
+            await self._up_resolving(spec.depends_on, stack)
+            stack.remove(name)
+            existing = self._instances.get(name)
+            if existing is not None:
+                # A previous start left a non-READY backend (e.g. ReadyTimeout). Stop it
+                # before recreating so we don't orphan a process/container.
+                with contextlib.suppress(Exception):
+                    await existing.stop(spec)
+                self._instances.pop(name, None)
+            backend = self._backends.create(spec.backend)
+            await backend.start(spec, self._ctx)
+            self._instances[name] = backend
+            self._statuses[name] = HealthStatus.STARTING
+            ok = await self._wait_ready(name, spec)
+            if not ok:
+                self._statuses[name] = HealthStatus.DEGRADED
+                raise ReadyTimeout(f"service {name!r} did not become ready")
+            self._statuses[name] = HealthStatus.READY
+            self._ctx.endpoints.set(name, spec.endpoint)
+
+    async def _wait_ready(self, name: str, spec: ServiceSpec) -> bool:
+        backend = self._instances[name]
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + spec.ready.timeout_s
+        while loop.time() < deadline:
+            s = await backend.probe(spec)
+            if s is HealthStatus.READY:
+                return True
+            await asyncio.sleep(spec.ready.interval_s)
+        return False
+
+    async def down(self, name: str) -> None:
+        # TODO(v2): stop services that depend on `name` first; V1 does not check dependents.
+        async with self._lock:
+            backend = self._instances.pop(name, None)
+            if backend is None:
+                return
+            spec = self._specs[name]
+            try:
+                await backend.stop(spec)
+            finally:
+                self._statuses[name] = HealthStatus.STOPPED
+                self._ctx.endpoints.remove(name)
+
+    def started_names(self) -> list[str]:
+        """Names of services that have a started backend instance (running or degraded)."""
+        return list(self._instances)
+
+    def status(self, name: str | None = None) -> ServiceStatus | list[ServiceStatus]:
+        if name is not None:
+            spec = self._specs.get(name)
+            return ServiceStatus(
+                name=name,
+                status=self._statuses.get(name, HealthStatus.STOPPED),
+                endpoint=spec.endpoint if spec else None,
+            )
+        return [
+            ServiceStatus(
+                name=n,
+                status=self._statuses.get(n, HealthStatus.STOPPED),
+                endpoint=s.endpoint,
+            )
+            for n, s in self._specs.items()
+        ]

--- a/app/src/context-engine/bootstrap/host_wiring.py
+++ b/app/src/context-engine/bootstrap/host_wiring.py
@@ -51,6 +51,14 @@ def default_backend_profile() -> str:
     return (os.getenv("CONTEXT_ENGINE_BACKEND") or "embedded").strip().lower()
 
 
+def default_host_mode() -> str:
+    # 'in_process' is the default (host runs in the CLI process); $CONTEXT_ENGINE_HOST_MODE
+    # = 'daemon' opts into the real detached background daemon. The 'setup' command also
+    # flips this per-run via --daemon. When detached, the daemon/installer setup steps
+    # become hard (see DefaultSetupOrchestrator._HOST_GATED).
+    return (os.getenv("CONTEXT_ENGINE_HOST_MODE") or "in_process").strip().lower()
+
+
 def build_host_shell(
     *,
     backend: GraphBackend | None = None,
@@ -88,7 +96,7 @@ def build_host_shell(
     )
 
     # Lifecycle components (each independently ownable; see the setup orchestrator).
-    daemon = Daemon()
+    daemon = Daemon(in_process=(default_host_mode() != "daemon"))
     config = LocalConfigService()
     installer = LocalInstaller()
     auth = LocalAuthService()

--- a/app/src/context-engine/host/daemon.py
+++ b/app/src/context-engine/host/daemon.py
@@ -1,58 +1,96 @@
-"""``Daemon`` — local host lifecycle (thin skeleton).
+"""``Daemon`` — local host lifecycle.
 
-The daemon shell is the local background process for lifecycle, auth, IPC,
-health, and logs — it is *not* the business layer. In this skeleton the host
-runs in-process, so the daemon reports a synthetic "in-process" liveness and the
-real process-management commands are TODO.
+The daemon shell is the local background process for lifecycle, IPC, health, and logs —
+it is *not* the business layer. When ``in_process`` (the default), the host runs in the
+CLI process and the daemon reports a synthetic "in-process" liveness. When detached
+(``host_mode = "daemon"``), the real bodies here drive
+``adapters.outbound.daemon_process`` to start/stop a background process that runs
+``host.daemon_runtime`` and serves the host's surfaces over a Unix socket.
 
-    TODO(stage-N): real daemon — install/start/stop as a background process,
-    Unix-socket IPC, log files under the pot home, version/health endpoint.
-
-Liveness and readiness are separate (see observability.md): the daemon can be
-live while a backend or semantic index is not ready.
+Liveness and readiness are separate (see observability.md): the daemon can be live while
+a backend or semantic index is not ready.
 """
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from adapters.outbound.pots.local_pot_store import default_home
-from domain.errors import CapabilityNotImplemented
-from domain.lifecycle import SKIPPED, SetupPlan, StepResult
+from domain.lifecycle import DONE, SKIPPED, SetupPlan, StepResult
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, PermissionError):
+        return False
+    except OSError:
+        return False
 
 
 @dataclass(slots=True)
 class Daemon:
-    """In-process daemon stand-in with a real lifecycle interface."""
+    """Local daemon lifecycle: in-process stand-in by default, detached process when asked."""
 
     home: Path = field(default_factory=default_home)
     in_process: bool = True
 
+    # --- introspection ------------------------------------------------------
     def status(self) -> dict[str, Any]:
+        if self.in_process:
+            return {
+                "up": True,
+                "mode": "in_process",
+                "home": str(self.home),
+                "detail": "in-process host; no detached daemon",
+            }
+        from adapters.outbound.daemon_process.ipc_client import load_discovery
+        from adapters.outbound.daemon_process.pidfile import read_pid_file
+
+        pid = read_pid_file(self.home / "daemon.pid")
+        up = bool(pid and _pid_alive(pid))
+        disc = load_discovery(self.home) or {}
+        bind = disc.get("bind", "")
+        socket = bind[len("unix:"):] if bind.startswith("unix:") else bind
         return {
-            "up": True,
-            "mode": "in_process" if self.in_process else "detached",
+            "up": up,
+            "mode": "detached",
             "home": str(self.home),
-            "detail": "in-process host; no detached daemon yet (TODO)",
+            "pid": pid,
+            "socket": socket,
+            "detail": "detached daemon running" if up else "detached daemon not running",
         }
 
     def health(self) -> dict[str, Any]:
         # Liveness only — readiness is the services'/backend's concern.
-        return {"live": True, "mode": "in_process"}
+        if self.in_process:
+            return {"live": True, "mode": "in_process"}
+        from adapters.outbound.daemon_process.ipc_client import client_for
+
+        try:
+            with client_for(self.home) as c:
+                r = c.get("/admin/health")
+                return {"live": r.status_code < 500, "mode": "detached", **r.json()}
+        except Exception:
+            return {"live": False, "mode": "detached"}
 
     def logs(self, *, follow: bool = False) -> list[str]:
-        log_file = self.home / "daemon.log"
-        if not log_file.exists():
-            return []
-        return log_file.read_text(encoding="utf-8").splitlines()
+        for name in ("logs/potpied.log", "daemon.log"):
+            log_file = self.home / name
+            if log_file.exists():
+                return log_file.read_text(encoding="utf-8", errors="replace").splitlines()
+        return []
 
+    # --- setup seam ---------------------------------------------------------
     def ensure(self, plan: SetupPlan | None = None) -> StepResult:
         """Idempotent setup seam: make sure the host is running.
 
-        In-process hosts have nothing to start, so this is a no-op that reports
-        ``skipped``. A detached daemon owner fills this with install+start (idempotent).
+        In-process hosts have nothing to start (reports ``skipped``). A detached daemon
+        starts the background process if it is not already running and reports ``done``.
         """
         if self.in_process:
             return StepResult(
@@ -61,36 +99,41 @@ class Daemon:
                 detail="in-process host; no detached daemon to start",
                 metadata={"mode": "in_process"},
             )
-        raise CapabilityNotImplemented(
-            "host.daemon.ensure",
-            detail="detached daemon install/start not implemented",
-            recommended_next_action="implement detached daemon lifecycle",
+        st = self.status()
+        if st["up"]:
+            return StepResult(
+                step="daemon.ensure",
+                state=DONE,
+                detail=f"daemon already running (pid={st.get('pid')})",
+                metadata={"mode": "detached", "pid": st.get("pid"), "socket": st.get("socket")},
+            )
+        info = self.start()
+        return StepResult(
+            step="daemon.ensure",
+            state=DONE,
+            detail=f"daemon started (pid={info.get('pid')})",
+            metadata={"mode": "detached", **info},
         )
 
+    # --- lifecycle ----------------------------------------------------------
     def install(self) -> dict[str, Any]:
-        raise CapabilityNotImplemented(
-            "host.daemon.install",
-            detail="detached daemon install not implemented",
-            recommended_next_action="host runs in-process; no install needed for the POC",
-        )
+        # No OS service unit for the local OSS daemon; idempotent no-op so the
+        # host-gated 'installer' setup step succeeds rather than gating the run.
+        return {"installed": False, "detail": "no service unit for the local OSS daemon"}
 
     def start(self) -> dict[str, Any]:
-        raise CapabilityNotImplemented(
-            "host.daemon.start",
-            recommended_next_action="host runs in-process; no start needed for the POC",
-        )
+        from adapters.outbound.daemon_process.launcher import start_detached
+
+        return start_detached(self.home)
 
     def stop(self) -> dict[str, Any]:
-        raise CapabilityNotImplemented(
-            "host.daemon.stop",
-            recommended_next_action="host runs in-process; nothing to stop",
-        )
+        from adapters.outbound.daemon_process.launcher import stop_daemon
+
+        return {"detail": stop_daemon(self.home)}
 
     def restart(self) -> dict[str, Any]:
-        raise CapabilityNotImplemented(
-            "host.daemon.restart",
-            recommended_next_action="host runs in-process; nothing to restart",
-        )
+        self.stop()
+        return self.start()
 
 
 __all__ = ["Daemon"]

--- a/app/src/context-engine/host/daemon_runtime/__main__.py
+++ b/app/src/context-engine/host/daemon_runtime/__main__.py
@@ -1,0 +1,74 @@
+"""Detached daemon child entrypoint: ``python -m host.daemon_runtime run --home <home>``.
+
+Invoked by ``adapters.outbound.daemon_process.launcher.start_detached`` (never a public
+CLI command). Builds an in-process ``HostShell``, derives the daemon manifest in code,
+and runs the ``DaemonRuntime`` — exposing the host's services over the socket — until a
+SIGTERM/SIGINT stops it.
+"""
+from __future__ import annotations
+import argparse, asyncio, os, pathlib, signal
+
+
+def _serve(home: pathlib.Path) -> None:
+    # The child hosts the services in-process; force in_process so it never tries to
+    # spawn another detached daemon (recursion guard).
+    os.environ["CONTEXT_ENGINE_HOST_MODE"] = "in_process"
+
+    from bootstrap.host_wiring import build_host_shell
+    from host.daemon_runtime.config import build_daemon_config
+    from host.daemon_runtime.shell import (
+        DaemonRuntime, default_registries, EntryPointPluginsLoader,
+    )
+    from adapters.outbound.daemon_process.pidfile import (
+        write_pid_file, remove_pid_file, write_discovery,
+    )
+
+    host = build_host_shell()
+    cfg = build_daemon_config(home)
+    pid_file = home / "daemon.pid"
+    disc_file = home / "discovery.json"
+
+    write_pid_file(pid_file, os.getpid())
+    http_t = next((t for t in cfg.transports if t.type == "http"), None)
+
+    def _on_ready() -> None:
+        if http_t:
+            write_discovery(disc_file, transport="http", bind=http_t.bind)
+
+    runtime = DaemonRuntime(
+        config=cfg,
+        registries=default_registries(),
+        plugins_loader=EntryPointPluginsLoader(),
+        on_ready=_on_ready,
+        deps=host,
+    )
+
+    async def _run() -> None:
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            try:
+                loop.add_signal_handler(sig, runtime.request_stop)
+            except (NotImplementedError, RuntimeError):
+                pass
+        await runtime.run()
+
+    try:
+        asyncio.run(_run())
+    finally:
+        remove_pid_file(pid_file)
+        if disc_file.exists():
+            disc_file.unlink()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(prog="python -m host.daemon_runtime")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    runp = sub.add_parser("run", help="Run the daemon in the foreground (internal).")
+    runp.add_argument("--home", required=True)
+    args = ap.parse_args()
+    if args.cmd == "run":
+        _serve(pathlib.Path(args.home))
+
+
+if __name__ == "__main__":
+    main()

--- a/app/src/context-engine/host/daemon_runtime/config.py
+++ b/app/src/context-engine/host/daemon_runtime/config.py
@@ -1,0 +1,83 @@
+"""In-code daemon config: the manifest the ``DaemonRuntime`` runs.
+
+Unlike a user-facing config file, the daemon manifest (transports/services/components)
+is *derived in code* at start time from the home dir + active backend profile — see
+``build_daemon_config``. This keeps the daemon dependency-pure (no TOML parser) and
+avoids a second config file colliding with ``ConfigService``'s ``config.json``.
+"""
+from __future__ import annotations
+import pathlib
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ShellSettings:
+    data_dir: str
+    log_level: str = "info"
+
+
+@dataclass(frozen=True)
+class TransportEntry:
+    type: str
+    bind: str
+
+
+@dataclass(frozen=True)
+class ReadyProbeEntry:
+    kind: str
+    target: str
+    interval_s: float = 0.5
+    timeout_s: float = 30.0
+
+
+@dataclass(frozen=True)
+class ServiceEntry:
+    name: str
+    backend: str
+    config: dict[str, Any]
+    ready: ReadyProbeEntry
+    endpoint: str
+    restart: str = "on_failure"
+    depends_on: list[str] = field(default_factory=list)
+    data_dir: str | None = None
+
+
+@dataclass(frozen=True)
+class ComponentEntry:
+    type: str
+    requires_services: list[str] = field(default_factory=list)
+    config: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class DaemonConfig:
+    shell: ShellSettings
+    transports: list[TransportEntry]
+    services: list[ServiceEntry]
+    components: list[ComponentEntry]
+
+
+def build_daemon_config(
+    home: pathlib.Path,
+    *,
+    log_level: str = "info",
+    services: list[ServiceEntry] | None = None,
+    components: list[ComponentEntry] | None = None,
+) -> DaemonConfig:
+    """Derive the daemon manifest from ``home`` (+ optional managed services/components).
+
+    Defaults to a single HTTP transport over a Unix socket at ``<home>/daemon.sock``
+    and the ``context_graph`` component (which serves ``context.*`` by delegating to the
+    in-process ``HostShell`` — no managed services required for V1).
+    """
+    home = pathlib.Path(home)
+    services = services or []
+    if components is None:
+        components = [ComponentEntry(type="context_graph", requires_services=[], config={})]
+    return DaemonConfig(
+        shell=ShellSettings(data_dir=str(home), log_level=log_level),
+        transports=[TransportEntry(type="http", bind=f"unix:{home}/daemon.sock")],
+        services=services,
+        components=components,
+    )

--- a/app/src/context-engine/host/daemon_runtime/shell.py
+++ b/app/src/context-engine/host/daemon_runtime/shell.py
@@ -1,0 +1,189 @@
+"""DaemonRuntime: assembles registries, plugins, transports, components, services. Runs until shutdown.
+
+This is the async runtime the detached daemon process executes (``python -m host.daemon_runtime``).
+It is distinct from ``host.shell.HostShell`` (the in-process service facade) — the runtime
+*hosts* services and exposes them over a transport.
+"""
+from __future__ import annotations
+import asyncio, importlib.metadata, logging, pathlib
+from dataclasses import dataclass
+
+from host.daemon_runtime.registry import Registry
+from domain.ports.daemon.shell import Transport, Component, ServiceBackend, HealthStatus
+from domain.ports.daemon.service import ServiceSpec, ReadyProbe, RestartPolicy
+from domain.ports.daemon.operations import OperationRegistry
+from host.daemon_runtime.context import ShellContext, ServiceEndpoints
+from host.daemon_runtime.health import HealthRegistrar
+from host.daemon_runtime.ipc_auth import IpcAuthGate
+from host.daemon_runtime.config import DaemonConfig
+from application.services.managed_service_manager import ServiceManager
+from adapters.outbound.managed_services.subprocess_backend import SubprocessBackend
+from adapters.outbound.managed_services.container_backend import ContainerBackend
+from adapters.outbound.managed_services.external_backend import ExternalBackend
+from adapters.inbound.daemon_http.transport import HttpTransport
+
+logger = logging.getLogger("potpied.shell")
+
+
+@dataclass
+class Registries:
+    transports: Registry[Transport]
+    components: Registry[Component]
+    service_backends: Registry[ServiceBackend]
+
+
+def default_registries() -> Registries:
+    transports: Registry[Transport] = Registry()
+    transports.register("http", lambda bind, auth, health: HttpTransport(bind=bind, auth=auth, health=health))
+
+    components: Registry[Component] = Registry()  # populated by entry points / tests
+    backends: Registry[ServiceBackend] = Registry()
+    backends.register("subprocess", lambda: SubprocessBackend())
+    backends.register("container",  lambda: ContainerBackend())
+    backends.register("external",   lambda: ExternalBackend())
+    return Registries(transports=transports, components=components, service_backends=backends)
+
+
+class BuiltinPluginsLoader:
+    """No-op loader: only the built-in/test-registered plugins are used."""
+    def load(self, regs: Registries) -> None:
+        return None
+
+
+class EntryPointPluginsLoader:
+    """Loads plugins from the three entry-point groups. Each entry point is called with the matching registry."""
+    GROUPS = {
+        "potpie.shell.transports":       "transports",
+        "potpie.shell.components":       "components",
+        "potpie.shell.service_backends": "service_backends",
+    }
+    def load(self, regs: Registries) -> None:
+        for group, attr in self.GROUPS.items():
+            for ep in importlib.metadata.entry_points(group=group):
+                ep.load()(getattr(regs, attr))
+
+
+class DaemonRuntime:
+    def __init__(self, config: DaemonConfig, registries: Registries, plugins_loader=None, on_ready=None, deps=None) -> None:
+        self._cfg = config
+        self._regs = registries
+        self._loader = plugins_loader or BuiltinPluginsLoader()
+        self._on_ready = on_ready
+        self._deps = deps  # opaque wired deps (e.g. HostShell) handed to components + ops
+        self._stop = asyncio.Event()
+        self._tasks: list[asyncio.Task] = []
+        self._svc_mgr: ServiceManager | None = None
+        self._transports: list[Transport] = []
+        self._components: list[Component] = []
+        self._health = HealthRegistrar()
+
+    async def run(self) -> None:
+        self._loader.load(self._regs)
+
+        data_dir = pathlib.Path(self._cfg.shell.data_dir)
+        data_dir.mkdir(parents=True, exist_ok=True)
+        (data_dir / "logs").mkdir(parents=True, exist_ok=True)
+
+        ctx = ShellContext(
+            config={},
+            data_dir=data_dir,
+            logger=logging.getLogger("potpied"),
+            endpoints=ServiceEndpoints(),
+        )
+        ctx.config["deps"] = self._deps  # available to components (on_start) and ops (OperationContext.deps)
+
+        # services
+        specs: dict[str, ServiceSpec] = {}
+        for se in self._cfg.services:
+            specs[se.name] = ServiceSpec(
+                name=se.name, backend=se.backend, config=se.config,
+                ready=ReadyProbe(kind=se.ready.kind, target=se.ready.target,
+                                 interval_s=se.ready.interval_s, timeout_s=se.ready.timeout_s),
+                endpoint=se.endpoint,
+                restart=RestartPolicy(se.restart),
+                depends_on=se.depends_on,
+                data_dir=se.data_dir,
+            )
+        self._svc_mgr = ServiceManager(specs=specs, backends=self._regs.service_backends, ctx=ctx)
+        ctx.config["service_manager"] = self._svc_mgr
+
+        # operations registry
+        op_reg = OperationRegistry()
+
+        try:
+            # components: bring up their required services, then start
+            for ce in self._cfg.components:
+                for s in ce.requires_services:
+                    await self._svc_mgr.up(s)
+                comp = self._regs.components.create(ce.type, **ce.config)
+                await comp.on_start(ctx)
+                for op in comp.operations():
+                    op_reg.register(op)
+                self._components.append(comp)
+
+            # transports
+            for te in self._cfg.transports:
+                t = self._regs.transports.create(te.type, bind=te.bind, auth=IpcAuthGate(token=None), health=self._health)
+                t.bind(ctx)
+                self._transports.append(t)
+                self._tasks.append(asyncio.create_task(t.serve(op_reg)))
+
+            await self._await_transports_ready()
+        except BaseException:
+            logger.exception("shell startup failed; tearing down partial startup")
+            await self._shutdown()
+            raise
+
+        if self._on_ready is not None:
+            try:
+                self._on_ready()
+            except Exception:
+                logger.warning("on_ready callback failed", exc_info=True)
+        await self._stop.wait()
+        await self._shutdown()
+
+    async def _await_transports_ready(self, timeout_s: float = 30.0) -> None:
+        """Block until every transport reports READY (socket bound + serving), so readiness is only
+        signalled once the daemon is actually usable."""
+        if not self._transports:
+            return
+        deadline = asyncio.get_running_loop().time() + timeout_s
+        while asyncio.get_running_loop().time() < deadline:
+            if all(t.health() is HealthStatus.READY for t in self._transports):
+                return
+            await asyncio.sleep(0.02)
+        raise RuntimeError("transports did not become ready within timeout")
+
+    def request_stop(self) -> None:
+        """Synchronous stop trigger, safe to call from a signal handler."""
+        self._stop.set()
+
+    async def stop(self) -> None:
+        self._stop.set()
+
+    async def _shutdown(self) -> None:
+        for t in self._transports:
+            try:
+                await t.stop()
+            except Exception:
+                logger.warning("transport stop failed", exc_info=True)
+        for task in self._tasks:
+            task.cancel()
+        for task in self._tasks:
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.warning("serve task raised during shutdown", exc_info=True)
+        for c in self._components:
+            try:
+                await c.on_stop()
+            except Exception:
+                logger.warning("component on_stop failed", exc_info=True)
+        if self._svc_mgr:
+            for s in self._svc_mgr.started_names():
+                try:
+                    await self._svc_mgr.down(s)
+                except Exception:
+                    logger.warning("service down failed for %s", s, exc_info=True)

--- a/app/src/context-engine/tests/integration/test_daemon_external_backend.py
+++ b/app/src/context-engine/tests/integration/test_daemon_external_backend.py
@@ -1,0 +1,59 @@
+import asyncio, logging, pathlib, socket, pytest
+from adapters.outbound.managed_services.external_backend import ExternalBackend
+from domain.ports.daemon.shell import ServiceSpec, ReadyProbe, HealthStatus
+from host.daemon_runtime.context import ShellContext, ServiceEndpoints
+
+
+def _free_port_and_listener() -> tuple[int, socket.socket]:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    s.listen()
+    return s.getsockname()[1], s
+
+
+@pytest.fixture
+def ctx(tmp_path: pathlib.Path) -> ShellContext:
+    return ShellContext(
+        config={}, data_dir=tmp_path, logger=logging.getLogger("t"),
+        endpoints=ServiceEndpoints(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_external_does_not_start_anything(ctx):
+    be = ExternalBackend()
+    spec = ServiceSpec(
+        name="x", backend="external", config={},
+        ready=ReadyProbe(kind="tcp", target="127.0.0.1:1"),
+        endpoint="tcp://127.0.0.1:1",
+    )
+    await be.start(spec, ctx)
+    await be.stop(spec)
+
+
+@pytest.mark.asyncio
+async def test_external_probe_ready_when_target_listening(ctx):
+    port, sock = _free_port_and_listener()
+    try:
+        be = ExternalBackend()
+        spec = ServiceSpec(
+            name="ext", backend="external", config={},
+            ready=ReadyProbe(kind="tcp", target=f"127.0.0.1:{port}"),
+            endpoint=f"tcp://127.0.0.1:{port}",
+        )
+        await be.start(spec, ctx)
+        assert await be.probe(spec) is HealthStatus.READY
+    finally:
+        sock.close()
+
+
+@pytest.mark.asyncio
+async def test_external_probe_starting_when_target_down(ctx):
+    be = ExternalBackend()
+    spec = ServiceSpec(
+        name="dn", backend="external", config={},
+        ready=ReadyProbe(kind="tcp", target="127.0.0.1:1"),
+        endpoint="tcp://127.0.0.1:1",
+    )
+    await be.start(spec, ctx)
+    assert await be.probe(spec) is HealthStatus.STARTING

--- a/app/src/context-engine/tests/integration/test_daemon_http_transport.py
+++ b/app/src/context-engine/tests/integration/test_daemon_http_transport.py
@@ -1,0 +1,153 @@
+import asyncio, logging, pathlib, pytest
+import httpx
+from pydantic import BaseModel
+from domain.ports.daemon.operations import (
+    OperationRegistry, OperationSpec, OperationContext, OperationError, AuthRequirement,
+)
+from host.daemon_runtime.context import ShellContext, ServiceEndpoints
+from host.daemon_runtime.health import HealthRegistrar
+from host.daemon_runtime.ipc_auth import IpcAuthGate
+from adapters.inbound.daemon_http.transport import HttpTransport
+
+
+class EchoIn(BaseModel):
+    msg: str
+
+class EchoOut(BaseModel):
+    echoed: str
+
+
+async def echo(inp: EchoIn, ctx: OperationContext) -> EchoOut:
+    return EchoOut(echoed=inp.msg)
+
+
+async def boom(inp: EchoIn, ctx: OperationContext) -> EchoOut:
+    raise OperationError("not_found", "missing", detail={"k": inp.msg})
+
+
+@pytest.fixture
+def ops() -> OperationRegistry:
+    r = OperationRegistry()
+    r.register(OperationSpec(
+        name="echo.say", input_model=EchoIn, output_model=EchoOut,
+        handler=echo, summary="echo", mutating=False, auth=AuthRequirement.NONE,
+    ))
+    r.register(OperationSpec(
+        name="echo.boom", input_model=EchoIn, output_model=EchoOut,
+        handler=boom, summary="boom", mutating=False, auth=AuthRequirement.NONE,
+    ))
+    return r
+
+
+@pytest.fixture
+def ctx(tmp_path: pathlib.Path) -> ShellContext:
+    return ShellContext(
+        config={}, data_dir=tmp_path, logger=logging.getLogger("test"),
+        endpoints=ServiceEndpoints(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_uds_dispatch_success(tmp_path: pathlib.Path, ops, ctx):
+    sock = tmp_path / "d.sock"
+    t = HttpTransport(bind=f"unix:{sock}", auth=IpcAuthGate(token=None), health=HealthRegistrar())
+    t.bind(ctx)
+    task = asyncio.create_task(t.serve(ops))
+    try:
+        for _ in range(50):
+            if sock.exists():
+                break
+            await asyncio.sleep(0.05)
+        async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=str(sock))) as c:
+            r = await c.post("http://localhost/op/echo.say", json={"msg": "hi"})
+            assert r.status_code == 200
+            assert r.json() == {"echoed": "hi"}
+    finally:
+        await t.stop()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_error_maps_to_http_status(tmp_path: pathlib.Path, ops, ctx):
+    sock = tmp_path / "d.sock"
+    t = HttpTransport(bind=f"unix:{sock}", auth=IpcAuthGate(token=None), health=HealthRegistrar())
+    t.bind(ctx)
+    task = asyncio.create_task(t.serve(ops))
+    try:
+        for _ in range(50):
+            if sock.exists():
+                break
+            await asyncio.sleep(0.05)
+        async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=str(sock))) as c:
+            r = await c.post("http://localhost/op/echo.boom", json={"msg": "x"})
+            assert r.status_code == 404
+            body = r.json()
+            assert body["error"]["code"] == "not_found"
+            assert body["error"]["message"] == "missing"
+            assert body["error"]["detail"] == {"k": "x"}
+    finally:
+        await t.stop()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_tcp_bind_works(ops, ctx):
+    t = HttpTransport(bind="tcp:127.0.0.1:0", auth=IpcAuthGate(token=None), health=HealthRegistrar())
+    t.bind(ctx)
+    task = asyncio.create_task(t.serve(ops))
+    try:
+        for _ in range(50):
+            if t.bound_port():
+                break
+            await asyncio.sleep(0.05)
+        port = t.bound_port()
+        assert port is not None and port > 0
+        async with httpx.AsyncClient() as c:
+            r = await c.post(f"http://127.0.0.1:{port}/op/echo.say", json={"msg": "ok"})
+            assert r.status_code == 200
+    finally:
+        await t.stop()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_tcp_required_auth_rejected_without_token(ctx):
+    reg = OperationRegistry()
+
+    async def secret(inp: EchoIn, c: OperationContext) -> EchoOut:
+        return EchoOut(echoed=inp.msg)
+
+    reg.register(OperationSpec(
+        name="echo.secret", input_model=EchoIn, output_model=EchoOut,
+        handler=secret, summary="s", auth=AuthRequirement.REQUIRED,
+    ))
+    t = HttpTransport(bind="tcp:127.0.0.1:0", auth=IpcAuthGate(token="tok-abc"), health=HealthRegistrar())
+    t.bind(ctx)
+    task = asyncio.create_task(t.serve(reg))
+    try:
+        for _ in range(50):
+            if t.bound_port():
+                break
+            await asyncio.sleep(0.05)
+        port = t.bound_port()
+        async with httpx.AsyncClient() as c:
+            r = await c.post(f"http://127.0.0.1:{port}/op/echo.secret", json={"msg": "x"})
+            assert r.status_code == 401
+            assert r.json()["error"]["code"] == "unauthorized"
+            r = await c.post(
+                f"http://127.0.0.1:{port}/op/echo.secret", json={"msg": "x"},
+                headers={"x-potpie-token": "tok-abc"},
+            )
+            assert r.status_code == 200
+            assert r.json() == {"echoed": "x"}
+    finally:
+        await t.stop()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task

--- a/app/src/context-engine/tests/integration/test_daemon_http_transport_extra.py
+++ b/app/src/context-engine/tests/integration/test_daemon_http_transport_extra.py
@@ -1,0 +1,315 @@
+"""Additional http transport coverage: edge cases, admin endpoints, error paths."""
+from __future__ import annotations
+import asyncio, logging, pathlib, pytest
+import httpx
+from pydantic import BaseModel
+from domain.ports.daemon.operations import (
+    OperationRegistry, OperationSpec, OperationContext, OperationError, AuthRequirement,
+)
+from host.daemon_runtime.context import ShellContext, ServiceEndpoints
+from host.daemon_runtime.health import HealthRegistrar
+from host.daemon_runtime.ipc_auth import IpcAuthGate
+from adapters.inbound.daemon_http.transport import HttpTransport
+from domain.ports.daemon.shell import HealthStatus
+
+
+class EchoIn(BaseModel):
+    msg: str
+
+class EchoOut(BaseModel):
+    echoed: str
+
+
+async def echo(inp: EchoIn, ctx: OperationContext) -> EchoOut:
+    return EchoOut(echoed=inp.msg)
+
+
+async def boom_generic(inp: EchoIn, ctx: OperationContext) -> EchoOut:
+    raise RuntimeError("unexpected failure")
+
+
+@pytest.fixture
+def ctx(tmp_path: pathlib.Path) -> ShellContext:
+    return ShellContext(
+        config={}, data_dir=tmp_path, logger=logging.getLogger("test"),
+        endpoints=ServiceEndpoints(),
+    )
+
+
+@pytest.fixture
+def ops() -> OperationRegistry:
+    r = OperationRegistry()
+    r.register(OperationSpec(
+        name="echo.say", input_model=EchoIn, output_model=EchoOut,
+        handler=echo, summary="echo", mutating=False, auth=AuthRequirement.NONE,
+    ))
+    r.register(OperationSpec(
+        name="echo.boom", input_model=EchoIn, output_model=EchoOut,
+        handler=boom_generic, summary="boom", mutating=False, auth=AuthRequirement.NONE,
+    ))
+    return r
+
+
+def test_bind_raises_on_unsupported_scheme(ctx):
+    t = HttpTransport(bind="ftp://something", auth=IpcAuthGate(token=None), health=HealthRegistrar())
+    with pytest.raises(ValueError, match="unsupported bind"):
+        t.bind(ctx)
+
+
+def test_health_returns_starting_before_serve(ctx):
+    t = HttpTransport(bind="tcp:127.0.0.1:0", auth=IpcAuthGate(token=None), health=HealthRegistrar())
+    t.bind(ctx)
+    assert t.health() == HealthStatus.STARTING
+
+
+@pytest.mark.asyncio
+async def test_serve_raises_if_bind_not_called(ops):
+    t = HttpTransport(bind="tcp:127.0.0.1:0", auth=IpcAuthGate(token=None), health=HealthRegistrar())
+    with pytest.raises(RuntimeError, match="bind"):
+        await t.serve(ops)
+
+
+@pytest.mark.asyncio
+async def test_stop_before_serve_closes_sock(ctx):
+    """Calling stop() before serve() should release the listening socket."""
+    t = HttpTransport(bind="tcp:127.0.0.1:0", auth=IpcAuthGate(token=None), health=HealthRegistrar())
+    t.bind(ctx)
+    assert t._sock is not None
+    await t.stop()
+    assert t._sock is None
+
+
+@pytest.mark.asyncio
+async def test_unknown_operation_returns_404(tmp_path: pathlib.Path, ops, ctx):
+    sock = tmp_path / "d.sock"
+    t = HttpTransport(bind=f"unix:{sock}", auth=IpcAuthGate(token=None), health=HealthRegistrar())
+    t.bind(ctx)
+    task = asyncio.create_task(t.serve(ops))
+    try:
+        for _ in range(50):
+            if sock.exists():
+                break
+            await asyncio.sleep(0.05)
+        async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=str(sock))) as c:
+            r = await c.post("http://localhost/op/not.exist", json={})
+            assert r.status_code == 404
+            assert r.json()["error"]["code"] == "not_found"
+    finally:
+        await t.stop()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_invalid_json_body_returns_400(tmp_path: pathlib.Path, ctx):
+    """When the body fails pydantic validation, should get a 400."""
+    sock = tmp_path / "d.sock"
+    ops = OperationRegistry()
+    ops.register(OperationSpec(
+        name="echo.say", input_model=EchoIn, output_model=EchoOut,
+        handler=echo, summary="echo", mutating=False, auth=AuthRequirement.NONE,
+    ))
+    t = HttpTransport(bind=f"unix:{sock}", auth=IpcAuthGate(token=None), health=HealthRegistrar())
+    t.bind(ctx)
+    task = asyncio.create_task(t.serve(ops))
+    try:
+        for _ in range(50):
+            if sock.exists():
+                break
+            await asyncio.sleep(0.05)
+        async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=str(sock))) as c:
+            # Missing required "msg" field → ValidationError → 400
+            r = await c.post("http://localhost/op/echo.say", json={})
+            assert r.status_code == 400
+            assert r.json()["error"]["code"] == "invalid_input"
+    finally:
+        await t.stop()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_handler_exception_returns_500(tmp_path: pathlib.Path, ctx):
+    sock = tmp_path / "d.sock"
+    ops = OperationRegistry()
+    ops.register(OperationSpec(
+        name="echo.boom", input_model=EchoIn, output_model=EchoOut,
+        handler=boom_generic, summary="boom", mutating=False, auth=AuthRequirement.NONE,
+    ))
+    t = HttpTransport(bind=f"unix:{sock}", auth=IpcAuthGate(token=None), health=HealthRegistrar())
+    t.bind(ctx)
+    task = asyncio.create_task(t.serve(ops))
+    try:
+        for _ in range(50):
+            if sock.exists():
+                break
+            await asyncio.sleep(0.05)
+        async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=str(sock))) as c:
+            r = await c.post("http://localhost/op/echo.boom", json={"msg": "x"})
+            assert r.status_code == 500
+            assert r.json()["error"]["code"] == "internal_error"
+    finally:
+        await t.stop()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_list_ops_endpoint(tmp_path: pathlib.Path, ops, ctx):
+    sock = tmp_path / "d.sock"
+    t = HttpTransport(bind=f"unix:{sock}", auth=IpcAuthGate(token=None), health=HealthRegistrar())
+    t.bind(ctx)
+    task = asyncio.create_task(t.serve(ops))
+    try:
+        for _ in range(50):
+            if sock.exists():
+                break
+            await asyncio.sleep(0.05)
+        async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=str(sock))) as c:
+            r = await c.get("http://localhost/op")
+            assert r.status_code == 200
+            assert "echo.say" in r.json()["operations"]
+    finally:
+        await t.stop()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_admin_health_endpoint(tmp_path: pathlib.Path, ops, ctx):
+    sock = tmp_path / "d.sock"
+    t = HttpTransport(bind=f"unix:{sock}", auth=IpcAuthGate(token=None), health=HealthRegistrar())
+    t.bind(ctx)
+    task = asyncio.create_task(t.serve(ops))
+    try:
+        for _ in range(50):
+            if sock.exists():
+                break
+            await asyncio.sleep(0.05)
+        async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=str(sock))) as c:
+            r = await c.get("http://localhost/admin/health")
+            assert r.status_code == 200
+            assert "status" in r.json()
+    finally:
+        await t.stop()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_admin_services_no_manager(tmp_path: pathlib.Path, ops, ctx):
+    sock = tmp_path / "d.sock"
+    # ctx.config has no "service_manager" key
+    t = HttpTransport(bind=f"unix:{sock}", auth=IpcAuthGate(token=None), health=HealthRegistrar())
+    t.bind(ctx)
+    task = asyncio.create_task(t.serve(ops))
+    try:
+        for _ in range(50):
+            if sock.exists():
+                break
+            await asyncio.sleep(0.05)
+        async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=str(sock))) as c:
+            r = await c.get("http://localhost/admin/services")
+            assert r.status_code == 200
+            assert r.json()["services"] == []
+    finally:
+        await t.stop()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_admin_service_up_no_manager(tmp_path: pathlib.Path, ops, ctx):
+    sock = tmp_path / "d.sock"
+    t = HttpTransport(bind=f"unix:{sock}", auth=IpcAuthGate(token=None), health=HealthRegistrar())
+    t.bind(ctx)
+    task = asyncio.create_task(t.serve(ops))
+    try:
+        for _ in range(50):
+            if sock.exists():
+                break
+            await asyncio.sleep(0.05)
+        async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=str(sock))) as c:
+            r = await c.post("http://localhost/admin/services/myservice/up")
+            assert r.status_code == 503
+            assert r.json()["error"]["code"] == "unavailable"
+    finally:
+        await t.stop()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_admin_service_down_no_manager(tmp_path: pathlib.Path, ops, ctx):
+    sock = tmp_path / "d.sock"
+    t = HttpTransport(bind=f"unix:{sock}", auth=IpcAuthGate(token=None), health=HealthRegistrar())
+    t.bind(ctx)
+    task = asyncio.create_task(t.serve(ops))
+    try:
+        for _ in range(50):
+            if sock.exists():
+                break
+            await asyncio.sleep(0.05)
+        async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=str(sock))) as c:
+            r = await c.post("http://localhost/admin/services/myservice/down")
+            assert r.status_code == 503
+    finally:
+        await t.stop()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_tcp_no_auth_configured_anonymous_access(ctx):
+    """TCP transport with no token configured allows anonymous access."""
+    ops = OperationRegistry()
+    ops.register(OperationSpec(
+        name="echo.say", input_model=EchoIn, output_model=EchoOut,
+        handler=echo, summary="echo", mutating=False, auth=AuthRequirement.NONE,
+    ))
+    t = HttpTransport(bind="tcp:127.0.0.1:0", auth=IpcAuthGate(token=None), health=HealthRegistrar())
+    t.bind(ctx)
+    task = asyncio.create_task(t.serve(ops))
+    try:
+        for _ in range(50):
+            if t.bound_port():
+                break
+            await asyncio.sleep(0.05)
+        port = t.bound_port()
+        async with httpx.AsyncClient() as c:
+            r = await c.post(f"http://127.0.0.1:{port}/op/echo.say", json={"msg": "hi"})
+            assert r.status_code == 200
+    finally:
+        await t.stop()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_uds_reuses_existing_sock_file(tmp_path: pathlib.Path, ops, ctx):
+    """If a stale .sock file exists, bind should unlink it before creating new."""
+    sock = tmp_path / "stale.sock"
+    sock.write_text("stale")  # create a fake stale socket file
+    t = HttpTransport(bind=f"unix:{sock}", auth=IpcAuthGate(token=None), health=HealthRegistrar())
+    t.bind(ctx)
+    task = asyncio.create_task(t.serve(ops))
+    try:
+        for _ in range(50):
+            if sock.exists():
+                break
+            await asyncio.sleep(0.05)
+        assert sock.exists()  # real socket now exists
+    finally:
+        await t.stop()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task

--- a/app/src/context-engine/tests/integration/test_daemon_ipc_client.py
+++ b/app/src/context-engine/tests/integration/test_daemon_ipc_client.py
@@ -1,0 +1,32 @@
+"""Additional client.py coverage: tcp bind path, missing discovery, unknown bind."""
+from __future__ import annotations
+import json, pathlib, pytest
+from adapters.outbound.daemon_process.ipc_client import client_for, load_discovery, discovery_path
+
+
+def test_load_discovery_missing(tmp_path: pathlib.Path):
+    assert load_discovery(tmp_path) is None
+
+
+def test_load_discovery_present(tmp_path: pathlib.Path):
+    (tmp_path / "discovery.json").write_text(json.dumps({"bind": "unix:/tmp/x.sock"}))
+    d = load_discovery(tmp_path)
+    assert d["bind"] == "unix:/tmp/x.sock"
+
+
+def test_client_for_raises_when_no_discovery(tmp_path: pathlib.Path):
+    with pytest.raises(RuntimeError, match="no discovery file"):
+        client_for(tmp_path)
+
+
+def test_client_for_tcp_bind(tmp_path: pathlib.Path):
+    (tmp_path / "discovery.json").write_text(json.dumps({"bind": "tcp:127.0.0.1:9999"}))
+    c = client_for(tmp_path)
+    # Should return an httpx.Client without raising
+    c.close()
+
+
+def test_client_for_unknown_bind_raises(tmp_path: pathlib.Path):
+    (tmp_path / "discovery.json").write_text(json.dumps({"bind": "ftp://something"}))
+    with pytest.raises(RuntimeError, match="unknown bind"):
+        client_for(tmp_path)

--- a/app/src/context-engine/tests/integration/test_daemon_runtime_run.py
+++ b/app/src/context-engine/tests/integration/test_daemon_runtime_run.py
@@ -1,0 +1,113 @@
+import asyncio, logging, pathlib, pytest, httpx
+from pydantic import BaseModel
+from host.daemon_runtime.shell import DaemonRuntime, default_registries, BuiltinPluginsLoader
+from host.daemon_runtime.config import (
+    DaemonConfig, ShellSettings, TransportEntry, ComponentEntry,
+)
+from domain.ports.daemon.operations import OperationSpec, OperationContext, AuthRequirement
+from domain.ports.daemon.shell import HealthStatus
+
+
+class PingIn(BaseModel):
+    nonce: int
+
+class PingOut(BaseModel):
+    nonce: int
+
+
+async def ping(inp: PingIn, ctx: OperationContext) -> PingOut:
+    return PingOut(nonce=inp.nonce)
+
+
+class StubComponent:
+    name = "stub"
+    def __init__(self, **_cfg): pass
+    async def on_start(self, ctx) -> None: return None
+    async def on_stop(self) -> None: return None
+    def health(self) -> HealthStatus: return HealthStatus.READY
+    def operations(self) -> list:
+        return [OperationSpec(
+            name="stub.ping", input_model=PingIn, output_model=PingOut,
+            handler=ping, summary="ping", auth=AuthRequirement.NONE,
+        )]
+
+
+@pytest.mark.asyncio
+async def test_on_ready_fires_after_transport_serving(tmp_path: pathlib.Path):
+    sock = tmp_path / "d.sock"
+    cfg = DaemonConfig(
+        shell=ShellSettings(data_dir=str(tmp_path), log_level="warning"),
+        transports=[TransportEntry(type="http", bind=f"unix:{sock}")],
+        services=[], components=[ComponentEntry(type="stub", requires_services=[], config={})],
+    )
+    regs = default_registries()
+    regs.components.register("stub", lambda **cfg: StubComponent(**cfg))
+    flags = {}
+    def _on_ready():
+        flags["ready"] = True
+        flags["socket_existed"] = sock.exists()
+    shell = DaemonRuntime(config=cfg, registries=regs, plugins_loader=BuiltinPluginsLoader(), on_ready=_on_ready)
+    run_task = asyncio.create_task(shell.run())
+    try:
+        for _ in range(100):
+            if flags.get("ready"):
+                break
+            await asyncio.sleep(0.02)
+        assert flags.get("ready") is True
+        assert flags.get("socket_existed") is True  # socket was bound before readiness was signalled
+    finally:
+        await shell.stop()
+        await asyncio.wait_for(run_task, timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_on_ready_not_called_when_startup_fails(tmp_path: pathlib.Path):
+    sock = tmp_path / "d.sock"
+    cfg = DaemonConfig(
+        shell=ShellSettings(data_dir=str(tmp_path), log_level="warning"),
+        transports=[TransportEntry(type="http", bind=f"unix:{sock}")],
+        services=[], components=[ComponentEntry(type="boom", requires_services=[], config={})],
+    )
+    class BoomComponent:
+        name = "boom"
+        def __init__(self, **_): pass
+        async def on_start(self, ctx): raise RuntimeError("startup boom")
+        async def on_stop(self): return None
+        def health(self): return HealthStatus.STOPPED
+        def operations(self): return []
+    regs = default_registries()
+    regs.components.register("boom", lambda **cfg: BoomComponent(**cfg))
+    called = {"ready": False}
+    shell = DaemonRuntime(config=cfg, registries=regs, plugins_loader=BuiltinPluginsLoader(),
+                  on_ready=lambda: called.__setitem__("ready", True))
+    with pytest.raises(RuntimeError):
+        await shell.run()
+    assert called["ready"] is False
+
+
+@pytest.mark.asyncio
+async def test_shell_runs_and_serves_stub_component(tmp_path: pathlib.Path):
+    sock = tmp_path / "d.sock"
+    cfg = DaemonConfig(
+        shell=ShellSettings(data_dir=str(tmp_path), log_level="warning"),
+        transports=[TransportEntry(type="http", bind=f"unix:{sock}")],
+        services=[],
+        components=[ComponentEntry(type="stub", requires_services=[], config={})],
+    )
+    regs = default_registries()
+    regs.components.register("stub", lambda **cfg: StubComponent(**cfg))
+
+    shell = DaemonRuntime(config=cfg, registries=regs, plugins_loader=BuiltinPluginsLoader())
+    run_task = asyncio.create_task(shell.run())
+    try:
+        for _ in range(50):
+            if sock.exists():
+                break
+            await asyncio.sleep(0.05)
+        async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=str(sock))) as c:
+            r = await c.post("http://localhost/op/stub.ping", json={"nonce": 7})
+            assert r.status_code == 200
+            assert r.json() == {"nonce": 7}
+    finally:
+        await shell.stop()
+        await asyncio.wait_for(run_task, timeout=5.0)

--- a/app/src/context-engine/tests/integration/test_daemon_subprocess_backend.py
+++ b/app/src/context-engine/tests/integration/test_daemon_subprocess_backend.py
@@ -1,0 +1,78 @@
+import asyncio, logging, pathlib, socket, pytest
+from adapters.outbound.managed_services.subprocess_backend import SubprocessBackend
+from domain.ports.daemon.shell import ServiceSpec, ReadyProbe, HealthStatus
+from host.daemon_runtime.context import ShellContext, ServiceEndpoints
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+@pytest.fixture
+def ctx(tmp_path: pathlib.Path) -> ShellContext:
+    return ShellContext(
+        config={}, data_dir=tmp_path, logger=logging.getLogger("t"),
+        endpoints=ServiceEndpoints(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_and_probe_tcp(tmp_path: pathlib.Path, ctx):
+    port = _free_port()
+    script = tmp_path / "srv.py"
+    script.write_text(
+        "import socket, sys\n"
+        "s = socket.socket(); s.bind(('127.0.0.1', int(sys.argv[1]))); s.listen()\n"
+        "while True:\n"
+        "    c, _ = s.accept(); c.close()\n"
+    )
+    spec = ServiceSpec(
+        name="stub", backend="subprocess",
+        config={"command": ["python", str(script), str(port)]},
+        ready=ReadyProbe(kind="tcp", target=f"127.0.0.1:{port}"),
+        endpoint=f"tcp://127.0.0.1:{port}",
+    )
+    be = SubprocessBackend()
+    try:
+        await be.start(spec, ctx)
+        for _ in range(60):
+            if await be.probe(spec) is HealthStatus.READY:
+                break
+            await asyncio.sleep(0.1)
+        assert await be.probe(spec) is HealthStatus.READY
+    finally:
+        await be.stop(spec)
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_starting_before_ready(ctx, tmp_path: pathlib.Path):
+    spec = ServiceSpec(
+        name="noop", backend="subprocess",
+        config={"command": ["python", "-c", "import time; time.sleep(60)"]},
+        ready=ReadyProbe(kind="tcp", target="127.0.0.1:1"),  # unreachable
+        endpoint="tcp://127.0.0.1:1",
+    )
+    be = SubprocessBackend()
+    try:
+        await be.start(spec, ctx)
+        assert await be.probe(spec) is HealthStatus.STARTING
+    finally:
+        await be.stop(spec)
+
+
+@pytest.mark.asyncio
+async def test_stop_terminates(ctx, tmp_path: pathlib.Path):
+    spec = ServiceSpec(
+        name="x", backend="subprocess",
+        config={"command": ["python", "-c", "import time; time.sleep(60)"]},
+        ready=ReadyProbe(kind="tcp", target="127.0.0.1:1"),
+        endpoint="tcp://127.0.0.1:1",
+    )
+    be = SubprocessBackend()
+    await be.start(spec, ctx)
+    await be.stop(spec)
+    await be.stop(spec)  # double-stop must be safe

--- a/app/src/context-engine/tests/integration/test_daemon_subprocess_backend_extra.py
+++ b/app/src/context-engine/tests/integration/test_daemon_subprocess_backend_extra.py
@@ -1,0 +1,154 @@
+"""Additional subprocess backend coverage: http probe, cmd probe, degraded path."""
+from __future__ import annotations
+import asyncio, logging, pathlib, socket, subprocess, pytest
+from adapters.outbound.managed_services.subprocess_backend import SubprocessBackend, _tcp_probe
+from domain.ports.daemon.shell import ServiceSpec, ReadyProbe, HealthStatus
+from host.daemon_runtime.context import ShellContext, ServiceEndpoints
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+@pytest.fixture
+def ctx(tmp_path: pathlib.Path) -> ShellContext:
+    return ShellContext(
+        config={}, data_dir=tmp_path, logger=logging.getLogger("t"),
+        endpoints=ServiceEndpoints(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_stopped_when_no_proc(ctx):
+    be = SubprocessBackend()
+    spec = ServiceSpec(
+        name="missing", backend="subprocess",
+        config={"command": ["python", "-c", "pass"]},
+        ready=ReadyProbe(kind="tcp", target="127.0.0.1:1"),
+        endpoint="tcp://127.0.0.1:1",
+    )
+    assert await be.probe(spec) is HealthStatus.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_degraded_after_exit(ctx, tmp_path: pathlib.Path):
+    spec = ServiceSpec(
+        name="exit0", backend="subprocess",
+        config={"command": ["python", "-c", "import sys; sys.exit(0)"]},
+        ready=ReadyProbe(kind="tcp", target="127.0.0.1:1"),
+        endpoint="tcp://127.0.0.1:1",
+    )
+    be = SubprocessBackend()
+    await be.start(spec, ctx)
+    # Wait for process to exit
+    for _ in range(50):
+        proc = be._procs.get("exit0")
+        if proc and proc.returncode is not None:
+            break
+        await asyncio.sleep(0.05)
+    assert await be.probe(spec) is HealthStatus.DEGRADED
+    await be.stop(spec)
+
+
+@pytest.mark.asyncio
+async def test_probe_http_kind_returns_starting_on_no_server(ctx, tmp_path: pathlib.Path):
+    """http probe kind returns STARTING when endpoint is unreachable."""
+    spec = ServiceSpec(
+        name="httptest", backend="subprocess",
+        config={"command": ["python", "-c", "import time; time.sleep(60)"]},
+        ready=ReadyProbe(kind="http", target="http://127.0.0.1:1/health", interval_s=0.1),
+        endpoint="tcp://127.0.0.1:1",
+    )
+    be = SubprocessBackend()
+    await be.start(spec, ctx)
+    try:
+        result = await be.probe(spec)
+        assert result is HealthStatus.STARTING
+    finally:
+        await be.stop(spec)
+
+
+@pytest.mark.asyncio
+async def test_probe_cmd_kind_returns_ready_on_success(ctx, tmp_path: pathlib.Path):
+    """cmd probe kind returns READY when command exits 0."""
+    spec = ServiceSpec(
+        name="cmdtest", backend="subprocess",
+        config={"command": ["python", "-c", "import time; time.sleep(60)"]},
+        ready=ReadyProbe(kind="cmd", target="python -c pass", interval_s=2.0),
+        endpoint="tcp://127.0.0.1:1",
+    )
+    be = SubprocessBackend()
+    await be.start(spec, ctx)
+    try:
+        result = await be.probe(spec)
+        assert result is HealthStatus.READY
+    finally:
+        await be.stop(spec)
+
+
+@pytest.mark.asyncio
+async def test_probe_cmd_kind_returns_starting_on_failure(ctx, tmp_path: pathlib.Path):
+    """cmd probe kind returns STARTING when command exits non-zero."""
+    spec = ServiceSpec(
+        name="cmdfail", backend="subprocess",
+        config={"command": ["python", "-c", "import time; time.sleep(60)"]},
+        ready=ReadyProbe(kind="cmd", target="python -c import sys; sys.exit(1)", interval_s=2.0),
+        endpoint="tcp://127.0.0.1:1",
+    )
+    be = SubprocessBackend()
+    await be.start(spec, ctx)
+    try:
+        result = await be.probe(spec)
+        assert result is HealthStatus.STARTING
+    finally:
+        await be.stop(spec)
+
+
+@pytest.mark.asyncio
+async def test_probe_unknown_kind_returns_degraded(ctx, tmp_path: pathlib.Path):
+    """Unknown probe kind returns DEGRADED."""
+    spec = ServiceSpec(
+        name="unknown", backend="subprocess",
+        config={"command": ["python", "-c", "import time; time.sleep(60)"]},
+        ready=ReadyProbe(kind="unknown", target="whatever"),
+        endpoint="tcp://127.0.0.1:1",
+    )
+    be = SubprocessBackend()
+    await be.start(spec, ctx)
+    try:
+        result = await be.probe(spec)
+        assert result is HealthStatus.DEGRADED
+    finally:
+        await be.stop(spec)
+
+
+@pytest.mark.asyncio
+async def test_tcp_probe_failure_returns_false():
+    """_tcp_probe returns False when connection refused."""
+    result = await _tcp_probe("127.0.0.1", 1, timeout_s=0.1)
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_stop_already_exited_proc(ctx, tmp_path: pathlib.Path):
+    """Stopping an already-exited process must not raise."""
+    spec = ServiceSpec(
+        name="quickexit", backend="subprocess",
+        config={"command": ["python", "-c", "pass"]},
+        ready=ReadyProbe(kind="tcp", target="127.0.0.1:1"),
+        endpoint="tcp://127.0.0.1:1",
+    )
+    be = SubprocessBackend()
+    await be.start(spec, ctx)
+    # Let it exit naturally
+    for _ in range(50):
+        proc = be._procs.get("quickexit")
+        if proc and proc.returncode is not None:
+            break
+        await asyncio.sleep(0.05)
+    # Stop on already-exited process should be safe
+    await be.stop(spec)

--- a/app/src/context-engine/tests/unit/test_daemon_config.py
+++ b/app/src/context-engine/tests/unit/test_daemon_config.py
@@ -1,0 +1,37 @@
+"""build_daemon_config derives the in-code daemon manifest (no TOML file)."""
+from __future__ import annotations
+
+import pathlib
+
+from host.daemon_runtime.config import (
+    DaemonConfig, ShellSettings, TransportEntry, ServiceEntry, ComponentEntry,
+    ReadyProbeEntry, build_daemon_config,
+)
+
+
+def test_defaults_one_uds_transport_and_context_component(tmp_path: pathlib.Path):
+    cfg = build_daemon_config(tmp_path)
+    assert isinstance(cfg, DaemonConfig)
+    assert cfg.shell.data_dir == str(tmp_path)
+    assert [(t.type, t.bind) for t in cfg.transports] == [("http", f"unix:{tmp_path}/daemon.sock")]
+    assert cfg.services == []
+    assert [c.type for c in cfg.components] == ["context_graph"]
+    assert cfg.components[0].requires_services == []
+
+
+def test_custom_services_and_components_pass_through(tmp_path: pathlib.Path):
+    svc = ServiceEntry(
+        name="graph-db", backend="external",
+        config={}, ready=ReadyProbeEntry(kind="tcp", target="127.0.0.1:7687"),
+        endpoint="bolt://127.0.0.1:7687",
+    )
+    comp = ComponentEntry(type="context_graph", requires_services=["graph-db"], config={"k": "v"})
+    cfg = build_daemon_config(tmp_path, services=[svc], components=[comp], log_level="debug")
+    assert cfg.shell == ShellSettings(data_dir=str(tmp_path), log_level="debug")
+    assert cfg.services[0].name == "graph-db"
+    assert cfg.components[0].requires_services == ["graph-db"]
+
+
+def test_transport_entry_and_settings_are_frozen():
+    t = TransportEntry(type="http", bind="unix:/x/daemon.sock")
+    assert t.type == "http"

--- a/app/src/context-engine/tests/unit/test_daemon_container_backend.py
+++ b/app/src/context-engine/tests/unit/test_daemon_container_backend.py
@@ -1,0 +1,76 @@
+import asyncio, logging, pathlib, pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from adapters.outbound.managed_services.container_backend import ContainerBackend
+from domain.ports.daemon.shell import ServiceSpec, ReadyProbe
+from host.daemon_runtime.context import ShellContext, ServiceEndpoints
+
+
+@pytest.fixture
+def ctx(tmp_path: pathlib.Path) -> ShellContext:
+    return ShellContext(
+        config={}, data_dir=tmp_path, logger=logging.getLogger("t"),
+        endpoints=ServiceEndpoints(),
+    )
+
+
+def _spec(name="g") -> ServiceSpec:
+    return ServiceSpec(
+        name=name, backend="container",
+        config={"image": "alpine:latest", "ports": {"7687": 7687}, "env": {"X": "1"}},
+        ready=ReadyProbe(kind="tcp", target="127.0.0.1:7687"),
+        endpoint="bolt://127.0.0.1:7687",
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_invokes_docker_run(ctx):
+    be = ContainerBackend()
+    fake_proc = MagicMock(returncode=0)
+    fake_proc.communicate = AsyncMock(return_value=(b"abc123\n", b""))
+    with patch("adapters.outbound.managed_services.container_backend.asyncio.create_subprocess_exec",
+               new=AsyncMock(return_value=fake_proc)) as run:
+        await be.start(_spec(), ctx)
+        argv = run.await_args_list[-1].args
+        assert "docker" in argv[0] or argv[0].endswith("docker")
+        assert "run" in argv
+        assert "-d" in argv
+        assert "alpine:latest" in argv
+        assert "--rm" in argv
+        assert "--name" in argv
+        assert "potpie_g" in argv
+        # port mapping -p 7687:7687
+        assert "-p" in argv
+        assert "7687:7687" in argv
+        # env -e X=1
+        assert "-e" in argv
+        assert "X=1" in argv
+        # image is the final positional (no command in this spec)
+        assert argv[-1] == "alpine:latest"
+
+
+@pytest.mark.asyncio
+async def test_stop_invokes_docker_stop(ctx):
+    be = ContainerBackend()
+    be._containers["g"] = "abc123"
+    fake_proc = MagicMock(returncode=0)
+    fake_proc.communicate = AsyncMock(return_value=(b"", b""))
+    with patch("adapters.outbound.managed_services.container_backend.asyncio.create_subprocess_exec",
+               new=AsyncMock(return_value=fake_proc)) as run:
+        await be.stop(_spec())
+        argvs = [c.args for c in run.await_args_list]
+        flat = [tok for argv in argvs for tok in argv]
+        assert "stop" in flat
+        assert "abc123" in flat
+        assert "rm" in flat
+
+
+@pytest.mark.asyncio
+async def test_start_failure_raises(ctx):
+    be = ContainerBackend()
+    fake_proc = MagicMock(returncode=125)
+    fake_proc.communicate = AsyncMock(return_value=(b"", b"image not found"))
+    with patch("adapters.outbound.managed_services.container_backend.asyncio.create_subprocess_exec",
+               new=AsyncMock(return_value=fake_proc)):
+        with pytest.raises(RuntimeError) as ei:
+            await be.start(_spec(), ctx)
+        assert "image not found" in str(ei.value)

--- a/app/src/context-engine/tests/unit/test_daemon_seam.py
+++ b/app/src/context-engine/tests/unit/test_daemon_seam.py
@@ -1,0 +1,55 @@
+"""host.daemon.Daemon seam: in-process stand-in vs detached lifecycle (launcher faked)."""
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from domain.lifecycle import DONE, SKIPPED
+from host.daemon import Daemon
+
+
+def test_in_process_status_health_and_ensure_skips(tmp_path: pathlib.Path):
+    d = Daemon(home=tmp_path, in_process=True)
+    assert d.status()["mode"] == "in_process" and d.status()["up"] is True
+    assert d.health() == {"live": True, "mode": "in_process"}
+    res = d.ensure()
+    assert res.state == SKIPPED and res.metadata["mode"] == "in_process"
+
+
+def test_detached_ensure_starts_when_not_running(tmp_path: pathlib.Path, monkeypatch):
+    started = {}
+
+    def fake_start_detached(home, **kw):
+        started["home"] = home
+        return {"pid": 4242, "socket": str(home / "daemon.sock"), "bind": f"unix:{home}/daemon.sock"}
+
+    monkeypatch.setattr(
+        "adapters.outbound.daemon_process.launcher.start_detached", fake_start_detached
+    )
+    d = Daemon(home=tmp_path, in_process=False)
+    res = d.ensure()
+    assert res.state == DONE
+    assert res.metadata["pid"] == 4242
+    assert started["home"] == tmp_path
+
+
+def test_detached_ensure_reuses_running_daemon(tmp_path: pathlib.Path, monkeypatch):
+    # Pretend a live daemon is already recorded.
+    (tmp_path / "daemon.pid").write_text("999999\n")
+    (tmp_path / "discovery.json").write_text('{"bind": "unix:/x/daemon.sock"}')
+    monkeypatch.setattr("host.daemon._pid_alive", lambda pid: True)
+
+    def _boom(*a, **k):  # must NOT be called when already running
+        raise AssertionError("start_detached should not be called when daemon is up")
+
+    monkeypatch.setattr("adapters.outbound.daemon_process.launcher.start_detached", _boom)
+    d = Daemon(home=tmp_path, in_process=False)
+    res = d.ensure()
+    assert res.state == DONE and "already running" in (res.detail or "")
+
+
+def test_install_is_idempotent_noop(tmp_path: pathlib.Path):
+    d = Daemon(home=tmp_path, in_process=False)
+    out = d.install()
+    assert out["installed"] is False  # never raises; does not gate the installer setup step

--- a/app/src/context-engine/tests/unit/test_daemon_service_manager.py
+++ b/app/src/context-engine/tests/unit/test_daemon_service_manager.py
@@ -1,0 +1,96 @@
+import asyncio, logging, pathlib, socket, pytest
+from application.services.managed_service_manager import ServiceManager, ServiceNotFound, DependencyCycle
+from adapters.outbound.managed_services.subprocess_backend import SubprocessBackend
+from domain.ports.daemon.shell import ServiceSpec, ReadyProbe, HealthStatus, RestartPolicy
+from host.daemon_runtime.context import ShellContext, ServiceEndpoints
+from host.daemon_runtime.registry import Registry
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def _spec(name: str, cmd: list[str], port: int, deps: list[str] | None = None) -> ServiceSpec:
+    return ServiceSpec(
+        name=name, backend="subprocess",
+        config={"command": cmd},
+        ready=ReadyProbe(kind="tcp", target=f"127.0.0.1:{port}", interval_s=0.2, timeout_s=10.0),
+        endpoint=f"tcp://127.0.0.1:{port}",
+        depends_on=deps or [],
+    )
+
+
+@pytest.fixture
+def ctx(tmp_path: pathlib.Path) -> ShellContext:
+    return ShellContext(
+        config={}, data_dir=tmp_path, logger=logging.getLogger("t"),
+        endpoints=ServiceEndpoints(),
+    )
+
+
+def _backends() -> Registry:
+    r: Registry = Registry()
+    r.register("subprocess", lambda: SubprocessBackend())
+    return r
+
+
+@pytest.mark.asyncio
+async def test_up_waits_for_ready_and_registers_endpoint(tmp_path: pathlib.Path, ctx):
+    port = _free_port()
+    script = tmp_path / "srv.py"
+    script.write_text(
+        "import socket, sys\n"
+        "s = socket.socket(); s.bind(('127.0.0.1', int(sys.argv[1]))); s.listen()\n"
+        "while True:\n"
+        "    c, _ = s.accept(); c.close()\n"
+    )
+    spec = _spec("a", ["python", str(script), str(port)], port)
+    mgr = ServiceManager(specs={spec.name: spec}, backends=_backends(), ctx=ctx)
+    try:
+        await mgr.up("a")
+        assert ctx.endpoints.get("a") == f"tcp://127.0.0.1:{port}"
+        assert mgr.status("a").status is HealthStatus.READY
+    finally:
+        await mgr.down("a")
+
+
+@pytest.mark.asyncio
+async def test_dependency_order(tmp_path: pathlib.Path, ctx):
+    p1, p2 = _free_port(), _free_port()
+    script = tmp_path / "srv.py"
+    script.write_text(
+        "import socket, sys\n"
+        "s = socket.socket(); s.bind(('127.0.0.1', int(sys.argv[1]))); s.listen()\n"
+        "while True:\n"
+        "    c, _ = s.accept(); c.close()\n"
+    )
+    a = _spec("a", ["python", str(script), str(p1)], p1)
+    b = _spec("b", ["python", str(script), str(p2)], p2, deps=["a"])
+    mgr = ServiceManager(specs={"a": a, "b": b}, backends=_backends(), ctx=ctx)
+    try:
+        await mgr.up("b")     # transitively brings up "a" first
+        assert mgr.status("a").status is HealthStatus.READY
+        assert mgr.status("b").status is HealthStatus.READY
+    finally:
+        await mgr.down("b")
+        await mgr.down("a")
+
+
+@pytest.mark.asyncio
+async def test_cycle_detected(ctx):
+    a = _spec("a", ["true"], 0, deps=["b"])
+    b = _spec("b", ["true"], 0, deps=["a"])
+    mgr = ServiceManager(specs={"a": a, "b": b}, backends=_backends(), ctx=ctx)
+    with pytest.raises(DependencyCycle):
+        await mgr.up("a")
+
+
+@pytest.mark.asyncio
+async def test_unknown_service_raises(ctx):
+    mgr = ServiceManager(specs={}, backends=_backends(), ctx=ctx)
+    with pytest.raises(ServiceNotFound):
+        await mgr.up("nope")


### PR DESCRIPTION
**Stack 2/3** · base `pr/1-daemon-core` (#842) · 29 files

Replaces the stub `host.daemon.Daemon` with a **real detached daemon process**, behind the seam that already exists on trunk. In-process stays the default — trunk behavior is unchanged; the daemon path opts in via `--daemon`/`$CONTEXT_ENGINE_HOST_MODE`.

- `host/daemon_runtime/` — `DaemonRuntime` (transports + components + services loop), in-code `DaemonConfig` (no TOML), and the `python -m host.daemon_runtime` child entrypoint
- `application` + `adapters` — `ServiceManager`; subprocess/container/external service backends; HTTP-over-UDS transport (generic `/op` dispatch); detached launcher; UDS IPC client
- `host/daemon.py` — real `start/stop/restart/status/health/ensure` bodies (the `daemon` setup step becomes hard + executed when detached)
- `bootstrap/host_wiring` — `default_host_mode()`; `Daemon(in_process=…)`
- CLI — `daemon start`, new `service` group, `setup --daemon/--in-process`; errors surfaced via the `fail()` contract (no tracebacks)

**Tests:** managed-services, transport, runtime, lifecycle, daemon seam — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)