### PR TITLE
feat(daemon): serve context.* over the daemon, delegating to HostShell (3/3)

### DIFF
--- a/app/src/context-engine/adapters/inbound/shell_component/batch_worker.py
+++ b/app/src/context-engine/adapters/inbound/shell_component/batch_worker.py
@@ -1,0 +1,48 @@
+"""In-process background worker for context-graph batch processing.
+
+Generic loop: each tick runs flush(windowed) -> claim+process one batch -> reap(stale).
+The durable queue is the relational batch table, so no external broker is needed. The
+three steps are injected as async callables, so this worker is decoupled from the concrete
+reconciliation use-cases (which require a built container + DB session). The component
+starts this once that wiring lands.
+"""
+from __future__ import annotations
+import asyncio
+import logging
+from typing import Awaitable, Callable
+
+logger = logging.getLogger("context_graph.batch_worker")
+
+
+class BatchWorker:
+    def __init__(
+        self,
+        *,
+        flush_windowed: Callable[[], Awaitable[None]],
+        claim_one: Callable[[], Awaitable[str | None]],
+        reap_stale: Callable[[], Awaitable[None]],
+        poll_interval_s: float = 1.0,
+    ) -> None:
+        self._flush = flush_windowed
+        self._claim = claim_one
+        self._reap = reap_stale
+        self._poll = poll_interval_s
+        self._stop = asyncio.Event()
+
+    async def run_forever(self) -> None:
+        while not self._stop.is_set():
+            claimed: str | None = None
+            try:
+                await self._flush()
+                claimed = await self._claim()
+                await self._reap()
+            except Exception:  # noqa: BLE001 — a transient step failure must not kill the loop
+                logger.warning("batch worker tick failed", exc_info=True)
+            if not claimed:
+                try:
+                    await asyncio.wait_for(self._stop.wait(), timeout=self._poll)
+                except asyncio.TimeoutError:
+                    pass
+
+    async def stop(self) -> None:
+        self._stop.set()

--- a/app/src/context-engine/adapters/inbound/shell_component/component.py
+++ b/app/src/context-engine/adapters/inbound/shell_component/component.py
@@ -1,0 +1,98 @@
+"""ContextGraphComponent — exposes the context-engine agent surface under the daemon shell.
+
+The detached daemon runs this component; its four operations (``context.resolve``/``search``/
+``record``/``status``) delegate to the in-process ``HostShell.agent_context`` handed in via
+``ShellContext.config["deps"]``. So the CLI path (``potpie resolve`` in-process) and the daemon
+path (``context.resolve`` over the socket) terminate at the *same* ``AgentContextPort``.
+"""
+from __future__ import annotations
+import logging
+from typing import Any
+
+from domain.ports.daemon.shell import HealthStatus
+from host.daemon_runtime.context import ShellContext
+from domain.ports.daemon.operations import OperationError, OperationSpec
+
+logger = logging.getLogger("context_graph.component")
+
+
+class ContextGraphComponent:
+    name = "context_graph"
+
+    def __init__(self, *, graph: str | None = None, relational: str | None = None, **extra: Any) -> None:
+        self._graph_ref = graph
+        self._relational_ref = relational
+        self._extra = extra
+        self._ctx: ShellContext | None = None
+        self._host: Any = None  # HostShell, from ctx.config["deps"]
+        self._graph_endpoint: str | None = None
+        self._relational_url: str | None = None
+        self._status: HealthStatus = HealthStatus.STOPPED
+
+    async def on_start(self, ctx: ShellContext) -> None:
+        self._ctx = ctx
+        self._status = HealthStatus.STARTING
+        self._host = (ctx.config or {}).get("deps")
+        # Optional managed-service refs: "service:<name>" -> endpoint; any other value passes through.
+        if self._graph_ref:
+            self._graph_endpoint = ctx.endpoints.resolve(self._graph_ref)
+        if self._relational_ref:
+            self._relational_url = ctx.endpoints.resolve(self._relational_ref)
+        logger.info(
+            "context_graph ready (host=%s, graph=%s, relational=%s)",
+            type(self._host).__name__ if self._host else None,
+            self._graph_endpoint, self._relational_url,
+        )
+        self._status = HealthStatus.READY
+
+    async def on_stop(self) -> None:
+        self._status = HealthStatus.STOPPED
+
+    def health(self) -> HealthStatus:
+        return self._status
+
+    # --- host access used by the ops ---------------------------------------
+    @property
+    def agent_context(self):
+        if self._host is None:
+            raise OperationError(
+                "unavailable",
+                "context host not wired",
+                recommended_next_action="start the daemon via `potpie daemon start`",
+            )
+        return self._host.agent_context
+
+    def resolve_pot_id(self, explicit: str | None) -> str:
+        """Resolve an explicit pot ref → id, else the active pot. Raises if none."""
+        if self._host is None:
+            raise OperationError(
+                "unavailable",
+                "context host not wired",
+                recommended_next_action="start the daemon via `potpie daemon start`",
+            )
+        pots = self._host.pots
+        if explicit:
+            for pot in pots.list_pots():
+                if explicit in (pot.pot_id, pot.name):
+                    return pot.pot_id
+            raise OperationError("not_found", f"no pot matching {explicit!r}")
+        active = pots.active_pot()
+        if active is None:
+            raise OperationError(
+                "not_found",
+                "no active pot",
+                recommended_next_action="run `potpie setup` or `potpie pot create`",
+            )
+        return active.pot_id
+
+    def operations(self) -> list[OperationSpec]:
+        from adapters.inbound.shell_component.ops_resolve import build_op as _resolve
+        from adapters.inbound.shell_component.ops_search import build_op as _search
+        from adapters.inbound.shell_component.ops_record import build_op as _record
+        from adapters.inbound.shell_component.ops_status import build_op as _status
+        return [_resolve(self), _search(self), _record(self), _status(self)]
+
+
+def register(registry) -> None:
+    """Entry point for ``potpie.shell.components``: register the context_graph factory."""
+    registry.register("context_graph", lambda **cfg: ContextGraphComponent(**cfg))

--- a/app/src/context-engine/adapters/inbound/shell_component/ops_record.py
+++ b/app/src/context-engine/adapters/inbound/shell_component/ops_record.py
@@ -1,0 +1,53 @@
+"""context.record operation — delegates to HostShell.agent_context.record."""
+from __future__ import annotations
+import asyncio
+from typing import Any
+from pydantic import BaseModel, Field
+from domain.ports.daemon.operations import OperationSpec, OperationContext, AuthRequirement
+from domain.ports.agent_context import RecordRequest
+
+
+class ContextRecordInput(BaseModel):
+    type: str = Field(..., description="Record type (fix, preference, decision, ...).")
+    summary: str = Field(..., description="One-line durable memory.")
+    details: dict[str, Any] = Field(default_factory=dict)
+    scope: dict[str, Any] = Field(default_factory=dict)
+    source_refs: list[str] = Field(default_factory=list)
+    idempotency_key: str | None = None
+    pot_id: str | None = None
+
+
+class RecordResult(BaseModel):
+    record_id: str | None = None
+    accepted: bool = True
+    status: str = "recorded"
+    mutations_applied: int = 0
+    detail: str | None = None
+
+
+def build_op(component) -> OperationSpec:
+    async def handler(inp: ContextRecordInput, ctx: OperationContext) -> RecordResult:
+        pot_id = component.resolve_pot_id(inp.pot_id)
+        req = RecordRequest(
+            pot_id=pot_id,
+            record_type=inp.type,
+            summary=inp.summary,
+            details=inp.details,
+            scope=inp.scope,
+            source_refs=tuple(inp.source_refs),
+            idempotency_key=inp.idempotency_key,
+        )
+        receipt = await asyncio.to_thread(component.agent_context.record, req)
+        return RecordResult(
+            record_id=receipt.record_id,
+            accepted=receipt.accepted,
+            status=receipt.status,
+            mutations_applied=receipt.mutations_applied,
+            detail=receipt.detail,
+        )
+
+    return OperationSpec(
+        name="context.record", input_model=ContextRecordInput, output_model=RecordResult,
+        handler=handler, summary="Durable project-memory write.",
+        mutating=True, auth=AuthRequirement.REQUIRED,
+    )

--- a/app/src/context-engine/adapters/inbound/shell_component/ops_resolve.py
+++ b/app/src/context-engine/adapters/inbound/shell_component/ops_resolve.py
@@ -1,0 +1,84 @@
+"""context.resolve operation — delegates to HostShell.agent_context.resolve."""
+from __future__ import annotations
+import asyncio
+from typing import Any
+from pydantic import BaseModel, Field
+from domain.ports.daemon.operations import OperationSpec, OperationContext, AuthRequirement
+from domain.ports.agent_context import ResolveRequest
+
+
+class ResolveInput(BaseModel):
+    task: str = Field(..., description="Task description / agent prompt.")
+    intent: str = Field("feature", description="Task shape (feature/debugging/review/...).")
+    include: list[str] = Field(default_factory=list, description="Evidence families to retrieve.")
+    scope: dict[str, Any] = Field(default_factory=dict)
+    mode: str = "fast"
+    source_policy: str = "references_only"
+    pot_id: str | None = None
+
+
+class WireEvidenceItem(BaseModel):
+    include: str
+    score: float = 0.0
+    payload: dict = Field(default_factory=dict)
+
+
+class WireCoverage(BaseModel):
+    include: str
+    status: str
+
+
+class WireUnsupported(BaseModel):
+    name: str
+    reason: str
+
+
+class AgentEnvelope(BaseModel):
+    """Wire shape of the canonical agent envelope (mirrors domain.agent_envelope.AgentEnvelope)."""
+    pot_id: str | None = None
+    intent: str | None = None
+    overall_confidence: str = "unknown"
+    items: list[WireEvidenceItem] = Field(default_factory=list)
+    coverage: list[WireCoverage] = Field(default_factory=list)
+    unsupported_includes: list[WireUnsupported] = Field(default_factory=list)
+    metadata: dict = Field(default_factory=dict)
+
+
+def to_wire_envelope(env) -> AgentEnvelope:
+    """Translate a domain ``AgentEnvelope`` into the wire shape."""
+    return AgentEnvelope(
+        pot_id=env.pot_id,
+        intent=env.intent,
+        overall_confidence=env.overall_confidence,
+        items=[
+            WireEvidenceItem(include=i.include, score=i.score, payload=dict(i.payload))
+            for i in env.items
+        ],
+        coverage=[WireCoverage(include=c.include, status=c.status) for c in env.coverage],
+        unsupported_includes=[
+            WireUnsupported(name=u.name, reason=u.reason) for u in env.unsupported_includes
+        ],
+        metadata=dict(env.metadata),
+    )
+
+
+def build_op(component) -> OperationSpec:
+    async def handler(inp: ResolveInput, ctx: OperationContext) -> AgentEnvelope:
+        pot_id = component.resolve_pot_id(inp.pot_id)
+        req = ResolveRequest(
+            pot_id=pot_id,
+            task=inp.task,
+            intent=inp.intent or None,
+            include=tuple(inp.include),
+            scope=inp.scope,
+            mode=inp.mode,
+            source_policy=inp.source_policy,
+        )
+        env = await asyncio.to_thread(component.agent_context.resolve, req)
+        return to_wire_envelope(env)
+
+    return OperationSpec(
+        name="context.resolve", input_model=ResolveInput, output_model=AgentEnvelope,
+        handler=handler, summary="Resolve bounded task context.",
+        mutating=False, auth=AuthRequirement.REQUIRED,
+    )

--- a/app/src/context-engine/adapters/inbound/shell_component/ops_search.py
+++ b/app/src/context-engine/adapters/inbound/shell_component/ops_search.py
@@ -1,0 +1,36 @@
+"""context.search operation — delegates to HostShell.agent_context.search."""
+from __future__ import annotations
+import asyncio
+from typing import Any
+from pydantic import BaseModel, Field
+from domain.ports.daemon.operations import OperationSpec, OperationContext, AuthRequirement
+from domain.ports.agent_context import SearchRequest
+from adapters.inbound.shell_component.ops_resolve import AgentEnvelope, to_wire_envelope
+
+
+class SearchInput(BaseModel):
+    lookup: str = Field(..., description="Targeted lookup string.")
+    include: list[str] = Field(default_factory=list)
+    scope: dict[str, Any] = Field(default_factory=dict)
+    mode: str = "fast"
+    pot_id: str | None = None
+
+
+def build_op(component) -> OperationSpec:
+    async def handler(inp: SearchInput, ctx: OperationContext) -> AgentEnvelope:
+        pot_id = component.resolve_pot_id(inp.pot_id)
+        req = SearchRequest(
+            pot_id=pot_id,
+            query=inp.lookup,
+            include=tuple(inp.include),
+            scope=inp.scope,
+            mode=inp.mode,
+        )
+        env = await asyncio.to_thread(component.agent_context.search, req)
+        return to_wire_envelope(env)
+
+    return OperationSpec(
+        name="context.search", input_model=SearchInput, output_model=AgentEnvelope,
+        handler=handler, summary="Targeted context lookup.",
+        mutating=False, auth=AuthRequirement.REQUIRED,
+    )

--- a/app/src/context-engine/adapters/inbound/shell_component/ops_status.py
+++ b/app/src/context-engine/adapters/inbound/shell_component/ops_status.py
@@ -1,0 +1,64 @@
+"""context.status operation — delegates to HostShell.agent_context.status."""
+from __future__ import annotations
+import asyncio
+from typing import Any
+from pydantic import BaseModel, Field
+from domain.ports.daemon.operations import OperationSpec, OperationContext, AuthRequirement
+from domain.ports.agent_context import StatusRequest
+
+
+class ContextStatusInput(BaseModel):
+    intent: str | None = None
+    harness: str | None = None
+    pot_id: str | None = None
+
+
+class SkillNudge(BaseModel):
+    agent: str | None = None
+    missing: list[str] = Field(default_factory=list)
+    outdated: list[str] = Field(default_factory=list)
+    install_command: str | None = None
+
+
+class StatusReport(BaseModel):
+    pot_id: str | None = None
+    profile: str | None = None
+    daemon_up: bool = True
+    active_pot: str | None = None
+    backend_ready: bool = False
+    data_plane: dict[str, Any] = Field(default_factory=dict)
+    pot_summary: dict[str, Any] = Field(default_factory=dict)
+    skills: SkillNudge | None = None
+    recommended_next_action: str | None = None
+
+
+def build_op(component) -> OperationSpec:
+    async def handler(inp: ContextStatusInput, ctx: OperationContext) -> StatusReport:
+        pot_id = component.resolve_pot_id(inp.pot_id)
+        req = StatusRequest(pot_id=pot_id, intent=inp.intent, harness=inp.harness)
+        report = await asyncio.to_thread(component.agent_context.status, req)
+        skills = None
+        if report.skills is not None:
+            skills = SkillNudge(
+                agent=report.skills.agent,
+                missing=list(report.skills.missing),
+                outdated=list(report.skills.outdated),
+                install_command=report.skills.install_command,
+            )
+        return StatusReport(
+            pot_id=report.pot_id,
+            profile=report.profile,
+            daemon_up=report.daemon_up,
+            active_pot=report.active_pot,
+            backend_ready=report.backend_ready,
+            data_plane=dict(report.data_plane),
+            pot_summary=dict(report.pot_summary),
+            skills=skills,
+            recommended_next_action=report.recommended_next_action,
+        )
+
+    return OperationSpec(
+        name="context.status", input_model=ContextStatusInput, output_model=StatusReport,
+        handler=handler, summary="Health, readiness, freshness, and skills.",
+        mutating=False, auth=AuthRequirement.NONE,
+    )

--- a/app/src/context-engine/pyproject.toml
+++ b/app/src/context-engine/pyproject.toml
@@ -70,6 +70,11 @@ dev = [
 potpie = "adapters.inbound.cli.host_cli:main"
 potpie-mcp = "adapters.inbound.mcp.server:main"
 
+# Daemon-shell components loaded by the detached daemon's runtime
+# (host.daemon_runtime.EntryPointPluginsLoader).
+[project.entry-points."potpie.shell.components"]
+context_graph = "adapters.inbound.shell_component.component:register"
+
 [tool.hatch.build.targets.wheel]
 packages = ["domain", "application", "adapters", "bootstrap", "benchmarks", "host"]
 include = [

--- a/app/src/context-engine/tests/integration/test_daemon_lifecycle_e2e.py
+++ b/app/src/context-engine/tests/integration/test_daemon_lifecycle_e2e.py
@@ -1,0 +1,58 @@
+"""End-to-end: the real detached daemon starts, serves the context ops over UDS, and stops.
+
+Exercises the dissolved daemon path: launcher.start_detached spawns ``host.daemon_runtime``
+(which builds a real HostShell), the http transport serves the registered context_graph
+component, and stop_daemon tears it down cleanly. Replaces potpied's CLI-app readiness/e2e
+tests, which targeted the old standalone ``potpie init/daemon`` typer apps.
+"""
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from adapters.outbound.daemon_process.launcher import start_detached, stop_daemon, DaemonStartError
+from adapters.outbound.daemon_process.ipc_client import client_for
+
+
+@pytest.mark.integration
+def test_detached_daemon_starts_serves_and_stops(tmp_path: pathlib.Path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("CONTEXT_ENGINE_HOME", str(home))
+    monkeypatch.setenv("CONTEXT_ENGINE_HOST_MODE", "in_process")  # child hosts in-process
+
+    info = start_detached(home, ready_timeout_s=60.0)
+    try:
+        assert info["pid"] > 0
+        assert info["socket"] == str(home / "daemon.sock")
+        assert (home / "discovery.json").exists()
+        assert (home / "daemon.pid").exists()
+
+        with client_for(home) as c:
+            ops = c.get("/op").json()["operations"]
+            assert set(ops) == {
+                "context.resolve", "context.search", "context.record", "context.status",
+            }
+            assert c.get("/admin/health").json()["status"] == "ready"
+    finally:
+        msg = stop_daemon(home)
+
+    assert msg == "daemon stopped"
+    assert not (home / "daemon.pid").exists()
+    assert not (home / "daemon.sock").exists()
+
+
+@pytest.mark.integration
+def test_start_detached_rejects_double_start(tmp_path: pathlib.Path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("CONTEXT_ENGINE_HOME", str(home))
+    monkeypatch.setenv("CONTEXT_ENGINE_HOST_MODE", "in_process")
+
+    start_detached(home, ready_timeout_s=60.0)
+    try:
+        with pytest.raises(DaemonStartError, match="already running"):
+            start_detached(home, ready_timeout_s=5.0)
+    finally:
+        stop_daemon(home)

--- a/app/src/context-engine/tests/unit/test_daemon_shell_component.py
+++ b/app/src/context-engine/tests/unit/test_daemon_shell_component.py
@@ -1,0 +1,168 @@
+"""ContextGraphComponent + ops: delegate to HostShell.agent_context, translate to wire shapes."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import pathlib
+from types import SimpleNamespace
+
+import pytest
+
+from adapters.inbound.shell_component.component import ContextGraphComponent, register
+from host.daemon_runtime.context import ShellContext, ServiceEndpoints
+from host.daemon_runtime.registry import Registry
+from domain.ports.daemon.operations import OperationContext, OperationError, Principal
+from domain.ports.daemon.shell import HealthStatus
+from domain.agent_envelope import AgentEnvelope, EvidenceItem, CoverageReport, UnsupportedInclude
+from domain.ports.agent_context import RecordReceipt, StatusReport, SkillNudge
+
+
+# --- fakes -----------------------------------------------------------------
+class FakeAgentContext:
+    def __init__(self):
+        self.calls = []
+
+    def resolve(self, req):
+        self.calls.append(("resolve", req))
+        return AgentEnvelope(
+            pot_id=req.pot_id, intent=req.intent or "feature",
+            items=(EvidenceItem(include="prior_bugs", candidate_key="c1", score=0.9,
+                                payload={"fact": "x"}, coverage_status="complete"),),
+            coverage=(CoverageReport(include="prior_bugs", status="complete", candidate_pool=1),),
+            unsupported_includes=(UnsupportedInclude(name="weird", reason="unknown"),),
+            overall_confidence="high",
+        )
+
+    def search(self, req):
+        self.calls.append(("search", req))
+        return AgentEnvelope(pot_id=req.pot_id, intent="feature", items=(), coverage=())
+
+    def record(self, req):
+        self.calls.append(("record", req))
+        return RecordReceipt(pot_id=req.pot_id, record_type=req.record_type, accepted=True,
+                             record_id="rec_1", status="recorded", mutations_applied=2)
+
+    def status(self, req):
+        self.calls.append(("status", req))
+        return StatusReport(pot_id=req.pot_id, profile="local", daemon_up=True,
+                            active_pot="default", backend_ready=True,
+                            skills=SkillNudge(agent="claude", missing=("a",)),
+                            recommended_next_action="go")
+
+
+def _fake_host():
+    pots = SimpleNamespace(
+        active_pot=lambda: SimpleNamespace(pot_id="pot_x", name="default"),
+        list_pots=lambda: [SimpleNamespace(pot_id="pot_x", name="default")],
+    )
+    return SimpleNamespace(agent_context=FakeAgentContext(), pots=pots)
+
+
+async def _started_component(host) -> ContextGraphComponent:
+    comp = ContextGraphComponent()
+    ctx = ShellContext(config={"deps": host}, data_dir=pathlib.Path("/tmp"),
+                       logger=logging.getLogger("t"), endpoints=ServiceEndpoints())
+    await comp.on_start(ctx)
+    return comp
+
+
+def _octx():
+    return OperationContext(principal=Principal(name="local"), request_id="r1")
+
+
+# --- tests -----------------------------------------------------------------
+def test_register_adds_factory():
+    reg = Registry()
+    register(reg)
+    assert "context_graph" in reg.names()
+    assert reg.create("context_graph").name == "context_graph"
+
+
+@pytest.mark.asyncio
+async def test_component_lifecycle_and_ops_list():
+    comp = await _started_component(_fake_host())
+    assert comp.health() is HealthStatus.READY
+    assert [o.name for o in comp.operations()] == [
+        "context.resolve", "context.search", "context.record", "context.status",
+    ]
+    await comp.on_stop()
+    assert comp.health() is HealthStatus.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_resolve_delegates_and_translates():
+    host = _fake_host()
+    comp = await _started_component(host)
+    op = next(o for o in comp.operations() if o.name == "context.resolve")
+    inp = op.input_model(task="fix login", intent="debugging", include=["prior_bugs"])
+    out = await op.handler(inp, _octx())
+    assert host.agent_context.calls[0][0] == "resolve"
+    assert out.pot_id == "pot_x" and out.intent == "debugging"
+    assert out.overall_confidence == "high"
+    assert out.items[0].include == "prior_bugs" and out.items[0].payload["fact"] == "x"
+    assert out.coverage[0].status == "complete"
+    assert out.unsupported_includes[0].name == "weird"
+
+
+@pytest.mark.asyncio
+async def test_search_delegates():
+    host = _fake_host()
+    comp = await _started_component(host)
+    op = next(o for o in comp.operations() if o.name == "context.search")
+    out = await op.handler(op.input_model(lookup="OrderService"), _octx())
+    assert host.agent_context.calls[0][0] == "search"
+    assert out.pot_id == "pot_x"
+
+
+@pytest.mark.asyncio
+async def test_record_delegates_and_translates():
+    host = _fake_host()
+    comp = await _started_component(host)
+    op = next(o for o in comp.operations() if o.name == "context.record")
+    out = await op.handler(op.input_model(type="fix", summary="patched"), _octx())
+    assert host.agent_context.calls[0][0] == "record"
+    assert out.record_id == "rec_1" and out.status == "recorded" and out.mutations_applied == 2
+
+
+@pytest.mark.asyncio
+async def test_status_delegates_and_translates():
+    host = _fake_host()
+    comp = await _started_component(host)
+    op = next(o for o in comp.operations() if o.name == "context.status")
+    out = await op.handler(op.input_model(), _octx())
+    assert host.agent_context.calls[0][0] == "status"
+    assert out.daemon_up is True and out.active_pot == "default" and out.backend_ready is True
+    assert out.skills.agent == "claude" and out.skills.missing == ["a"]
+
+
+@pytest.mark.asyncio
+async def test_explicit_pot_id_is_resolved_by_name():
+    host = _fake_host()
+    comp = await _started_component(host)
+    op = next(o for o in comp.operations() if o.name == "context.resolve")
+    await op.handler(op.input_model(task="t", pot_id="default"), _octx())
+    # the request the host saw carried the resolved id, not the name
+    assert host.agent_context.calls[0][1].pot_id == "pot_x"
+
+
+@pytest.mark.asyncio
+async def test_no_active_pot_raises_operation_error():
+    host = _fake_host()
+    host.pots.active_pot = lambda: None
+    comp = await _started_component(host)
+    op = next(o for o in comp.operations() if o.name == "context.status")
+    with pytest.raises(OperationError) as ei:
+        await op.handler(op.input_model(), _octx())
+    assert ei.value.code == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_unwired_host_raises_on_op():
+    comp = ContextGraphComponent()
+    ctx = ShellContext(config={}, data_dir=pathlib.Path("/tmp"),
+                       logger=logging.getLogger("t"), endpoints=ServiceEndpoints())
+    await comp.on_start(ctx)  # no deps wired
+    op = next(o for o in comp.operations() if o.name == "context.status")
+    with pytest.raises(OperationError) as ei:
+        await op.handler(op.input_model(), _octx())
+    assert ei.value.code == "unavailable"


### PR DESCRIPTION
**Stack 3/3** · base `pr/2-services-shell-cli` (#843) · 10 files

Adds the `context_graph` daemon component: `context.{resolve,search,record,status}` ops **delegate to `HostShell.agent_context`** and translate the domain results to the wire shape. Registered via the `potpie.shell.components` entry point so the detached daemon loads it.

So the CLI path (in-process) and the daemon path (over the Unix socket) terminate at the **same `AgentContextPort`** — no second implementation.

Includes the real **start → serve → stop** end-to-end integration test (spawns the daemon, calls `context.*` over UDS, asserts clean teardown).

**Verified end-to-end:** `potpie setup --daemon` provisions a genuinely running daemon serving real context data over the socket; idempotent re-run reuses it; failure paths (bad config, child crash, unready service, double-start) fail fast and surface the cause with no leftover process. A manual testing guide lives at `app/src/context-engine/docs/daemon/manual-testing.md` (local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)