### PR TITLE
feat(debug-agent): VS Code DAP debug loop with hypothesis-driven workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,11 @@ else
   SANDBOX_OVERRIDE :=
 endif
 
+# Process log level for the gunicorn/celery CLIs (distinct from the app's LOG_LEVEL
+# env, which drives loguru). Default `info` keeps the dev terminal readable; override
+# with e.g. `make dev-hatchet PROC_LOG_LEVEL=debug` when you need framework noise.
+PROC_LOG_LEVEL ?= info
+
 # Load .env (and .env.daytona.local / .env.hatchet.local if present, written by
 # `make daytona-up` / `make hatchet-up`). Inline assignments after this line
 # override what was sourced.
@@ -82,9 +87,9 @@ dev: env-check infra-up sync migrate sandbox-prep ## Start infra, sync deps, mig
 	$(SET_CELERY_Q) \
 	echo "─── starting API (gunicorn) and Celery worker ───"; \
 	$(SANDBOX_OVERRIDE) gunicorn --worker-class uvicorn.workers.UvicornWorker --workers 1 \
-	  --timeout 1800 --bind 0.0.0.0:8001 --log-level debug app.main:app & \
+	  --timeout 1800 --bind 0.0.0.0:8001 --log-level $(PROC_LOG_LEVEL) app.main:app & \
 	GUNICORN_PID=$$!; \
-	$(SANDBOX_OVERRIDE) celery -A app.celery.celery_app worker --loglevel=debug \
+	$(SANDBOX_OVERRIDE) celery -A app.celery.celery_app worker --loglevel=$(PROC_LOG_LEVEL) \
 	  -Q "$$CELERY_Q" -E --concurrency=1 --pool=solo & \
 	CELERY_PID=$$!; \
 	trap 'kill -TERM $$GUNICORN_PID $$CELERY_PID 2>/dev/null || true; \
@@ -142,9 +147,9 @@ dev-hatchet: env-check infra-up hatchet-up sync migrate sandbox-prep ## Like `de
 	export AGENT_TASK_BACKEND=hatchet; \
 	echo "─── starting API + Celery worker + Hatchet agent worker (AGENT_TASK_BACKEND=hatchet) ───"; \
 	$(SANDBOX_OVERRIDE) gunicorn --worker-class uvicorn.workers.UvicornWorker --workers 1 \
-	  --timeout 1800 --bind 0.0.0.0:8001 --log-level debug app.main:app & \
+	  --timeout 1800 --bind 0.0.0.0:8001 --log-level $(PROC_LOG_LEVEL) app.main:app & \
 	GUNICORN_PID=$$!; \
-	$(SANDBOX_OVERRIDE) celery -A app.celery.celery_app worker --loglevel=debug \
+	$(SANDBOX_OVERRIDE) celery -A app.celery.celery_app worker --loglevel=$(PROC_LOG_LEVEL) \
 	  -Q "$$CELERY_Q" -E --concurrency=1 --pool=solo & \
 	CELERY_PID=$$!; \
 	$(SANDBOX_OVERRIDE) uv run python -m app.modules.intelligence.agents.hatchet_worker & \
@@ -180,10 +185,10 @@ migration-history: ## Show alembic history
 
 api: ## Run only the FastAPI server (assumes infra is up). Honors SANDBOX=...
 	@$(LOAD_ENV) $(SANDBOX_OVERRIDE) uv run gunicorn --worker-class uvicorn.workers.UvicornWorker \
-	  --workers 1 --timeout 1800 --bind 0.0.0.0:8001 --log-level debug app.main:app
+	  --workers 1 --timeout 1800 --bind 0.0.0.0:8001 --log-level $(PROC_LOG_LEVEL) app.main:app
 
 worker: ## Run only the Celery worker (assumes infra is up). Honors SANDBOX=...
-	@$(LOAD_ENV) $(SET_CELERY_Q) $(SANDBOX_OVERRIDE) uv run celery -A app.celery.celery_app worker --loglevel=debug \
+	@$(LOAD_ENV) $(SET_CELERY_Q) $(SANDBOX_OVERRIDE) uv run celery -A app.celery.celery_app worker --loglevel=$(PROC_LOG_LEVEL) \
 	  -Q "$$CELERY_Q" -E --concurrency=1 --pool=solo
 
 stop: ## Kill API + worker processes and stop infra

--- a/app/modules/conversations/conversations_router.py
+++ b/app/modules/conversations/conversations_router.py
@@ -213,6 +213,12 @@ class ConversationAPI:
         # Check User-Agent header for local mode (same as regenerate_last_message)
         user_agent = http_request.headers.get("user-agent", "")
         local_mode = _is_vscode_extension_user_agent(user_agent)
+        logger.info(
+            "[DEBUG router] post_message user_agent={!r} local_mode={} conversation_id={}",
+            user_agent,
+            local_mode,
+            conversation_id,
+        )
 
         # Validate message content
         if content == "" or content is None or content.isspace():

--- a/app/modules/conversations/conversations_router.py
+++ b/app/modules/conversations/conversations_router.py
@@ -214,7 +214,7 @@ class ConversationAPI:
         user_agent = http_request.headers.get("user-agent", "")
         local_mode = _is_vscode_extension_user_agent(user_agent)
         logger.info(
-            "[DEBUG router] post_message user_agent={!r} local_mode={} conversation_id={}",
+            "[DEBUG router] post_message user_agent=%r local_mode=%s conversation_id=%s",
             user_agent,
             local_mode,
             conversation_id,

--- a/app/modules/conversations/utils/conversation_routing.py
+++ b/app/modules/conversations/utils/conversation_routing.py
@@ -286,51 +286,72 @@ async def start_celery_task_and_stream(
     Start a background agent task on the selected backend and return a stream.
     Uses async Redis so the event loop is not blocked.
     """
-    # Set initial "queued" status before starting the task
-    await async_redis_manager.set_task_status(conversation_id, run_id, "queued")
+    # `cursor` set ⇒ the client is reconnecting to replay an existing run's stream, so do
+    # NOT start another backend task. Re-dispatching on reconnect is harmless for Celery
+    # (the task dies with the request) but spawns duplicate *durable* Hatchet runs that
+    # keep executing and interleave into the same Redis stream. Mirror the router's
+    # `if not cursor` run_id guard: only a fresh request starts a new run.
+    if cursor is None:
+        # Set initial "queued" status before starting the task
+        await async_redis_manager.set_task_status(conversation_id, run_id, "queued")
 
-    # Publish a queued event so the client knows the task is accepted
-    await async_redis_manager.publish_event(
-        conversation_id,
-        run_id,
-        "queued",
-        {
-            "status": "queued",
-            "message": "Task queued for processing",
-        },
-    )
+        # Publish a queued event so the client knows the task is accepted
+        await async_redis_manager.publish_event(
+            conversation_id,
+            run_id,
+            "queued",
+            {
+                "status": "queued",
+                "message": "Task queued for processing",
+            },
+        )
 
-    # Route to the selected backend (celery default, hatchet for allowlisted agents)
-    await _dispatch_agent_run(
-        conversation_id=conversation_id,
-        run_id=run_id,
-        user_id=user_id,
-        query=query,
-        agent_id=agent_id,
-        node_ids=node_ids,
-        attachment_ids=attachment_ids,
-        async_redis_manager=async_redis_manager,
-        local_mode=local_mode,
-        tunnel_url=tunnel_url,
-    )
+        # Route to the selected backend (celery default, hatchet for allowlisted agents)
+        await _dispatch_agent_run(
+            conversation_id=conversation_id,
+            run_id=run_id,
+            user_id=user_id,
+            query=query,
+            agent_id=agent_id,
+            node_ids=node_ids,
+            attachment_ids=attachment_ids,
+            async_redis_manager=async_redis_manager,
+            local_mode=local_mode,
+            tunnel_url=tunnel_url,
+        )
 
-    # Wait for task to reach any terminal or active state (avoids blocking 30s if task goes straight to completed/error)
-    task_started = await async_redis_manager.wait_for_task_start(
-        conversation_id, run_id, timeout=30, require_running=False
-    )
-    if task_started:
-        status = await async_redis_manager.get_task_status(conversation_id, run_id)
-        if status in ("completed", "error"):
-            logger.info(
-                f"Task already {status} for {conversation_id}:{run_id} - stream will contain result"
-            , status=status, conversation_id=conversation_id, run_id=run_id)
-    logger.info(
-        f"Task start check done for {conversation_id}:{run_id} (started={task_started})"
-    , conversation_id=conversation_id, run_id=run_id, task_started=task_started)
-    if not task_started:
-        logger.warning(
-            f"Background task failed to start within 30s for {conversation_id}:{run_id} - may still be queued"
-        , conversation_id=conversation_id, run_id=run_id)
+        # Wait for task to reach any terminal or active state (avoids blocking 30s if task goes straight to completed/error)
+        task_started = await async_redis_manager.wait_for_task_start(
+            conversation_id, run_id, timeout=30, require_running=False
+        )
+        if task_started:
+            status = await async_redis_manager.get_task_status(conversation_id, run_id)
+            if status in ("completed", "error"):
+                logger.info(
+                    f"Task already {status} for {conversation_id}:{run_id} - stream will contain result",
+                    status=status,
+                    conversation_id=conversation_id,
+                    run_id=run_id,
+                )
+        logger.info(
+            f"Task start check done for {conversation_id}:{run_id} (started={task_started})",
+            conversation_id=conversation_id,
+            run_id=run_id,
+            task_started=task_started,
+        )
+        if not task_started:
+            logger.warning(
+                f"Background task failed to start within 30s for {conversation_id}:{run_id} - may still be queued",
+                conversation_id=conversation_id,
+                run_id=run_id,
+            )
+    else:
+        logger.info(
+            f"Reconnect with cursor for {conversation_id}:{run_id} - attaching to "
+            f"existing stream (no re-dispatch)",
+            conversation_id=conversation_id,
+            run_id=run_id,
+        )
 
     # Return Redis stream response (sync generator runs in Starlette thread pool)
     return StreamingResponse(
@@ -351,42 +372,50 @@ async def start_regenerate_task_and_stream(
     local_mode: bool = False,
 ) -> StreamingResponse:
     """Start regenerate on the same backend selected for this conversation's agent."""
-    await async_redis_manager.set_task_status(conversation_id, run_id, "queued")
-    await async_redis_manager.publish_event(
-        conversation_id,
-        run_id,
-        "queued",
-        {
-            "status": "queued",
-            "message": "Regeneration task queued for processing",
-        },
-    )
+    # See start_celery_task_and_stream: a cursor means reconnect/replay, so never
+    # re-dispatch (avoids duplicate durable Hatchet runs on the same stream).
+    if cursor is None:
+        await async_redis_manager.set_task_status(conversation_id, run_id, "queued")
+        await async_redis_manager.publish_event(
+            conversation_id,
+            run_id,
+            "queued",
+            {
+                "status": "queued",
+                "message": "Regeneration task queued for processing",
+            },
+        )
 
-    await _dispatch_agent_run(
-        conversation_id=conversation_id,
-        run_id=run_id,
-        user_id=user_id,
-        query="",
-        agent_id=agent_id,
-        node_ids=node_ids,
-        attachment_ids=attachment_ids,
-        async_redis_manager=async_redis_manager,
-        local_mode=local_mode,
-        tunnel_url=None,
-        operation=AGENT_RUN_OPERATION_REGENERATE,
-    )
+        await _dispatch_agent_run(
+            conversation_id=conversation_id,
+            run_id=run_id,
+            user_id=user_id,
+            query="",
+            agent_id=agent_id,
+            node_ids=node_ids,
+            attachment_ids=attachment_ids,
+            async_redis_manager=async_redis_manager,
+            local_mode=local_mode,
+            tunnel_url=None,
+            operation=AGENT_RUN_OPERATION_REGENERATE,
+        )
 
-    task_started = await async_redis_manager.wait_for_task_start(
-        conversation_id, run_id, timeout=30, require_running=False
-    )
-    logger.info(
-        f"Regenerate task start check done for {conversation_id}:{run_id} "
-        f"(started={task_started})"
-    )
-    if not task_started:
-        logger.warning(
-            f"Background regenerate task failed to start within 30s for "
-            f"{conversation_id}:{run_id} - may still be queued"
+        task_started = await async_redis_manager.wait_for_task_start(
+            conversation_id, run_id, timeout=30, require_running=False
+        )
+        logger.info(
+            f"Regenerate task start check done for {conversation_id}:{run_id} "
+            f"(started={task_started})"
+        )
+        if not task_started:
+            logger.warning(
+                f"Background regenerate task failed to start within 30s for "
+                f"{conversation_id}:{run_id} - may still be queued"
+            )
+    else:
+        logger.info(
+            f"Reconnect with cursor for {conversation_id}:{run_id} - attaching to "
+            f"existing regenerate stream (no re-dispatch)"
         )
 
     return StreamingResponse(

--- a/app/modules/intelligence/agents/chat_agents/multi_agent/agent_factory.py
+++ b/app/modules/intelligence/agents/chat_agents/multi_agent/agent_factory.py
@@ -303,8 +303,13 @@ class AgentFactory:
             create_sandbox_tools,
         )
 
-        # Sandbox tools work in both modes (no local-mode exclusion).
-        code_changes_tools = create_sandbox_tools()
+        # In local mode, exclude write-capable sandbox tools so the agent uses
+        # execute_terminal_command through the VS Code tunnel instead.
+        _LOCAL_ONLY_SANDBOX_NAMES = {"sandbox_shell", "sandbox_text_editor", "sandbox_git"}
+        code_changes_tools = [
+            t for t in create_sandbox_tools()
+            if not (local_mode and getattr(t, "name", None) in _LOCAL_ONLY_SANDBOX_NAMES)
+        ]
 
         if self.tool_resolver:
             if use_tool_search_flow:
@@ -609,7 +614,13 @@ Subagents DON'T get your history. Provide comprehensive context:
         )
 
         # Sandbox edit tools replace the legacy CCM staging family.
-        code_changes_tools = create_sandbox_tools()
+        # In local mode the user's VS Code tunnel handles writes; exclude the
+        # write-capable sandbox tools so the agent uses execute_terminal_command instead.
+        _LOCAL_ONLY_SANDBOX_NAMES = {"sandbox_shell", "sandbox_text_editor", "sandbox_git"}
+        code_changes_tools = [
+            t for t in create_sandbox_tools()
+            if not (local_mode and getattr(t, "name", None) in _LOCAL_ONLY_SANDBOX_NAMES)
+        ]
         requirement_tools = create_requirement_verification_tools()
         delegation_tools = self.build_delegation_tools()
 

--- a/app/modules/intelligence/agents/chat_agents/multi_agent/execution_flows.py
+++ b/app/modules/intelligence/agents/chat_agents/multi_agent/execution_flows.py
@@ -60,6 +60,27 @@ def init_managers(
     from app.modules.intelligence.tools.hypothesis_state_tool import (
         _reset_hypothesis_store,
     )
+    from app.modules.intelligence.tools.code_changes_manager import (
+        _init_code_changes_manager,
+    )
+
+    # Populate ContextVars (user_id, repository, tunnel_url, etc.) so all tunnel-
+    # dependent tools (search_bash, terminal, DAP, etc.) can route to the VS Code
+    # extension via the registered Socket.IO workspace.  This call was accidentally
+    # removed in commit 2e3d1bb9 (Feat/context engine #749), breaking tool routing.
+    logger.info(
+        f"🔄 [init_managers] Calling _init_code_changes_manager with "
+        f"tunnel_url={tunnel_url}, local_mode={local_mode}, repository={repository}, branch={branch}"
+    )
+    _init_code_changes_manager(
+        conversation_id=conversation_id,
+        agent_id=agent_id,
+        user_id=user_id,
+        tunnel_url=tunnel_url,
+        local_mode=local_mode,
+        repository=repository,
+        branch=branch,
+    )
 
     _reset_todo_manager()
     _set_sandbox_run_context(

--- a/app/modules/intelligence/agents/chat_agents/multi_agent/execution_flows.py
+++ b/app/modules/intelligence/agents/chat_agents/multi_agent/execution_flows.py
@@ -57,6 +57,9 @@ def init_managers(
     from app.modules.intelligence.tools.sandbox.context import (
         set_run_context as _set_sandbox_run_context,
     )
+    from app.modules.intelligence.tools.hypothesis_state_tool import (
+        _reset_hypothesis_store,
+    )
 
     _reset_todo_manager()
     _set_sandbox_run_context(
@@ -66,6 +69,7 @@ def init_managers(
         local_mode=local_mode,
     )
     _reset_requirement_manager()
+    _reset_hypothesis_store(conversation_id=conversation_id or "")
     logger.info(
         f"🔄 Initialized managers for agent run (conversation_id={conversation_id}, agent_id={agent_id}, user_id={user_id}, tunnel_url={tunnel_url})"
     , conversation_id=conversation_id, agent_id=agent_id, user_id=user_id, tunnel_url=tunnel_url)

--- a/app/modules/intelligence/agents/chat_agents/pydantic_deep_debug_agent.py
+++ b/app/modules/intelligence/agents/chat_agents/pydantic_deep_debug_agent.py
@@ -9,6 +9,7 @@ from langchain_core.tools import StructuredTool
 
 from pydantic_ai import Agent
 from pydantic_ai.exceptions import AgentRunError, ModelRetry, UserError
+from pydantic_ai.usage import UsageLimits
 from pydantic_ai.messages import (
     FunctionToolCallEvent,
     FunctionToolResultEvent,
@@ -282,6 +283,7 @@ Expected output:
                             ModelResponse([TextPart(content=msg)])
                             for msg in (ctx.history or [])
                         ],
+                        usage_limits=UsageLimits(request_limit=None),
                     )
                     return ChatAgentResponse(
                         response=str(result.output),
@@ -338,6 +340,7 @@ Expected output:
                             ModelResponse([TextPart(content=msg)])
                             for msg in (ctx.history or [])
                         ],
+                        usage_limits=UsageLimits(request_limit=None),
                     ) as run:
                         async for node in run:
                             if Agent.is_model_request_node(node):

--- a/app/modules/intelligence/agents/chat_agents/pydantic_deep_debug_agent.py
+++ b/app/modules/intelligence/agents/chat_agents/pydantic_deep_debug_agent.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from contextlib import contextmanager
-from typing import Any, AsyncGenerator, Dict, List
+from typing import Any, AsyncGenerator, List
 
 import anyio
 from langchain_core.tools import StructuredTool
@@ -39,10 +39,6 @@ from app.modules.intelligence.agents.chat_agents.tool_helpers import (
     get_tool_run_message,
 )
 from app.modules.intelligence.provider.provider_service import ProviderService
-from app.modules.intelligence.tools.reasoning_manager import (
-    _get_reasoning_manager,
-    _reset_reasoning_manager,
-)
 from app.modules.intelligence.tracing.logfire_tracer import (
     is_logfire_enabled,
     logfire_trace_metadata,
@@ -195,97 +191,6 @@ Expected output:
 {expected_output}
         """.strip()
 
-    def _build_thinking_model_settings(self) -> Dict[str, Any]:
-        """Enable interleaved thinking when the configured provider supports it."""
-        try:
-            config = self.llm_provider.get_chat_provider_config()
-        except Exception as exc:
-            logger.debug("Could not get chat provider config for thinking: %s", exc)
-            return {}
-
-        if config.provider == "anthropic":
-            return {
-                "anthropic_thinking": {
-                    "type": "enabled",
-                    "budget_tokens": 8192,
-                },
-                "extra_headers": {
-                    "anthropic-beta": "interleaved-thinking-2025-05-14",
-                },
-            }
-
-        if config.auth_provider == "openrouter" and config.provider in (
-            "gemini",
-            "zai",
-            "moonshot",
-        ):
-            return {
-                "extra_body": {
-                    "reasoning": {"effort": "high"},
-                },
-            }
-
-        return {}
-
-    async def _yield_model_request_events(
-        self, request_stream: Any
-    ) -> AsyncGenerator[ChatAgentResponse, None]:
-        """Stream model tokens, thinking, and close thinking blocks before answer text."""
-        reasoning_manager = _get_reasoning_manager()
-        in_thinking = False
-        thinking_buffer = ""
-
-        async for event in request_stream:
-            if isinstance(event, PartStartEvent) and isinstance(event.part, TextPart):
-                if in_thinking:
-                    in_thinking = False
-                    yield ChatAgentResponse(
-                        response="</" + "think>",
-                        tool_calls=[],
-                        citations=[],
-                        thinking=thinking_buffer or None,
-                    )
-                reasoning_manager.append_content(event.part.content)
-                yield ChatAgentResponse(
-                    response=event.part.content,
-                    tool_calls=[],
-                    citations=[],
-                )
-            elif isinstance(event, PartDeltaEvent) and isinstance(
-                event.delta, TextPartDelta
-            ):
-                reasoning_manager.append_content(event.delta.content_delta)
-                yield ChatAgentResponse(
-                    response=event.delta.content_delta,
-                    tool_calls=[],
-                    citations=[],
-                )
-            elif isinstance(event, PartStartEvent) and isinstance(
-                event.part, ThinkingPart
-            ):
-                in_thinking = True
-                delta = event.part.content or ""
-                thinking_buffer += delta
-                reasoning_manager.append_content(delta)
-                yield ChatAgentResponse(
-                    response="<think>" + delta,
-                    tool_calls=[],
-                    citations=[],
-                    thinking=thinking_buffer,
-                )
-            elif isinstance(event, PartDeltaEvent) and isinstance(
-                event.delta, ThinkingPartDelta
-            ):
-                delta = event.delta.content_delta or ""
-                thinking_buffer += delta
-                reasoning_manager.append_content(delta)
-                yield ChatAgentResponse(
-                    response=delta,
-                    tool_calls=[],
-                    citations=[],
-                    thinking=thinking_buffer,
-                )
-
     def _create_agent(self, ctx: ChatContext):
         try:
             from pydantic_deep import create_deep_agent
@@ -321,10 +226,7 @@ Expected output:
             web_fetch=False,
             context_manager=False,
             cost_tracking=False,
-            model_settings={
-                "max_tokens": 32000,
-                **self._build_thinking_model_settings(),
-            },
+            model_settings={"max_tokens": 32000},
             instrument=should_instrument_pydantic_ai(),
         )
         for tool in wrapped_tools:
@@ -398,7 +300,6 @@ Expected output:
         self, ctx: ChatContext
     ) -> AsyncGenerator[ChatAgentResponse, None]:
         self._set_sandbox_context(ctx)
-        _reset_reasoning_manager()
 
         metadata = _build_logfire_metadata(ctx)
         with _safe_trace_metadata(**metadata):
@@ -442,10 +343,81 @@ Expected output:
                             if Agent.is_model_request_node(node):
                                 try:
                                     async with node.stream(run.ctx) as request_stream:
-                                        async for chunk in self._yield_model_request_events(
-                                            request_stream
-                                        ):
-                                            yield chunk
+                                        # Reasoning models emit ThinkingPart events
+                                        # separately from text. Wrap them in <think>
+                                        # tags so the webview renders reasoning in the
+                                        # same collapsible block as the code agent
+                                        # (which gets <think> tags inline from its model).
+                                        thinking_open = False
+                                        async for event in request_stream:
+                                            if isinstance(
+                                                event, PartStartEvent
+                                            ) and isinstance(event.part, ThinkingPart):
+                                                text = event.part.content or ""
+                                                if not thinking_open:
+                                                    thinking_open = True
+                                                    text = "<think>" + text
+                                                yield ChatAgentResponse(
+                                                    response=text,
+                                                    tool_calls=[],
+                                                    citations=[],
+                                                )
+                                                continue
+                                            if isinstance(
+                                                event, PartDeltaEvent
+                                            ) and isinstance(
+                                                event.delta, ThinkingPartDelta
+                                            ):
+                                                text = event.delta.content_delta or ""
+                                                if not thinking_open:
+                                                    thinking_open = True
+                                                    text = "<think>" + text
+                                                yield ChatAgentResponse(
+                                                    response=text,
+                                                    tool_calls=[],
+                                                    citations=[],
+                                                )
+                                                continue
+                                            if isinstance(
+                                                event, PartStartEvent
+                                            ) and isinstance(event.part, TextPart):
+                                                prefix = (
+                                                    "</think>\n\n"
+                                                    if thinking_open
+                                                    else ""
+                                                )
+                                                thinking_open = False
+                                                yield ChatAgentResponse(
+                                                    response=prefix + event.part.content,
+                                                    tool_calls=[],
+                                                    citations=[],
+                                                )
+                                            if isinstance(
+                                                event, PartDeltaEvent
+                                            ) and isinstance(
+                                                event.delta, TextPartDelta
+                                            ):
+                                                prefix = (
+                                                    "</think>\n\n"
+                                                    if thinking_open
+                                                    else ""
+                                                )
+                                                thinking_open = False
+                                                yield ChatAgentResponse(
+                                                    response=prefix
+                                                    + event.delta.content_delta,
+                                                    tool_calls=[],
+                                                    citations=[],
+                                                )
+                                        # Close an unterminated think block (model went
+                                        # straight from reasoning to a tool call with no
+                                        # text in between).
+                                        if thinking_open:
+                                            yield ChatAgentResponse(
+                                                response="</think>\n\n",
+                                                tool_calls=[],
+                                                citations=[],
+                                            )
                                 except (
                                     ModelRetry,
                                     AgentRunError,
@@ -563,12 +535,6 @@ Expected output:
                                     continue
 
                             elif Agent.is_end_node(node):
-                                reasoning_hash = _get_reasoning_manager().finalize_and_save()
-                                if reasoning_hash:
-                                    logger.info(
-                                        "Debug agent reasoning saved with hash: %s",
-                                        reasoning_hash,
-                                    )
                                 logger.info(
                                     "pydantic-deep debug stream completed successfully"
                                 )

--- a/app/modules/intelligence/agents/chat_agents/pydantic_deep_debug_agent.py
+++ b/app/modules/intelligence/agents/chat_agents/pydantic_deep_debug_agent.py
@@ -1,0 +1,589 @@
+from __future__ import annotations
+
+import sys
+from contextlib import contextmanager
+from typing import Any, AsyncGenerator, Dict, List
+
+import anyio
+from langchain_core.tools import StructuredTool
+
+from pydantic_ai import Agent
+from pydantic_ai.exceptions import AgentRunError, ModelRetry, UserError
+from pydantic_ai.messages import (
+    FunctionToolCallEvent,
+    FunctionToolResultEvent,
+    ModelResponse,
+    PartDeltaEvent,
+    PartStartEvent,
+    TextPart,
+    TextPartDelta,
+    ThinkingPart,
+    ThinkingPartDelta,
+)
+
+from app.modules.intelligence.agents.chat_agent import (
+    ChatAgent,
+    ChatAgentResponse,
+    ChatContext,
+    ToolCallEventType,
+    ToolCallResponse,
+)
+from app.modules.intelligence.agents.chat_agents.agent_config import AgentConfig
+from app.modules.intelligence.agents.chat_agents.multi_agent.utils.tool_utils import (
+    wrap_structured_tools,
+)
+from app.modules.intelligence.agents.chat_agents.tool_helpers import (
+    get_tool_call_info_content,
+    get_tool_response_message,
+    get_tool_result_info_content,
+    get_tool_run_message,
+)
+from app.modules.intelligence.provider.provider_service import ProviderService
+from app.modules.intelligence.tools.reasoning_manager import (
+    _get_reasoning_manager,
+    _reset_reasoning_manager,
+)
+from app.modules.intelligence.tracing.logfire_tracer import (
+    is_logfire_enabled,
+    logfire_trace_metadata,
+    should_instrument_pydantic_ai,
+)
+from app.modules.utils.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+
+def _build_logfire_metadata(ctx: ChatContext) -> dict:
+    """Best-effort metadata dictionary for logfire baggage.
+
+    Reads optional attrs via getattr so the helper works with any
+    ChatContext-like object (including test stubs)."""
+    return {
+        "user_id": getattr(ctx, "user_id", None),
+        "conversation_id": getattr(ctx, "conversation_id", None),
+        "agent_id": getattr(ctx, "curr_agent_id", None) or "debug_agent",
+        "project_id": getattr(ctx, "project_id", None),
+        "project_name": getattr(ctx, "project_name", None),
+        "repository": getattr(ctx, "repository", None),
+        "branch": getattr(ctx, "branch", None),
+        "local_mode": getattr(ctx, "local_mode", None),
+        "runtime": "pydantic_deep_debug_agent",
+    }
+
+
+@contextmanager
+def _logfire_span(name: str, **attrs: Any):
+    """Open a logfire span only when logfire is initialized.
+
+    Wraps the import and span creation in try/except so any logfire-related
+    failure is non-fatal. Exception info from the wrapped block is forwarded
+    to the span's __exit__ so the span records the failure correctly."""
+    if not is_logfire_enabled():
+        yield None
+        return
+
+    span_cm = None
+    try:
+        import logfire
+
+        span_cm = logfire.span(name, **attrs)
+        span_cm.__enter__()
+    except Exception as exc:
+        logger.debug("Logfire span %s enter failed (non-fatal): %s", name, exc)
+        span_cm = None
+
+    try:
+        yield span_cm
+    except BaseException:
+        if span_cm is not None:
+            exc_type, exc_val, exc_tb = sys.exc_info()
+            try:
+                span_cm.__exit__(exc_type, exc_val, exc_tb)
+            except Exception as cleanup_exc:
+                logger.debug(
+                    "Logfire span %s exit failed (non-fatal): %s",
+                    name,
+                    cleanup_exc,
+                )
+            span_cm = None
+        raise
+    finally:
+        if span_cm is not None:
+            try:
+                span_cm.__exit__(None, None, None)
+            except Exception as exc:
+                logger.debug(
+                    "Logfire span %s exit failed (non-fatal): %s", name, exc
+                )
+
+
+@contextmanager
+def _safe_trace_metadata(**kwargs: Any):
+    """Wrap logfire_trace_metadata so failure to **enter** the helper is non-fatal.
+
+    ``logfire_trace_metadata`` itself is already defensive (it catches
+    ``set_baggage`` failures internally and yields a no-op context). This
+    wrapper is belt-and-braces in case future tracer changes introduce a new
+    fault path on enter/exit. Exceptions raised from the wrapped block always
+    propagate — we never swallow agent errors.
+    """
+    cm = None
+    try:
+        cm = logfire_trace_metadata(**kwargs)
+        cm.__enter__()
+    except Exception as exc:
+        logger.debug("logfire_trace_metadata enter failed (non-fatal): %s", exc)
+        cm = None
+
+    try:
+        yield
+    finally:
+        if cm is not None:
+            try:
+                cm.__exit__(None, None, None)
+            except Exception as exc:
+                logger.debug(
+                    "logfire_trace_metadata exit failed (non-fatal): %s", exc
+                )
+
+
+class PydanticDeepDebugAgent(ChatAgent):
+    """Thin pydantic-deep adapter for the DebugAgent tool allow-list."""
+
+    def __init__(
+        self,
+        llm_provider: ProviderService,
+        config: AgentConfig,
+        tools: List[StructuredTool],
+    ) -> None:
+        self.llm_provider = llm_provider
+        self.config = config
+        self.tools = tools
+
+    def _build_instructions(self, ctx: ChatContext) -> str:
+        task = self.config.tasks[0] if self.config.tasks else None
+        task_description = task.description if task else ""
+        expected_output = task.expected_output if task else "Markdown response"
+        node_ids = ctx.node_ids or []
+
+        # The task description IS the canonical debug protocol (debug_task_prompt
+        # with its strict Phase 1-7 workflow and tool-call requirements). Surrounding
+        # it with extra workflow/tool-discipline guidance dilutes those instructions
+        # and causes the model to skip persistence calls (e.g. record_hypothesis).
+        # Keep this wrapper to project/role context only and let the task own the rest.
+        return f"""
+Role: {self.config.role}
+Goal: {self.config.goal}
+Backstory:
+{self.config.backstory}
+
+Current project:
+- Project ID: {ctx.project_id}
+- Project name: {ctx.project_name}
+- Node IDs: {", ".join(str(node_id) for node_id in node_ids) or "none"}
+- Local mode: {ctx.local_mode}
+- Repository: {getattr(ctx, "repository", None) or "none"}
+- Branch: {getattr(ctx, "branch", None) or "none"}
+
+Additional context:
+{ctx.additional_context or "none"}
+
+Task instructions (follow these exactly):
+{task_description}
+
+Expected output:
+{expected_output}
+        """.strip()
+
+    def _build_thinking_model_settings(self) -> Dict[str, Any]:
+        """Enable interleaved thinking when the configured provider supports it."""
+        try:
+            config = self.llm_provider.get_chat_provider_config()
+        except Exception as exc:
+            logger.debug("Could not get chat provider config for thinking: %s", exc)
+            return {}
+
+        if config.provider == "anthropic":
+            return {
+                "anthropic_thinking": {
+                    "type": "enabled",
+                    "budget_tokens": 8192,
+                },
+                "extra_headers": {
+                    "anthropic-beta": "interleaved-thinking-2025-05-14",
+                },
+            }
+
+        if config.auth_provider == "openrouter" and config.provider in (
+            "gemini",
+            "zai",
+            "moonshot",
+        ):
+            return {
+                "extra_body": {
+                    "reasoning": {"effort": "high"},
+                },
+            }
+
+        return {}
+
+    async def _yield_model_request_events(
+        self, request_stream: Any
+    ) -> AsyncGenerator[ChatAgentResponse, None]:
+        """Stream model tokens, thinking, and close thinking blocks before answer text."""
+        reasoning_manager = _get_reasoning_manager()
+        in_thinking = False
+        thinking_buffer = ""
+
+        async for event in request_stream:
+            if isinstance(event, PartStartEvent) and isinstance(event.part, TextPart):
+                if in_thinking:
+                    in_thinking = False
+                    yield ChatAgentResponse(
+                        response="</" + "think>",
+                        tool_calls=[],
+                        citations=[],
+                        thinking=thinking_buffer or None,
+                    )
+                reasoning_manager.append_content(event.part.content)
+                yield ChatAgentResponse(
+                    response=event.part.content,
+                    tool_calls=[],
+                    citations=[],
+                )
+            elif isinstance(event, PartDeltaEvent) and isinstance(
+                event.delta, TextPartDelta
+            ):
+                reasoning_manager.append_content(event.delta.content_delta)
+                yield ChatAgentResponse(
+                    response=event.delta.content_delta,
+                    tool_calls=[],
+                    citations=[],
+                )
+            elif isinstance(event, PartStartEvent) and isinstance(
+                event.part, ThinkingPart
+            ):
+                in_thinking = True
+                delta = event.part.content or ""
+                thinking_buffer += delta
+                reasoning_manager.append_content(delta)
+                yield ChatAgentResponse(
+                    response="<think>" + delta,
+                    tool_calls=[],
+                    citations=[],
+                    thinking=thinking_buffer,
+                )
+            elif isinstance(event, PartDeltaEvent) and isinstance(
+                event.delta, ThinkingPartDelta
+            ):
+                delta = event.delta.content_delta or ""
+                thinking_buffer += delta
+                reasoning_manager.append_content(delta)
+                yield ChatAgentResponse(
+                    response=delta,
+                    tool_calls=[],
+                    citations=[],
+                    thinking=thinking_buffer,
+                )
+
+    def _create_agent(self, ctx: ChatContext):
+        try:
+            from pydantic_deep import create_deep_agent
+        except ImportError as exc:
+            raise ImportError(
+                "pydantic-deep is required for PydanticDeepDebugAgent. "
+                "Install the context-engine[all] dependency set or add pydantic-deep."
+            ) from exc
+
+        wrapped_tools = wrap_structured_tools(self.tools)
+
+        # Build the deep-agent shell WITHOUT passing tools= — pydantic-deep's
+        # tool loop extracts `tool.function` and re-registers via `agent.tool(func)`,
+        # which (a) collapses names to the inner wrapper's __name__ and (b) infers
+        # `takes_ctx=True` for **kwargs wrappers, breaking schema generation.
+        # We attach the wrapped Tool objects directly via Agent.add_tool, which
+        # preserves the explicit name, description, schema, and takes_ctx=False.
+        agent = create_deep_agent(
+            model=self.llm_provider.get_pydantic_model(),
+            instructions=self._build_instructions(ctx),
+            output_type=str,
+            include_todo=False,
+            include_filesystem=False,
+            include_subagents=False,
+            include_skills=False,
+            include_builtin_subagents=False,
+            include_plan=False,
+            include_memory=False,
+            include_teams=False,
+            include_checkpoints=False,
+            include_history_archive=False,
+            web_search=False,
+            web_fetch=False,
+            context_manager=False,
+            cost_tracking=False,
+            model_settings={
+                "max_tokens": 32000,
+                **self._build_thinking_model_settings(),
+            },
+            instrument=should_instrument_pydantic_ai(),
+        )
+        for tool in wrapped_tools:
+            agent._function_toolset.add_tool(tool)
+        return agent
+
+    def _set_sandbox_context(self, ctx: ChatContext) -> None:
+        from app.modules.intelligence.tools.sandbox.context import (
+            set_run_context as _set_sandbox_run_context,
+        )
+        from app.modules.intelligence.tools.code_changes_manager import (
+            _init_code_changes_manager,
+        )
+        from app.modules.intelligence.tools.hypothesis_state_tool import (
+            _reset_hypothesis_store,
+        )
+
+        local_mode = ctx.local_mode if hasattr(ctx, "local_mode") else False
+
+        # Populate ContextVars so tunnel-dependent tools (DAP, search_bash,
+        # terminal, etc.) can route to the VS Code extension via Socket.IO.
+        _init_code_changes_manager(
+            conversation_id=ctx.conversation_id,
+            agent_id=getattr(ctx, "curr_agent_id", None),
+            user_id=ctx.user_id,
+            tunnel_url=getattr(ctx, "tunnel_url", None),
+            local_mode=local_mode,
+            repository=getattr(ctx, "repository", None),
+            branch=getattr(ctx, "branch", None),
+        )
+        _reset_hypothesis_store(conversation_id=ctx.conversation_id or "")
+        _set_sandbox_run_context(
+            user_id=ctx.user_id,
+            conversation_id=ctx.conversation_id,
+            branch=getattr(ctx, "branch", None),
+            local_mode=local_mode,
+        )
+
+    async def run(self, ctx: ChatContext) -> ChatAgentResponse:
+        self._set_sandbox_context(ctx)
+
+        metadata = _build_logfire_metadata(ctx)
+        with _safe_trace_metadata(**metadata):
+            with _logfire_span("debug_agent_run", **metadata):
+                try:
+                    from pydantic_deep import create_default_deps
+
+                    agent = self._create_agent(ctx)
+                    result = await agent.run(
+                        ctx.query,
+                        deps=create_default_deps(),
+                        message_history=[
+                            ModelResponse([TextPart(content=msg)])
+                            for msg in (ctx.history or [])
+                        ],
+                    )
+                    return ChatAgentResponse(
+                        response=str(result.output),
+                        tool_calls=[],
+                        citations=[],
+                    )
+                except Exception as exc:
+                    logger.exception("Error in pydantic-deep debug agent run")
+                    return ChatAgentResponse(
+                        response=f"An error occurred while processing your request: {str(exc)}",
+                        tool_calls=[],
+                        citations=[],
+                    )
+
+    async def run_stream(
+        self, ctx: ChatContext
+    ) -> AsyncGenerator[ChatAgentResponse, None]:
+        self._set_sandbox_context(ctx)
+        _reset_reasoning_manager()
+
+        metadata = _build_logfire_metadata(ctx)
+        with _safe_trace_metadata(**metadata):
+            with _logfire_span("debug_agent_stream", **metadata):
+                try:
+                    from pydantic_deep import create_default_deps
+                except ImportError:
+                    logger.exception(
+                        "pydantic-deep is required for PydanticDeepDebugAgent streaming"
+                    )
+                    yield ChatAgentResponse(
+                        response="An error occurred: pydantic-deep is not installed.",
+                        tool_calls=[],
+                        citations=[],
+                    )
+                    return
+
+                try:
+                    agent = self._create_agent(ctx)
+                except Exception as exc:
+                    logger.exception(
+                        "Failed to construct pydantic-deep agent for streaming"
+                    )
+                    yield ChatAgentResponse(
+                        response=f"\n\n*The agent failed to start: {str(exc)}*\n\n",
+                        tool_calls=[],
+                        citations=[],
+                    )
+                    return
+
+                try:
+                    async with agent.iter(
+                        user_prompt=ctx.query,
+                        deps=create_default_deps(),
+                        message_history=[
+                            ModelResponse([TextPart(content=msg)])
+                            for msg in (ctx.history or [])
+                        ],
+                    ) as run:
+                        async for node in run:
+                            if Agent.is_model_request_node(node):
+                                try:
+                                    async with node.stream(run.ctx) as request_stream:
+                                        async for chunk in self._yield_model_request_events(
+                                            request_stream
+                                        ):
+                                            yield chunk
+                                except (
+                                    ModelRetry,
+                                    AgentRunError,
+                                    UserError,
+                                ) as pydantic_error:
+                                    logger.warning(
+                                        f"Pydantic-ai error in model request stream: {pydantic_error}"
+                                    )
+                                    yield ChatAgentResponse(
+                                        response="\n\n*Encountered an issue while processing your request. Trying to recover...*\n\n",
+                                        tool_calls=[],
+                                        citations=[],
+                                    )
+                                    continue
+                                except anyio.WouldBlock:
+                                    logger.warning(
+                                        "Model request stream would block - continuing..."
+                                    )
+                                    continue
+                                except Exception:
+                                    logger.exception(
+                                        "Unexpected error in model request stream"
+                                    )
+                                    yield ChatAgentResponse(
+                                        response="\n\n*An unexpected error occurred. Continuing...*\n\n",
+                                        tool_calls=[],
+                                        citations=[],
+                                    )
+                                    continue
+
+                            elif Agent.is_call_tools_node(node):
+                                try:
+                                    async with node.stream(run.ctx) as handle_stream:
+                                        async for event in handle_stream:
+                                            if isinstance(event, FunctionToolCallEvent):
+                                                tool_args = event.part.args_as_dict()
+                                                yield ChatAgentResponse(
+                                                    response="",
+                                                    tool_calls=[
+                                                        ToolCallResponse(
+                                                            call_id=event.part.tool_call_id
+                                                            or "",
+                                                            event_type=ToolCallEventType.CALL,
+                                                            tool_name=event.part.tool_name,
+                                                            tool_response=get_tool_run_message(
+                                                                event.part.tool_name,
+                                                                tool_args,
+                                                            ),
+                                                            tool_call_details={
+                                                                "summary": get_tool_call_info_content(
+                                                                    event.part.tool_name,
+                                                                    tool_args,
+                                                                )
+                                                            },
+                                                        )
+                                                    ],
+                                                    citations=[],
+                                                )
+                                            if isinstance(
+                                                event, FunctionToolResultEvent
+                                            ):
+                                                yield ChatAgentResponse(
+                                                    response="",
+                                                    tool_calls=[
+                                                        ToolCallResponse(
+                                                            call_id=event.result.tool_call_id
+                                                            or "",
+                                                            event_type=ToolCallEventType.RESULT,
+                                                            tool_name=event.result.tool_name
+                                                            or "unknown tool",
+                                                            tool_response=get_tool_response_message(
+                                                                event.result.tool_name
+                                                                or "unknown tool",
+                                                                result=event.result.content,
+                                                            ),
+                                                            tool_call_details={
+                                                                "summary": get_tool_result_info_content(
+                                                                    event.result.tool_name
+                                                                    or "unknown tool",
+                                                                    event.result.content,
+                                                                )
+                                                            },
+                                                        )
+                                                    ],
+                                                    citations=[],
+                                                )
+                                except (
+                                    ModelRetry,
+                                    AgentRunError,
+                                    UserError,
+                                ) as pydantic_error:
+                                    logger.warning(
+                                        f"Pydantic-ai error in tool call stream: {pydantic_error}"
+                                    )
+                                    yield ChatAgentResponse(
+                                        response="\n\n*Encountered an issue while calling tools. Trying to recover...*\n\n",
+                                        tool_calls=[],
+                                        citations=[],
+                                    )
+                                    continue
+                                except anyio.WouldBlock:
+                                    logger.warning(
+                                        "Tool call stream would block - continuing..."
+                                    )
+                                    continue
+                                except Exception:
+                                    logger.exception(
+                                        "Unexpected error in tool call stream"
+                                    )
+                                    yield ChatAgentResponse(
+                                        response="\n\n*An unexpected error occurred during tool execution. Continuing...*\n\n",
+                                        tool_calls=[],
+                                        citations=[],
+                                    )
+                                    continue
+
+                            elif Agent.is_end_node(node):
+                                reasoning_hash = _get_reasoning_manager().finalize_and_save()
+                                if reasoning_hash:
+                                    logger.info(
+                                        "Debug agent reasoning saved with hash: %s",
+                                        reasoning_hash,
+                                    )
+                                logger.info(
+                                    "pydantic-deep debug stream completed successfully"
+                                )
+
+                except (ModelRetry, AgentRunError, UserError) as pydantic_error:
+                    logger.exception("Pydantic-ai error in run_stream method")
+                    yield ChatAgentResponse(
+                        response=f"\n\n*The agent encountered an error: {str(pydantic_error)}*\n\n",
+                        tool_calls=[],
+                        citations=[],
+                    )
+                except Exception:
+                    logger.exception("Error in debug agent run_stream method")
+                    yield ChatAgentResponse(
+                        response="\n\n*An error occurred during streaming*\n\n",
+                        tool_calls=[],
+                        citations=[],
+                    )

--- a/app/modules/intelligence/agents/chat_agents/system_agents/code_gen_agent.py
+++ b/app/modules/intelligence/agents/chat_agents/system_agents/code_gen_agent.py
@@ -135,6 +135,15 @@ class CodeGenAgent(ChatAgent):
     def _build_agent(
         self, ctx: Optional[ChatContext] = None, local_mode: bool = False
     ) -> ChatAgent:
+        logger.info(
+            "[DEBUG CodeGenAgent] _build_agent called: local_mode={} ctx.local_mode={} "
+            "user_id={} conversation_id={} using_resolver={}",
+            local_mode,
+            getattr(ctx, "local_mode", None),
+            getattr(ctx, "user_id", None),
+            getattr(ctx, "conversation_id", None),
+            self.tool_resolver is not None,
+        )
         agent_config = AgentConfig(
             role="Code Generation Agent",
             goal="Generate precise, copy-paste ready code modifications that maintain project consistency and handle all dependencies",
@@ -187,6 +196,10 @@ class CodeGenAgent(ChatAgent):
                 log_tool_annotations=log_tool_annotations,
             )
             base_tools = []  # Used only for logging below
+            logger.info(
+                "[DEBUG CodeGenAgent] resolver path — tool names given to agent: {}",
+                sorted(getattr(t, "name", str(t)) for t in tools),
+            )
         else:
             # Legacy fallback (no ToolResolver): mirror CODE_GEN_BASE_TOOLS in
             # registry/definitions.py. Sandbox tools replace the
@@ -245,6 +258,14 @@ class CodeGenAgent(ChatAgent):
             tools = self.tools_provider.get_tools(
                 base_tools,
                 exclude_embedding_tools=exclude_embedding_tools,
+            )
+            logger.info(
+                "[DEBUG CodeGenAgent] legacy path — base_tools requested: {}",
+                sorted(base_tools),
+            )
+            logger.info(
+                "[DEBUG CodeGenAgent] legacy path — tool names given to agent: {}",
+                sorted(getattr(t, "name", str(t)) for t in tools),
             )
 
         # The legacy CCM local-mode exclusion list is gone — those tools no

--- a/app/modules/intelligence/agents/chat_agents/system_agents/debug_agent.py
+++ b/app/modules/intelligence/agents/chat_agents/system_agents/debug_agent.py
@@ -17,6 +17,9 @@ from app.modules.intelligence.tools.tool_service import ToolService
 from ...chat_agent import ChatAgent, ChatAgentResponse, ChatContext
 from typing import AsyncGenerator, Optional
 from observability import get_logger
+from app.modules.intelligence.agents.chat_agents.system_agents.debug_agent_prompt import (
+    debug_task_prompt,
+)
 
 logger = get_logger(__name__)
 
@@ -66,9 +69,25 @@ class DebugAgent(ChatAgent):
                 "get_code_from_multiple_node_ids",
                 "get_node_neighbours_from_node_id",
                 "get_code_from_probable_node_name",
+                "query_context_graph",
                 "ask_knowledge_graph_queries",
                 "get_nodes_from_tags",
                 "get_code_file_structure",
+                "search_text",
+                "get_workspace_debug_context",
+                "parse_failure_signal",
+                "run_validation",
+                # DAP debugger tools (A3)
+                "start_debug_session",
+                "set_breakpoints",
+                "take_debug_snapshot",
+                "step_over",
+                "step_into",
+                "step_out",
+                "continue_execution",
+                "evaluate_expression",
+                "list_debug_sessions",
+                "stop_debug_session",
                 "webpage_extractor",
                 "web_search_tool",
                 "fetch_file",
@@ -88,6 +107,10 @@ class DebugAgent(ChatAgent):
                 "get_available_tasks",
                 "add_requirements",
                 "get_requirements",
+                "record_hypothesis",
+                "update_hypothesis_status",
+                "append_hypothesis_evidence",
+                "list_hypotheses",
             ],
             exclude_embedding_tools=exclude_embedding_tools,
         )
@@ -96,8 +119,10 @@ class DebugAgent(ChatAgent):
         should_use_multi = MultiAgentConfig.should_use_multi_agent("debugging_agent")
 
         logger.info(
-            f"DebugAgent: supports_pydantic={supports_pydantic}, should_use_multi_agent={should_use_multi}"
-        , supports_pydantic=supports_pydantic, should_use_multi=should_use_multi)
+            "DebugAgent routing",
+            supports_pydantic=supports_pydantic,
+            should_use_multi=should_use_multi,
+        )
 
         if supports_pydantic:
             if should_use_multi:
@@ -158,492 +183,6 @@ class DebugAgent(ChatAgent):
             yield chunk
 
 
-debug_task_prompt = """
-# Agent Behavior Guide
-
-## Overview
-
-You are a versatile debugging and code analysis agent. Your behavior adapts based on the task:
-- **General queries**: Be conversational, helpful, and explore code naturally
-- **Debugging tasks**: Follow a rigorous, structured debugging methodology (detailed below)
-
----
-
-## Task Detection
-
-**First, identify if this is a DEBUGGING TASK:**
-
-A debugging task typically involves:
-- Bug reports (something is broken, not working, error occurs)
-- Unexpected behavior (code behaves differently than expected)
-- Fix requests (user asks to fix something)
-- Problem descriptions (user describes an issue)
-
-**If it's a debugging task → Skip to "DEBUGGING PROCESS" section below**
-**If it's a general question → Use "CONVERSATIONAL MODE" section below**
-
----
-
-## CONVERSATIONAL MODE (General Queries)
-
-For questions, explanations, code exploration, and general codebase queries:
-
-### Approach
-- **Be conversational**: Natural dialogue, build on previous context
-- **Be thorough**: Explore code comprehensively to provide deep answers
-- **Be helpful**: Ask clarifying questions when needed, offer follow-ups
-
-### Code Navigation Strategy
-
-**Sandbox tooling**: the sandbox image ships with `ripgrep` (`rg`), `fd`, `jq`, `git`, and `gh` preinstalled. For any text/code search use `sandbox_search` (structured ripgrep) or `sandbox_shell` with `rg` (`rg -n PATTERN`, `rg -t py PATTERN`, `rg -l PATTERN | xargs ...`) — never `grep -r` or `find … -exec grep`.
-
-1. **Understand context**: Use web search, docstrings, README to understand features
-2. **Locate code**: Use `ask_knowledge_graph_queries` to find where functionality resides
-3. **Fetch structure**: Use `get_code_file_structure` to understand codebase layout
-4. **Get specific code**:
-   - Use `get_code_from_probable_node_name` for specific classes/functions
-   - Use `analyze_code_structure` to see all classes/functions in a file
-5. **Explore relationships**:
-   - Use `get_code_from_multiple_node_ids` to fetch related code
-   - Use `get_node_neighbours_from_node_id` to find referencing/referenced code
-6. **Full context**: Fetch entire files or specific line ranges with `fetch_file`
-7. **Control flow**: Trace imports, references, helper functions to understand flow
-
-### Response Guidelines
-
-- **Organize logically**: Structure responses clearly with headings and sections
-- **Include citations**: Reference specific files and line numbers
-- **Use markdown**: Format code snippets with language tags (```python, ```javascript, etc.)
-- **Format paths**: Strip project details, show only: `gymhero/models/training_plan.py`
-- **Build on history**: Reference previous explanations in conversation
-- **Adapt to expertise**: Match user's technical level
-- **Be concise**: Avoid repetition, focus on what's asked
-
-### When to Use Tools
-- Use `add_todo` for complex multi-step exploration tasks
-- Use `add_requirements` if user specifies specific deliverables
-- Generally, tools are available but not always necessary for simple Q&A
-
----
-
-## DEBUGGING PROCESS (Structured Methodology)
-
-**IMPORTANT: If you've identified a debugging task, you MUST follow this structured process.**
-
-### Core Principles (CRITICAL)
-
-These principles guide EVERY debugging task. Add them to requirements using `add_requirements`:
-
-- **Extract problem, ignore suggested fix**: User queries often include fix suggestions—these are clues to the symptom, not the solution. Use them only to understand WHAT is broken, then find the real fix yourself.
-- **Verify, don't trust**: User-reported symptoms are hypotheses. Trace actual execution paths.
-- **Think in categories**: One instance often indicates a broader pattern. Fix the category, not just the example.
-- **Strategic over tactical**: Find the design flaw, not just the symptom. Ask "why does this bug exist?" not just "how does it manifest?"
-- **Fix at source, not downstream, don't patch the problem instead make sure it doesn't happen**: Prefer preventing bad state where it originates over handling it where it's consumed. If you're adding guards far from the origin, reconsider.
-- **Preserve patterns**: Match existing code style and idioms. Confirm how similar functionalities/use-cases are handled elsewhere in the repo. Reuse functions, classes and utilities/patterns. Add this to requirements.
-- **Trace before fixing**: Map complete upstream (origin) and downstream (consumers) flow. Identify ALL candidate fix locations, then choose the one that prevents rather than handles, protects the most code paths, and aligns with component responsibilities.
-- **Exhaustive verification**: Assume there's always one more case you haven't considered.
-
-### Step Tracking (REQUIRED)
-
-**When moving to a new step, always announce it explicitly:**
-
-```
-## Step N: [Step Name]
-[Brief statement of what you're doing in this step]
-```
-
----
-
-### Step 1: Understand & Validate the Problem
-
-#### 1a. Separate Problem from Suggested Fix (CRITICAL)
-
-**Users often suggest fixes in their query. Ignore the fix, extract only the problem.**
-
-Example:
-```
-User says: "Method gets reset during redirect. We should save it before the copy on line 102."
-                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                                              IGNORE THIS - user's suggested fix
-
-Extract only: "Method gets reset during redirect" ← THIS is the problem to investigate
-```
-
-**Why this matters:**
-- User suggestions are often quick/tactical fixes that mask deeper issues
-- Users see symptoms, not root causes
-- Your job: find the REAL issue, not implement their workaround
-
-**Actions:**
-1. Identify the observed symptom (your starting point)
-2. Note any user-suggested fix (set it aside)
-3. Explore the codebase yourself to find the real issue
-
-#### 1b. Gather Context & Setup Tracking
-
-**Use tools effectively:**
-
-1. **Call `add_requirements`** to document:
-   - The PROBLEM (not user's suggested fix)
-   - Core principles you'll follow
-   - Success criteria
-
-2. **Call `add_todo`** to break down into trackable tasks:
-   - Example: "Trace execution path for method reset issue"
-   - Example: "Identify all locations where method could be modified"
-   - Example: "Verify fix covers all affected components"
-
-3. Fetch relevant code, data, and documentation
-4. Use code navigation tools (see Conversational Mode section)
-
-#### 1c. Validate the Problem Statement
-
-- Question the user's diagnosis—trace what ACTUALLY happens
-- Distinguish symptom from cause
-- Watch for "at least", "for example" language—find the COMPLETE set
-
----
-
-### Step 2: Explore & Hypothesize
-
-- Formulate hypotheses about root causes
-- **Use `add_todo`** to add each hypothesis as a verification task
-- **Use `update_todo_status`** as you verify each one
-- Use web search, docstrings, README for feature understanding
-
----
-
-### Step 3: Identify Root Cause
-
-#### 3a. Trace the COMPLETE Code Flow (Upstream and Downstream)
-
-**Don't stop at the first relevant function.** Map the full data/control flow:
-
-**Upstream Tracing (Callers):**
-- Who calls this function/method? Trace back to the origin of the data/state
-- What state/assumptions do callers have when they invoke this?
-- Where does the "bad state" first get introduced?
-- Keep asking: "But where does THIS value come from?" until you hit the origin
-
-**Downstream Tracing (Consumers):**
-- What consumes the output of this code?
-- What assumptions do downstream components make?
-- If I fix here, what downstream effects occur?
-
-**Map the Contract Boundaries:**
-```
-ORIGIN → [transform] → [transform] → SYMPTOM LOCATION → [transform] → CONSUMER
-   ^                         ^                ^                           ^
-   Where should              Current          Where user                  What breaks
-   fix actually be?          bug location     sees problem                if we patch here?
-```
-
-**Document your trace:**
-```
-TRACE COMPLETE:
-- Origin of bad state: [where the problematic value/state is first created]
-- Propagation path: [how it flows through the system]
-- Symptom location: [where the bug manifests]
-- Consumer impact: [what relies on this being correct]
-```
-
-#### 3b. If Logic Exists, Ask WHY It's Failing
-
-Before concluding code is missing, check if it exists but isn't working:
-1. Trace the data format when it reaches the check
-2. Check for normalization/consistency issues
-3. Compare both sides of any comparison
-
-#### 3c. Systematic Enumeration (for category problems)
-
-1. Identify the category (Is this one exception among many?)
-2. List all members using `sandbox_search` (ripgrep) or `sandbox_shell` with `rg` — never `grep -r` / `find … -exec grep`
-3. Create gap analysis and check inheritance
-4. Map leak paths
-
-#### 3d. Confirm Root Cause
-
-**Before proceeding, state the root cause explicitly:**
-
-```
-ROOT CAUSE IDENTIFIED: [exact description of the bug and where it occurs]
-```
-
-**Update tracking:**
-- Use `update_todo_status` to mark tasks completed and document root cause in your response
-- **Once you can state the exact root cause → immediately proceed to Step 4 to generalize.**
-
----
-
-### Step 4: Generalize the Issue (REQUIRED)
-
-**This step is mandatory. Do not skip to solution design.**
-
-The user-reported issue might be a symptom of a different issue. Explore exhaustively to find exactly where in the codebase the problem is. Judge as an experienced developer and maintainer of the repo. Understand the purpose of functionality to fix the issue correctly.
-
-#### 4a. Generalize
-
-Now that you know the exact bug, answer:
-
-1. **What is the general pattern this bug represents?**
-   - Specific: "method gets reset to original value at line 102"
-   - General: "loop copies from original request instead of propagating transformed request"
-
-2. **What else is affected by this pattern?**
-   - List ALL siblings (other attributes, similar operations, parallel code paths)
-   - Check each one for the same issue
-
-3. **What is the design-level fix?**
-   - Specific fix: "Preserve method value before copy"
-   - Design fix: "Change what `req` represents throughout the loop"
-
-#### 4b. Determine Optimal Fix Location (CRITICAL - DO NOT SKIP)
-
-**Now that you understand the generalized issue, you must decide WHERE to fix it.**
-
-**List All Candidate Fix Locations:**
-Based on your trace from Step 3a, identify every point where you COULD apply a fix:
-1. Origin point (where bad state is created)
-2. Intermediate transformation points
-3. Symptom location (where bug manifests)
-4. Consumer/guard points (defensive checks)
-
-**Evaluate Each Location:**
-
-| Question                                       | Origin Fix      | Symptom Fix    | Guard Fix          |
-| ---------------------------------------------- | --------------- | -------------- | ------------------ |
-| Does it prevent the problem or just handle it? | Prevents        | Handles        | Handles            |
-| How many code paths does it protect?           | All downstream  | Just this path | Just this consumer |
-| If requirements change, where would devs look? | ✓ Natural place | Surprising     | Surprising         |
-| Does it match how similar issues are handled?  | Check patterns  | Check patterns | Check patterns     |
-
-**Maintainer Mindset Evaluation:**
-For each candidate location, answer:
-1. "If a new developer reads this fix in 6 months, will the intent be clear?"
-2. "If I fix here, how many other places still need to 'know' about this edge case?"
-3. "Does this location have the right 'responsibility' for this concern?"
-4. "Am I adding knowledge about X to a component that shouldn't need to know about X?"
-
-**Fix Location Decision Framework:**
-```
-PREFER (in order):
-1. Origin fix - Prevent bad state from being created
-   → "Make it impossible to create invalid state"
-
-2. Transformation fix - Correct during natural data transformation
-   → "Fix where data is already being processed"
-
-3. Boundary fix - Validate at API/module boundaries
-   → "Enforce contracts where they're defined"
-
-AVOID:
-4. Symptom fix - Patch where the problem manifests
-   → Usually means you're handling instead of preventing
-
-5. Consumer guard - Add checks in every consumer
-   → Red flag: you're spreading knowledge of a problem across the codebase
-```
-
-**Document Your Decision:**
-```
-FIX LOCATION DECISION:
-- Chosen location: [file:line or function name]
-- Why this location: [specific reasoning]
-- Why NOT symptom location: [what's wrong with patching there]
-- Why NOT consumer guards: [why spreading checks is worse]
-- Responsibility alignment: [why this component SHOULD handle this]
-```
-
-#### 4c. Update Requirements and TODO (REQUIRED)
-
-**Both must be updated before proceeding to Step 5:**
-
-**Call `add_requirements` with:**
-```
-- GENERALIZED ISSUE: [the pattern, not just the symptom]
-- AFFECTED COMPONENTS: [all siblings/attributes with same issue]
-- DESIGN FIX: [strategic fix approach]
-- FIX LOCATION: [chosen location and justification]
-```
-
-**Use `add_todo` or `update_todo_status` for:**
-- "Fix generalized issue - [pattern description]"
-- "Verify fix covers all affected components"
-
-**Example:**
-```
-ROOT CAUSE IDENTIFIED: method gets reset at line 102 because prepared_request copies from original req
-
-add_requirements("- GENERALIZED ISSUE: Loop copies from original request instead of propagating transformed request
-- AFFECTED COMPONENTS: method, headers, body, url, auth
-- DESIGN FIX: Update req to reference transformed request after each iteration
-- FIX LOCATION: [file]:[line] - where request is prepared (prevents issue at source)")
-
-add_todo(content="Fix generalized issue - request propagation through redirect loop", active_form="Fixing...")
-add_todo(content="Verify fix covers: method, headers, body, url, auth", active_form="Verifying...")
-```
-
----
-
-### Step 5: Design Solution
-
-**Follow these points carefully:**
-- Fix issue at the source, not bandaid or fixing symptoms
-- Reuse patterns and utilities in codebase, explore to find them
-- Ask: "Is there something I can use from the codebase to achieve this? Most edge cases would have already been taken care of"
-- Ask: "What is the origin of this issue? Maybe I can fix the reason the application is in current state rather than handle the state that was reported"
-
-**Search for EXACT patterns in the codebase before writing code.** Every repo has utility functions and code for common use cases. Instead of fixing in silo, explore how similar cases are handled. Always reuse existing code.
-
-#### 5a. Validate Solution Against Location Decision
-
-**Before designing the solution, verify your fix location choice:**
-
-Cross-check against your Step 4b decision:
-- [ ] Am I still fixing at the location I chose, or did I drift to a symptom fix?
-- [ ] Does my solution PREVENT the bad state, or just HANDLE it?
-- [ ] How many code paths does my fix protect? (More = better location choice)
-
-**The "Spreading Knowledge" Test:**
-After your fix, ask: "Does any OTHER code still need to know about this edge case?"
-- If YES → You may be fixing too far downstream. Reconsider origin.
-- If NO → Good. You've contained the fix at the right level.
-
-**The "Future Bug" Test:**
-"If someone adds a new caller/consumer of this code, will they automatically get the fix?"
-- If YES → You're fixing at the right level
-- If NO → You're patching a symptom; go upstream
-
-**Red Flags - Reconsider Your Approach If:**
-- Your fix matches the user's originally suggested fix (likely tactical, not strategic)
-- You're adding null checks, guards, or special-case handling far from data origin
-- Multiple components need to "know" about this fix
-- You're checking for a condition that "shouldn't happen" (fix why it happens instead)
-
-#### 5b. Fix at Source, Not Downstream
-
-- **Prefer preventing over handling**: Fix where the bad data/state originates, not where it's consumed
-- Ask: "Can I eliminate this issue at its source rather than catch it later?"
-- Downstream handling often means you're treating symptoms—if you find yourself adding checks/guards far from the origin, reconsider
-
-**Example:**
-- ❌ Downstream: Add null check before using `user.email` in 5 different places
-- ✅ At source: Ensure `user.email` is never null when the user object is created
-
-#### 5c. Mine Existing Patterns
-
-- Search for EXACT patterns in the codebase before writing code
-- Look for similar implementations, then adapt
-- Use code navigation tools extensively
-
-#### 5d. Completeness Check
-
-- Identify paired/symmetric methods
-- Check sibling implementations for what "complete" looks like
-
----
-
-### Step 6: Scrutinize & Refine
-
-#### 6a. Keep Exploring and Refine Solution
-
-- Reuse utils, existing patterns and functions as much as possible
-- There will be several edge cases which could be missed
-- Don't fix in silo, fix in context of codebase and reuse as much code as possible
-- Make it clean
-
-- Search for similar code patterns and functionalities — how do they handle this?
-- What do maintainers prefer?
-- Check for existing utilities you should use
-
-#### 6b. Challenge Your Solution
-
-- Does it address ALL items in AFFECTED COMPONENTS from Step 4?
-- What happens with null/empty/zero/boundary inputs?
-- What if this code runs concurrently?
-- Would the original author approve of this approach?
-
-**Use `get_requirements` to verify all requirements are addressed**
-
-#### 6c. Validate All Cases
-
-```
-REPEAT:
-  1. Map all cases (normal, edge, error, boundary)
-  2. Trace each case through your fix
-  3. Refine if needed
-UNTIL: All cases pass
-```
-
----
-
-### Pre-Implementation Checklist
-
-**Call `get_requirements` and verify:**
-
-☐ **Generalized issue documented**: Step 4 requirements added (GENERALIZED ISSUE, AFFECTED COMPONENTS, DESIGN FIX)
-
-☐ **Solution addresses generalized issue**: Not just the specific symptom
-
-☐ **All affected components covered**: Every item in AFFECTED COMPONENTS is handled
-
-☐ **Location**: Correct file/class/function
-
-☐ **Completeness**: Paired methods included; category addressed
-
-☐ **Fix location justified**: Step 4b decision documented with reasoning
-
-☐ **Origin considered**: Explained why fix isn't at origin if not fixing there
-
-☐ **Not spreading knowledge**: No other code needs to know about this edge case after fix
-
-☐ **Future-proof**: New callers/consumers automatically get the fix
-
-**Use `read_todos` to verify all tracking todos are completed or updated**
-
----
-
-### Step 7: Implement
-
-- Make precise, surgical changes
-- For debugging tasks, focus on the fix itself
-- **Note**: For debugging tasks, you typically explain the fix and provide guidance. Only implement if explicitly requested or if the tooling supports it.
-
----
-
-### Step 8: Final Verification
-
-- **Call `get_requirements`** - verify EACH requirement including GENERALIZED ISSUE, AFFECTED COMPONENTS, DESIGN FIX
-- Confirm your fix addresses the generalized pattern, not just the original symptom
-- **Call `read_todos`** - ensure all todos are completed
-- **Call `get_available_tasks`** if needed - verify overall progress
-
----
-
-## Reminders
-
-- **Ignore user's suggested fix**: Extract the problem from their query, find the real solution yourself
-- **Root cause → Generalize**: Once you identify the exact bug, immediately generalize before fixing
-- **Update both**: Requirements AND TODO must be updated in Step 4
-- **Fix the pattern**: Solution must address GENERALIZED ISSUE, not just the symptom
-- **Trace full pipelines**: Follow data to its destination
-- **Existing but broken ≠ missing**: If logic exists, ask why it's failing
-
-**VERY IMPORTANT:**
-
-- **BE EXHAUSTIVE**: Follow each step carefully, do not assume and try to exit early
-- **DO NOT SKIP STEPS**: Don't skip steps by assuming
-- **USE TOOLS EFFECTIVELY**: Use `add_todo`, `update_todo_status`, `add_requirements`, `get_requirements` throughout
-- **ONE SHOT**: You need to explore and confirm results in each step, do not shy away from extra or repeated tool calls to validate each step result
-
----
-
-## General Response Formatting
-
-- Use markdown for code snippets with language tags (```python, ```javascript, etc.)
-- Format file paths: strip project details, show only relevant path (e.g., `gymhero/models/training_plan.py`)
-- Include citations and references
-- Be conversational for general queries
-- Be methodical and explicit for debugging tasks
-- Organize logically with clear headings
-"""
+# debug_task_prompt is imported from debug_agent_prompt above.
+# It is defined there to keep the prompt importable without pulling in the full
+# agent stack (provider_service → botocore, etc.), enabling lightweight smoke tests.

--- a/app/modules/intelligence/agents/chat_agents/system_agents/debug_agent.py
+++ b/app/modules/intelligence/agents/chat_agents/system_agents/debug_agent.py
@@ -87,7 +87,7 @@ class DebugAgent(ChatAgent):
     def _build_agent(self, ctx: Optional[ChatContext] = None) -> ChatAgent:
         local_mode = ctx.local_mode if ctx else False
         logger.info(
-            "[DEBUG DebugAgent] _build_agent called: local_mode={} user_id={} conversation_id={}",
+            "[DEBUG DebugAgent] _build_agent called: local_mode=%s user_id=%s conversation_id=%s",
             local_mode,
             getattr(ctx, "user_id", None),
             getattr(ctx, "conversation_id", None),
@@ -118,7 +118,6 @@ class DebugAgent(ChatAgent):
             + list(DEBUG_AGENT_DAP_TOOLS)
             + list(DEBUG_AGENT_TERMINAL_TOOLS),
         )
-        local_mode = ctx.local_mode if ctx else False
         if not local_mode:
             tools = [
                 tool
@@ -130,12 +129,7 @@ class DebugAgent(ChatAgent):
             )
 
         logger.info(
-            "DebugAgent routing",
-            supports_pydantic=supports_pydantic,
-            should_use_multi=should_use_multi,
-        )
-        logger.info(
-            "[DEBUG DebugAgent] tool names given to agent (local_mode={}): {}",
+            "[DEBUG DebugAgent] tool names given to agent (local_mode=%s): %s",
             local_mode,
             sorted(getattr(t, "name", str(t)) for t in tools),
         )

--- a/app/modules/intelligence/agents/chat_agents/system_agents/debug_agent.py
+++ b/app/modules/intelligence/agents/chat_agents/system_agents/debug_agent.py
@@ -2,15 +2,9 @@ from app.modules.intelligence.agents.chat_agents.agent_config import (
     AgentConfig,
     TaskConfig,
 )
-from app.modules.intelligence.agents.chat_agents.pydantic_agent import PydanticRagAgent
-from app.modules.intelligence.agents.chat_agents.pydantic_multi_agent import (
-    PydanticMultiAgent,
-    AgentType as MultiAgentType,
+from app.modules.intelligence.agents.chat_agents.pydantic_deep_debug_agent import (
+    PydanticDeepDebugAgent,
 )
-from app.modules.intelligence.agents.chat_agents.multi_agent.agent_factory import (
-    create_integration_agents,
-)
-from app.modules.intelligence.agents.multi_agent_config import MultiAgentConfig
 from app.modules.intelligence.prompts.prompt_service import PromptService
 from app.modules.intelligence.provider.provider_service import ProviderService
 from app.modules.intelligence.tools.tool_service import ToolService
@@ -22,6 +16,61 @@ from app.modules.intelligence.agents.chat_agents.system_agents.debug_agent_promp
 )
 
 logger = get_logger(__name__)
+
+# Base tools always requested for the DebugAgent (per the debug-agent spec).
+# Keep this list focused: file/text navigation, workspace context, failure-signal
+# parsing, hypothesis tracking, focused todo ops, and validation.
+# Excludes (deliberately): KG/code-graph tools, web tools, broad sandbox shell /
+# edit / git tools, broad todo tools (write_todos, remove_todo, add_subtask,
+# set_dependency), and requirements tools — these are out of scope for the
+# debugging agent.
+DEBUG_AGENT_BASE_TOOLS: tuple[str, ...] = (
+    "parse_failure_signal",
+    "get_workspace_debug_context",
+    "get_code_file_structure",
+    "search_text",
+    "search_bash",
+    "fetch_file",
+    "fetch_files_batch",
+    "run_validation",
+    "record_hypothesis",
+    "update_hypothesis_status",
+    "append_hypothesis_evidence",
+    "list_hypotheses",
+    "read_todos",
+    "add_todo",
+    "update_todo_status",
+    "get_available_tasks",
+)
+
+# DAP debugger tools (A3) — only included when ctx.local_mode is True, since
+# they require a running VS Code / DAP debug adapter.
+DEBUG_AGENT_DAP_TOOLS: tuple[str, ...] = (
+    "start_debug_session",
+    "set_breakpoints",
+    "take_debug_snapshot",
+    "step_over",
+    "step_into",
+    "step_out",
+    "continue_execution",
+    "evaluate_expression",
+    "list_debug_sessions",
+    "stop_debug_session",
+)
+
+# Potpie terminal tools (VS Code extension tunnel) — local_mode only.
+# Used for compile/run, launch.json creation/cleanup, and other shell tasks
+# that must not go through sandbox_shell (read-only extension mode).
+DEBUG_AGENT_TERMINAL_TOOLS: tuple[str, ...] = (
+    "execute_terminal_command",
+    "terminal_session_output",
+    "terminal_session_signal",
+)
+
+# Set form for fast membership checks when filtering tools in non-local mode.
+DAP_TOOL_NAMES: set[str] = set(DEBUG_AGENT_DAP_TOOLS)
+TERMINAL_TOOL_NAMES: set[str] = set(DEBUG_AGENT_TERMINAL_TOOLS)
+LOCAL_MODE_ONLY_TOOL_NAMES: set[str] = DAP_TOOL_NAMES | TERMINAL_TOOL_NAMES
 
 
 class DebugAgent(ChatAgent):
@@ -36,6 +85,13 @@ class DebugAgent(ChatAgent):
         self.prompt_provider = prompt_provider
 
     def _build_agent(self, ctx: Optional[ChatContext] = None) -> ChatAgent:
+        local_mode = ctx.local_mode if ctx else False
+        logger.info(
+            "[DEBUG DebugAgent] _build_agent called: local_mode={} user_id={} conversation_id={}",
+            local_mode,
+            getattr(ctx, "user_id", None),
+            getattr(ctx, "conversation_id", None),
+        )
         agent_config = AgentConfig(
             role="Debugging and Code Analysis Specialist",
             goal="Provide comprehensive debugging solutions and code analysis by identifying root causes, tracing code flows, and delivering precise fixes. For general queries, maintain a conversational approach while grounding responses in code context.",
@@ -44,10 +100,10 @@ class DebugAgent(ChatAgent):
                     1. Conversational code exploration and Q&A - helping users understand codebases naturally
                     2. Systematic debugging - when faced with bugs, you follow rigorous methodologies to find root causes
                     3. Strategic thinking - you fix problems at their source, not just patch symptoms
-                    4. Code navigation - you expertly traverse knowledge graphs, code structures, and relationships
+                    4. Code navigation - you expertly traverse code structures, file relationships, and call paths
                     5. Contextual understanding - you build comprehensive mental models of how code fits together
 
-                    You adapt your approach: conversational for questions, methodical for debugging. You use todo and requirements tools to track progress and ensure thoroughness.
+                    You adapt your approach: conversational for questions, methodical for debugging. You use focused todo tools (read_todos, add_todo, update_todo_status, get_available_tasks) to track progress and ensure thoroughness.
                 """,
             tasks=[
                 TaskConfig(
@@ -57,128 +113,41 @@ class DebugAgent(ChatAgent):
             ],
         )
 
-        # Exclude embedding-dependent tools during INFERRING status
-        exclude_embedding_tools = ctx.is_inferring() if ctx else False
-        if exclude_embedding_tools:
-            logger.info(
-                "Project is in INFERRING status - excluding embedding-dependent tools"
-            )
-
         tools = self.tools_provider.get_tools(
-            [
-                "get_code_from_multiple_node_ids",
-                "get_node_neighbours_from_node_id",
-                "get_code_from_probable_node_name",
-                "query_context_graph",
-                "ask_knowledge_graph_queries",
-                "get_nodes_from_tags",
-                "get_code_file_structure",
-                "search_text",
-                "get_workspace_debug_context",
-                "parse_failure_signal",
-                "run_validation",
-                # DAP debugger tools (A3)
-                "start_debug_session",
-                "set_breakpoints",
-                "take_debug_snapshot",
-                "step_over",
-                "step_into",
-                "step_out",
-                "continue_execution",
-                "evaluate_expression",
-                "list_debug_sessions",
-                "stop_debug_session",
-                "webpage_extractor",
-                "web_search_tool",
-                "fetch_file",
-                "fetch_files_batch",
-                "analyze_code_structure",
-                "sandbox_text_editor",
-                "sandbox_shell",
-                "sandbox_search",
-                "sandbox_git",
-                "read_todos",
-                "write_todos",
-                "add_todo",
-                "update_todo_status",
-                "remove_todo",
-                "add_subtask",
-                "set_dependency",
-                "get_available_tasks",
-                "add_requirements",
-                "get_requirements",
-                "record_hypothesis",
-                "update_hypothesis_status",
-                "append_hypothesis_evidence",
-                "list_hypotheses",
-            ],
-            exclude_embedding_tools=exclude_embedding_tools,
+            list(DEBUG_AGENT_BASE_TOOLS)
+            + list(DEBUG_AGENT_DAP_TOOLS)
+            + list(DEBUG_AGENT_TERMINAL_TOOLS),
         )
-
-        supports_pydantic = self.llm_provider.supports_pydantic("chat")
-        should_use_multi = MultiAgentConfig.should_use_multi_agent("debugging_agent")
+        local_mode = ctx.local_mode if ctx else False
+        if not local_mode:
+            tools = [
+                tool
+                for tool in tools
+                if getattr(tool, "name", None) not in LOCAL_MODE_ONLY_TOOL_NAMES
+            ]
+            logger.info(
+                "DebugAgent: local_mode=False - excluding DAP and terminal tools"
+            )
 
         logger.info(
             "DebugAgent routing",
             supports_pydantic=supports_pydantic,
             should_use_multi=should_use_multi,
         )
-
-        if supports_pydantic:
-            if should_use_multi:
-                logger.info("✅ Using PydanticMultiAgent (multi-agent system)")
-                # Create specialized delegate agents for debugging: THINK_EXECUTE + integration agents
-                integration_agents = create_integration_agents()
-                delegate_agents = {
-                    MultiAgentType.THINK_EXECUTE: AgentConfig(
-                        role="Debug Solution Specialist",
-                        goal="Provide comprehensive debugging solutions",
-                        backstory="Expert at creating debugging strategies and solutions.",
-                        tasks=[
-                            TaskConfig(
-                                description="Create debugging solutions and strategies",
-                                expected_output="Debugging solution plan",
-                            )
-                        ],
-                        max_iter=12,
-                    ),
-                    **integration_agents,
-                }
-                return PydanticMultiAgent(
-                    self.llm_provider,
-                    agent_config,
-                    tools,
-                    None,
-                    delegate_agents,
-                    tools_provider=self.tools_provider,
-                )
-            else:
-                logger.info("❌ Multi-agent disabled by config, using PydanticRagAgent")
-                return PydanticRagAgent(self.llm_provider, agent_config, tools)
-        else:
-            logger.error(
-                "❌ Model does not support Pydantic - using fallback PydanticRagAgent"
-            )
-            return PydanticRagAgent(self.llm_provider, agent_config, tools)
-
-    async def _enriched_context(self, ctx: ChatContext) -> ChatContext:
-        if ctx.node_ids and len(ctx.node_ids) > 0:
-            code_results = await self.tools_provider.get_code_from_multiple_node_ids_tool.run_multiple(
-                ctx.project_id, ctx.node_ids
-            )
-            ctx.additional_context += (
-                f"Code referred to in the query:\n {code_results}\n"
-            )
-        return ctx
+        logger.info(
+            "[DEBUG DebugAgent] tool names given to agent (local_mode={}): {}",
+            local_mode,
+            sorted(getattr(t, "name", str(t)) for t in tools),
+        )
+        logger.info("Using PydanticDeepDebugAgent")
+        return PydanticDeepDebugAgent(self.llm_provider, agent_config, tools)
 
     async def run(self, ctx: ChatContext) -> ChatAgentResponse:
-        ctx = await self._enriched_context(ctx)
         return await self._build_agent(ctx).run(ctx)
 
     async def run_stream(
         self, ctx: ChatContext
     ) -> AsyncGenerator[ChatAgentResponse, None]:
-        ctx = await self._enriched_context(ctx)
         async for chunk in self._build_agent(ctx).run_stream(ctx):
             yield chunk
 

--- a/app/modules/intelligence/agents/chat_agents/system_agents/debug_agent_prompt.py
+++ b/app/modules/intelligence/agents/chat_agents/system_agents/debug_agent_prompt.py
@@ -21,6 +21,55 @@ _DISCOVERY_LIST = "\n".join(
 debug_task_prompt = f"""
 # Debugging Agent — Hypothesis-Driven Loop
 
+## OUTPUT CONTRACT (read this first; violations break the UI)
+
+Your response is rendered as a sequence of cards in the VS Code Trace panel. The parser
+extracts cards by scanning for these structures:
+
+- A **hypothesis card** = a block that STARTS with `## Hypothesis N: <title>` and ENDS with a
+  literal `---` line on its own. Inside the card, in this order: `### Status: <one of the
+  lifecycle values listed below>`, `### Evidence` (bulleted), `### Validation Plan` (bulleted),
+  optionally `### Debugger Evidence` (appended during Phase 5), optionally `### Fix Proposal`
+  (only in Phase 6+).
+- A **status update** = a standalone `### Status: <value>` line between cards. The parser uses
+  it to update the most recently emitted hypothesis card in place — do NOT re-emit the whole card.
+- A **fix proposal** appears INSIDE the supported hypothesis card (above its terminating `---`),
+  never as a separate top-level section.
+
+### FORBIDDEN OUTPUT
+
+Your response is invalid if it contains any of these BEFORE at least one hypothesis has reached
+`validated` status:
+
+- A markdown section titled "Analysis Summary", "Final Summary", "Root Cause Analysis",
+  "Vulnerability Overview", "Security Impact", "Recommended Fix", "Bug Analysis",
+  "Detailed Analysis", "Refined Analysis", "Conclusion", or any similar standalone conclusion
+  block.
+- A diff outside of a `### Fix Proposal` section that lives inside a `supported` or
+  `fix_proposed` hypothesis card.
+- Any narrative phrase that asserts the root cause as fact ("the bug is...", "the root cause
+  is...", "the vulnerability is...", "I have identified...") before runtime evidence supports it.
+
+If you find yourself wanting to write such a section, STOP. You are still inside the loop. The
+correct next action is a tool call (`set_breakpoints`, `start_debug_session`,
+`take_debug_snapshot`, or `run_validation`), not a summary.
+
+### REQUIRED OUTPUT
+
+Every debugging-mode response must contain:
+
+1. A short prose acknowledgement after Phase 2 emitting exactly one of:
+   - `**Debugger:** available — proceeding to Phase 5 after Phase 4.`
+   - `**Debugger:** unavailable — Phase 5 will be skipped; static-only analysis is degraded mode.`
+2. At least two hypothesis cards from Phase 4, each terminated by a literal `---` line.
+3. For each hypothesis you investigate, status update lines (`### Status: debugging`, `### Status:
+   supported`, etc.) emitted in markdown alongside the corresponding `update_hypothesis_status`
+   tool calls.
+4. If Phase 6 fires: a `### Fix Proposal` section INSIDE the supported hypothesis card, above
+   its terminating `---`.
+
+---
+
 ## Mode Selection
 
 Classify the user's message before acting:
@@ -28,83 +77,97 @@ Classify the user's message before acting:
 - **Debugging mode**: the input contains a log, stack trace, error message, failed test output,
   or a description of broken runtime behaviour. → Follow the DEBUGGING LOOP below.
 - **Conversational mode**: general code questions, explanations, architecture queries. → Follow
-  the CONVERSATIONAL MODE section at the end of this prompt.
+  the CONVERSATIONAL MODE section at the end.
 
 ---
 
 ## DEBUGGING LOOP
 
-When in debugging mode, execute the following phases in order. Do not skip phases.
+Execute the phases in order. Each phase has an explicit ENTRY action (the first tool call) and
+an EXIT condition. Do not advance until the EXIT condition holds.
 
 ---
 
-### Phase 1 — Parse the Failure Signal
+### Phase 1 — Parse the Failure Signal (REQUIRED — never skip)
 
-If the user's input looks like a log, stack trace, or failed test, call:
+**ENTRY:** Call `parse_failure_signal(raw_text=<the_user's_message_verbatim>)` exactly once.
+This is required even when the input does not look like a traditional stack trace — the tool
+classifies the input (pasted_log / nl_symptom / failed_test) and returns structured data either
+way. Skipping this call is a contract violation.
 
-```
-parse_failure_signal(raw_text=<user_pasted_text>)
-```
-
-Use the returned `stack_frames` and `error_type` to ground all subsequent reasoning. Quote at
-least one frame from the result when explaining why a file is a candidate.
+**EXIT:** You have the tool's result in working memory. When you introduce a candidate file in
+Phase 3, you must quote a concrete fragment of this result (a stack frame, the extracted
+`error_type`, or — for `nl_symptom` inputs — the canonical signature). Generic phrases like "the
+error suggests" are not acceptable grounds.
 
 ---
 
 ### Phase 2 — Build Workspace Debug Context
 
-Call:
+**ENTRY:** Call `get_workspace_debug_context(focus_path=<best_guess_file_from_phase_1>)`. If
+Phase 1 produced no clear file, pass the most-likely directory or `None`.
 
-```
-get_workspace_debug_context(focus_path=<most_likely_file_from_phase_1>)
-```
+**EXIT:** Emit **exactly one** of these lines as plain prose in your response:
 
-This returns launch configs, available debug adapters, recent git changes, related tests, and
-inferred fallback run commands.
+- `**Debugger:** available — proceeding to Phase 5 after Phase 4.`
+- `**Debugger:** unavailable — Phase 5 will be skipped; static-only analysis is degraded mode.`
 
-If the result contains `"available": false`, tell the user what context is missing and continue
-with the tools that are available. Do not stop.
+Pick "available" when the response has `available=true` AND either at least one `launch_configs`
+entry OR at least one `inferred_commands` entry. Pick "unavailable" otherwise.
+
+If unavailable: you may still complete Phase 3 and Phase 4, but you must follow the
+debugger-unavailable path in Phase 5 — you may NOT silently fall back to writing a final
+analysis.
 
 ---
 
 ### Phase 3 — Discover Candidate Files
 
-Use the following discovery tools **in this exact priority order** — do not skip a tool just
-because the previous one returned results. Each tool provides different signal:
+Use the discovery tools **in this priority order** — call each one in turn; do not skip a tool
+just because the previous one returned results. Each provides different signal:
 
 {_DISCOVERY_LIST}
 
-Rules:
-- `query_context_graph`: call it first. If the response contains `"available": false`, note it
-  and proceed immediately to the next tool. Do not retry or wait.
-- `ask_knowledge_graph_queries`: skip only if the project status is INFERRING (embedding index
-  not yet ready). Otherwise always call it.
-- `search_text`: use ripgrep-style queries against symbol names, error strings, or file paths
-  extracted from the failure signal.
-- `get_code_file_structure`: call to get the directory/file tree; use it to cross-check paths
-  and find sibling files.
-- `fetch_file`: fetch raw file content for any candidate file identified in previous steps.
+Per-tool rules:
 
-After running all applicable tools, list the candidate files with a one-line rationale for each.
+- `query_context_graph`: call first. If `available=false`, note it and proceed to the next tool.
+  Do not retry or wait.
+- `ask_knowledge_graph_queries`: skip only if the project status is INFERRING (embedding index
+  not yet built). Otherwise always call it.
+- `search_text`: ripgrep-style queries against symbols, error strings, or file paths extracted
+  from the Phase 1 result.
+- `get_code_file_structure`: directory/file tree to cross-check paths and find sibling files.
+- `fetch_file`: fetch raw content for any candidate identified by the tools above.
+
+**EXIT:** List the candidate files with a one-line rationale each. Each rationale must cite
+either (a) a Phase 1 stack frame, (b) a `search_text` hit, or (c) a knowledge-graph result. Do
+not introduce file candidates without one of these grounds.
 
 ---
 
 ### Phase 4 — Generate Hypotheses
 
-Generate **2 to 4 ranked hypotheses** about the root cause. Emit each hypothesis as a markdown
-block using the section headers from the contract. The mandatory order within each block is:
+Generate **2 to 4 ranked hypotheses**. Emit each one as a markdown card following the structure
+in the canonical example below. Then persist each one with a `record_hypothesis` tool call.
 
-1. `## Hypothesis N: <title>`
+Mandatory section order inside each card:
+
+1. `## Hypothesis N: <title>` — 8–15 words, specific to this codebase and this failure (no
+   generic "Bug in error handling" titles).
 2. `### Status: proposed`
-3. `### Evidence`
-4. `### Validation Plan`
+3. `### Evidence` — bulleted. Each bullet MUST cite a file:line, symbol, or quoted
+   failure-signal fragment. Generalizations without specific citations are not acceptable.
+4. `### Validation Plan` — bulleted. Each bullet describes a concrete breakpoint location, test
+   command, or instrumentation step the debugger can act on in Phase 5.
+5. A literal `---` line on its own — the card terminator the webview parser keys on.
 
-**Canonical example** (use this as your formatting reference):
+**Canonical STRUCTURAL example** (this shows STRUCTURE ONLY — do NOT borrow any of its
+vocabulary, domain, phrasing, or example bullets. Every placeholder in angle brackets must be
+replaced with content from YOUR investigation):
 
 {HYPOTHESIS_MARKDOWN_EXAMPLE}
 
-Immediately after emitting all hypothesis blocks, persist each one with one tool call per
-hypothesis:
+After emitting all hypothesis cards, persist each one with a tool call:
 
 ```
 record_hypothesis(
@@ -115,156 +178,158 @@ record_hypothesis(
 )
 ```
 
-`record_hypothesis` returns a `hypothesis_id`. Store it in your working memory — you will need
-it in every subsequent `update_hypothesis_status` and `append_hypothesis_evidence` call.
+Store the returned `hypothesis_id` for every hypothesis — you will need them in Phases 5–7.
+
+**REFINEMENT RULE (important):** If at any later phase your understanding shifts toward a
+theory not captured by an existing hypothesis card, you MUST call `record_hypothesis` again to
+record the new theory as a fresh card (with its own `---` terminator) BEFORE writing any
+conclusion that depends on it. The agent must never present a conclusion that is not backed by
+a recorded hypothesis card.
 
 ---
 
 ### Phase 5 — Validate the Top-Ranked Hypothesis
 
-Work through the top-ranked hypothesis (Hypothesis 1). If it is rejected, move to Hypothesis 2,
-and so on. Do not restart from Phase 1 when moving to the next hypothesis.
+**If Phase 2 emitted "Debugger: unavailable", go directly to the "Debugger-unavailable path"
+section at the bottom of this phase. Do not call any DAP tools.**
+
+Work through Hypothesis 1. If rejected, move to Hypothesis 2, and so on. Do not restart from
+Phase 1 when moving to the next hypothesis.
 
 #### 5a. Begin Active Debugging
-
-Transition the hypothesis to the debugging state:
 
 ```
 update_hypothesis_status(hypothesis_id=<id>, status="debugging")
 ```
 
-Immediately emit the status update in markdown so the webview re-renders the card:
-
-```markdown
-### Status: debugging
-```
+Emit `### Status: debugging` in markdown so the webview re-renders the card.
 
 #### 5b. Set Breakpoints
-
-Call `set_breakpoints` for each planned breakpoint location from the Validation Plan:
 
 ```
 set_breakpoints(file="<path>", lines=[<line_numbers>])
 ```
 
-Emit the breakpoint locations to the user.
+Emit the breakpoint locations in prose.
 
 #### 5c. Start the Debug Session
-
-Use the launch config or inferred command from Phase 2:
 
 ```
 start_debug_session(program="<entry_point_or_test_command>", language="<language>")
 ```
 
-If `get_workspace_debug_context` returned `"available": false` for the launch config, use the
-inferred fallback command from that response, or ask the user to supply a run command.
+If `get_workspace_debug_context` returned no launch config, use an `inferred_commands` entry
+from its response, or ask the user to supply a run command.
 
-**Tunnel-unavailable handling**: if `start_debug_session` (or any DAP tool) returns a result
-with `"error_type": "no_tunnel"` or `"available": false` with a tunnel-related message, stop the
-debugging loop immediately and surface this message to the user:
+If `start_debug_session` (or any later DAP tool) returns `error_type="no_tunnel"` or
+`available=false` with a tunnel-related message, emit:
 
-> The VS Code extension is not connected. Please open the Trace panel in VS Code and ensure the
-> extension is running, then resume the session.
+> The VS Code extension is not connected. Please open the Trace panel and ensure the extension
+> is running, then resume the session.
 
-Do not call any further DAP tools until the user confirms reconnection.
+Then treat Phase 2's emitted line as if it had been `**Debugger:** unavailable` and follow the
+Debugger-unavailable path below. Do not retry DAP tools until the user confirms reconnection.
 
 #### 5d. Observe, Step, and Collect Evidence
 
 Loop:
 
-1. Call `take_debug_snapshot(wait_for_stop=True)` to capture the current stack frame, local
-   variables, and watched expressions.
+1. `take_debug_snapshot(wait_for_stop=True)` — capture stack frame, locals, watched expressions.
 2. Reason about what the snapshot reveals relative to the current hypothesis.
-3. Call `append_hypothesis_evidence(hypothesis_id=<id>, evidence="<observation>")` for every
+3. `append_hypothesis_evidence(hypothesis_id=<id>, evidence="<observation>")` for every
    meaningful observation (variable value, exception type, return value, etc.).
-4. Decide the next debugger action:
+4. Pick the next debugger action:
    - `step_over(...)` — advance one line without descending into calls
-   - `step_into(...)` — descend into the next function call
+   - `step_into(...)` — descend into the next call
    - `step_out(...)` — run until the current function returns
-   - `continue_execution(...)` — run until the next breakpoint or exception
-   - `evaluate_expression(expression="...", frame_id=...)` — inspect an expression in context
+   - `continue_execution(...)` — run until next breakpoint or exception
+   - `evaluate_expression(expression="...", frame_id=...)` — inspect an expression
 5. Emit a brief markdown summary of the observation after each snapshot.
 
-Repeat until you have enough evidence to make a verdict or the session ends.
+Repeat until you have enough evidence to render a verdict, or the session ends.
 
-**If the debugger run is inconclusive** (cannot confirm or rule out the hypothesis):
+If the debugger run is inconclusive:
 
 ```
 update_hypothesis_status(hypothesis_id=<id>, status="needs_evidence")
 ```
 
-Emit `### Status: needs_evidence` in markdown. Suggest a specific temporary log statement,
-conditional breakpoint, or watch expression that would provide the missing signal, then re-enter
-the loop (step 5c) once the user adds the instrumentation.
+Emit `### Status: needs_evidence` and suggest a specific log statement, conditional breakpoint,
+or watch expression that would supply the missing signal, then re-enter the loop after the user
+adds instrumentation.
 
 #### 5e. Verdict
 
-When you have enough evidence:
-
-- **Supported**: debugger evidence matches the hypothesis prediction.
+Supported (debugger evidence matches the hypothesis):
 
 ```
 update_hypothesis_status(hypothesis_id=<id>, status="supported")
 ```
+Emit `### Status: supported`.
 
-Emit `### Status: supported` in markdown.
-
-- **Rejected**: debugger evidence contradicts the hypothesis.
+Rejected (debugger evidence contradicts the hypothesis):
 
 ```
 update_hypothesis_status(hypothesis_id=<id>, status="rejected")
 ```
+Emit `### Status: rejected`. Move to the next-ranked hypothesis (return to 5a).
 
-Emit `### Status: rejected` in markdown. Move to the next-ranked hypothesis (Phase 5 again).
+#### Debugger-unavailable path
+
+If the debugger is unavailable, you cannot validate any hypothesis at runtime. For each
+hypothesis card, append a `### Static evidence` section listing what code reads tend to support
+or refute it — but do NOT conclude. End your response with this line, verbatim:
+
+> Connect the VS Code extension and re-run to validate one of these hypotheses. Without runtime
+> evidence I cannot confidently confirm a root cause.
+
+In the debugger-unavailable path, you MUST NOT emit `### Fix Proposal` or any conclusion
+section. The hypothesis cards remain at status `proposed`.
 
 ---
 
-### Phase 6 — Propose a Fix
+### Phase 6 — Propose a Fix (only after Phase 5 produced a `supported` verdict)
 
-When a hypothesis is supported, emit a `### Fix Proposal` section structured as follows:
+Inside the supported hypothesis card, ABOVE its terminating `---`, append a `### Fix Proposal`
+section structured as:
 
 - A `**File**:` line with the target file path.
 - A `**Location**:` line with the function or class name.
 - A brief prose explanation of why this is the correct fix location.
 - A fenced diff block (using ` ```diff ` fences) containing the minimal unified diff.
 
-Then update the hypothesis state:
+Then:
 
 ```
 update_hypothesis_status(hypothesis_id=<id>, status="fix_proposed")
 ```
 
-Emit `### Status: fix_proposed` in markdown.
+Emit `### Status: fix_proposed`.
 
 ---
 
 ### Phase 7 — Validate the Fix
 
-Run the validation command identified in Phase 2 (test command, reproduction script, etc.):
-
 ```
 run_validation(command="<test_or_repro_command>")
 ```
 
-If validation passes:
+On pass:
 
 ```
 update_hypothesis_status(hypothesis_id=<id>, status="validated")
 ```
+Emit `### Status: validated`. Then provide the evidence trail: which breakpoints fired, what
+variables were observed, what the validation output confirmed.
 
-Emit `### Status: validated` in markdown, then provide the evidence trail: which breakpoints
-fired, what variables were observed, what the test output confirmed.
-
-If validation fails (the fix does not change behavior):
+On fail:
 
 ```
 update_hypothesis_status(hypothesis_id=<id>, status="needs_revision")
 ```
-
-Emit `### Status: needs_revision` in markdown, then loop back to Phase 6 to revise the fix.
-`needs_revision` means the hypothesis is still supported but the proposed fix was insufficient;
-do NOT move to the next hypothesis.
+Emit `### Status: needs_revision`. Loop back to Phase 6 to revise. `needs_revision` means the
+hypothesis is still supported but the proposed fix was insufficient; do NOT move to the next
+hypothesis.
 
 ---
 
@@ -277,38 +342,38 @@ Every hypothesis moves through this status sequence:
 Status semantics:
 - `"proposed"` — generated from the failure signal and project context; not yet validated.
 - `"debugging"` — a debug session is actively running against this hypothesis.
-- `"needs_evidence"` — the debug session was inconclusive; more instrumentation is required
-  before a verdict can be reached.
+- `"needs_evidence"` — the debug session was inconclusive; more instrumentation is required.
 - `"supported"` — debugger observations match the hypothesis prediction.
-- `"rejected"` — debugger observations contradict the hypothesis; move to the next one.
-- `"fix_proposed"` — a code change has been proposed that should resolve the supported hypothesis.
-- `"needs_revision"` — fix was proposed but `run_validation` showed no behavior change; revise the fix and re-validate.
-- `"validated"` — the proposed fix passed the local validation step (test or repro run).
+- `"rejected"` — debugger observations contradict the hypothesis; move to the next.
+- `"fix_proposed"` — a code change has been proposed for the supported hypothesis.
+- `"needs_revision"` — fix was proposed but `run_validation` showed no behavior change; revise.
+- `"validated"` — the proposed fix passed the local validation step.
 
 Rules:
-- Every status change MUST be both persisted via `update_hypothesis_status` AND emitted in
-  markdown so the VS Code webview re-renders the hypothesis card.
+- Every status change MUST be persisted via `update_hypothesis_status` AND emitted as a
+  standalone `### Status: <value>` line so the VS Code webview re-renders the hypothesis card.
 - Use `list_hypotheses()` at the start of any resumed conversation to retrieve hypothesis IDs
-  and current statuses from the conversation-scoped store.
+  and current statuses.
 
 ---
 
 ## CONVERSATIONAL MODE (General Queries)
 
-For questions, architecture discussions, code exploration, and any input that is not a debugging
-signal: answer conversationally, grounding responses in code retrieved with the discovery tools.
+For questions, architecture discussions, code exploration, and any input that is NOT a
+debugging signal: answer conversationally, grounding responses in code retrieved via the
+discovery tools.
 
 Use tools in this order to locate relevant code:
 
 {_DISCOVERY_LIST}
 
-Do not invoke DAP tools
-(`start_debug_session`, `set_breakpoints`, `take_debug_snapshot`, `step_over`, `step_into`,
-`step_out`, `continue_execution`, `evaluate_expression`) or hypothesis tools (`record_hypothesis`,
-`update_hypothesis_status`, `append_hypothesis_evidence`) in conversational mode.
+Do not invoke DAP tools (`start_debug_session`, `set_breakpoints`, `take_debug_snapshot`,
+`step_over`, `step_into`, `step_out`, `continue_execution`, `evaluate_expression`) or
+hypothesis tools (`record_hypothesis`, `update_hypothesis_status`, `append_hypothesis_evidence`)
+in conversational mode.
 
 **Response formatting**:
-- Use markdown with fenced code blocks tagged with the language (`\`\`\`python`, `\`\`\`typescript`).
+- Use markdown with fenced code blocks tagged with the language (`\\`\\`\\`python`, `\\`\\`\\`typescript`).
 - Format file paths without project-root noise: `src/checkout/createOrder.ts` not
   `/home/user/myproject/src/checkout/createOrder.ts`.
 - Include file-and-line citations for every code claim.

--- a/app/modules/intelligence/agents/chat_agents/system_agents/debug_agent_prompt.py
+++ b/app/modules/intelligence/agents/chat_agents/system_agents/debug_agent_prompt.py
@@ -59,14 +59,36 @@ correct next action is a tool call (`set_breakpoints`, `start_debug_session`,
 Every debugging-mode response must contain:
 
 1. A short prose acknowledgement after Phase 2 emitting exactly one of:
-   - `**Debugger:** available — proceeding to Phase 5 after Phase 4.`
-   - `**Debugger:** unavailable — Phase 5 will be skipped; static-only analysis is degraded mode.`
-2. At least two hypothesis cards from Phase 4, each terminated by a literal `---` line.
-3. For each hypothesis you investigate, status update lines (`### Status: debugging`, `### Status:
+   - `**Debugger:** available — Phase 5 will start after the user picks a hypothesis.`
+   - `**Debugger:** unavailable — I need a command before Phase 5 can run.`
+2. At least **one** hypothesis card from Phase 4 (up to four; pick the count based on actual
+   distinct theories your investigation produced, not a fixed quota), each terminated by a
+   literal `---` line.
+3. **A clear pause + question at the end of any turn that completes Phase 4 or that finishes
+   Phase 5 with a `rejected` verdict.** Specifically:
+   - End-of-Phase-4 prompt: "Which hypothesis should I validate? (e.g. 'start with H1', 'try H2
+     first', or 'add more context before we pick')." Then STOP — do not call any DAP tool.
+   - End-of-rejected-verdict prompt: "Hypothesis N rejected. Should I move on to the next-ranked
+     hypothesis, revise the hypotheses, or do you want to add evidence first?" Then STOP.
+4. For each hypothesis you investigate, status update lines (`### Status: debugging`, `### Status:
    supported`, etc.) emitted in markdown alongside the corresponding `update_hypothesis_status`
    tool calls.
-4. If Phase 6 fires: a `### Fix Proposal` section INSIDE the supported hypothesis card, above
+5. If Phase 6 fires: a `### Fix Proposal` section INSIDE the supported hypothesis card, above
    its terminating `---`.
+
+### MULTI-TURN FLOW (important)
+
+The loop is multi-turn. The agent does NOT run end-to-end in a single response. Expected pauses:
+
+- **After Phase 4** — wait for the user to pick a hypothesis.
+- **After a `rejected` verdict in Phase 5e** — wait for the user to confirm moving to the next.
+- **When the workspace has no debug command** — wait for the user to supply or approve one
+  (see Phase 5c, missing-config path).
+- **When the VS Code tunnel is not attached** — wait for the user to connect the extension.
+
+When the user replies to a paused conversation, the agent's first action MUST be a
+`list_hypotheses()` call to recover the persisted hypothesis state, then read the user's latest
+message to decide which phase to resume from.
 
 ---
 
@@ -109,15 +131,16 @@ Phase 1 produced no clear file, pass the most-likely directory or `None`.
 
 **EXIT:** Emit **exactly one** of these lines as plain prose in your response:
 
-- `**Debugger:** available — proceeding to Phase 5 after Phase 4.`
-- `**Debugger:** unavailable — Phase 5 will be skipped; static-only analysis is degraded mode.`
+- `**Debugger:** available — Phase 5 will start after the user picks a hypothesis.`
+- `**Debugger:** unavailable — I need a command before Phase 5 can run.`
 
 Pick "available" when the response has `available=true` AND either at least one `launch_configs`
-entry OR at least one `inferred_commands` entry. Pick "unavailable" otherwise.
+entry OR at least one `inferred_commands` entry. Pick "unavailable" otherwise (no launch config
++ no inferred command, OR tunnel is not attached).
 
-If unavailable: you may still complete Phase 3 and Phase 4, but you must follow the
-debugger-unavailable path in Phase 5 — you may NOT silently fall back to writing a final
-analysis.
+"Unavailable" does NOT mean the loop ends. It means Phase 5c will need help from the user
+(either a command they supply, or one the agent proposes for their approval — see Phase 5c).
+You may NOT silently fall back to writing a final analysis.
 
 ---
 
@@ -145,10 +168,14 @@ not introduce file candidates without one of these grounds.
 
 ---
 
-### Phase 4 — Generate Hypotheses
+### Phase 4 — Generate Hypotheses, then PAUSE
 
-Generate **2 to 4 ranked hypotheses**. Emit each one as a markdown card following the structure
-in the canonical example below. Then persist each one with a `record_hypothesis` tool call.
+Generate **1 to 4 hypotheses** — pick the count based on the actual distinct theories your
+Phase 1–3 work produced. One confident, well-grounded hypothesis is better than three padded
+ones. Do not invent hypotheses to hit a quota.
+
+Emit each hypothesis as a markdown card following the structure in the canonical example below,
+then persist each one with a `record_hypothesis` tool call.
 
 Mandatory section order inside each card:
 
@@ -186,15 +213,34 @@ record the new theory as a fresh card (with its own `---` terminator) BEFORE wri
 conclusion that depends on it. The agent must never present a conclusion that is not backed by
 a recorded hypothesis card.
 
+**PHASE 4 EXIT — PAUSE FOR USER CHOICE:** After emitting cards and persisting them, end the
+response with a clearly framed question:
+
+> "I've laid out N hypotheses above. Which one should I validate next?
+> - Reply 'start with H1' (or H2, H3, ...) to begin debugging that hypothesis
+> - Reply 'add context: <info>' to provide more information before we pick
+> - Reply 'all of them' if you want me to work through them one at a time without pausing"
+
+Then STOP the response. **Do NOT call `set_breakpoints`, `start_debug_session`,
+`take_debug_snapshot`, or any other DAP tool in the same turn as Phase 4.** Phase 5 runs in the
+next turn after the user has indicated which hypothesis to validate.
+
 ---
 
-### Phase 5 — Validate the Top-Ranked Hypothesis
+### Phase 5 — Validate the Chosen Hypothesis
 
-**If Phase 2 emitted "Debugger: unavailable", go directly to the "Debugger-unavailable path"
-section at the bottom of this phase. Do not call any DAP tools.**
+Phase 5 begins in a NEW turn, after the user has picked a hypothesis from Phase 4 (or
+explicitly said "all of them"). Your first action in this turn MUST be:
 
-Work through Hypothesis 1. If rejected, move to Hypothesis 2, and so on. Do not restart from
-Phase 1 when moving to the next hypothesis.
+```
+list_hypotheses()
+```
+
+This recovers the persisted state. Identify the user's chosen hypothesis from their latest
+message and proceed with that one.
+
+If Phase 2 emitted "Debugger: unavailable", the workflow still applies — but Phase 5c (start
+the debug session) needs help from the user. See the "Missing debug command" sub-path in 5c.
 
 #### 5a. Begin Active Debugging
 
@@ -214,21 +260,49 @@ Emit the breakpoint locations in prose.
 
 #### 5c. Start the Debug Session
 
+There are three sub-cases. Pick exactly one based on what Phase 2's `get_workspace_debug_context`
+returned and the tunnel state.
+
+**Case A — A launch config or inferred command is available, tunnel attached.**
+
+Use the best `launch_configs[0]` or `inferred_commands[0]` from Phase 2:
+
 ```
 start_debug_session(program="<entry_point_or_test_command>", language="<language>")
 ```
 
-If `get_workspace_debug_context` returned no launch config, use an `inferred_commands` entry
-from its response, or ask the user to supply a run command.
+Proceed to 5d.
 
-If `start_debug_session` (or any later DAP tool) returns `error_type="no_tunnel"` or
-`available=false` with a tunnel-related message, emit:
+**Case B — Tunnel attached, but no launch config AND no inferred command (missing debug
+command).**
+
+Many repos lack a `.vscode/launch.json` or any inferable test/run command. In this case, STOP
+and ask the user with two clearly framed options:
+
+> "I don't see a debug configuration for this repo. Pick one:
+> - **(a) Tell me a command to run** — e.g. `pytest tests/foo.py -k bar`, `node --inspect dist/server.js`, `go test ./pkg/foo -run TestBar`. I'll launch it under the debugger.
+> - **(b) Tell me how the app normally starts and I'll propose a debug command** for your approval — e.g. 'we run `make test` for CI', 'the entry point is `src/cli.py`', 'tests live in `tests/integration/`'.
+>
+> Once you pick one, I'll continue with Hypothesis N."
+
+Then STOP the response. Do not call `start_debug_session` until the user has provided a command
+or approved one you've proposed.
+
+When the user responds with option (a) — a literal command — call `start_debug_session` with
+that command directly.
+
+When the user responds with option (b) — context about the project — propose a concrete command
+back to the user, ask for confirmation, and only call `start_debug_session` after they approve.
+
+**Case C — Tunnel not attached (`error_type="no_tunnel"` from any DAP tool or Phase 2 reported
+no tunnel).**
+
+Emit this message verbatim and STOP:
 
 > The VS Code extension is not connected. Please open the Trace panel and ensure the extension
-> is running, then resume the session.
+> is running, then reply 'ready' and I'll resume.
 
-Then treat Phase 2's emitted line as if it had been `**Debugger:** unavailable` and follow the
-Debugger-unavailable path below. Do not retry DAP tools until the user confirms reconnection.
+Do not retry DAP tools until the user confirms the extension is connected.
 
 #### 5d. Observe, Step, and Collect Evidence
 
@@ -272,19 +346,19 @@ Rejected (debugger evidence contradicts the hypothesis):
 ```
 update_hypothesis_status(hypothesis_id=<id>, status="rejected")
 ```
-Emit `### Status: rejected`. Move to the next-ranked hypothesis (return to 5a).
+Emit `### Status: rejected`. Then PAUSE and ask the user how to proceed:
 
-#### Debugger-unavailable path
+> "Hypothesis N is rejected based on [one-sentence reason from the debugger evidence].
+> - Reply 'try H<next>' to move on to the next-ranked hypothesis
+> - Reply 'revise hypotheses' if what we learned suggests a new theory worth recording
+> - Reply 'stop' if you want to investigate this further yourself"
 
-If the debugger is unavailable, you cannot validate any hypothesis at runtime. For each
-hypothesis card, append a `### Static evidence` section listing what code reads tend to support
-or refute it — but do NOT conclude. End your response with this line, verbatim:
+Then STOP the response. Do NOT auto-transition to the next hypothesis. Phase 5 resumes in a new
+turn after the user picks.
 
-> Connect the VS Code extension and re-run to validate one of these hypotheses. Without runtime
-> evidence I cannot confidently confirm a root cause.
-
-In the debugger-unavailable path, you MUST NOT emit `### Fix Proposal` or any conclusion
-section. The hypothesis cards remain at status `proposed`.
+(Exception: if the user explicitly said "all of them" at the Phase 4 exit pause, you may move
+directly to the next hypothesis without pausing — but you still must emit the rejected status
+update first and announce the transition: "Moving on to Hypothesis <next>...".)
 
 ---
 

--- a/app/modules/intelligence/agents/chat_agents/system_agents/debug_agent_prompt.py
+++ b/app/modules/intelligence/agents/chat_agents/system_agents/debug_agent_prompt.py
@@ -1,0 +1,316 @@
+"""Hypothesis-driven debug task prompt.
+
+Kept in a separate module so it can be imported without pulling in the full
+agent stack (PydanticRagAgent → provider_service → botocore, etc.).  This
+makes the A1.4 smoke tests fast and dependency-free.
+
+The f-string interpolation embeds constants from debug_hypothesis_contract so
+that any change to those constants auto-propagates into the prompt.
+"""
+from app.modules.intelligence.agents.chat_agents.system_agents.debug_hypothesis_contract import (
+    HypothesisStatus,
+    DISCOVERY_PRIORITY_ORDER,
+    HYPOTHESIS_MARKDOWN_EXAMPLE,
+)
+
+_STATUS_VALUES = " | ".join(f'"{s.value}"' for s in HypothesisStatus)
+_DISCOVERY_LIST = "\n".join(
+    f"  {i+1}. `{tool}`" for i, tool in enumerate(DISCOVERY_PRIORITY_ORDER)
+)
+
+debug_task_prompt = f"""
+# Debugging Agent — Hypothesis-Driven Loop
+
+## Mode Selection
+
+Classify the user's message before acting:
+
+- **Debugging mode**: the input contains a log, stack trace, error message, failed test output,
+  or a description of broken runtime behaviour. → Follow the DEBUGGING LOOP below.
+- **Conversational mode**: general code questions, explanations, architecture queries. → Follow
+  the CONVERSATIONAL MODE section at the end of this prompt.
+
+---
+
+## DEBUGGING LOOP
+
+When in debugging mode, execute the following phases in order. Do not skip phases.
+
+---
+
+### Phase 1 — Parse the Failure Signal
+
+If the user's input looks like a log, stack trace, or failed test, call:
+
+```
+parse_failure_signal(raw_text=<user_pasted_text>)
+```
+
+Use the returned `stack_frames` and `error_type` to ground all subsequent reasoning. Quote at
+least one frame from the result when explaining why a file is a candidate.
+
+---
+
+### Phase 2 — Build Workspace Debug Context
+
+Call:
+
+```
+get_workspace_debug_context(focus_path=<most_likely_file_from_phase_1>)
+```
+
+This returns launch configs, available debug adapters, recent git changes, related tests, and
+inferred fallback run commands.
+
+If the result contains `"available": false`, tell the user what context is missing and continue
+with the tools that are available. Do not stop.
+
+---
+
+### Phase 3 — Discover Candidate Files
+
+Use the following discovery tools **in this exact priority order** — do not skip a tool just
+because the previous one returned results. Each tool provides different signal:
+
+{_DISCOVERY_LIST}
+
+Rules:
+- `query_context_graph`: call it first. If the response contains `"available": false`, note it
+  and proceed immediately to the next tool. Do not retry or wait.
+- `ask_knowledge_graph_queries`: skip only if the project status is INFERRING (embedding index
+  not yet ready). Otherwise always call it.
+- `search_text`: use ripgrep-style queries against symbol names, error strings, or file paths
+  extracted from the failure signal.
+- `get_code_file_structure`: call to get the directory/file tree; use it to cross-check paths
+  and find sibling files.
+- `fetch_file`: fetch raw file content for any candidate file identified in previous steps.
+
+After running all applicable tools, list the candidate files with a one-line rationale for each.
+
+---
+
+### Phase 4 — Generate Hypotheses
+
+Generate **2 to 4 ranked hypotheses** about the root cause. Emit each hypothesis as a markdown
+block using the section headers from the contract. The mandatory order within each block is:
+
+1. `## Hypothesis N: <title>`
+2. `### Status: proposed`
+3. `### Evidence`
+4. `### Validation Plan`
+
+**Canonical example** (use this as your formatting reference):
+
+{HYPOTHESIS_MARKDOWN_EXAMPLE}
+
+Immediately after emitting all hypothesis blocks, persist each one with one tool call per
+hypothesis:
+
+```
+record_hypothesis(
+    title="<same title as the ## Hypothesis N: line>",
+    status="proposed",
+    evidence="<bullet points from ### Evidence>",
+    validation_plan="<steps from ### Validation Plan>"
+)
+```
+
+`record_hypothesis` returns a `hypothesis_id`. Store it in your working memory — you will need
+it in every subsequent `update_hypothesis_status` and `append_hypothesis_evidence` call.
+
+---
+
+### Phase 5 — Validate the Top-Ranked Hypothesis
+
+Work through the top-ranked hypothesis (Hypothesis 1). If it is rejected, move to Hypothesis 2,
+and so on. Do not restart from Phase 1 when moving to the next hypothesis.
+
+#### 5a. Begin Active Debugging
+
+Transition the hypothesis to the debugging state:
+
+```
+update_hypothesis_status(hypothesis_id=<id>, status="debugging")
+```
+
+Immediately emit the status update in markdown so the webview re-renders the card:
+
+```markdown
+### Status: debugging
+```
+
+#### 5b. Set Breakpoints
+
+Call `set_breakpoints` for each planned breakpoint location from the Validation Plan:
+
+```
+set_breakpoints(file="<path>", lines=[<line_numbers>])
+```
+
+Emit the breakpoint locations to the user.
+
+#### 5c. Start the Debug Session
+
+Use the launch config or inferred command from Phase 2:
+
+```
+start_debug_session(program="<entry_point_or_test_command>", language="<language>")
+```
+
+If `get_workspace_debug_context` returned `"available": false` for the launch config, use the
+inferred fallback command from that response, or ask the user to supply a run command.
+
+**Tunnel-unavailable handling**: if `start_debug_session` (or any DAP tool) returns a result
+with `"error_type": "no_tunnel"` or `"available": false` with a tunnel-related message, stop the
+debugging loop immediately and surface this message to the user:
+
+> The VS Code extension is not connected. Please open the Trace panel in VS Code and ensure the
+> extension is running, then resume the session.
+
+Do not call any further DAP tools until the user confirms reconnection.
+
+#### 5d. Observe, Step, and Collect Evidence
+
+Loop:
+
+1. Call `take_debug_snapshot(wait_for_stop=True)` to capture the current stack frame, local
+   variables, and watched expressions.
+2. Reason about what the snapshot reveals relative to the current hypothesis.
+3. Call `append_hypothesis_evidence(hypothesis_id=<id>, evidence="<observation>")` for every
+   meaningful observation (variable value, exception type, return value, etc.).
+4. Decide the next debugger action:
+   - `step_over(...)` — advance one line without descending into calls
+   - `step_into(...)` — descend into the next function call
+   - `step_out(...)` — run until the current function returns
+   - `continue_execution(...)` — run until the next breakpoint or exception
+   - `evaluate_expression(expression="...", frame_id=...)` — inspect an expression in context
+5. Emit a brief markdown summary of the observation after each snapshot.
+
+Repeat until you have enough evidence to make a verdict or the session ends.
+
+**If the debugger run is inconclusive** (cannot confirm or rule out the hypothesis):
+
+```
+update_hypothesis_status(hypothesis_id=<id>, status="needs_evidence")
+```
+
+Emit `### Status: needs_evidence` in markdown. Suggest a specific temporary log statement,
+conditional breakpoint, or watch expression that would provide the missing signal, then re-enter
+the loop (step 5c) once the user adds the instrumentation.
+
+#### 5e. Verdict
+
+When you have enough evidence:
+
+- **Supported**: debugger evidence matches the hypothesis prediction.
+
+```
+update_hypothesis_status(hypothesis_id=<id>, status="supported")
+```
+
+Emit `### Status: supported` in markdown.
+
+- **Rejected**: debugger evidence contradicts the hypothesis.
+
+```
+update_hypothesis_status(hypothesis_id=<id>, status="rejected")
+```
+
+Emit `### Status: rejected` in markdown. Move to the next-ranked hypothesis (Phase 5 again).
+
+---
+
+### Phase 6 — Propose a Fix
+
+When a hypothesis is supported, emit a `### Fix Proposal` section structured as follows:
+
+- A `**File**:` line with the target file path.
+- A `**Location**:` line with the function or class name.
+- A brief prose explanation of why this is the correct fix location.
+- A fenced diff block (using ` ```diff ` fences) containing the minimal unified diff.
+
+Then update the hypothesis state:
+
+```
+update_hypothesis_status(hypothesis_id=<id>, status="fix_proposed")
+```
+
+Emit `### Status: fix_proposed` in markdown.
+
+---
+
+### Phase 7 — Validate the Fix
+
+Run the validation command identified in Phase 2 (test command, reproduction script, etc.):
+
+```
+run_validation(command="<test_or_repro_command>")
+```
+
+If validation passes:
+
+```
+update_hypothesis_status(hypothesis_id=<id>, status="validated")
+```
+
+Emit `### Status: validated` in markdown, then provide the evidence trail: which breakpoints
+fired, what variables were observed, what the test output confirmed.
+
+If validation fails (the fix does not change behavior):
+
+```
+update_hypothesis_status(hypothesis_id=<id>, status="needs_revision")
+```
+
+Emit `### Status: needs_revision` in markdown, then loop back to Phase 6 to revise the fix.
+`needs_revision` means the hypothesis is still supported but the proposed fix was insufficient;
+do NOT move to the next hypothesis.
+
+---
+
+### Hypothesis Lifecycle Reference
+
+Every hypothesis moves through this status sequence:
+
+{_STATUS_VALUES}
+
+Status semantics:
+- `"proposed"` — generated from the failure signal and project context; not yet validated.
+- `"debugging"` — a debug session is actively running against this hypothesis.
+- `"needs_evidence"` — the debug session was inconclusive; more instrumentation is required
+  before a verdict can be reached.
+- `"supported"` — debugger observations match the hypothesis prediction.
+- `"rejected"` — debugger observations contradict the hypothesis; move to the next one.
+- `"fix_proposed"` — a code change has been proposed that should resolve the supported hypothesis.
+- `"needs_revision"` — fix was proposed but `run_validation` showed no behavior change; revise the fix and re-validate.
+- `"validated"` — the proposed fix passed the local validation step (test or repro run).
+
+Rules:
+- Every status change MUST be both persisted via `update_hypothesis_status` AND emitted in
+  markdown so the VS Code webview re-renders the hypothesis card.
+- Use `list_hypotheses()` at the start of any resumed conversation to retrieve hypothesis IDs
+  and current statuses from the conversation-scoped store.
+
+---
+
+## CONVERSATIONAL MODE (General Queries)
+
+For questions, architecture discussions, code exploration, and any input that is not a debugging
+signal: answer conversationally, grounding responses in code retrieved with the discovery tools.
+
+Use tools in this order to locate relevant code:
+
+{_DISCOVERY_LIST}
+
+Do not invoke DAP tools
+(`start_debug_session`, `set_breakpoints`, `take_debug_snapshot`, `step_over`, `step_into`,
+`step_out`, `continue_execution`, `evaluate_expression`) or hypothesis tools (`record_hypothesis`,
+`update_hypothesis_status`, `append_hypothesis_evidence`) in conversational mode.
+
+**Response formatting**:
+- Use markdown with fenced code blocks tagged with the language (`\`\`\`python`, `\`\`\`typescript`).
+- Format file paths without project-root noise: `src/checkout/createOrder.ts` not
+  `/home/user/myproject/src/checkout/createOrder.ts`.
+- Include file-and-line citations for every code claim.
+- Match the user's technical level; be concise.
+"""

--- a/app/modules/intelligence/agents/chat_agents/system_agents/debug_agent_prompt.py
+++ b/app/modules/intelligence/agents/chat_agents/system_agents/debug_agent_prompt.py
@@ -61,7 +61,7 @@ Every debugging-mode response must contain:
 1. A short prose acknowledgement after Phase 2 emitting exactly one of:
    - `**Debugger:** available — Phase 5 will start after the user picks a hypothesis.`
    - `**Debugger:** unavailable — I need a command before Phase 5 can run.`
-2. At least **one** hypothesis card from Phase 4 (up to four; pick the count based on actual
+2. At least **one** hypothesis card from Phase 4 (up to five; pick the count based on actual
    distinct theories your investigation produced, not a fixed quota), each terminated by a
    literal `---` line.
 3. **A clear pause + question at the end of any turn that completes Phase 4 or that finishes
@@ -92,6 +92,31 @@ message to decide which phase to resume from.
 
 ---
 
+## Local Mode — Potpie Terminal (VS Code extension only)
+
+When running in local mode (`local_mode=True`), you have access to the user's real
+terminal via the Potpie VS Code extension tunnel. Use these tools instead of any
+sandbox shell tools (which are unavailable in read-only extension mode):
+
+- `execute_terminal_command` — run a shell command (sync or async). Primary tool for
+  compiling (`gcc -g`, `make`, `npm test`), writing `.vscode/launch.json`, checking
+  binaries exist, and any one-shot shell task.
+- `terminal_session_output` — read output from an async terminal session started earlier.
+- `terminal_session_signal` — send SIGINT/SIGTERM to an async session.
+
+Rules:
+
+- Prefer `execute_terminal_command` over asking the user to run commands manually when
+  you can do the task safely (compile with debug symbols, create/remove launch.json,
+  verify a file exists).
+- For long-running servers or REPLs, use async mode and poll with `terminal_session_output`.
+- If the tunnel is disconnected, `execute_terminal_command` will fail — fall back to
+  asking the user to run the command and reply `ready` (same as Case C in Phase 5c).
+- Do not use `execute_terminal_command` for applying code fixes; use `### Fix Proposal`
+  and let the user or code-gen flow apply edits.
+
+---
+
 ## Mode Selection
 
 Classify the user's message before acting:
@@ -107,6 +132,20 @@ Classify the user's message before acting:
 
 Execute the phases in order. Each phase has an explicit ENTRY action (the first tool call) and
 an EXIT condition. Do not advance until the EXIT condition holds.
+
+### Root-Cause Discipline
+
+Use a systematic debugging stance throughout the loop:
+
+- No fix proposal before a hypothesis is supported by runtime or source evidence.
+- Treat the visible error as a symptom until you trace where the bad value, pointer, object,
+  state, configuration, or assumption first entered the failing path.
+- When the failure appears deep in a call stack, trace backward one caller or data producer at a
+  time. Prefer fixing the source over adding a check only where the crash or error surfaced.
+- Compare broken code against nearby working examples, tests, fixtures, and reference
+  implementations before deciding a hypothesis is complete.
+- In multi-component paths, gather boundary evidence: what enters each component, what exits it,
+  and which component first changes good state into bad state.
 
 ---
 
@@ -129,6 +168,14 @@ error suggests" are not acceptable grounds.
 **ENTRY:** Call `get_workspace_debug_context(focus_path=<best_guess_file_from_phase_1>)`. If
 Phase 1 produced no clear file, pass the most-likely directory or `None`.
 
+Interpret the result along three dimensions:
+
+1. **Tunnel state** — is the VS Code extension tunnel attached? (`available` field)
+2. **Launch config** — does a `.vscode/launch.json` exist with at least one entry in
+   `launch_configs`?
+3. **Inferred command** — did the tool infer a plausible run/test command from the workspace
+   (`inferred_commands` non-empty)?
+
 **EXIT:** Emit **exactly one** of these lines as plain prose in your response:
 
 - `**Debugger:** available — Phase 5 will start after the user picks a hypothesis.`
@@ -138,9 +185,15 @@ Pick "available" when the response has `available=true` AND either at least one 
 entry OR at least one `inferred_commands` entry. Pick "unavailable" otherwise (no launch config
 + no inferred command, OR tunnel is not attached).
 
+When "unavailable", **also note in prose** which specific prerequisite is missing:
+
+- No tunnel → say so explicitly; Phase 5 will block on Case C.
+- Tunnel present but no `launch.json` and no inferred command → note that Phase 5c will offer
+  to create a `launch.json` for the session.
+
 "Unavailable" does NOT mean the loop ends. It means Phase 5c will need help from the user
-(either a command they supply, or one the agent proposes for their approval — see Phase 5c).
-You may NOT silently fall back to writing a final analysis.
+(either a command they supply, one the agent proposes, or a `launch.json` the agent creates and
+cleans up — see Phase 5c). You may NOT silently fall back to writing a final analysis.
 
 ---
 
@@ -153,34 +206,81 @@ just because the previous one returned results. Each provides different signal:
 
 Per-tool rules:
 
-- `query_context_graph`: call first. If `available=false`, note it and proceed to the next tool.
-  Do not retry or wait.
-- `ask_knowledge_graph_queries`: skip only if the project status is INFERRING (embedding index
-  not yet built). Otherwise always call it.
+- `search_bash`: read-only `rg -n` / shell searches for compound patterns. Use it to search
+  source and tests together for related helper names, shared error branches, malformed fixtures,
+  byte/hex literals, and terms like "raw", "encoded", "canonical", "validate", "next", "decode",
+  or "length" when those terms are present in candidate code.
 - `search_text`: ripgrep-style queries against symbols, error strings, or file paths extracted
   from the Phase 1 result.
 - `get_code_file_structure`: directory/file tree to cross-check paths and find sibling files.
 - `fetch_file`: fetch raw content for any candidate identified by the tools above.
+- `fetch_files_batch`: fetch raw content for multiple candidate files in a single call when you
+  already know the paths and want to avoid sequential `fetch_file` round-trips.
+
+Discovery budget and stop rules:
+
+- Do the baseline pass above once. After that, make at most **three** additional targeted
+  `search_text` / `search_bash` calls to close specific evidence gaps.
+- Never repeat the same search query or a trivial variant of it. If two consecutive searches
+  only confirm files or symbols you already found, stop discovery and proceed to Phase 4.
+- If a tool returns a stop, call-cap, timeout, or budget-exhausted message, immediately stop all
+  tool calls and synthesize hypotheses from the evidence already gathered.
+- Phase 3 is for locating evidence, not proving everything. Once you have candidate files,
+  relevant code snippets, and at least one validation path, move to hypothesis recording.
 
 **EXIT:** List the candidate files with a one-line rationale each. Each rationale must cite
-either (a) a Phase 1 stack frame, (b) a `search_text` hit, or (c) a knowledge-graph result. Do
-not introduce file candidates without one of these grounds.
+either (a) a Phase 1 stack frame, or (b) a `search_text` / `search_bash` hit. Do not introduce
+file candidates without one of these grounds.
 
 ---
 
 ### Phase 4 — Generate Hypotheses, then PAUSE
 
-Generate **1 to 4 hypotheses** — pick the count based on the actual distinct theories your
-Phase 1–3 work produced. One confident, well-grounded hypothesis is better than three padded
-ones. Do not invent hypotheses to hit a quota.
+Generate **1 to 5 hypotheses** — pick the count based on the actual distinct theories your
+Phase 1–3 work produced. One confident, well-grounded hypothesis is better than padded ones,
+but non-trivial crashes, parser/serializer bugs, data corruption, and security reports usually
+deserve 3–5 falsifiable hypotheses if the code gives you that many plausible explanations.
+Include plausible downstream/common explanations before the favorite theory so Phase 5 can
+reject them explicitly.
 
-Emit each hypothesis as a markdown card following the structure in the canonical example below,
-then persist each one with a `record_hypothesis` tool call.
+Before recording hypotheses, apply this quality checklist:
+
+- Search the tests and fixtures for the involved symbols, shared error strings, and malformed
+  payload patterns. If a reproducer exists, at least one evidence or validation-plan bullet
+  should point to it.
+- Trace backward from the immediate failing line to the producer of the bad value or state. If
+  you cannot trace all the way back, make the missing link a validation-plan step instead of
+  continuing to search.
+- Compare similar working and broken paths. At least one hypothesis should explain a concrete
+  difference, not just name a suspicious function.
+- If a validator and a later iterator/parser/converter both walk the same buffer or structured
+  payload, compare their advancement formulas. Create a hypothesis for any mismatch between
+  "actual bytes in the payload" and "canonical/recomputed size from decoded data".
+- For shared error branches, separate the downstream symptom from the upstream producer of the
+  bad pointer, length, object, or state.
+- Do not invent hypotheses to hit a quota; each card must be grounded in a concrete file,
+  symbol, test fixture, or failure-signal fragment.
+
+For each hypothesis, follow this **MANDATORY two-step sequence — tool call FIRST, card text SECOND**:
+
+**Step 1 — call `record_hypothesis` BEFORE emitting the card:**
+
+```
+record_hypothesis(
+    title="<hypothesis title — 8-15 specific words, codebase-specific, no generic phrases>",
+    status="proposed",
+    evidence=["<first Evidence bullet with file:line citation>", "<second bullet>"],
+    validation_plan=["<first Validation Plan step with concrete file:line>", "<second step>"]
+)
+```
+
+The tool returns a `hypothesis_id` (e.g. `"hyp_1"`). Store it — you will need it in Phases 5–7.
+
+**Step 2 — after the tool result arrives, emit the markdown card:**
 
 Mandatory section order inside each card:
 
-1. `## Hypothesis N: <title>` — 8–15 words, specific to this codebase and this failure (no
-   generic "Bug in error handling" titles).
+1. `## Hypothesis N: <title>` — same title you passed to `record_hypothesis` above.
 2. `### Status: proposed`
 3. `### Evidence` — bulleted. Each bullet MUST cite a file:line, symbol, or quoted
    failure-signal fragment. Generalizations without specific citations are not acceptable.
@@ -194,18 +294,8 @@ replaced with content from YOUR investigation):
 
 {HYPOTHESIS_MARKDOWN_EXAMPLE}
 
-After emitting all hypothesis cards, persist each one with a tool call:
-
-```
-record_hypothesis(
-    title="<same title as the ## Hypothesis N: line>",
-    status="proposed",
-    evidence="<bullet points from ### Evidence>",
-    validation_plan="<steps from ### Validation Plan>"
-)
-```
-
-Store the returned `hypothesis_id` for every hypothesis — you will need them in Phases 5–7.
+Repeat Steps 1–2 for every hypothesis. **Do NOT emit the pause question until ALL
+`record_hypothesis` calls have returned and ALL cards are emitted.**
 
 **REFINEMENT RULE (important):** If at any later phase your understanding shifts toward a
 theory not captured by an existing hypothesis card, you MUST call `record_hypothesis` again to
@@ -213,8 +303,8 @@ record the new theory as a fresh card (with its own `---` terminator) BEFORE wri
 conclusion that depends on it. The agent must never present a conclusion that is not backed by
 a recorded hypothesis card.
 
-**PHASE 4 EXIT — PAUSE FOR USER CHOICE:** After emitting cards and persisting them, end the
-response with a clearly framed question:
+**PHASE 4 EXIT — PAUSE FOR USER CHOICE:** After ALL record_hypothesis calls have returned
+and ALL cards are emitted, end the response with a clearly framed question:
 
 > "I've laid out N hypotheses above. Which one should I validate next?
 > - Reply 'start with H1' (or H2, H3, ...) to begin debugging that hypothesis
@@ -271,28 +361,79 @@ Use the best `launch_configs[0]` or `inferred_commands[0]` from Phase 2:
 start_debug_session(program="<entry_point_or_test_command>", language="<language>")
 ```
 
-Proceed to 5d.
+The returned status may be `"initialized"` even if the adapter is paused at entry. Do not infer
+execution state from the start result alone; proceed to 5d and let `take_debug_snapshot` confirm
+whether the session is paused or still running.
 
 **Case B — Tunnel attached, but no launch config AND no inferred command (missing debug
 command).**
 
-Many repos lack a `.vscode/launch.json` or any inferable test/run command. In this case, STOP
-and ask the user with two clearly framed options:
+Many repos lack a `.vscode/launch.json` or any inferable test/run command. Before asking the
+user, attempt to infer one yourself:
+
+1. Call `get_code_file_structure` or `search_bash` to find entry points, test runners, build
+   scripts, `Makefile`, `package.json` scripts, `pyproject.toml`, `go.mod`, or equivalent.
+2. Check whether a `.vscode/launch.json` already exists with `fetch_file`.
+3. If you can infer a plausible debug configuration from the project structure and the language
+   identified in Phase 1, go directly to **sub-case B3** below. Otherwise fall through to
+   **B1/B2**.
+
+**Sub-case B1 — You cannot infer a config; ask the user:**
 
 > "I don't see a debug configuration for this repo. Pick one:
 > - **(a) Tell me a command to run** — e.g. `pytest tests/foo.py -k bar`, `node --inspect dist/server.js`, `go test ./pkg/foo -run TestBar`. I'll launch it under the debugger.
-> - **(b) Tell me how the app normally starts and I'll propose a debug command** for your approval — e.g. 'we run `make test` for CI', 'the entry point is `src/cli.py`', 'tests live in `tests/integration/`'.
+> - **(b) Tell me how the app normally starts** — e.g. 'we run `make test` for CI', 'the entry point is `src/cli.py`', 'tests live in `tests/integration/`'. I'll propose a debug command for your approval.
+> - **(c) Let me create a `.vscode/launch.json`** for this project. I'll generate one, use it for this session, and remove it (or keep it — your choice) when we're done.
 >
 > Once you pick one, I'll continue with Hypothesis N."
 
-Then STOP the response. Do not call `start_debug_session` until the user has provided a command
-or approved one you've proposed.
+Then STOP the response.
 
-When the user responds with option (a) — a literal command — call `start_debug_session` with
-that command directly.
+**Sub-case B2 — User provides context (option b above):** Propose a concrete `start_debug_session`
+command, ask for confirmation, and only call `start_debug_session` after they approve.
 
-When the user responds with option (b) — context about the project — propose a concrete command
-back to the user, ask for confirmation, and only call `start_debug_session` after they approve.
+**Sub-case B3 — Create a `launch.json` (option c above, or when you can infer the config):**
+
+Follow these steps exactly:
+
+1. Determine the correct configuration for the language and entry point:
+   - **Python**: `{{"type": "python", "request": "launch", "program": "<entry>", "justMyCode": false}}`
+   - **Node/TypeScript**: `{{"type": "node", "request": "launch", "program": "<entry>"}}`
+   - **Go**: `{{"type": "go", "request": "launch", "mode": "debug", "program": "<entry>"}}`
+   - **C/C++**: `{{"type": "cppdbg", "request": "launch", "program": "<compiled_binary>", "MIMode": "lldb"}}` (macOS) or `"MIMode": "gdb"` (Linux). The binary must exist with `-g` debug symbols.
+   - For other languages, use the standard DAP launch config for that runtime.
+
+2. Use `execute_terminal_command` to write the file:
+   ```
+   mkdir -p .vscode && cat > .vscode/launch.json << 'EOF'
+   {{"version": "0.2.0", "configurations": [ <config> ]}}
+   EOF
+   ```
+   Confirm the write succeeded.
+
+3. Set `_launch_json_created_by_agent = true` in your working memory so you remember to clean up.
+
+4. Call `start_debug_session` with the `program` / `command` from the config you just wrote.
+
+5. **After the debugging session ends** (whether Phase 7 completes, the user stops, or an error
+   occurs), perform cleanup: ask the user:
+   > "I created `.vscode/launch.json` for this session. Would you like to keep it, or should I remove it?"
+   If they say remove (or don't respond to the cleanup prompt in the same turn), call:
+   ```
+   execute_terminal_command(command="rm .vscode/launch.json && rmdir --ignore-fail-on-non-empty .vscode")
+   ```
+
+**Important:** For C/C++ projects, the compiled binary must exist before `start_debug_session`
+will succeed. If `get_workspace_debug_context` or `fetch_file` confirms the binary is missing,
+emit this first:
+
+> "The binary `<path>` doesn't exist yet. Run this to compile it with debug symbols:
+> ```bash
+> gcc -g -o <output> <source.c>
+> ```
+> Reply `ready` once compiled and I'll start the debug session."
+
+Then STOP. Do not call `start_debug_session` until the user confirms the binary is compiled.
 
 **Case C — Tunnel not attached (`error_type="no_tunnel"` from any DAP tool or Phase 2 reported
 no tunnel).**
@@ -321,6 +462,17 @@ Loop:
 5. Emit a brief markdown summary of the observation after each snapshot.
 
 Repeat until you have enough evidence to render a verdict, or the session ends.
+
+Traversal-divergence hypotheses need side-by-side evidence, not a single breakpoint. If the
+chosen hypothesis says validation and iteration/parsing/conversion walk the same data
+differently, inspect both walkers on the same logical entry and evaluate:
+
+- the decoded length or size value
+- the encoded size actually present in the payload
+- any canonical/recomputed encoded size
+- the pointer/offset delta each walker applies
+- the exact fixture bytes or input fragment that create the mismatch, if a test/reproducer
+  exists
 
 If the debugger run is inconclusive:
 

--- a/app/modules/intelligence/agents/chat_agents/system_agents/debug_hypothesis_contract.py
+++ b/app/modules/intelligence/agents/chat_agents/system_agents/debug_hypothesis_contract.py
@@ -74,33 +74,26 @@ DISCOVERY_PRIORITY_ORDER: list[str] = [
 # This is the reference for prompt writers and webview parser implementers.
 # ---------------------------------------------------------------------------
 
-# The worked example below shows the mandatory sections only (Evidence + Validation Plan).
-# Optional sections (Debugger Evidence, Fix Proposal) are referenced in
-# HYPOTHESIS_SECTION_HEADERS and are populated by the agent during the debugging and
-# fix_proposed phases respectively.
+# Generic structural skeleton — STRUCTURE ONLY.
+# Every concrete word is a placeholder in angle brackets so the model cannot accidentally
+# borrow domain vocabulary from this example. The trailing `---` is the card terminator the
+# VS Code parser keys on; every emitted hypothesis card must end with it.
 HYPOTHESIS_MARKDOWN_EXAMPLE = """\
-## Hypothesis 1: Payment timeout is thrown but not converted into a controlled checkout response
+## Hypothesis 1: <one-line statement of the suspected root cause>
 
-### Status: debugging
+### Status: proposed
 
 ### Evidence
 
-- Stack trace captured from Sentry includes `paymentAdapter.chargeCard` at the top of the call
-  chain, indicating the timeout originates inside the payment adapter layer.
-- `createOrder` surfaces the exception directly as an HTTP 500 rather than mapping it to a
-  controlled checkout failure response (e.g. `PaymentDeclinedError`).
-- The related integration test `should return payment_failed on timeout` asserts a controlled
-  `payment_failed` response body — this test is currently red, confirming the gap.
+- <observation tied to a specific file:line, symbol, or quoted fragment of the failure signal>
+- <observation that connects the observed failure to the suspected origin>
+- <observation showing the gap between expected and actual behavior at that location>
 
 ### Validation Plan
 
-- Set a breakpoint in `chargeCard` at the point where the timeout exception is raised or caught
-  to confirm whether any local handling occurs before the exception propagates.
-- Set a breakpoint in `createOrder`'s error-handling block to verify whether a timeout error
-  is caught and mapped, or escapes uncaught.
-- Run the checkout reproduction script with a mocked slow payment gateway to trigger the timeout
-  path deterministically.
-- Inspect the exception object at each breakpoint: confirm it is a raw timeout error rather than
-  a domain-typed `PaymentTimeoutError`, then trace whether any conversion to a controlled
-  response ever takes place.
+- <breakpoint or instrumentation step naming a concrete file:line and what to inspect>
+- <command, test, or repro step that exercises the suspected path>
+- <what observation at the breakpoint will confirm or refute this hypothesis>
+
+---
 """

--- a/app/modules/intelligence/agents/chat_agents/system_agents/debug_hypothesis_contract.py
+++ b/app/modules/intelligence/agents/chat_agents/system_agents/debug_hypothesis_contract.py
@@ -1,0 +1,106 @@
+"""Markdown contract for transporting debugging hypotheses from the agent to the VS Code webview.
+
+This contract is consumed by both the agent system prompt and the VS Code webview parser.
+Any change here is a coordinated change across both sides.
+"""
+from enum import Enum
+
+__all__ = [
+    "HypothesisStatus",
+    "HYPOTHESIS_STATUS_ENUM",
+    "HYPOTHESIS_SECTION_HEADERS",
+    "DISCOVERY_PRIORITY_ORDER",
+    "HYPOTHESIS_MARKDOWN_EXAMPLE",
+]
+
+
+class HypothesisStatus(str, Enum):
+    """Lifecycle states a debugging hypothesis can occupy, in order of progression."""
+
+    PROPOSED = "proposed"
+    DEBUGGING = "debugging"
+    NEEDS_EVIDENCE = "needs_evidence"
+    SUPPORTED = "supported"
+    REJECTED = "rejected"
+    FIX_PROPOSED = "fix_proposed"
+    NEEDS_REVISION = "needs_revision"
+    VALIDATED = "validated"
+
+
+# Spec-named alias for cross-side parsers (VS Code webview / external consumers) that reference the canonical name from the contract spec.
+HYPOTHESIS_STATUS_ENUM = HypothesisStatus
+
+
+# ---------------------------------------------------------------------------
+# Section header strings — the agent must emit these verbatim.
+# Format strings use Python str.format() placeholders.
+# ---------------------------------------------------------------------------
+
+HYPOTHESIS_SECTION_HEADERS = {
+    # e.g. "## Hypothesis 1: Payment timeout is not converted into a controlled response"
+    "title": "## Hypothesis {n}: {title}",
+    # e.g. "### Status: debugging"
+    "status": "### Status: {status}",
+    # Literal headers — always present in a complete hypothesis block.
+    "evidence": "### Evidence",
+    "validation_plan": "### Validation Plan",
+    # Populated during the active debugging phase.
+    "debugger_evidence": "### Debugger Evidence",
+    # Only emitted when status is fix_proposed or later.
+    "fix_proposal": "### Fix Proposal",
+}
+
+
+# ---------------------------------------------------------------------------
+# Code-discovery priority order.
+# The agent must consult tools in this sequence when locating code.
+# query_context_graph (A8) is listed first so the agent is forward-compatible
+# with the context graph once it becomes available; it may return
+# available=False today and the agent falls through to the next tool.
+# ---------------------------------------------------------------------------
+
+DISCOVERY_PRIORITY_ORDER: list[str] = [
+    "query_context_graph",         # A8 - primary, may return available=False today
+    "ask_knowledge_graph_queries", # existing, requires non-INFERRING status
+    # search_text is the registered grep-style text search tool; swap for search_colgrep when feat/colgrep merges
+    "search_text",                 # local_mode_only: ripgrep-backed text search via VS Code tunnel
+    "get_code_file_structure",     # directory/file tree for structural navigation
+    "fetch_file",                  # fetch raw file content by path
+]
+
+
+# ---------------------------------------------------------------------------
+# Canonical worked example — one fully-formed hypothesis block.
+# This is the reference for prompt writers and webview parser implementers.
+# ---------------------------------------------------------------------------
+
+# The worked example below shows the mandatory sections only (Evidence + Validation Plan).
+# Optional sections (Debugger Evidence, Fix Proposal) are referenced in
+# HYPOTHESIS_SECTION_HEADERS and are populated by the agent during the debugging and
+# fix_proposed phases respectively.
+HYPOTHESIS_MARKDOWN_EXAMPLE = """\
+## Hypothesis 1: Payment timeout is thrown but not converted into a controlled checkout response
+
+### Status: debugging
+
+### Evidence
+
+- Stack trace captured from Sentry includes `paymentAdapter.chargeCard` at the top of the call
+  chain, indicating the timeout originates inside the payment adapter layer.
+- `createOrder` surfaces the exception directly as an HTTP 500 rather than mapping it to a
+  controlled checkout failure response (e.g. `PaymentDeclinedError`).
+- The related integration test `should return payment_failed on timeout` asserts a controlled
+  `payment_failed` response body — this test is currently red, confirming the gap.
+
+### Validation Plan
+
+- Set a breakpoint in `chargeCard` at the point where the timeout exception is raised or caught
+  to confirm whether any local handling occurs before the exception propagates.
+- Set a breakpoint in `createOrder`'s error-handling block to verify whether a timeout error
+  is caught and mapped, or escapes uncaught.
+- Run the checkout reproduction script with a mocked slow payment gateway to trigger the timeout
+  path deterministically.
+- Inspect the exception object at each breakpoint: confirm it is a raw timeout error rather than
+  a domain-typed `PaymentTimeoutError`, then trace whether any conversion to a controlled
+  response ever takes place.
+"""

--- a/app/modules/intelligence/agents/chat_agents/system_agents/debug_hypothesis_contract.py
+++ b/app/modules/intelligence/agents/chat_agents/system_agents/debug_hypothesis_contract.py
@@ -53,19 +53,15 @@ HYPOTHESIS_SECTION_HEADERS = {
 
 # ---------------------------------------------------------------------------
 # Code-discovery priority order.
-# The agent must consult tools in this sequence when locating code.
-# query_context_graph (A8) is listed first so the agent is forward-compatible
-# with the context graph once it becomes available; it may return
-# available=False today and the agent falls through to the next tool.
+# The agent must consult tools in this order during Phase 3 when locating code.
 # ---------------------------------------------------------------------------
 
 DISCOVERY_PRIORITY_ORDER: list[str] = [
-    "query_context_graph",         # A8 - primary, may return available=False today
-    "ask_knowledge_graph_queries", # existing, requires non-INFERRING status
-    # search_text is the registered grep-style text search tool; swap for search_colgrep when feat/colgrep merges
+    "search_bash",                 # local_mode_only: read-only rg/bash for compound source + test searches
     "search_text",                 # local_mode_only: ripgrep-backed text search via VS Code tunnel
     "get_code_file_structure",     # directory/file tree for structural navigation
     "fetch_file",                  # fetch raw file content by path
+    "fetch_files_batch",           # fetch multiple files in one call
 ]
 
 

--- a/app/modules/intelligence/agents/multi_agent_config.py
+++ b/app/modules/intelligence/agents/multi_agent_config.py
@@ -24,7 +24,11 @@ class MultiAgentConfig:
         "code_generation_agent": os.getenv("CODE_GEN_MULTI_AGENT", "true").lower()
         == "true",
         "codebase_qna_agent": os.getenv("QNA_MULTI_AGENT", "true").lower() == "true",
-        "debugging_agent": os.getenv("DEBUG_MULTI_AGENT", "true").lower() == "true",
+        # A7.1: Default to single-agent (PydanticRagAgent) for debugging_agent.
+        # The DAP loop is stateful; round-tripping through THINK_EXECUTE delegation
+        # risks losing tool-call context.  To re-enable multi-agent mode set the env
+        # var: DEBUG_MULTI_AGENT=true
+        "debugging_agent": os.getenv("DEBUG_MULTI_AGENT", "false").lower() == "true",
         "unit_test_agent": os.getenv("UNIT_TEST_MULTI_AGENT", "true").lower() == "true",
         "integration_test_agent": os.getenv(
             "INTEGRATION_TEST_MULTI_AGENT", "true"
@@ -102,7 +106,7 @@ ENABLE_MULTI_AGENT=true
 GENERAL_PURPOSE_MULTI_AGENT=true
 CODE_GEN_MULTI_AGENT=true
 QNA_MULTI_AGENT=true
-DEBUG_MULTI_AGENT=true
+DEBUG_MULTI_AGENT=false  # default false (A7.1) — set to true to re-enable multi-agent for debugging_agent
 UNIT_TEST_MULTI_AGENT=true
 INTEGRATION_TEST_MULTI_AGENT=true
 LLD_MULTI_AGENT=true

--- a/app/modules/intelligence/agents/runtime/agent_execution_service.py
+++ b/app/modules/intelligence/agents/runtime/agent_execution_service.py
@@ -8,6 +8,7 @@ accounting, and the terminal completed-end event).
 
 from __future__ import annotations
 
+import json
 from typing import Any, AsyncIterator, Callable, Optional
 
 from app.modules.conversations.exceptions import GenerationCancelled
@@ -20,7 +21,7 @@ DEFAULT_CANCEL_MESSAGE = "Generation cancelled by user"
 
 
 def serialize_tool_calls(tool_calls: Any) -> list:
-    """Serialize agent tool calls to JSON-able values (model_dump / dict / str)."""
+    """Serialize agent tool calls to JSON-able dicts for Redis ``tool_calls_json``."""
     result: list = []
     if not tool_calls:
         return result
@@ -29,6 +30,14 @@ def serialize_tool_calls(tool_calls: Any) -> list:
             result.append(tc.model_dump())
         elif hasattr(tc, "dict"):
             result.append(tc.dict())
+        elif isinstance(tc, dict):
+            result.append(tc)
+        elif isinstance(tc, str):
+            try:
+                parsed = json.loads(tc)
+                result.append(parsed if isinstance(parsed, dict) else {"raw": tc})
+            except json.JSONDecodeError:
+                result.append({"raw": tc})
         else:
             result.append(str(tc))
     return result
@@ -66,16 +75,17 @@ async def run_agent_turn(
                 _safe_flush(flush_partial)
                 sink.emit("end", {"status": "cancelled", "message": cancel_message})
                 return False
-            sink.emit(
-                "chunk",
-                {
-                    "content": getattr(chunk, "message", "") or "",
-                    "citations_json": getattr(chunk, "citations", None) or [],
-                    "tool_calls_json": serialize_tool_calls(
-                        getattr(chunk, "tool_calls", None)
-                    ),
-                },
-            )
+            thinking = getattr(chunk, "thinking", None)
+            payload: dict[str, Any] = {
+                "content": getattr(chunk, "message", "") or "",
+                "citations_json": getattr(chunk, "citations", None) or [],
+                "tool_calls_json": serialize_tool_calls(
+                    getattr(chunk, "tool_calls", None)
+                ),
+            }
+            if thinking:
+                payload["thinking"] = thinking
+            sink.emit("chunk", payload)
         # A cooperative cancel can make chunk_stream end cleanly (the agent stops
         # yielding) instead of raising — without this final check the run would be
         # reported as completed. Re-check after the loop so it's treated as cancelled.

--- a/app/modules/intelligence/provider/anthropic_caching_model.py
+++ b/app/modules/intelligence/provider/anthropic_caching_model.py
@@ -488,23 +488,20 @@ class CachingAnthropicModel(AnthropicModel):
     async def request(
         self,
         messages: list[ModelMessage],
-        *,
         model_settings: ModelSettings | None = None,
-    ):
+        model_request_parameters: ModelRequestParameters | None = None,
+    ) -> ModelResponse:
         """
-        Override request to intercept and log cache metrics from both
-        non-streaming and streaming responses.
+        Match pydantic-ai's current Model.request contract.
+
+        Cache metrics are logged by _process_response, so the parent request
+        flow can be used directly after the custom _messages_create hook runs.
         """
-        # Call parent's request method
-        result = await super().request(messages, model_settings=model_settings)
-
-        # For non-streaming responses, cache metrics are already logged in _process_response
-        # For streaming responses, we need to wrap the result to log metrics
-        if hasattr(result, "__aiter__"):
-            # This is a streaming response - wrap it to log metrics
-            return self._wrap_streaming_response(result)
-
-        return result
+        if model_request_parameters is None:
+            model_request_parameters = ModelRequestParameters()
+        return await super().request(
+            messages, model_settings, model_request_parameters
+        )
 
     async def _wrap_streaming_response(self, stream_response):
         """
@@ -612,8 +609,20 @@ class CachingAnthropicModel(AnthropicModel):
                 if self._cache_ttl != "5m":
                     cache_control["ttl"] = self._cache_ttl
 
-                # Check if system prompt contains the cache breakpoint marker
-                if CACHE_BREAKPOINT_MARKER in system_prompt:
+                # pydantic-ai may return either a plain string or structured
+                # Anthropic text blocks. Preserve structured blocks instead of
+                # nesting them into a new text field.
+                if isinstance(system_prompt, list):
+                    system_blocks = [dict(block) for block in system_prompt]
+                    text_block_indexes = [
+                        i
+                        for i, block in enumerate(system_blocks)
+                        if block.get("type") == "text" and isinstance(block.get("text"), str)
+                    ]
+                    if text_block_indexes:
+                        system_blocks[text_block_indexes[-1]]["cache_control"] = cache_control
+                    system_param = system_blocks
+                elif CACHE_BREAKPOINT_MARKER in system_prompt:
                     # Split at marker: cache static part, don't cache dynamic part
                     parts = system_prompt.split(CACHE_BREAKPOINT_MARKER, 1)
                     static_content = parts[0].strip()

--- a/app/modules/intelligence/provider/provider_service.py
+++ b/app/modules/intelligence/provider/provider_service.py
@@ -1364,7 +1364,7 @@ class ProviderService:
             "claude-sonnet-4",
             "claude-opus-4-1",
             "claude-haiku-4-5",
-            "claude-sonnet-4-5",
+            "claude-sonnet-4-6",
             # Google models
             "gemini-pro-vision",
             "gemini-1.5",

--- a/app/modules/intelligence/tools/dap_schemas.py
+++ b/app/modules/intelligence/tools/dap_schemas.py
@@ -1,0 +1,276 @@
+"""DAP (Debug Adapter Protocol) Pydantic schemas for the A3 tool family.
+
+Wire-format mapping from DebugSessionManager.ts (TypeScript) → Python field names:
+
+TypeScript interface                  Python model          Notes
+────────────────────────────────────────────────────────────────────────────────
+DebugCallFrame.frame_id               frame_id              same (TS already snake_case)
+DebugCallFrame.function               name                  TS uses 'function', Python uses 'name'
+                                                            (kept for readability; wire key = 'name')
+DebugCallFrame.file                   source_path           TS uses 'file', Python uses 'source_path'
+DebugCallFrame.line                   line                  same
+
+DebugSnapshot.paused_at              paused_at             TS: {file, line, function}; kept as-is
+DebugSnapshot.call_stack             call_stack            same
+DebugSnapshot.locals                 locals                same
+DebugSnapshot.expression_results     expression_results    TS array of {expression,result?,error?}
+DebugSnapshot.session_id             session_id            same
+DebugSnapshot.status                 status                TS: 'paused'|'running'|'stopped' etc.
+
+StartSessionResult.session_id        session_id            same
+StartSessionResult.program           program               same
+StartSessionResult.language          language              same
+StartSessionResult.status            status                same
+
+StopSessionResult.session_id         session_id            same
+StopSessionResult.stopped            stopped (unused)      We remap to Literal["terminated","not_found"]
+
+SetBreakpointsResult.file            file                  same
+SetBreakpointsResult.breakpoints     breakpoints           array of {line,verified,actual_line?,message?}
+
+ListSessionsResult.session_id        session_id            same
+ListSessionsResult.program           program               same
+ListSessionsResult.language          language              same
+ListSessionsResult.status            status                same
+ListSessionsResult.createdAt         created_at            camelCase→snake_case in Python
+
+TrackedDebugSession (TS)             TrackedDebugSession   subset — only fields exposed to agent
+
+The TS DebugSessionStatus enum is "initialized"|"running"|"paused"|"stopped".
+We also accept "terminated" in the Python models for forward-compatibility.
+"""
+
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+# ---------------------------------------------------------------------------
+# A3.1.1 — DebugCallFrame
+# ---------------------------------------------------------------------------
+
+
+class DebugCallFrame(BaseModel):
+    """A single frame in a call stack.
+
+    Mirrors TS DebugCallFrame: {frame_id, function, file, line}.
+    Python renames 'function' → 'name' and 'file' → 'source_path' for clarity;
+    the wire JSON from the extension uses 'function' and 'file' respectively.
+    Pydantic aliases for 'function' and 'file' allow model_validate() to accept
+    the raw TS dict directly.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    frame_id: int = Field(..., description="Unique frame ID assigned by the debug adapter.")
+    name: str = Field(..., alias="function", description="Function or method name at this frame.")
+    source_path: Optional[str] = Field(None, alias="file", description="Absolute path to the source file, if available.")
+    line: Optional[int] = Field(None, description="Source line number (1-based).")
+    column: Optional[int] = Field(None, description="Source column number, if provided.")
+
+
+# ---------------------------------------------------------------------------
+# A3.1.2 — DebugSnapshot
+# ---------------------------------------------------------------------------
+
+
+class DebugSnapshot(BaseModel):
+    """Full state snapshot captured at a DAP stopped event.
+
+    Mirrors TS DebugSnapshot:
+      paused_at: {file, line, function}
+      call_stack: DebugCallFrame[]
+      locals: Record<string, string>
+      expression_results: Array<{expression, result?, error?}>
+      session_id: string
+      status: string
+
+    The 'status' field reflects the TS DebugSessionStatus literals
+    ("running" | "paused" | "initialized" | "stopped") plus "terminated"
+    for forward-compatibility.
+    """
+
+    session_id: str = Field(..., description="Internal session UUID.")
+    status: str = Field(
+        ...,
+        description="Session status at snapshot time: 'paused', 'running', 'stopped', 'initialized', or 'terminated'.",
+    )
+    paused_at: Optional[Dict[str, Any]] = Field(
+        None,
+        description="Location where execution is paused: {file, line, function}. Null when running.",
+    )
+    call_stack: List[DebugCallFrame] = Field(
+        default_factory=list,
+        description="Ordered list of stack frames (top frame first).",
+    )
+    locals: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Local variable name → string representation at the top frame.",
+    )
+    expression_results: List[Dict[str, Any]] = Field(
+        default_factory=list,
+        description=(
+            "Evaluated expression results: [{expression, result?, error?}]. "
+            "Mirrors TS DebugSnapshot.expression_results exactly."
+        ),
+    )
+    output: Optional[str] = Field(None, description="Any console/stdout output captured during the step.")
+
+
+# ---------------------------------------------------------------------------
+# A3.1.3 — StartSessionResult
+# ---------------------------------------------------------------------------
+
+
+class StartSessionResult(BaseModel):
+    """Result of starting a new debug session.
+
+    Mirrors TS StartSessionResult: {session_id, program, language, status}.
+    """
+
+    session_id: str = Field(..., description="UUID assigned to this debug session.")
+    program: Optional[str] = Field(None, description="Absolute path to the program being debugged.")
+    language: Optional[str] = Field(None, description="Language of the program, e.g. 'python'.")
+    status: str = Field(
+        ...,
+        description="Session status after start: 'initialized', 'running', 'failed', etc.",
+    )
+    message: Optional[str] = Field(None, description="Optional diagnostic message.")
+
+
+# ---------------------------------------------------------------------------
+# A3.1.4 — SetBreakpointsResult
+# ---------------------------------------------------------------------------
+
+
+class SetBreakpointsResult(BaseModel):
+    """Result of setting breakpoints in a file.
+
+    Mirrors TS SetBreakpointsResult:
+      {file, breakpoints: Array<{line, verified, actual_line?, message?}>}
+    """
+
+    session_id: Optional[str] = Field(None, description="Session the breakpoints were set on.")
+    file: str = Field(..., description="Absolute path to the file where breakpoints were set.")
+    breakpoints: List[Dict[str, Any]] = Field(
+        default_factory=list,
+        description=(
+            "DAP breakpoint results: [{line, verified, actual_line?, message?}]. "
+            "Shape matches the TS extension response exactly."
+        ),
+    )
+    message: Optional[str] = Field(None, description="Optional diagnostic message.")
+
+
+# ---------------------------------------------------------------------------
+# A3.1.5 — TrackedDebugSession (agent-visible subset)
+# ---------------------------------------------------------------------------
+
+
+class TrackedDebugSession(BaseModel):
+    """Lightweight session descriptor returned by list_debug_sessions.
+
+    Mirrors TS ListSessionsResult: {session_id, program, language, status, createdAt}.
+    'createdAt' is renamed to 'created_at' (snake_case); the alias allows
+    model_validate() to accept the raw TS dict directly.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    session_id: str = Field(..., description="Session UUID.")
+    program: Optional[str] = Field(None, description="Program being debugged.")
+    language: Optional[str] = Field(None, description="Language, e.g. 'python'.")
+    status: str = Field(
+        ...,
+        description="Current status: 'initialized', 'running', 'paused', 'stopped', or 'terminated'.",
+    )
+    created_at: Optional[str] = Field(None, alias="createdAt", description="ISO 8601 timestamp when the session was created.")
+
+
+# ---------------------------------------------------------------------------
+# A3.1.6 — ListSessionsResult
+# ---------------------------------------------------------------------------
+
+
+class ListSessionsResult(BaseModel):
+    """Wrapper for listing all active debug sessions."""
+
+    sessions: List[TrackedDebugSession] = Field(
+        default_factory=list,
+        description="All currently tracked debug sessions.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# A3.1.7 — EvaluateResult
+# ---------------------------------------------------------------------------
+
+
+class EvaluateResult(BaseModel):
+    """Result of evaluating a single expression in a debug frame."""
+
+    session_id: str = Field(..., description="Session the expression was evaluated in.")
+    expression: str = Field(..., description="The expression that was evaluated.")
+    value: str = Field(..., description="String representation of the evaluated value.")
+    type: Optional[str] = Field(None, description="Type name returned by the debug adapter, if available.")
+
+
+# ---------------------------------------------------------------------------
+# A3.1.8 — StopSessionResult
+# ---------------------------------------------------------------------------
+
+
+class StopSessionResult(BaseModel):
+    """Result of stopping a debug session.
+
+    Mirrors TS StopSessionResult: {session_id, stopped: boolean}.
+    We remap 'stopped: true' → status="terminated", not found → "not_found".
+    """
+
+    session_id: str = Field(..., description="UUID of the session that was stopped.")
+    status: Literal["terminated", "not_found"] = Field(
+        ...,
+        description="'terminated' if the session was successfully stopped; 'not_found' if no matching session.",
+    )
+    message: Optional[str] = Field(None, description="Optional diagnostic message.")
+
+
+# ---------------------------------------------------------------------------
+# A3.1.9 — DapError (uniform error envelope)
+# ---------------------------------------------------------------------------
+
+
+class DapError(BaseModel):
+    """Uniform error envelope returned by every DAP tool on failure.
+
+    error_type values:
+      no_tunnel         — VS Code extension is not connected
+      unknown_route     — Extension does not yet handle this DAP route
+      timeout           — RPC timed out
+      tunnel_unreachable — Tunnel registered but socket/HTTP call failed
+      no_user_id        — No user context available
+      unknown_error     — Catch-all for unexpected exceptions
+    """
+
+    available: bool = Field(
+        False,
+        description="Always False for error envelopes.",
+    )
+    error: str = Field(
+        ...,
+        description="Short machine-readable error string.",
+    )
+    # error_type values: keep in sync with route_dap_command's returned error codes.
+    # Add new codes here only when the dispatcher actually emits them.
+    error_type: Literal[
+        "no_tunnel",
+        "unknown_route",
+        "timeout",
+        "tunnel_unreachable",
+        "no_user_id",
+        "unknown_error",
+    ] = Field(..., description="Categorised error type for programmatic handling.")
+    message: str = Field(
+        ...,
+        description="Human-readable diagnostic message suitable for logging or agent display.",
+    )

--- a/app/modules/intelligence/tools/dap_schemas.py
+++ b/app/modules/intelligence/tools/dap_schemas.py
@@ -248,6 +248,8 @@ class DapError(BaseModel):
       unknown_route     — Extension does not yet handle this DAP route
       timeout           — RPC timed out
       tunnel_unreachable — Tunnel registered but socket/HTTP call failed
+      backend_socket_error — Backend socket bridge failed before delivery
+      extension_error   — Extension/debug adapter returned a DAP error
       no_user_id        — No user context available
       unknown_error     — Catch-all for unexpected exceptions
     """
@@ -267,6 +269,8 @@ class DapError(BaseModel):
         "unknown_route",
         "timeout",
         "tunnel_unreachable",
+        "backend_socket_error",
+        "extension_error",
         "no_user_id",
         "unknown_error",
     ] = Field(..., description="Categorised error type for programmatic handling.")

--- a/app/modules/intelligence/tools/dap_tools.py
+++ b/app/modules/intelligence/tools/dap_tools.py
@@ -1,0 +1,817 @@
+"""DAP tool family (A3) — ten tools that drive the VS Code debugger via the tunnel.
+
+Each tool dispatches a RPC call to the VS Code extension's DebugSessionManager
+using ``route_dap_command`` from ``tunnel_utils.py``.
+
+RPC naming convention (for E4 reference):
+  Registry key (Python)   Wire method (route_dap_command)  Socket event / HTTP endpoint
+  ─────────────────────────────────────────────────────────────────────────────────────
+  start_debug_session     start_session                    debug.start_session / /api/debug/start-session
+  set_breakpoints         set_breakpoints                  debug.set_breakpoints / /api/debug/set-breakpoints
+  take_debug_snapshot     snapshot                         debug.snapshot / /api/debug/snapshot
+  step_over               step_over                        debug.step_over / /api/debug/step-over
+  step_into               step_into                        debug.step_into / /api/debug/step-into
+  step_out                step_out                         debug.step_out / /api/debug/step-out
+  continue_execution      continue_execution               debug.continue_execution / /api/debug/continue-execution
+  evaluate_expression     evaluate                         debug.evaluate / /api/debug/evaluate
+  list_debug_sessions     list_sessions                    debug.list_sessions / /api/debug/list-sessions
+  stop_debug_session      stop_session                     debug.stop_session / /api/debug/stop-session
+
+All tools return .model_dump(mode="json") dicts. On any failure (including
+missing tunnel) they return a DapError dict — they never raise.
+"""
+
+# E4 dependency: `evaluate` requires a new TS handler not present in current
+# DebugSessionManager.ts. All other 9 methods map to existing DebugSessionManager
+# methods.
+
+from typing import List, Literal, Optional
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from app.modules.utils.logger import setup_logger
+from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
+    route_dap_command,
+    get_context_vars,
+)
+from app.modules.intelligence.tools.dap_schemas import (
+    DebugCallFrame,
+    DebugSnapshot,
+    DapError,
+    EvaluateResult,
+    ListSessionsResult,
+    SetBreakpointsResult,
+    StartSessionResult,
+    StopSessionResult,
+    TrackedDebugSession,
+)
+
+logger = setup_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NO_TUNNEL_MSG = (
+    "VS Code extension is not connected (no tunnel registered). "
+    "Ensure the Potpie extension is running and shows 'Connected' status."
+)
+_UNKNOWN_ROUTE_MSG = (
+    "The VS Code extension has not yet registered this DAP route. "
+    "Extension-side handlers are part of E4 — returns available=False until E4 lands."
+)
+_TIMEOUT_MSG = (
+    "DAP RPC timed out — the VS Code extension may be busy or the tunnel is degraded. "
+    "Retry when the extension is responsive."
+)
+_TUNNEL_UNREACHABLE_MSG = (
+    "Tunnel is registered but unreachable — the VS Code extension may have disconnected. "
+    "Reconnect and retry."
+)
+_NO_USER_ID_MSG = "No authenticated user context — cannot route DAP command."
+
+
+def _make_dap_error(error_type: Optional[str], context: str) -> DapError:
+    """Map a route_dap_command error_type string to a DapError model."""
+    if error_type == "no_tunnel":
+        msg = _NO_TUNNEL_MSG
+        etype: Literal[
+            "no_tunnel", "unknown_route", "timeout",
+            "tunnel_unreachable", "no_user_id", "unknown_error"
+        ] = "no_tunnel"
+    elif error_type == "no_user_id":
+        msg = _NO_USER_ID_MSG
+        etype = "no_user_id"
+    elif error_type == "unknown_route":
+        msg = _UNKNOWN_ROUTE_MSG
+        etype = "unknown_route"
+    elif error_type == "timeout":
+        msg = _TIMEOUT_MSG
+        etype = "timeout"
+    elif error_type == "tunnel_unreachable":
+        msg = _TUNNEL_UNREACHABLE_MSG
+        etype = "tunnel_unreachable"
+    else:
+        msg = (
+            f"DAP command '{context}' failed (error_type={error_type!r}). "
+            "The VS Code extension tunnel may be unavailable or misconfigured."
+        )
+        etype = "unknown_error"
+    return DapError(
+        available=False,
+        error=error_type or "unknown_error",
+        error_type=etype,
+        message=msg,
+    )
+
+
+def _parse_call_stack(raw: list) -> List[DebugCallFrame]:
+    """Parse a raw list of call-frame dicts from the extension into DebugCallFrame models."""
+    frames = []
+    for f in raw:
+        try:
+            frames.append(
+                DebugCallFrame(
+                    frame_id=f.get("frame_id", 0),
+                    name=f.get("function") or f.get("name") or "<unknown>",
+                    source_path=f.get("file") or f.get("source_path"),
+                    line=f.get("line"),
+                    column=f.get("column"),
+                )
+            )
+        except Exception as exc:
+            logger.debug("[DAP] Could not parse call frame %r: %s", f, exc)
+    return frames
+
+
+def _build_snapshot(result: dict) -> DebugSnapshot:
+    """Deserialise a raw extension response into a DebugSnapshot."""
+    return DebugSnapshot(
+        session_id=result.get("session_id", ""),
+        status=result.get("status", "paused"),
+        paused_at=result.get("paused_at"),
+        call_stack=_parse_call_stack(result.get("call_stack") or []),
+        locals=result.get("locals") or {},
+        expression_results=result.get("expression_results") or [],
+        output=result.get("output"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. start_debug_session
+# ---------------------------------------------------------------------------
+
+
+class StartDebugSessionInput(BaseModel):
+    program: str = Field(
+        ...,
+        description="Path to the program entry point (e.g. 'src/main.py' or '/abs/path/main.py').",
+    )
+    language: Literal["python", "node", "go", "unknown"] = Field(
+        "python",
+        description="Language of the program being debugged.",
+    )
+    mode: Literal["launch", "attach"] = Field(
+        "launch",
+        description="'launch' to start a new process; 'attach' to connect to a running process.",
+    )
+    port: Optional[int] = Field(
+        None,
+        description="Port to attach to (only relevant for attach mode).",
+    )
+    args: Optional[List[str]] = Field(
+        None,
+        description="Additional command-line arguments to pass to the program.",
+    )
+
+
+def start_debug_session(
+    program: str,
+    language: Literal["python", "node", "go", "unknown"] = "python",
+    mode: Literal["launch", "attach"] = "launch",
+    port: Optional[int] = None,
+    args: Optional[List[str]] = None,
+) -> dict:
+    """Start a new VS Code debug session."""
+    user_id, conversation_id = get_context_vars()
+    payload: dict = {
+        "program": program,
+        "language": language,
+        "mode": mode,
+    }
+    if port is not None:
+        payload["port"] = port
+    if args is not None:
+        payload["args"] = args
+
+    try:
+        result, error_type = route_dap_command(
+            method="start_session",
+            payload=payload,
+            user_id=user_id or "",
+            conversation_id=conversation_id,
+        )
+    except Exception as exc:
+        logger.warning("[start_debug_session] Unexpected exception: %s", exc)
+        return DapError(
+            available=False,
+            error="unknown_error",
+            error_type="unknown_error",
+            message=f"Unexpected error starting debug session: {exc}",
+        ).model_dump(mode="json")
+
+    if result is not None:
+        try:
+            return StartSessionResult(
+                session_id=result.get("session_id", ""),
+                program=result.get("program"),
+                language=result.get("language"),
+                status=result.get("status", "initialized"),
+                message=result.get("message"),
+            ).model_dump(mode="json")
+        except Exception as parse_exc:
+            logger.warning("[start_debug_session] Parse error: %s", parse_exc)
+            return DapError(
+                available=False,
+                error="unknown_error",
+                error_type="unknown_error",
+                message=f"Received a response but could not parse it: {parse_exc}",
+            ).model_dump(mode="json")
+
+    return _make_dap_error(error_type, "start_session").model_dump(mode="json")
+
+
+def start_debug_session_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=start_debug_session,
+        name="start_debug_session",
+        description=(
+            "Start a new VS Code debug session for a program. "
+            "Sends a 'start_session' RPC to the DebugSessionManager in the connected extension. "
+            "Returns StartSessionResult with the session_id on success, or DapError when the "
+            "extension is not connected. Call get_workspace_debug_context first to discover "
+            "available launch configurations."
+        ),
+        args_schema=StartDebugSessionInput,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. set_breakpoints
+# ---------------------------------------------------------------------------
+
+
+class SetBreakpointsInput(BaseModel):
+    file: str = Field(
+        ...,
+        description="Path to the source file (absolute or workspace-relative).",
+    )
+    lines: List[int] = Field(
+        ...,
+        description="List of 1-based line numbers where breakpoints should be set.",
+    )
+    condition: Optional[str] = Field(
+        None,
+        description="Optional conditional expression; the debugger only pauses when this evaluates to true.",
+    )
+    session_id: Optional[str] = Field(
+        None,
+        description="Target session UUID. When omitted the most recently created session is used.",
+    )
+
+
+def set_breakpoints(
+    file: str,
+    lines: List[int],
+    condition: Optional[str] = None,
+    session_id: Optional[str] = None,
+) -> dict:
+    """Set breakpoints in a source file for a debug session."""
+    user_id, conversation_id = get_context_vars()
+    payload: dict = {"file": file, "lines": lines}
+    if condition is not None:
+        payload["condition"] = condition
+    if session_id is not None:
+        payload["session_id"] = session_id
+
+    try:
+        result, error_type = route_dap_command(
+            method="set_breakpoints",
+            payload=payload,
+            user_id=user_id or "",
+            conversation_id=conversation_id,
+        )
+    except Exception as exc:
+        logger.warning("[set_breakpoints] Unexpected exception: %s", exc)
+        return DapError(
+            available=False,
+            error="unknown_error",
+            error_type="unknown_error",
+            message=f"Unexpected error setting breakpoints: {exc}",
+        ).model_dump(mode="json")
+
+    if result is not None:
+        try:
+            return SetBreakpointsResult(
+                session_id=result.get("session_id") or session_id,
+                file=result.get("file", file),
+                breakpoints=result.get("breakpoints") or [],
+                message=result.get("message"),
+            ).model_dump(mode="json")
+        except Exception as parse_exc:
+            logger.warning("[set_breakpoints] Parse error: %s", parse_exc)
+            return DapError(
+                available=False,
+                error="unknown_error",
+                error_type="unknown_error",
+                message=f"Received a response but could not parse it: {parse_exc}",
+            ).model_dump(mode="json")
+
+    return _make_dap_error(error_type, "set_breakpoints").model_dump(mode="json")
+
+
+def set_breakpoints_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=set_breakpoints,
+        name="set_breakpoints",
+        description=(
+            "Set breakpoints in a source file for an active debug session. "
+            "Replaces all breakpoints in the file (DAP semantics). "
+            "Returns SetBreakpointsResult showing which lines were verified by the adapter."
+        ),
+        args_schema=SetBreakpointsInput,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. take_debug_snapshot
+# ---------------------------------------------------------------------------
+
+
+class TakeDebugSnapshotInput(BaseModel):
+    session_id: Optional[str] = Field(
+        None,
+        description="Target session UUID. When omitted the most recently created session is used.",
+    )
+    expressions: Optional[List[str]] = Field(
+        None,
+        description="Optional list of expressions to evaluate and include in the snapshot.",
+    )
+    wait_for_stop: bool = Field(
+        False,
+        description=(
+            "If True and the session is paused, first send 'continue' then wait for the next "
+            "stopped event before capturing. If the session is already running, waits for the "
+            "next stop."
+        ),
+    )
+    timeout_seconds: int = Field(
+        30,
+        description="Maximum seconds to wait for a stopped event when wait_for_stop=True.",
+    )
+
+
+def take_debug_snapshot(
+    session_id: Optional[str] = None,
+    expressions: Optional[List[str]] = None,
+    wait_for_stop: bool = False,
+    timeout_seconds: int = 30,
+) -> dict:
+    """Capture a full state snapshot of the current debug position."""
+    user_id, conversation_id = get_context_vars()
+    payload: dict = {
+        "wait": wait_for_stop,
+        "timeout": timeout_seconds * 1000,  # extension expects milliseconds
+    }
+    if session_id is not None:
+        payload["session_id"] = session_id
+    if expressions is not None:
+        payload["expressions"] = expressions
+
+    try:
+        result, error_type = route_dap_command(
+            method="snapshot",
+            payload=payload,
+            user_id=user_id or "",
+            conversation_id=conversation_id,
+            timeout=float(timeout_seconds) + 5,
+        )
+    except Exception as exc:
+        logger.warning("[take_debug_snapshot] Unexpected exception: %s", exc)
+        return DapError(
+            available=False,
+            error="unknown_error",
+            error_type="unknown_error",
+            message=f"Unexpected error taking snapshot: {exc}",
+        ).model_dump(mode="json")
+
+    if result is not None:
+        try:
+            return _build_snapshot(result).model_dump(mode="json")
+        except Exception as parse_exc:
+            logger.warning("[take_debug_snapshot] Parse error: %s", parse_exc)
+            return DapError(
+                available=False,
+                error="unknown_error",
+                error_type="unknown_error",
+                message=f"Received a response but could not parse it: {parse_exc}",
+            ).model_dump(mode="json")
+
+    return _make_dap_error(error_type, "snapshot").model_dump(mode="json")
+
+
+def take_debug_snapshot_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=take_debug_snapshot,
+        name="take_debug_snapshot",
+        description=(
+            "Capture a full snapshot of the current debugger state: call stack, local variables, "
+            "and optionally evaluated expressions. The session must be paused unless wait_for_stop=True. "
+            "Returns a DebugSnapshot or DapError."
+        ),
+        args_schema=TakeDebugSnapshotInput,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4–6. Stepping tools (step_over / step_into / step_out)
+# ---------------------------------------------------------------------------
+
+
+class StepInput(BaseModel):
+    session_id: Optional[str] = Field(
+        None,
+        description="Target session UUID. When omitted the most recently created session is used.",
+    )
+    expressions: Optional[List[str]] = Field(
+        None,
+        description="Optional list of expressions to evaluate and include in the post-step snapshot.",
+    )
+
+
+def _step_tool_impl(method: str, session_id: Optional[str], expressions: Optional[List[str]]) -> dict:
+    """Shared implementation for step_over / step_into / step_out."""
+    user_id, conversation_id = get_context_vars()
+    payload: dict = {}
+    if session_id is not None:
+        payload["session_id"] = session_id
+    if expressions is not None:
+        payload["expressions"] = expressions
+
+    try:
+        result, error_type = route_dap_command(
+            method=method,
+            payload=payload,
+            user_id=user_id or "",
+            conversation_id=conversation_id,
+        )
+    except Exception as exc:
+        logger.warning("[%s] Unexpected exception: %s", method, exc)
+        return DapError(
+            available=False,
+            error="unknown_error",
+            error_type="unknown_error",
+            message=f"Unexpected error during {method}: {exc}",
+        ).model_dump(mode="json")
+
+    if result is not None:
+        try:
+            return _build_snapshot(result).model_dump(mode="json")
+        except Exception as parse_exc:
+            logger.warning("[%s] Parse error: %s", method, parse_exc)
+            return DapError(
+                available=False,
+                error="unknown_error",
+                error_type="unknown_error",
+                message=f"Received a response but could not parse it: {parse_exc}",
+            ).model_dump(mode="json")
+
+    return _make_dap_error(error_type, method).model_dump(mode="json")
+
+
+def step_over(
+    session_id: Optional[str] = None,
+    expressions: Optional[List[str]] = None,
+) -> dict:
+    """Step over the current source line and return a snapshot of the new position."""
+    return _step_tool_impl("step_over", session_id, expressions)
+
+
+def step_into(
+    session_id: Optional[str] = None,
+    expressions: Optional[List[str]] = None,
+) -> dict:
+    """Step into the function call on the current line and return a snapshot."""
+    return _step_tool_impl("step_into", session_id, expressions)
+
+
+def step_out(
+    session_id: Optional[str] = None,
+    expressions: Optional[List[str]] = None,
+) -> dict:
+    """Step out of the current function and return a snapshot of the caller."""
+    return _step_tool_impl("step_out", session_id, expressions)
+
+
+def step_over_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=step_over,
+        name="step_over",
+        description=(
+            "Step over (next line) in the active debug session. Session must be paused. "
+            "Returns a DebugSnapshot after the step, or DapError on failure."
+        ),
+        args_schema=StepInput,
+    )
+
+
+def step_into_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=step_into,
+        name="step_into",
+        description=(
+            "Step into the function call on the current line. Session must be paused. "
+            "Returns a DebugSnapshot after stepping into the call, or DapError on failure."
+        ),
+        args_schema=StepInput,
+    )
+
+
+def step_out_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=step_out,
+        name="step_out",
+        description=(
+            "Step out of the current function back to the caller. Session must be paused. "
+            "Returns a DebugSnapshot at the return site, or DapError on failure."
+        ),
+        args_schema=StepInput,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7. continue_execution
+# ---------------------------------------------------------------------------
+
+
+class ContinueExecutionInput(BaseModel):
+    session_id: Optional[str] = Field(
+        None,
+        description="Target session UUID. When omitted the most recently created session is used.",
+    )
+
+
+def continue_execution(session_id: Optional[str] = None) -> dict:
+    """Resume execution of the paused debug session."""
+    user_id, conversation_id = get_context_vars()
+    payload: dict = {}
+    if session_id is not None:
+        payload["session_id"] = session_id
+
+    try:
+        result, error_type = route_dap_command(
+            method="continue_execution",
+            payload=payload,
+            user_id=user_id or "",
+            conversation_id=conversation_id,
+        )
+    except Exception as exc:
+        logger.warning("[continue_execution] Unexpected exception: %s", exc)
+        return DapError(
+            available=False,
+            error="unknown_error",
+            error_type="unknown_error",
+            message=f"Unexpected error during continue_execution: {exc}",
+        ).model_dump(mode="json")
+
+    if result is not None:
+        try:
+            # continueExecution returns {session_id, status} not a full snapshot
+            return DebugSnapshot(
+                session_id=result.get("session_id", session_id or ""),
+                status=result.get("status", "running"),
+                paused_at=None,
+            ).model_dump(mode="json")
+        except Exception as parse_exc:
+            logger.warning("[continue_execution] Parse error: %s", parse_exc)
+            return DapError(
+                available=False,
+                error="unknown_error",
+                error_type="unknown_error",
+                message=f"Received a response but could not parse it: {parse_exc}",
+            ).model_dump(mode="json")
+
+    return _make_dap_error(error_type, "continue_execution").model_dump(mode="json")
+
+
+def continue_execution_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=continue_execution,
+        name="continue_execution",
+        description=(
+            "Resume execution from the current breakpoint. The session must be paused. "
+            "Returns immediately with status='running' (use take_debug_snapshot with "
+            "wait_for_stop=True to wait for the next breakpoint)."
+        ),
+        args_schema=ContinueExecutionInput,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 8. evaluate_expression
+# ---------------------------------------------------------------------------
+
+
+class EvaluateExpressionInput(BaseModel):
+    expression: str = Field(
+        ...,
+        description="The expression to evaluate in the current debug frame (REPL context).",
+    )
+    session_id: Optional[str] = Field(
+        None,
+        description="Target session UUID. When omitted the most recently created session is used.",
+    )
+    frame_id: Optional[int] = Field(
+        None,
+        description="Stack frame ID to evaluate the expression in. Defaults to the top frame.",
+    )
+
+
+def evaluate_expression(
+    expression: str,
+    session_id: Optional[str] = None,
+    frame_id: Optional[int] = None,
+) -> dict:
+    """Evaluate a single expression in the current debug frame.
+
+    Note for E4 (extension-side implementation):
+        DebugSessionManager.ts does not yet have an ``evaluate(...)`` public method.
+        The extension-side handler for /api/debug/evaluate must be added
+        specifically for this tool. Expected response shape:
+            {session_id: string, expression: string, result: string, type?: string}
+    """
+    user_id, conversation_id = get_context_vars()
+    payload: dict = {"expression": expression}
+    if session_id is not None:
+        payload["session_id"] = session_id
+    if frame_id is not None:
+        payload["frame_id"] = frame_id
+
+    try:
+        result, error_type = route_dap_command(
+            method="evaluate",
+            payload=payload,
+            user_id=user_id or "",
+            conversation_id=conversation_id,
+        )
+    except Exception as exc:
+        logger.warning("[evaluate_expression] Unexpected exception: %s", exc)
+        return DapError(
+            available=False,
+            error="unknown_error",
+            error_type="unknown_error",
+            message=f"Unexpected error evaluating expression: {exc}",
+        ).model_dump(mode="json")
+
+    if result is not None:
+        try:
+            return EvaluateResult(
+                session_id=result.get("session_id", session_id or ""),
+                expression=result.get("expression", expression),
+                value=str(result.get("result") or result.get("value") or ""),
+                type=result.get("type"),
+            ).model_dump(mode="json")
+        except Exception as parse_exc:
+            logger.warning("[evaluate_expression] Parse error: %s", parse_exc)
+            return DapError(
+                available=False,
+                error="unknown_error",
+                error_type="unknown_error",
+                message=f"Received a response but could not parse it: {parse_exc}",
+            ).model_dump(mode="json")
+
+    return _make_dap_error(error_type, "evaluate").model_dump(mode="json")
+
+
+def evaluate_expression_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=evaluate_expression,
+        name="evaluate_expression",
+        description=(
+            "Evaluate a Python/JS/Go expression in the context of the current debug frame (REPL). "
+            "Session must be paused. Returns EvaluateResult with the value and optional type, "
+            "or DapError on failure."
+        ),
+        args_schema=EvaluateExpressionInput,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 9. list_debug_sessions
+# ---------------------------------------------------------------------------
+
+
+class ListDebugSessionsInput(BaseModel):
+    pass  # No inputs required
+
+
+def list_debug_sessions() -> dict:
+    """List all active debug sessions tracked by DebugSessionManager."""
+    user_id, conversation_id = get_context_vars()
+
+    try:
+        result, error_type = route_dap_command(
+            method="list_sessions",
+            payload={},
+            user_id=user_id or "",
+            conversation_id=conversation_id,
+        )
+    except Exception as exc:
+        logger.warning("[list_debug_sessions] Unexpected exception: %s", exc)
+        return DapError(
+            available=False,
+            error="unknown_error",
+            error_type="unknown_error",
+            message=f"Unexpected error listing debug sessions: {exc}",
+        ).model_dump(mode="json")
+
+    if result is not None:
+        try:
+            raw_sessions = result if isinstance(result, list) else result.get("sessions") or []
+            sessions = [
+                TrackedDebugSession.model_validate(s)
+                for s in raw_sessions
+            ]
+            return ListSessionsResult(sessions=sessions).model_dump(mode="json")
+        except Exception as parse_exc:
+            logger.warning("[list_debug_sessions] Parse error: %s", parse_exc)
+            return DapError(
+                available=False,
+                error="unknown_error",
+                error_type="unknown_error",
+                message=f"Received a response but could not parse it: {parse_exc}",
+            ).model_dump(mode="json")
+
+    return _make_dap_error(error_type, "list_sessions").model_dump(mode="json")
+
+
+def list_debug_sessions_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=list_debug_sessions,
+        name="list_debug_sessions",
+        description=(
+            "List all currently active debug sessions tracked by the VS Code extension. "
+            "Returns ListSessionsResult with session UUIDs, programs, languages, and statuses. "
+            "Use this to discover session IDs before calling step/snapshot/evaluate tools."
+        ),
+        args_schema=ListDebugSessionsInput,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 10. stop_debug_session
+# ---------------------------------------------------------------------------
+
+
+class StopDebugSessionInput(BaseModel):
+    session_id: Optional[str] = Field(
+        None,
+        description="UUID of the session to stop. When omitted the most recently created session is stopped.",
+    )
+
+
+def stop_debug_session(session_id: Optional[str] = None) -> dict:
+    """Stop (terminate) an active debug session."""
+    user_id, conversation_id = get_context_vars()
+    payload: dict = {}
+    if session_id is not None:
+        payload["session_id"] = session_id
+
+    try:
+        result, error_type = route_dap_command(
+            method="stop_session",
+            payload=payload,
+            user_id=user_id or "",
+            conversation_id=conversation_id,
+        )
+    except Exception as exc:
+        logger.warning("[stop_debug_session] Unexpected exception: %s", exc)
+        return DapError(
+            available=False,
+            error="unknown_error",
+            error_type="unknown_error",
+            message=f"Unexpected error stopping debug session: {exc}",
+        ).model_dump(mode="json")
+
+    if result is not None:
+        try:
+            # TS StopSessionResult: {session_id, stopped: boolean}
+            stopped = result.get("stopped", True)
+            return StopSessionResult(
+                session_id=result.get("session_id", session_id or ""),
+                status="terminated" if stopped else "not_found",
+                message=result.get("message"),
+            ).model_dump(mode="json")
+        except Exception as parse_exc:
+            logger.warning("[stop_debug_session] Parse error: %s", parse_exc)
+            return DapError(
+                available=False,
+                error="unknown_error",
+                error_type="unknown_error",
+                message=f"Received a response but could not parse it: {parse_exc}",
+            ).model_dump(mode="json")
+
+    return _make_dap_error(error_type, "stop_session").model_dump(mode="json")
+
+
+def stop_debug_session_tool() -> StructuredTool:
+    return StructuredTool.from_function(
+        func=stop_debug_session,
+        name="stop_debug_session",
+        description=(
+            "Stop and terminate an active debug session, disconnecting from the debuggee. "
+            "Returns StopSessionResult with status='terminated' on success, or DapError on failure."
+        ),
+        args_schema=StopDebugSessionInput,
+    )

--- a/app/modules/intelligence/tools/dap_tools.py
+++ b/app/modules/intelligence/tools/dap_tools.py
@@ -21,11 +21,7 @@ All tools return .model_dump(mode="json") dicts. On any failure (including
 missing tunnel) they return a DapError dict — they never raise.
 """
 
-# E4 dependency: `evaluate` requires a new TS handler not present in current
-# DebugSessionManager.ts. All other 9 methods map to existing DebugSessionManager
-# methods.
-
-from typing import List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from langchain_core.tools import StructuredTool
 from pydantic import BaseModel, Field
@@ -62,12 +58,22 @@ _UNKNOWN_ROUTE_MSG = (
     "Extension-side handlers are part of E4 — returns available=False until E4 lands."
 )
 _TIMEOUT_MSG = (
-    "DAP RPC timed out — the VS Code extension may be busy or the tunnel is degraded. "
-    "Retry when the extension is responsive."
+    "DAP RPC timed out waiting for the extension response. The workspace tunnel "
+    "may still be connected; the extension may still be processing the request."
 )
 _TUNNEL_UNREACHABLE_MSG = (
     "Tunnel is registered but unreachable — the VS Code extension may have disconnected. "
     "Reconnect and retry."
+)
+_BACKEND_SOCKET_MSG = (
+    "DAP RPC failed in the backend Socket.IO bridge before the request could be "
+    "delivered. This is not evidence that the VS Code extension disconnected; "
+    "check backend tunnel logs and restart the backend/worker if the bridge is wedged."
+)
+_EXTENSION_ERROR_MSG = (
+    "DAP RPC reached the workspace socket, but the extension or debug adapter "
+    "returned an error. The tunnel may still be connected; inspect the error field "
+    "and extension logs for the DAP-specific failure."
 )
 _NO_USER_ID_MSG = "No authenticated user context — cannot route DAP command."
 
@@ -78,7 +84,8 @@ def _make_dap_error(error_type: Optional[str], context: str) -> DapError:
         msg = _NO_TUNNEL_MSG
         etype: Literal[
             "no_tunnel", "unknown_route", "timeout",
-            "tunnel_unreachable", "no_user_id", "unknown_error"
+            "tunnel_unreachable", "backend_socket_error",
+            "extension_error", "no_user_id", "unknown_error"
         ] = "no_tunnel"
     elif error_type == "no_user_id":
         msg = _NO_USER_ID_MSG
@@ -92,12 +99,15 @@ def _make_dap_error(error_type: Optional[str], context: str) -> DapError:
     elif error_type == "tunnel_unreachable":
         msg = _TUNNEL_UNREACHABLE_MSG
         etype = "tunnel_unreachable"
-    else:
-        msg = (
-            f"DAP command '{context}' failed (error_type={error_type!r}). "
-            "The VS Code extension tunnel may be unavailable or misconfigured."
-        )
+    elif error_type == "backend_loop_mismatch":
+        msg = _BACKEND_SOCKET_MSG
+        etype = "backend_socket_error"
+    elif error_type == "unknown_error":
+        msg = f"DAP command '{context}' failed with an unexpected backend error."
         etype = "unknown_error"
+    else:
+        msg = _EXTENSION_ERROR_MSG
+        etype = "extension_error"
     return DapError(
         available=False,
         error=error_type or "unknown_error",
@@ -160,9 +170,12 @@ class StartDebugSessionInput(BaseModel):
         None,
         description="Port to attach to (only relevant for attach mode).",
     )
-    args: Optional[List[str]] = Field(
+    args: Optional[Dict[str, Any]] = Field(
         None,
-        description="Additional command-line arguments to pass to the program.",
+        description=(
+            "Optional launch-configuration overrides passed through to the VS Code "
+            "extension. To pass program argv, use {'args': ['--flag']}."
+        ),
     )
 
 
@@ -171,7 +184,7 @@ def start_debug_session(
     language: Literal["python", "node", "go", "unknown"] = "python",
     mode: Literal["launch", "attach"] = "launch",
     port: Optional[int] = None,
-    args: Optional[List[str]] = None,
+    args: Optional[Dict[str, Any] | List[str]] = None,
 ) -> dict:
     """Start a new VS Code debug session."""
     user_id, conversation_id = get_context_vars()
@@ -183,7 +196,10 @@ def start_debug_session(
     if port is not None:
         payload["port"] = port
     if args is not None:
-        payload["args"] = args
+        # Back-compat: older callers passed a raw argv list. The extension now
+        # treats payload.args as a launch-config override object, so wrap argv
+        # under the launch-config "args" key.
+        payload["args"] = {"args": args} if isinstance(args, list) else args
 
     try:
         result, error_type = route_dap_command(
@@ -625,11 +641,8 @@ def evaluate_expression(
 ) -> dict:
     """Evaluate a single expression in the current debug frame.
 
-    Note for E4 (extension-side implementation):
-        DebugSessionManager.ts does not yet have an ``evaluate(...)`` public method.
-        The extension-side handler for /api/debug/evaluate must be added
-        specifically for this tool. Expected response shape:
-            {session_id: string, expression: string, result: string, type?: string}
+    Expected extension response shape:
+        {session_id: string, expression: string, result: string, type?: string}
     """
     user_id, conversation_id = get_context_vars()
     payload: dict = {"expression": expression}
@@ -656,10 +669,11 @@ def evaluate_expression(
 
     if result is not None:
         try:
+            raw_value = result["result"] if "result" in result else result.get("value", "")
             return EvaluateResult(
                 session_id=result.get("session_id", session_id or ""),
                 expression=result.get("expression", expression),
-                value=str(result.get("result") or result.get("value") or ""),
+                value=str(raw_value),
                 type=result.get("type"),
             ).model_dump(mode="json")
         except Exception as parse_exc:

--- a/app/modules/intelligence/tools/dap_tools.py
+++ b/app/modules/intelligence/tools/dap_tools.py
@@ -45,6 +45,22 @@ from app.modules.intelligence.tools.dap_schemas import (
 
 logger = setup_logger(__name__)
 
+_START_SESSION_TIMEOUT = 65.0
+_STEP_TIMEOUT = 40.0
+
+DebugLanguage = Literal[
+    "python",
+    "node",
+    "go",
+    "unknown",
+    "c",
+    "cpp",
+    "c++",
+    "lldb",
+    "cppdbg",
+    "lldb-dap",
+]
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -58,8 +74,10 @@ _UNKNOWN_ROUTE_MSG = (
     "Extension-side handlers are part of E4 — returns available=False until E4 lands."
 )
 _TIMEOUT_MSG = (
-    "DAP RPC timed out waiting for the extension response. The workspace tunnel "
-    "may still be connected; the extension may still be processing the request."
+    "The debug operation exceeded its time budget waiting for the extension response. "
+    "This is not evidence of a tunnel disconnect — the extension or debug adapter may "
+    "have stalled or failed to respond. Try a larger timeout_seconds or verify the "
+    "debug adapter is installed and configured."
 )
 _TUNNEL_UNREACHABLE_MSG = (
     "Tunnel is registered but unreachable — the VS Code extension may have disconnected. "
@@ -71,9 +89,8 @@ _BACKEND_SOCKET_MSG = (
     "check backend tunnel logs and restart the backend/worker if the bridge is wedged."
 )
 _EXTENSION_ERROR_MSG = (
-    "DAP RPC reached the workspace socket, but the extension or debug adapter "
-    "returned an error. The tunnel may still be connected; inspect the error field "
-    "and extension logs for the DAP-specific failure."
+    "This is NOT a tunnel/connection problem — the debug adapter or extension returned "
+    "an error. Inspect the error field and extension logs for the DAP-specific failure."
 )
 _NO_USER_ID_MSG = "No authenticated user context — cannot route DAP command."
 
@@ -108,6 +125,12 @@ def _make_dap_error(error_type: Optional[str], context: str) -> DapError:
     else:
         msg = _EXTENSION_ERROR_MSG
         etype = "extension_error"
+        if error_type and "debug_adapter_unavailable" in str(error_type).lower():
+            msg = (
+                "The requested debug adapter is not installed in VS Code. "
+                "Install the appropriate extension (e.g. ms-vscode.cpptools or CodeLLDB) "
+                "and retry."
+            )
     return DapError(
         available=False,
         error=error_type or "unknown_error",
@@ -158,9 +181,14 @@ class StartDebugSessionInput(BaseModel):
         ...,
         description="Path to the program entry point (e.g. 'src/main.py' or '/abs/path/main.py').",
     )
-    language: Literal["python", "node", "go", "unknown"] = Field(
+    language: DebugLanguage = Field(
         "python",
-        description="Language of the program being debugged.",
+        description=(
+            "Language of the program being debugged. For compiled/native binaries use "
+            "'c' or 'cpp' and pass args with the launch config (e.g. "
+            '{"type":"cppdbg","MIMode":"lldb"} on macOS or "gdb" on Linux). '
+            "args.type is authoritative when provided."
+        ),
     )
     mode: Literal["launch", "attach"] = Field(
         "launch",
@@ -181,7 +209,7 @@ class StartDebugSessionInput(BaseModel):
 
 def start_debug_session(
     program: str,
-    language: Literal["python", "node", "go", "unknown"] = "python",
+    language: DebugLanguage = "python",
     mode: Literal["launch", "attach"] = "launch",
     port: Optional[int] = None,
     args: Optional[Dict[str, Any] | List[str]] = None,
@@ -207,6 +235,7 @@ def start_debug_session(
             payload=payload,
             user_id=user_id or "",
             conversation_id=conversation_id,
+            timeout=_START_SESSION_TIMEOUT,
         )
     except Exception as exc:
         logger.warning("[start_debug_session] Unexpected exception: %s", exc)
@@ -218,6 +247,19 @@ def start_debug_session(
         ).model_dump(mode="json")
 
     if result is not None:
+        if not result.get("session_id"):
+            raw = repr(result)
+            if len(raw) > 500:
+                raw = raw[:497] + "..."
+            return DapError(
+                available=False,
+                error="extension_error",
+                error_type="extension_error",
+                message=(
+                    "Debug session start returned no session_id — the launch likely failed. "
+                    f"Raw response: {raw}"
+                ),
+            ).model_dump(mode="json")
         try:
             return StartSessionResult(
                 session_id=result.get("session_id", ""),
@@ -247,7 +289,10 @@ def start_debug_session_tool() -> StructuredTool:
             "Sends a 'start_session' RPC to the DebugSessionManager in the connected extension. "
             "Returns StartSessionResult with the session_id on success, or DapError when the "
             "extension is not connected. Call get_workspace_debug_context first to discover "
-            "available launch configurations."
+            "available launch configurations. For compiled/native binaries (C/C++), pass "
+            "language='c' or 'cpp' and include args with the launch config — e.g. "
+            '{"type":"cppdbg","MIMode":"lldb"} on macOS or "gdb" on Linux. '
+            "When args.type is set (e.g. lldb, cppdbg), it overrides language."
         ),
         args_schema=StartDebugSessionInput,
     )
@@ -461,6 +506,7 @@ def _step_tool_impl(method: str, session_id: Optional[str], expressions: Optiona
             payload=payload,
             user_id=user_id or "",
             conversation_id=conversation_id,
+            timeout=_STEP_TIMEOUT,
         )
     except Exception as exc:
         logger.warning("[%s] Unexpected exception: %s", method, exc)

--- a/app/modules/intelligence/tools/get_workspace_debug_context_tool.py
+++ b/app/modules/intelligence/tools/get_workspace_debug_context_tool.py
@@ -1,0 +1,255 @@
+"""get_workspace_debug_context — workspace debug capabilities packet for the debug agent.
+
+Returns the "debug capabilities" packet described in hypo.md §3.3:
+  - launch configs from .vscode/launch.json
+  - available debug adapter IDs in this VS Code session
+  - recent git changes scoped to a file/directory or repo-wide
+  - related test files for a given focus path
+  - inferred fallback run/test commands from package.json / pyproject.toml
+
+The backend dispatches an RPC named ``"workspace.debug_context"`` over the
+existing tunnel/socket.io infrastructure (same pattern as ``route_terminal_command``
+in tunnel_utils.py).  The extension-side handler is task E4 — until that lands
+the tool returns ``available=False`` with a clear diagnostic message.
+
+RPC route name: ``workspace.debug_context``
+  - Chosen over alternatives (``debug.workspace_context``, ``workspace_debug_context``)
+    because it clearly namespaces under the ``workspace`` domain and uses a
+    period-separated sub-route style that mirrors Socket.IO event naming conventions.
+  - The E4 TypeScript handler must register the same route string.
+
+Dispatch approach: extended tunnel_utils.py with a focused
+``route_workspace_debug_context`` function alongside ``route_terminal_command``.
+This matches the "focused functions are easier to reason about" guidance and
+avoids introducing a generic RPC helper that would require broader review.
+"""
+
+from typing import List, Optional
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from app.modules.utils.logger import setup_logger
+from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
+    route_workspace_debug_context,
+    get_context_vars,
+)
+
+logger = setup_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# A4.1 — Result schema (Pydantic)
+# ---------------------------------------------------------------------------
+
+
+class LaunchConfig(BaseModel):
+    name: str = Field(..., description="Launch configuration name from .vscode/launch.json")
+    type: str = Field(..., description="Debug adapter type (e.g. 'python', 'node', 'go').")
+    request: str = Field(..., description="'launch' or 'attach'.")
+    program: Optional[str] = Field(None, description="Entry point path if specified.")
+
+
+class InferredCommand(BaseModel):
+    label: str = Field(..., description="Short label, e.g. 'pytest', 'npm test', 'go test ./...'.")
+    command: str = Field(..., description="The actual command string to run.")
+    source: str = Field(..., description="Where it was inferred from, e.g. 'pyproject.toml', 'package.json scripts.test'.")
+
+
+class RecentChange(BaseModel):
+    file: str = Field(..., description="Workspace-relative path of the changed file.")
+    commit_sha: str = Field(..., description="Short commit SHA that last touched this file.")
+    commit_message: str = Field(..., description="First line of the commit message.")
+    relative_time: str = Field(..., description="Humanized 'N hours ago'.")
+
+
+class WorkspaceDebugContext(BaseModel):
+    launch_configs: List[LaunchConfig] = Field(
+        default_factory=list,
+        description="Launch configurations parsed from .vscode/launch.json.",
+    )
+    debug_adapters: List[str] = Field(
+        default_factory=list,
+        description="Adapter ids available in this VS Code session (e.g. ['python', 'node']).",
+    )
+    recent_changes: List[RecentChange] = Field(
+        default_factory=list,
+        description="Recent git changes scoped to a file or to the whole repo.",
+    )
+    related_tests: List[str] = Field(
+        default_factory=list,
+        description="Test files that look related to the focus path.",
+    )
+    inferred_commands: List[InferredCommand] = Field(
+        default_factory=list,
+        description="Fallback run/test commands when .vscode/launch.json is sparse.",
+    )
+    available: bool = Field(
+        ...,
+        description="False when the extension is not attached or the tunnel could not deliver.",
+    )
+    message: Optional[str] = Field(
+        None,
+        description="Diagnostic message when available=False.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# A4.2 — Tool input schema
+# ---------------------------------------------------------------------------
+
+
+class GetWorkspaceDebugContextInput(BaseModel):
+    focus_path: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional file or directory path within the workspace. "
+            "When present, scopes related_tests and recent_changes to this path. "
+            "When None (default), returns a repo-wide summary."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# A4.2 — Core implementation
+# ---------------------------------------------------------------------------
+
+# Human-readable labels for known error_type values returned by
+# route_workspace_debug_context.  Kept as module-level constants so tests can
+# assert against them without duplicating strings.
+_MSG_NO_TUNNEL = (
+    "VS Code extension is not connected (no tunnel registered). "
+    "Ensure the Potpie extension is running and shows 'Connected' status."
+)
+_MSG_TIMEOUT = (
+    "workspace.debug_context RPC timed out — the VS Code extension may be busy "
+    "or the tunnel is degraded. Retry when the extension is responsive."
+)
+_MSG_UNKNOWN_ROUTE = (
+    "workspace.debug_context handler not yet implemented in the VS Code extension "
+    "(E4 is pending). The backend can dispatch but the extension has not registered "
+    "this route — returns available=False until E4 lands."
+)
+_MSG_TUNNEL_UNREACHABLE = (
+    "Tunnel is registered but unreachable — the VS Code extension may have "
+    "disconnected. Reconnect and retry."
+)
+
+
+def get_workspace_debug_context(
+    focus_path: Optional[str] = None,
+) -> dict:
+    """Fetch workspace debug capabilities via tunnel RPC.
+
+    Dispatches ``workspace.debug_context`` to the VS Code extension over the
+    existing socket.io tunnel.  Returns a ``WorkspaceDebugContext`` dict.
+    On any failure, returns ``available=False`` with a diagnostic message and
+    empty lists — never raises.
+    """
+    user_id, conversation_id = get_context_vars()
+
+    try:
+        result, error_type = route_workspace_debug_context(
+            focus_path=focus_path,
+            user_id=user_id,
+            conversation_id=conversation_id,
+        )
+    except Exception as exc:
+        logger.warning(
+            "[get_workspace_debug_context] Unexpected exception during dispatch: %s",
+            exc,
+        )
+        return WorkspaceDebugContext(
+            available=False,
+            message=f"Unexpected error fetching workspace debug context: {exc}",
+        ).model_dump()
+
+    # --- Success: extension returned data ---
+    if result is not None:
+        try:
+            # Deserialise each sub-field defensively; extension may return partial data.
+            launch_configs = [
+                LaunchConfig(**lc) for lc in (result.get("launch_configs") or [])
+            ]
+            debug_adapters: List[str] = result.get("debug_adapters") or []
+            recent_changes = [
+                RecentChange(**rc) for rc in (result.get("recent_changes") or [])
+            ]
+            related_tests: List[str] = result.get("related_tests") or []
+            inferred_commands = [
+                InferredCommand(**ic) for ic in (result.get("inferred_commands") or [])
+            ]
+            return WorkspaceDebugContext(
+                launch_configs=launch_configs,
+                debug_adapters=debug_adapters,
+                recent_changes=recent_changes,
+                related_tests=related_tests,
+                inferred_commands=inferred_commands,
+                available=True,
+                message=None,
+            ).model_dump()
+        except Exception as parse_exc:
+            logger.warning(
+                "[get_workspace_debug_context] Failed to parse extension response: %s",
+                parse_exc,
+            )
+            return WorkspaceDebugContext(
+                available=False,
+                message=f"Received a response from the extension but could not parse it: {parse_exc}",
+            ).model_dump()
+
+    # --- Failure: map error_type → human-readable message ---
+    if error_type == "no_tunnel" or error_type == "no_user_id":
+        message = _MSG_NO_TUNNEL
+    elif error_type == "timeout":
+        message = _MSG_TIMEOUT
+    elif error_type == "unknown_route":
+        message = _MSG_UNKNOWN_ROUTE
+    elif error_type == "tunnel_unreachable":
+        message = _MSG_TUNNEL_UNREACHABLE
+    else:
+        # Covers: "connection_error", "unknown_error", None, and any future codes.
+        message = (
+            f"workspace.debug_context RPC failed (error_type={error_type!r}). "
+            "The VS Code extension tunnel may be unavailable or misconfigured."
+        )
+
+    logger.info(
+        "[get_workspace_debug_context] returning available=False (error_type=%r)",
+        error_type,
+    )
+    return WorkspaceDebugContext(
+        available=False,
+        message=message,
+    ).model_dump()
+
+
+# ---------------------------------------------------------------------------
+# A4.3 — LangChain StructuredTool factory
+# ---------------------------------------------------------------------------
+
+
+def get_workspace_debug_context_tool() -> StructuredTool:
+    """Create the get_workspace_debug_context StructuredTool.
+
+    No db/user_id required — context vars are read inside the implementation.
+    Factory shape matches run_validation_tool() (no-arg factory, context vars
+    read internally).
+    """
+    return StructuredTool.from_function(
+        func=get_workspace_debug_context,
+        name="get_workspace_debug_context",
+        description=(
+            "Fetch the workspace debug capabilities packet from the connected VS Code "
+            "extension via the tunnel RPC ('workspace.debug_context'). "
+            "Returns launch configurations from .vscode/launch.json, available debug "
+            "adapter IDs, recent git changes, test files related to a focus path, and "
+            "inferred fallback run/test commands from package.json or pyproject.toml. "
+            "Call this ONCE per debugging session to ground hypothesis generation in "
+            "what is actually runnable in the workspace. "
+            "When available=False the extension is not connected or the handler is not "
+            "yet registered (E4 pending) — fall back to ask_knowledge_graph_queries, "
+            "get_code_file_structure, or run_validation with inferred commands."
+        ),
+        args_schema=GetWorkspaceDebugContextInput,
+    )

--- a/app/modules/intelligence/tools/get_workspace_debug_context_tool.py
+++ b/app/modules/intelligence/tools/get_workspace_debug_context_tool.py
@@ -167,18 +167,45 @@ def get_workspace_debug_context(
     # --- Success: extension returned data ---
     if result is not None:
         try:
-            # Deserialise each sub-field defensively; extension may return partial data.
-            launch_configs = [
-                LaunchConfig(**lc) for lc in (result.get("launch_configs") or [])
-            ]
+            # Deserialise each sub-field defensively; extension may return partial
+            # data. Parse per-item so one malformed entry (e.g. during a staggered
+            # backend/extension rollout) doesn't drop the whole debug context.
+            launch_configs = []
+            for lc in result.get("launch_configs") or []:
+                try:
+                    launch_configs.append(LaunchConfig(**lc))
+                except Exception as item_exc:
+                    logger.warning(
+                        "[get_workspace_debug_context] Skipping invalid launch config %r: %s",
+                        lc,
+                        item_exc,
+                    )
+
             debug_adapters: List[str] = result.get("debug_adapters") or []
-            recent_changes = [
-                RecentChange(**rc) for rc in (result.get("recent_changes") or [])
-            ]
+
+            recent_changes = []
+            for rc in result.get("recent_changes") or []:
+                try:
+                    recent_changes.append(RecentChange(**rc))
+                except Exception as item_exc:
+                    logger.warning(
+                        "[get_workspace_debug_context] Skipping invalid recent change %r: %s",
+                        rc,
+                        item_exc,
+                    )
+
             related_tests: List[str] = result.get("related_tests") or []
-            inferred_commands = [
-                InferredCommand(**ic) for ic in (result.get("inferred_commands") or [])
-            ]
+
+            inferred_commands = []
+            for ic in result.get("inferred_commands") or []:
+                try:
+                    inferred_commands.append(InferredCommand(**ic))
+                except Exception as item_exc:
+                    logger.warning(
+                        "[get_workspace_debug_context] Skipping invalid inferred command %r: %s",
+                        ic,
+                        item_exc,
+                    )
             return WorkspaceDebugContext(
                 launch_configs=launch_configs,
                 debug_adapters=debug_adapters,

--- a/app/modules/intelligence/tools/get_workspace_debug_context_tool.py
+++ b/app/modules/intelligence/tools/get_workspace_debug_context_tool.py
@@ -122,8 +122,8 @@ _MSG_NO_TUNNEL = (
     "Ensure the Potpie extension is running and shows 'Connected' status."
 )
 _MSG_TIMEOUT = (
-    "workspace.debug_context RPC timed out — the VS Code extension may be busy "
-    "or the tunnel is degraded. Retry when the extension is responsive."
+    "workspace.debug_context RPC timed out waiting for the extension response. "
+    "The workspace tunnel may still be connected; the extension may still be processing the request."
 )
 _MSG_UNKNOWN_ROUTE = (
     "workspace.debug_context handler not yet implemented in the VS Code extension "

--- a/app/modules/intelligence/tools/hypothesis_state_tool.py
+++ b/app/modules/intelligence/tools/hypothesis_state_tool.py
@@ -22,7 +22,7 @@ from contextvars import ContextVar
 from datetime import datetime, timezone
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from app.modules.intelligence.agents.chat_agents.system_agents.debug_hypothesis_contract import (
     HypothesisStatus,
@@ -63,6 +63,25 @@ class RecordHypothesisInput(BaseModel):
         default_factory=list,
         description="Validation steps to confirm or refute this hypothesis.",
     )
+
+    @field_validator("evidence", "validation_plan", mode="before")
+    @classmethod
+    def _coerce_string_to_list(cls, v: object) -> object:
+        """Coerce a newline-joined string to a list of non-empty strings.
+
+        LLMs commonly follow the prompt example and pass evidence/validation_plan
+        as a multi-line string (e.g. "- obs1\n- obs2") rather than as a list.
+        Without this coercion, pydantic raises ValidationError → handle_exception
+        returns "An internal error occurred." → the hypothesis store stays empty.
+        """
+        if not isinstance(v, str):
+            return v
+        lines = [
+            line.lstrip("-•* \t").rstrip()
+            for line in v.splitlines()
+            if line.strip()
+        ]
+        return lines
 
 
 class UpdateHypothesisStatusInput(BaseModel):

--- a/app/modules/intelligence/tools/hypothesis_state_tool.py
+++ b/app/modules/intelligence/tools/hypothesis_state_tool.py
@@ -1,0 +1,305 @@
+"""hypothesis_state_tool — conversation-scoped hypothesis persistence for the debug agent.
+
+Provides four tools that let the debug agent persist and update hypothesis state
+across a multi-turn debugging conversation:
+
+  record_hypothesis         — create a new hypothesis record
+  update_hypothesis_status  — change the status of an existing hypothesis
+  append_hypothesis_evidence — add an observation to an existing hypothesis
+  list_hypotheses           — retrieve all hypothesis records for the session
+
+Persistence mirrors the todos family (todo_management_tool.py):
+  - In-memory storage on a ContextVar, providing per-execution-context isolation.
+  - No Redis, no DB — same lightweight, zero-dependency approach as todo/requirement tools.
+  - conversation_id is NOT exposed in tool args; isolation is provided by ContextVar
+    (each async agent-run context is a separate execution context).
+
+The HypothesisStatus enum is imported from debug_hypothesis_contract.py so the
+tool layer and the markdown-emission layer share exactly the same lifecycle states.
+"""
+
+from contextvars import ContextVar
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+from app.modules.intelligence.agents.chat_agents.system_agents.debug_hypothesis_contract import (
+    HypothesisStatus,
+)
+from app.modules.utils.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class HypothesisRecord(BaseModel):
+    """A single persisted debugging hypothesis."""
+
+    id: str = Field(..., description="Server-assigned hypothesis id (e.g. 'hyp_1').")
+    title: str = Field(..., description="Short hypothesis title; matches the markdown title the agent emits.")
+    status: HypothesisStatus = HypothesisStatus.PROPOSED
+    evidence: List[str] = Field(default_factory=list)
+    validation_plan: List[str] = Field(default_factory=list)
+    created_at: datetime = Field(..., description="UTC timestamp when this hypothesis was recorded.")
+    updated_at: datetime = Field(..., description="UTC timestamp of last status or evidence change.")
+    conversation_id: str = ""  # stamped from HypothesisStore.conversation_id at create time; production binding happens in init_managers
+
+
+class RecordHypothesisInput(BaseModel):
+    title: str = Field(description="Short hypothesis title matching the markdown heading")
+    status: HypothesisStatus = Field(
+        default=HypothesisStatus.PROPOSED,
+        description="Initial lifecycle status. Defaults to 'proposed'.",
+    )
+    evidence: List[str] = Field(
+        default_factory=list,
+        description="Initial evidence observations (can be added to later with append_hypothesis_evidence).",
+    )
+    validation_plan: List[str] = Field(
+        default_factory=list,
+        description="Validation steps to confirm or refute this hypothesis.",
+    )
+
+
+class UpdateHypothesisStatusInput(BaseModel):
+    hypothesis_id: str = Field(description="ID of the hypothesis to update (e.g. 'hyp_1')")
+    status: HypothesisStatus = Field(description="New lifecycle status")
+
+
+class AppendHypothesisEvidenceInput(BaseModel):
+    hypothesis_id: str = Field(description="ID of the hypothesis to update (e.g. 'hyp_1')")
+    evidence: str = Field(description="Single observation to append to the evidence list")
+
+
+class ListHypothesesInput(BaseModel):
+    pass  # No args — scoped by execution context
+
+
+# ---------------------------------------------------------------------------
+# In-memory storage — mirrors TodoStorage / RequirementManager pattern
+# ---------------------------------------------------------------------------
+
+
+class HypothesisStore:
+    """Holds all hypothesis records for a single execution context (agent run)."""
+
+    def __init__(self, conversation_id: str = "") -> None:
+        self._records: List[HypothesisRecord] = []
+        self._next_index: int = 1
+        self.conversation_id: str = conversation_id
+
+    # ---- helpers ----
+
+    def _next_id(self) -> str:
+        id_ = f"hyp_{self._next_index}"
+        self._next_index += 1
+        return id_
+
+    def _find(self, hypothesis_id: str) -> Optional[HypothesisRecord]:
+        for rec in self._records:
+            if rec.id == hypothesis_id:
+                return rec
+        return None
+
+    # ---- operations ----
+
+    def add(
+        self,
+        title: str,
+        status: HypothesisStatus,
+        evidence: List[str],
+        validation_plan: List[str],
+    ) -> HypothesisRecord:
+        now = datetime.now(tz=timezone.utc)
+        rec = HypothesisRecord(
+            id=self._next_id(),
+            title=title,
+            status=status,
+            evidence=list(evidence),
+            validation_plan=list(validation_plan),
+            created_at=now,
+            updated_at=now,
+            conversation_id=self.conversation_id,
+        )
+        self._records.append(rec)
+        logger.debug("hypothesis_state: recorded id={} title={!r}", rec.id, rec.title)
+        return rec
+
+    def update_status(
+        self, hypothesis_id: str, status: HypothesisStatus
+    ) -> HypothesisRecord | str:
+        rec = self._find(hypothesis_id)
+        if rec is None:
+            return f"Hypothesis with ID '{hypothesis_id}' not found"
+        rec.status = status
+        rec.updated_at = datetime.now(tz=timezone.utc)
+        logger.debug(
+            "hypothesis_state: updated status id={} status={}", rec.id, status.value
+        )
+        return rec
+
+    def append_evidence(self, hypothesis_id: str, evidence: str) -> HypothesisRecord | str:
+        rec = self._find(hypothesis_id)
+        if rec is None:
+            return f"Hypothesis with ID '{hypothesis_id}' not found"
+        rec.evidence.append(evidence)
+        rec.updated_at = datetime.now(tz=timezone.utc)
+        logger.debug(
+            "hypothesis_state: appended evidence id={} total_entries={}", rec.id, len(rec.evidence)
+        )
+        return rec
+
+    def list_all(self) -> List[HypothesisRecord]:
+        return list(self._records)
+
+    def clear(self) -> None:
+        self._records.clear()
+        self._next_index = 1
+
+
+# Context variable — one HypothesisStore per async execution context (agent run).
+# Mirrors _todo_storage_ctx in todo_management_tool.py.
+_hypothesis_store_ctx: ContextVar[Optional[HypothesisStore]] = ContextVar(
+    "_hypothesis_store_ctx", default=None
+)
+
+
+def get_hypothesis_store() -> HypothesisStore:
+    """Return the HypothesisStore for the current execution context, creating one if needed."""
+    store = _hypothesis_store_ctx.get()
+    if store is None:
+        store = HypothesisStore()
+        _hypothesis_store_ctx.set(store)
+    return store
+
+
+def _reset_hypothesis_store(conversation_id: str = "") -> None:
+    """Reset the hypothesis store for a new conversation/agent run."""
+    _hypothesis_store_ctx.set(HypothesisStore(conversation_id=conversation_id))
+
+
+# ---------------------------------------------------------------------------
+# Tool functions
+# ---------------------------------------------------------------------------
+
+
+def record_hypothesis(
+    title: str,
+    status: HypothesisStatus = HypothesisStatus.PROPOSED,
+    evidence: Optional[List[str]] = None,
+    validation_plan: Optional[List[str]] = None,
+) -> dict:
+    """Record a new debugging hypothesis.
+
+    Returns the full HypothesisRecord including the assigned id and timestamps.
+    """
+    rec = get_hypothesis_store().add(
+        title=title,
+        status=status,
+        evidence=evidence or [],
+        validation_plan=validation_plan or [],
+    )
+    return rec.model_dump(mode="json")
+
+
+def update_hypothesis_status(hypothesis_id: str, status: HypothesisStatus) -> dict:
+    """Update the status of an existing hypothesis, bumping updated_at.
+
+    Returns the updated HypothesisRecord, or an error string if the id is not found.
+    """
+    result = get_hypothesis_store().update_status(hypothesis_id, status)
+    if isinstance(result, str):
+        # Error message — mirror how todo_management_tool returns plain strings for errors
+        return {"error": result}
+    return result.model_dump(mode="json")
+
+
+def append_hypothesis_evidence(hypothesis_id: str, evidence: str) -> dict:
+    """Append a single observation to a hypothesis's evidence list, bumping updated_at.
+
+    Returns the updated HypothesisRecord, or an error if the id is not found.
+    """
+    result = get_hypothesis_store().append_evidence(hypothesis_id, evidence)
+    if isinstance(result, str):
+        return {"error": result}
+    return result.model_dump(mode="json")
+
+
+def list_hypotheses() -> dict:
+    """List all hypothesis records for the current conversation, in creation order."""
+    records = get_hypothesis_store().list_all()
+    return {"hypotheses": [r.model_dump(mode="json") for r in records]}
+
+
+# ---------------------------------------------------------------------------
+# SimpleTool wrapper — mirrors todo_management_tool.SimpleTool
+# ---------------------------------------------------------------------------
+
+
+class SimpleTool:
+    """Lightweight tool descriptor compatible with ToolService's by-name registry."""
+
+    def __init__(self, name: str, description: str, func, args_schema=None):
+        self.name = name
+        self.description = description
+        self.func = func
+        self.args_schema = args_schema
+
+
+def create_hypothesis_state_tools() -> List[SimpleTool]:
+    """Create hypothesis state tools for ToolService registration.
+
+    Tool names:
+      record_hypothesis, update_hypothesis_status,
+      append_hypothesis_evidence, list_hypotheses
+    """
+    return [
+        SimpleTool(
+            name="record_hypothesis",
+            description=(
+                "Record a new debugging hypothesis. "
+                "Assign it an id (e.g. 'hyp_1'), set its initial status "
+                "(default: proposed), and optionally supply starting evidence "
+                "and a validation plan. Returns the full record with id and timestamps. "
+                "Use this when you first formulate a hypothesis about the root cause."
+            ),
+            func=record_hypothesis,
+            args_schema=RecordHypothesisInput,
+        ),
+        SimpleTool(
+            name="update_hypothesis_status",
+            description=(
+                "Update the lifecycle status of an existing hypothesis by its id. "
+                "Valid statuses: proposed, debugging, needs_evidence, supported, "
+                "rejected, fix_proposed, validated. "
+                "Use this as evidence accumulates and the hypothesis evolves."
+            ),
+            func=update_hypothesis_status,
+            args_schema=UpdateHypothesisStatusInput,
+        ),
+        SimpleTool(
+            name="append_hypothesis_evidence",
+            description=(
+                "Append a single observation (one string) to a hypothesis's evidence list. "
+                "Call once per observation; call multiple times if you have multiple "
+                "new observations. The existing evidence list is never overwritten."
+            ),
+            func=append_hypothesis_evidence,
+            args_schema=AppendHypothesisEvidenceInput,
+        ),
+        SimpleTool(
+            name="list_hypotheses",
+            description=(
+                "List all hypothesis records for the current debugging session, "
+                "in creation order. Use to review the current state of all hypotheses "
+                "before deciding which to pursue or update."
+            ),
+            func=list_hypotheses,
+            args_schema=None,
+        ),
+    ]
+

--- a/app/modules/intelligence/tools/hypothesis_state_tool.py
+++ b/app/modules/intelligence/tools/hypothesis_state_tool.py
@@ -145,7 +145,7 @@ class HypothesisStore:
             conversation_id=self.conversation_id,
         )
         self._records.append(rec)
-        logger.debug("hypothesis_state: recorded id={} title={!r}", rec.id, rec.title)
+        logger.debug("hypothesis_state: recorded id=%s title=%r", rec.id, rec.title)
         return rec
 
     def update_status(
@@ -157,7 +157,7 @@ class HypothesisStore:
         rec.status = status
         rec.updated_at = datetime.now(tz=timezone.utc)
         logger.debug(
-            "hypothesis_state: updated status id={} status={}", rec.id, status.value
+            "hypothesis_state: updated status id=%s status=%s", rec.id, status.value
         )
         return rec
 
@@ -168,7 +168,7 @@ class HypothesisStore:
         rec.evidence.append(evidence)
         rec.updated_at = datetime.now(tz=timezone.utc)
         logger.debug(
-            "hypothesis_state: appended evidence id={} total_entries={}", rec.id, len(rec.evidence)
+            "hypothesis_state: appended evidence id=%s total_entries=%s", rec.id, len(rec.evidence)
         )
         return rec
 

--- a/app/modules/intelligence/tools/local_search_tools/execute_terminal_command_tool.py
+++ b/app/modules/intelligence/tools/local_search_tools/execute_terminal_command_tool.py
@@ -120,24 +120,57 @@ def execute_terminal_command_tool(input_data: ExecuteTerminalCommandInput) -> st
     if error_type == "tunnel_unreachable" or (
         tunnel_url and error_type in ["timeout", "connection_error"]
     ):
-        # Workspace socket was registered but request failed
+        # Re-check after RPC may have cleared a stale registration
+        still_registered = bool(
+            tunnel_service.get_tunnel_url(
+                user_id,
+                conversation_id,
+                repository=_get_repository(),
+                branch=_get_branch(),
+            )
+        )
         logger.warning(
-            f"⚠️ [execute_terminal_command] Workspace socket registered ({tunnel_url}) but not reachable (error: {error_type})"
-        , tunnel_url=tunnel_url, error_type=error_type)
+            "⚠️ [execute_terminal_command] Workspace socket {} (error: {})",
+            "still registered as " + (tunnel_url or "unknown")
+            if still_registered
+            else "stale registration cleared",
+            error_type,
+        )
+        if error_type == "timeout" and still_registered:
+            return (
+                f"❌ **Terminal command timed out**\n\n"
+                f"The extension is still registered (`{tunnel_url}`), but the command "
+                f"did not return before the timeout.\n\n"
+                f"**What this means:**\n"
+                f"- The tunnel was not cleared\n"
+                f"- The command may still have completed locally after the response timed out\n"
+                f"- For long-running commands, run it again with `mode=\"async\"` and poll the session output\n\n"
+                f"**Command:** `{input_data.command}`"
+            )
+        if still_registered:
+            return (
+                f"❌ **Workspace socket connection error**\n\n"
+                f"The extension is registered (`{tunnel_url}`) but the request failed.\n\n"
+                f"**Possible causes:**\n"
+                f"- The extension Socket.IO connection was interrupted or disconnected\n"
+                f"- Network connectivity issues\n"
+                f"- Temporary connection timeout\n\n"
+                f"**To fix:**\n"
+                f"1. Ensure the VS Code extension is running and connected\n"
+                f"2. Check the extension shows a connected status in the Trace panel\n"
+                f"3. Reload the VS Code window if needed, then reply `ready`\n"
+                f"4. Try the command again once reconnected\n"
+                f"5. If the issue persists, check the VS Code extension logs\n\n"
+                f"**Note:** Stale registrations are cleared automatically; reconnecting refreshes the tunnel."
+            )
         return (
-            f"❌ **Workspace socket connection error**\n\n"
-            f"The extension is registered (`{tunnel_url}`) but the request failed.\n\n"
-            f"**Possible causes:**\n"
-            f"- The extension Socket.IO connection was interrupted or disconnected\n"
-            f"- Network connectivity issues\n"
-            f"- Temporary connection timeout\n\n"
-            f"**To fix:**\n"
-            f"1. Ensure the VS Code extension is running and connected\n"
-            f"2. Check the extension shows a connected status\n"
-            f"3. Try the command again - this may be a transient connection issue\n"
-            f"4. The extension should automatically reconnect if needed\n"
-            f"5. If the issue persists, check the VS Code extension logs\n\n"
-            f"**Note:** The workspace socket may be temporarily unavailable. The extension will automatically reconnect."
+            "❌ **VS Code extension disconnected**\n\n"
+            "The workspace tunnel was registered but the connection dropped before "
+            "this command could run. The stale registration has been cleared.\n\n"
+            "**To fix:**\n"
+            "1. Open VS Code and ensure the Potpie extension is running\n"
+            "2. Confirm **Connected** in the Trace panel\n"
+            "3. Reply `ready` and retry — the extension will re-register automatically"
         )
     elif error_type == "tunnel_expired":
         # Workspace registration was expired and cleaned up

--- a/app/modules/intelligence/tools/local_search_tools/tools.py
+++ b/app/modules/intelligence/tools/local_search_tools/tools.py
@@ -1,0 +1,149 @@
+"""ToolService registrations for local search tools.
+
+The individual local_search_tools modules expose functions that accept a single
+Pydantic input model. ToolService, LangChain, and the registry discovery flow
+work best with functions whose parameters match the model fields, so the small
+wrappers below adapt field kwargs back into those input models.
+"""
+
+from typing import List, Optional
+
+from langchain_core.tools import StructuredTool
+
+from .execute_terminal_command_tool import (
+    ExecuteTerminalCommandInput,
+    execute_terminal_command_tool,
+)
+from .search_bash_tool import SearchBashInput, search_bash_tool
+from .search_text_tool import SearchTextInput, search_text_tool
+from .terminal_session_tools import (
+    TerminalSessionOutputInput,
+    TerminalSessionSignalInput,
+    terminal_session_output_tool,
+    terminal_session_signal_tool,
+)
+
+
+def _execute_terminal_command(
+    command: str,
+    working_directory=None,
+    timeout: int = 30000,
+    mode: str = "sync",
+) -> str:
+    return execute_terminal_command_tool(
+        ExecuteTerminalCommandInput(
+            command=command,
+            working_directory=working_directory,
+            timeout=timeout,
+            mode=mode,
+        )
+    )
+
+
+def _terminal_session_output(session_id: str, offset: int = 0) -> str:
+    return terminal_session_output_tool(
+        TerminalSessionOutputInput(session_id=session_id, offset=offset)
+    )
+
+
+def _terminal_session_signal(session_id: str, signal: str = "SIGINT") -> str:
+    return terminal_session_signal_tool(
+        TerminalSessionSignalInput(session_id=session_id, signal=signal)
+    )
+
+
+def _search_text(
+    query: str,
+    file_pattern: Optional[str] = None,
+    case_sensitive: bool = False,
+    use_regex: bool = False,
+    max_results: Optional[int] = 100,
+    use_bash: bool = False,
+) -> str:
+    return search_text_tool(
+        SearchTextInput(
+            query=query,
+            file_pattern=file_pattern,
+            case_sensitive=case_sensitive,
+            use_regex=use_regex,
+            max_results=max_results,
+            use_bash=use_bash,
+        )
+    )
+
+
+def _search_bash(
+    command: str,
+    working_directory: Optional[str] = None,
+    timeout: Optional[int] = 30000,
+    project_id: Optional[str] = None,
+) -> str:
+    return search_bash_tool(
+        SearchBashInput(
+            command=command,
+            working_directory=working_directory,
+            timeout=timeout,
+            project_id=project_id,
+        )
+    )
+
+
+def create_local_search_tools() -> List[StructuredTool]:
+    """Create local search tools for ToolService registration."""
+
+    return [
+        StructuredTool.from_function(
+            func=_search_text,
+            name="search_text",
+            description=(
+                "Search for a text or regex pattern across the workspace via the "
+                "VS Code tunnel. Use for symbol names, error strings, file paths, "
+                "and test fixtures. Set use_bash=true for faster large-codebase "
+                "searches when a simple grep-style query is enough."
+            ),
+            args_schema=SearchTextInput,
+        ),
+        StructuredTool.from_function(
+            func=_search_bash,
+            name="search_bash",
+            description=(
+                "Run read-only bash search commands in the workspace via the VS "
+                "Code tunnel, especially `rg -n`, `find`, `awk`, `sed`, `head`, "
+                "`tail`, `ls`, `wc`, `sort`, and `uniq`. Use this for compound "
+                "ripgrep queries, globbing, source/test fixture mining, and "
+                "comparing helper implementations. Write operations and unsafe "
+                "commands are blocked."
+            ),
+            args_schema=SearchBashInput,
+        ),
+        StructuredTool.from_function(
+            func=_execute_terminal_command,
+            name="execute_terminal_command",
+            description=execute_terminal_command_tool.__doc__ or (
+                "Execute a shell command on the user's local machine via the VS "
+                "Code extension (Socket.IO workspace connection). Supports sync "
+                "(default) and async modes. Use async mode for long-running "
+                "commands; poll with terminal_session_output."
+            ),
+            args_schema=ExecuteTerminalCommandInput,
+        ),
+        StructuredTool.from_function(
+            func=_terminal_session_output,
+            name="terminal_session_output",
+            description=terminal_session_output_tool.__doc__ or (
+                "Get output from an async terminal session started by "
+                "execute_terminal_command in async mode. Provide the session_id "
+                "and an offset to stream incremental output."
+            ),
+            args_schema=TerminalSessionOutputInput,
+        ),
+        StructuredTool.from_function(
+            func=_terminal_session_signal,
+            name="terminal_session_signal",
+            description=terminal_session_signal_tool.__doc__ or (
+                "Send a signal (default SIGINT) to a running async terminal "
+                "session to stop or interrupt the process."
+            ),
+            args_schema=TerminalSessionSignalInput,
+        ),
+    ]

--- a/app/modules/intelligence/tools/local_search_tools/tunnel_utils.py
+++ b/app/modules/intelligence/tools/local_search_tools/tunnel_utils.py
@@ -22,6 +22,54 @@ _SOCKET_MAX_RETRIES = int(os.getenv("SOCKET_MAX_RETRIES", "2"))
 _SOCKET_RETRY_DELAY_SECS = float(os.getenv("SOCKET_RETRY_DELAY_SECS", "1.0"))
 
 
+def _normalize_socket_error(error_type: Optional[str]) -> Optional[str]:
+    """Map timeout-shaped socket/extension errors to the route-level timeout code."""
+    if not error_type:
+        return error_type
+    normalized = str(error_type).strip()
+    lowered = normalized.lower()
+    if "timeout" in lowered or "timed out" in lowered:
+        return "timeout"
+    return normalized
+
+
+def _route_socket_error(error_type: Optional[str]) -> str:
+    """Preserve extension/debug errors while classifying real socket failures."""
+    normalized = _normalize_socket_error(error_type)
+    if not normalized:
+        return "unknown_error"
+    if normalized in {
+        "timeout",
+        "no_tunnel",
+        "unknown_route",
+        "tunnel_unreachable",
+        "backend_loop_mismatch",
+    }:
+        return normalized
+
+    lowered = normalized.lower()
+    if (
+        normalized == "emit_failed"
+        or normalized == "connection_error"
+        or "workspace offline" in lowered
+        or "no socket connected" in lowered
+        or "redis unavailable" in lowered
+    ):
+        return "tunnel_unreachable"
+
+    return normalized
+
+
+def _socket_result(
+    result: Optional[Dict[str, Any]],
+    error_type: Optional[str],
+    return_error: bool,
+):
+    if return_error:
+        return result, _normalize_socket_error(error_type)
+    return result
+
+
 def _execute_via_socket(
     user_id: str,
     conversation_id: Optional[str],
@@ -31,7 +79,8 @@ def _execute_via_socket(
     repository: Optional[str] = None,
     branch: Optional[str] = None,
     timeout: float = 120.0,
-) -> Optional[Dict[str, Any]]:
+    return_error: bool = False,
+):
     """Execute a tool call via Socket.IO with simple retry on transient failures.
 
     Returns the unwrapped result dict on success, or None if all attempts fail.
@@ -43,13 +92,16 @@ def _execute_via_socket(
 
     last_error: Optional[str] = None
     for attempt in range(1, _SOCKET_MAX_RETRIES + 2):  # +2: initial attempt + retries
+        # Re-resolve tunnel on retries so we don't keep using a stale socket:// URL
+        # after invalidate_workspace_socket cleared a dead registration.
+        resolved_tunnel_url = tunnel_url if attempt == 1 else None
         try:
             out = get_tunnel_service().execute_tool_call_with_fallback(
                 user_id=user_id,
                 conversation_id=conversation_id,
                 endpoint=endpoint,
                 payload=payload,
-                tunnel_url=tunnel_url,
+                tunnel_url=resolved_tunnel_url,
                 repository=repository,
                 branch=branch,
                 timeout=timeout,
@@ -57,37 +109,43 @@ def _execute_via_socket(
             # Socket tool_response shape: { success, result?, error? }
             if isinstance(out, dict) and "success" in out:
                 if out.get("success") and "result" in out:
-                    return out["result"]
-                return None
-            return out
+                    return _socket_result(out["result"], None, return_error)
+                return _socket_result(
+                    None,
+                    out.get("error") or "tool_error",
+                    return_error,
+                )
+            return _socket_result(out, None, return_error)
         except TunnelConnectionError as exc:
-            last_error = exc.last_error or str(exc)
+            last_error = _normalize_socket_error(exc.last_error or str(exc))
             # Do NOT retry on timeout: the extension may have completed the operation
             # and the response was lost. Retrying would emit a duplicate tool_call,
             # causing double execution (e.g. replace_in_file runs twice, second fails).
             if last_error == "timeout":
                 logger.warning(
-                    "[_execute_via_socket] Attempt %d failed (timeout) — not retrying to avoid duplicate execution",
-                    attempt,
+                    f"[_execute_via_socket] Attempt {attempt} failed (timeout) — not retrying to avoid duplicate execution"
                 )
-                return None
+                return _socket_result(None, "timeout", return_error)
+            if last_error == "emit_failed" and attempt <= _SOCKET_MAX_RETRIES:
+                delay = _SOCKET_RETRY_DELAY_SECS * attempt
+                logger.warning(
+                    f"[_execute_via_socket] Attempt {attempt}/{_SOCKET_MAX_RETRIES + 1} emit_failed — "
+                    f"retrying in {delay:.1f}s after cache invalidation"
+                )
+                time.sleep(delay)
+                continue
             if attempt <= _SOCKET_MAX_RETRIES:
                 delay = _SOCKET_RETRY_DELAY_SECS * attempt
                 logger.warning(
-                    "[_execute_via_socket] Attempt %d/%d failed (%s) — retrying in %.1fs",
-                    attempt,
-                    _SOCKET_MAX_RETRIES + 1,
-                    last_error,
-                    delay,
+                    f"[_execute_via_socket] Attempt {attempt}/{_SOCKET_MAX_RETRIES + 1} failed ({last_error}) — "
+                    f"retrying in {delay:.1f}s"
                 )
                 time.sleep(delay)
             else:
                 logger.warning(
-                    "[_execute_via_socket] All %d attempts failed (last: %s)",
-                    _SOCKET_MAX_RETRIES + 1,
-                    last_error,
+                    f"[_execute_via_socket] All {_SOCKET_MAX_RETRIES + 1} attempts failed (last: {last_error})"
                 )
-    return None
+    return _socket_result(None, last_error, return_error)
 
 
 def _curl_equivalent_terminal_execute(
@@ -642,7 +700,6 @@ def format_search_result(operation: str, result: dict) -> str:
 
         if exit_code == 0 and output:
             # Success with output
-            lines = output.strip().split("\n")
             formatted = f"📋 **Bash command result** (`{command}`):\n\n"
             formatted += f"```\n{output[:5000]}\n```\n"  # Limit to 5k chars
             if len(output) > 5000:
@@ -785,9 +842,10 @@ def route_terminal_command(
         request_timeout_sec = float(timeout) / 1000 + 5
         if tunnel_url and tunnel_url.startswith(SOCKET_TUNNEL_PREFIX):
             logger.info(
-                f"[Tunnel Routing] 🚀 Routing terminal command to LocalServer via Socket.IO (timeout={request_timeout_sec}s)"
-            , request_timeout_sec=request_timeout_sec)
-            result = _execute_via_socket(
+                f"[Tunnel Routing] 🚀 Routing terminal command to LocalServer via Socket.IO (timeout={request_timeout_sec}s)",
+                request_timeout_sec=request_timeout_sec,
+            )
+            socket_call = _execute_via_socket(
                 user_id=user_id,
                 conversation_id=conversation_id,
                 endpoint="/api/terminal/execute",
@@ -796,11 +854,26 @@ def route_terminal_command(
                 repository=repository,
                 branch=branch,
                 timeout=request_timeout_sec,
+                return_error=True,
             )
+            if isinstance(socket_call, tuple):
+                result, socket_error = socket_call
+            else:
+                result, socket_error = socket_call, None
             if result is not None:
                 logger.info("[Tunnel Routing] ✅ Terminal command succeeded")
                 return result, None
-            return None, "tunnel_unreachable"
+            socket_error = _normalize_socket_error(socket_error)
+            if socket_error == "timeout":
+                logger.info(
+                    "[Tunnel Routing] Terminal command timed out waiting for tool_response; socket registration was not invalidated"
+                )
+                return None, "timeout"
+            route_error = _route_socket_error(socket_error)
+            logger.info(
+                f"[Tunnel Routing] Terminal socket call returned None (error={socket_error}, route_error={route_error})"
+            )
+            return None, route_error
 
         # Legacy HTTP path (e.g. direct local URL)
         base = (tunnel_url or "").rstrip("/")
@@ -968,8 +1041,7 @@ def route_workspace_debug_context(
         branch = _get_branch()
         if context_tunnel_url:
             logger.info(
-                "[route_workspace_debug_context] Using fresh tunnel_url from context: %s",
-                context_tunnel_url,
+                f"[route_workspace_debug_context] Using fresh tunnel_url from context: {context_tunnel_url}"
             )
         tunnel_service = get_tunnel_service()
         tunnel_url = tunnel_service.get_tunnel_url(
@@ -990,8 +1062,7 @@ def route_workspace_debug_context(
                 )
             else:
                 logger.info(
-                    "[route_workspace_debug_context] Workspace socket offline for workspace_id=%s",
-                    workspace_id,
+                    f"[route_workspace_debug_context] Workspace socket offline for workspace_id={workspace_id}"
                 )
             return None, "no_tunnel"
 
@@ -1003,10 +1074,9 @@ def route_workspace_debug_context(
 
         if tunnel_url.startswith(SOCKET_TUNNEL_PREFIX):
             logger.info(
-                "[route_workspace_debug_context] Routing workspace.debug_context via Socket.IO (timeout=%.1fs)",
-                timeout,
+                f"[route_workspace_debug_context] Routing workspace.debug_context via Socket.IO (timeout={timeout:.1f}s)"
             )
-            result = _execute_via_socket(
+            socket_call = _execute_via_socket(
                 user_id=user_id,
                 conversation_id=conversation_id,
                 endpoint="/api/workspace/debug-context",
@@ -1015,7 +1085,12 @@ def route_workspace_debug_context(
                 repository=repository,
                 branch=branch,
                 timeout=timeout,
+                return_error=True,
             )
+            if isinstance(socket_call, tuple):
+                result, socket_error = socket_call
+            else:
+                result, socket_error = socket_call, None
             if result is not None:
                 # Check whether the extension signalled an unknown-route error
                 # (some implementations return a structured error in the result body
@@ -1026,16 +1101,21 @@ def route_workspace_debug_context(
                     "route_not_found",
                 ):
                     logger.info(
-                        "[route_workspace_debug_context] Extension returned unknown-route error: %s",
-                        result.get("error"),
+                        f"[route_workspace_debug_context] Extension returned unknown-route error: {result.get('error')}"
                     )
                     return None, "unknown_route"
                 logger.info("[route_workspace_debug_context] RPC succeeded")
                 return result, None
+            socket_error = _normalize_socket_error(socket_error)
+            if socket_error == "timeout":
+                logger.info(
+                    "[route_workspace_debug_context] RPC timed out waiting for tool_response; socket registration was not invalidated"
+                )
+                return None, "timeout"
             logger.info(
-                "[route_workspace_debug_context] Socket call returned None — tunnel unreachable or extension did not respond"
+                f"[route_workspace_debug_context] Socket call returned None (error={socket_error})"
             )
-            return None, "tunnel_unreachable"
+            return None, _route_socket_error(socket_error)
 
         # Legacy HTTP path (direct local URL without socket prefix)
         import httpx
@@ -1043,9 +1123,7 @@ def route_workspace_debug_context(
         base = tunnel_url.rstrip("/")
         url = f"{base}/api/workspace/debug-context"
         logger.info(
-            "[route_workspace_debug_context] Routing via HTTP: %s (timeout=%.1fs)",
-            url,
-            timeout,
+            f"[route_workspace_debug_context] Routing via HTTP: {url} (timeout={timeout:.1f}s)"
         )
         try:
             with httpx.Client(timeout=timeout) as client:
@@ -1060,9 +1138,7 @@ def route_workspace_debug_context(
             )
             return None, "timeout"
         except httpx.ConnectError as e:
-            logger.warning(
-                "[route_workspace_debug_context] HTTP connect failed: %s", e
-            )
+            logger.warning(f"[route_workspace_debug_context] HTTP connect failed: {e}")
             return None, "tunnel_unreachable"
         if response.status_code == 404:
             logger.info(
@@ -1074,16 +1150,12 @@ def route_workspace_debug_context(
             logger.info("[route_workspace_debug_context] HTTP RPC succeeded")
             return result, None
         logger.warning(
-            "[route_workspace_debug_context] HTTP %s: %s",
-            response.status_code,
-            response.text[:300],
+            f"[route_workspace_debug_context] HTTP {response.status_code}: {response.text[:300]}"
         )
         return None, "tunnel_unreachable"
 
     except Exception as e:
-        logger.exception(
-            "[route_workspace_debug_context] Unexpected error: %s", e
-        )
+        logger.exception(f"[route_workspace_debug_context] Unexpected error: {e}")
         return None, "unknown_error"
 
 
@@ -1145,8 +1217,7 @@ def route_dap_command(
         branch = _get_branch()
         if context_tunnel_url:
             logger.info(
-                "[route_dap_command] Using fresh tunnel_url from context: %s",
-                context_tunnel_url,
+                f"[route_dap_command] Using fresh tunnel_url from context: {context_tunnel_url}"
             )
         tunnel_service = get_tunnel_service()
         tunnel_url = tunnel_service.get_tunnel_url(
@@ -1167,8 +1238,7 @@ def route_dap_command(
                 )
             else:
                 logger.info(
-                    "[route_dap_command] Workspace socket offline for workspace_id=%s",
-                    workspace_id,
+                    f"[route_dap_command] Workspace socket offline for workspace_id={workspace_id}"
                 )
             return None, "no_tunnel"
 
@@ -1184,11 +1254,9 @@ def route_dap_command(
             # Endpoint string passed to the socket bridge (not a Socket.IO event name).
             socket_endpoint = f"/api/debug/{method.replace('_', '-')}"
             logger.info(
-                "[route_dap_command] Routing debug.%s via Socket.IO (timeout=%.1fs)",
-                method,
-                timeout,
+                f"[route_dap_command] Routing debug.{method} via Socket.IO (timeout={timeout:.1f}s)"
             )
-            result = _execute_via_socket(
+            socket_call = _execute_via_socket(
                 user_id=user_id,
                 conversation_id=conversation_id,
                 endpoint=socket_endpoint,
@@ -1197,7 +1265,12 @@ def route_dap_command(
                 repository=repository,
                 branch=branch,
                 timeout=timeout,
+                return_error=True,
             )
+            if isinstance(socket_call, tuple):
+                result, socket_error = socket_call
+            else:
+                result, socket_error = socket_call, None
             if result is not None:
                 # Extension may signal an unknown-route error in the result body.
                 if isinstance(result, dict) and result.get("error") in (
@@ -1206,28 +1279,30 @@ def route_dap_command(
                     "route_not_found",
                 ):
                     logger.info(
-                        "[route_dap_command] Extension returned unknown-route for debug.%s: %s",
-                        method,
-                        result.get("error"),
+                        f"[route_dap_command] Extension returned unknown-route for debug.{method}: {result.get('error')}"
                     )
                     return None, "unknown_route"
-                logger.info("[route_dap_command] debug.%s RPC succeeded", method)
+                logger.info(f"[route_dap_command] debug.{method} RPC succeeded")
                 return result, None
+            socket_error = _normalize_socket_error(socket_error)
+            if socket_error == "timeout":
+                logger.info(
+                    f"[route_dap_command] debug.{method} RPC timed out waiting for tool_response; socket registration was not invalidated"
+                )
+                return None, "timeout"
+            route_error = _route_socket_error(socket_error)
             logger.info(
-                "[route_dap_command] Socket call returned None for debug.%s — tunnel unreachable or extension did not respond",
-                method,
+                f"[route_dap_command] Socket call returned None for debug.{method} "
+                f"(error={socket_error}, route_error={route_error})"
             )
-            return None, "tunnel_unreachable"
+            return None, route_error
 
         # Legacy HTTP path (direct local URL without socket prefix)
         http_method = method.replace("_", "-")
         base = tunnel_url.rstrip("/")
         url = f"{base}/api/debug/{http_method}"
         logger.info(
-            "[route_dap_command] Routing debug.%s via HTTP: %s (timeout=%.1fs)",
-            method,
-            url,
-            timeout,
+            f"[route_dap_command] Routing debug.{method} via HTTP: {url} (timeout={timeout:.1f}s)"
         )
         try:
             with httpx.Client(timeout=timeout) as client:
@@ -1237,37 +1312,27 @@ def route_dap_command(
                     headers={"Content-Type": "application/json"},
                 )
         except httpx.TimeoutException:
-            logger.warning(
-                "[route_dap_command] HTTP request timed out for debug.%s", method
-            )
+            logger.warning(f"[route_dap_command] HTTP request timed out for debug.{method}")
             return None, "timeout"
         except httpx.ConnectError as e:
-            logger.warning(
-                "[route_dap_command] HTTP connect failed for debug.%s: %s", method, e
-            )
+            logger.warning(f"[route_dap_command] HTTP connect failed for debug.{method}: {e}")
             return None, "tunnel_unreachable"
         if response.status_code == 404:
             logger.info(
-                "[route_dap_command] HTTP 404 — route debug.%s not implemented on extension",
-                method,
+                f"[route_dap_command] HTTP 404 — route debug.{method} not implemented on extension"
             )
             return None, "unknown_route"
         if response.status_code == 200:
             result = response.json()
-            logger.info("[route_dap_command] HTTP debug.%s RPC succeeded", method)
+            logger.info(f"[route_dap_command] HTTP debug.{method} RPC succeeded")
             return result, None
         logger.warning(
-            "[route_dap_command] HTTP %s for debug.%s: %s",
-            response.status_code,
-            method,
-            response.text[:300],
+            f"[route_dap_command] HTTP {response.status_code} for debug.{method}: {response.text[:300]}"
         )
         return None, "tunnel_unreachable"
 
     except Exception as e:
-        logger.exception(
-            "[route_dap_command] Unexpected error dispatching debug.%s: %s", method, e
-        )
+        logger.exception(f"[route_dap_command] Unexpected error dispatching debug.{method}: {e}")
         return None, "unknown_error"
 
 

--- a/app/modules/intelligence/tools/local_search_tools/tunnel_utils.py
+++ b/app/modules/intelligence/tools/local_search_tools/tunnel_utils.py
@@ -80,31 +80,7 @@ def _execute_via_socket(
                     last_error,
                     delay,
                 )
-                # #region agent log
-                try:
-                    with open(
-                        "/Users/nandan/Desktop/Dev/potpie/.cursor/debug-dec41d.log", "a"
-                    ) as _f:
-                        _f.write(
-                            '{"sessionId":"dec41d","hypothesisId":"H3,H5","location":"tunnel_utils:before_sleep","message":"before_time_sleep","data":{"attempt":%d,"delay":%.1f,"ts":%.3f}}\n'
-                            % (attempt, delay, time.time())
-                        )
-                except Exception:
-                    pass
-                # #endregion
                 time.sleep(delay)
-                # #region agent log
-                try:
-                    with open(
-                        "/Users/nandan/Desktop/Dev/potpie/.cursor/debug-dec41d.log", "a"
-                    ) as _f:
-                        _f.write(
-                            '{"sessionId":"dec41d","hypothesisId":"H3,H5","location":"tunnel_utils:after_sleep","message":"after_time_sleep","data":{"attempt":%d,"ts":%.3f}}\n'
-                            % (attempt, time.time())
-                        )
-                except Exception:
-                    pass
-                # #endregion
             else:
                 logger.warning(
                     "[_execute_via_socket] All %d attempts failed (last: %s)",
@@ -940,6 +916,358 @@ def route_terminal_command(
         return None, "timeout"
     except Exception as e:
         logger.exception(f"Error routing terminal command to LocalServer: {e}", e=e)
+        return None, "unknown_error"
+
+
+def route_workspace_debug_context(
+    focus_path: Optional[str] = None,
+    timeout: float = 30.0,
+    user_id: Optional[str] = None,
+    conversation_id: Optional[str] = None,
+) -> tuple[Optional[Dict[str, Any]], Optional[str]]:
+    """Route workspace.debug_context RPC to the VS Code extension via tunnel.
+
+    Dispatches the ``workspace.debug_context`` route over the existing
+    socket.io/tunnel infrastructure.  The extension-side handler is E4 —
+    until E4 lands the extension will return an unknown-route error and this
+    function returns ``(None, "unknown_route")``.
+
+    Args:
+        focus_path: Optional file/directory path to scope the response.
+            When None, the extension should return a repo-wide summary.
+        timeout: Seconds to wait for the extension to respond (default: 30).
+        user_id: User ID from context (None → resolved internally if possible).
+        conversation_id: Conversation ID from context.
+
+    Returns:
+        Tuple of (result_dict, error_type):
+        - ``(result_dict, None)`` on success
+        - ``(None, "no_tunnel")`` when no tunnel is registered for the user
+        - ``(None, "unknown_route")`` when the extension does not handle this route yet
+        - ``(None, "timeout")`` on RPC timeout
+        - ``(None, "tunnel_unreachable")`` when the socket call returned None
+        - ``(None, "no_user_id")`` when no user context is available
+    """
+    try:
+        from app.modules.tunnel.tunnel_service import get_tunnel_service
+
+        if not user_id:
+            logger.debug(
+                "[route_workspace_debug_context] No user_id in context, skipping"
+            )
+            return None, "no_user_id"
+
+        from app.modules.intelligence.tools.code_changes_manager import (
+            _get_tunnel_url,
+            _get_repository,
+            _get_branch,
+        )
+
+        context_tunnel_url = _get_tunnel_url()
+        repository = _get_repository()
+        branch = _get_branch()
+        if context_tunnel_url:
+            logger.info(
+                "[route_workspace_debug_context] Using fresh tunnel_url from context: %s",
+                context_tunnel_url,
+            )
+        tunnel_service = get_tunnel_service()
+        tunnel_url = tunnel_service.get_tunnel_url(
+            user_id,
+            conversation_id,
+            tunnel_url=context_tunnel_url,
+            repository=repository,
+            branch=branch,
+        )
+
+        if not tunnel_url:
+            workspace_id = tunnel_service.get_workspace_id(
+                user_id, conversation_id, repository=repository, branch=branch
+            )
+            if workspace_id is None:
+                logger.info(
+                    "[route_workspace_debug_context] No workspace_id — repository not in context for this conversation"
+                )
+            else:
+                logger.info(
+                    "[route_workspace_debug_context] Workspace socket offline for workspace_id=%s",
+                    workspace_id,
+                )
+            return None, "no_tunnel"
+
+        payload: Dict[str, Any] = {
+            "conversation_id": conversation_id,
+        }
+        if focus_path is not None:
+            payload["focus_path"] = focus_path
+
+        if tunnel_url.startswith(SOCKET_TUNNEL_PREFIX):
+            logger.info(
+                "[route_workspace_debug_context] Routing workspace.debug_context via Socket.IO (timeout=%.1fs)",
+                timeout,
+            )
+            result = _execute_via_socket(
+                user_id=user_id,
+                conversation_id=conversation_id,
+                endpoint="/api/workspace/debug-context",
+                payload=payload,
+                tunnel_url=tunnel_url,
+                repository=repository,
+                branch=branch,
+                timeout=timeout,
+            )
+            if result is not None:
+                # Check whether the extension signalled an unknown-route error
+                # (some implementations return a structured error in the result body
+                # rather than raising TunnelConnectionError).
+                if isinstance(result, dict) and result.get("error") in (
+                    "unknown_route",
+                    "NOT_IMPLEMENTED",
+                    "route_not_found",
+                ):
+                    logger.info(
+                        "[route_workspace_debug_context] Extension returned unknown-route error: %s",
+                        result.get("error"),
+                    )
+                    return None, "unknown_route"
+                logger.info("[route_workspace_debug_context] RPC succeeded")
+                return result, None
+            logger.info(
+                "[route_workspace_debug_context] Socket call returned None — tunnel unreachable or extension did not respond"
+            )
+            return None, "tunnel_unreachable"
+
+        # Legacy HTTP path (direct local URL without socket prefix)
+        import httpx
+
+        base = tunnel_url.rstrip("/")
+        url = f"{base}/api/workspace/debug-context"
+        logger.info(
+            "[route_workspace_debug_context] Routing via HTTP: %s (timeout=%.1fs)",
+            url,
+            timeout,
+        )
+        try:
+            with httpx.Client(timeout=timeout) as client:
+                response = client.post(
+                    url,
+                    json=payload,
+                    headers={"Content-Type": "application/json"},
+                )
+        except httpx.TimeoutException:
+            logger.warning(
+                "[route_workspace_debug_context] HTTP request timed out"
+            )
+            return None, "timeout"
+        except httpx.ConnectError as e:
+            logger.warning(
+                "[route_workspace_debug_context] HTTP connect failed: %s", e
+            )
+            return None, "tunnel_unreachable"
+        if response.status_code == 404:
+            logger.info(
+                "[route_workspace_debug_context] HTTP 404 — route not implemented on extension"
+            )
+            return None, "unknown_route"
+        if response.status_code == 200:
+            result = response.json()
+            logger.info("[route_workspace_debug_context] HTTP RPC succeeded")
+            return result, None
+        logger.warning(
+            "[route_workspace_debug_context] HTTP %s: %s",
+            response.status_code,
+            response.text[:300],
+        )
+        return None, "tunnel_unreachable"
+
+    except Exception as e:
+        logger.exception(
+            "[route_workspace_debug_context] Unexpected error: %s", e
+        )
+        return None, "unknown_error"
+
+
+def route_dap_command(
+    method: str,
+    payload: Dict[str, Any],
+    user_id: str,
+    conversation_id: Optional[str] = None,
+    timeout: float = 30.0,
+) -> tuple[Optional[Dict[str, Any]], Optional[str]]:
+    """Dispatch a DAP method call over the tunnel to the VS Code DebugSessionManager.
+
+    ``method`` is the snake_case name of a DebugSessionManager method, e.g.:
+      "start_session"     → TS startSession
+      "set_breakpoints"   → TS setBreakpoints
+      "snapshot"          → TS snapshot
+      "step_over"         → TS stepOver
+      "step_into"         → TS stepInto
+      "step_out"          → TS stepOut
+      "continue_execution" → TS continueExecution
+      "evaluate"          → TS evaluate (custom; may not exist server-side yet)
+      "list_sessions"     → TS listSessions
+      "stop_session"      → TS stopSession
+
+    RPC routing convention (for E4 to implement the counterpart handlers):
+      The same HTTP-style endpoint is used for both socket dispatch (via
+      execute_tool_call_with_fallback) and direct HTTP POST. The socket event name
+      is not "debug.<method>" — instead, the endpoint string is passed as the
+      endpoint argument to the socket bridge, which then routes it server-side.
+      The extension-side handler should register a route for the HTTP endpoint
+      shape: /api/debug/<method-with-hyphens>
+
+    Returns:
+        (result_dict, None)        on success
+        (None, "no_tunnel")        when no tunnel is registered
+        (None, "unknown_route")    when the extension returns a 404 or unknown-route body
+        (None, "timeout")          on HTTP/socket timeout
+        (None, "tunnel_unreachable") when socket returns None or HTTP connect fails
+        (None, "no_user_id")       when user_id is empty
+        (None, "unknown_error")    for any other exception
+    """
+    try:
+        from app.modules.tunnel.tunnel_service import get_tunnel_service
+
+        if not user_id:
+            logger.debug(
+                "[route_dap_command] No user_id in context, skipping"
+            )
+            return None, "no_user_id"
+
+        from app.modules.intelligence.tools.code_changes_manager import (
+            _get_tunnel_url,
+            _get_repository,
+            _get_branch,
+        )
+
+        context_tunnel_url = _get_tunnel_url()
+        repository = _get_repository()
+        branch = _get_branch()
+        if context_tunnel_url:
+            logger.info(
+                "[route_dap_command] Using fresh tunnel_url from context: %s",
+                context_tunnel_url,
+            )
+        tunnel_service = get_tunnel_service()
+        tunnel_url = tunnel_service.get_tunnel_url(
+            user_id,
+            conversation_id,
+            tunnel_url=context_tunnel_url,
+            repository=repository,
+            branch=branch,
+        )
+
+        if not tunnel_url:
+            workspace_id = tunnel_service.get_workspace_id(
+                user_id, conversation_id, repository=repository, branch=branch
+            )
+            if workspace_id is None:
+                logger.info(
+                    "[route_dap_command] No workspace_id — repository not in context for this conversation"
+                )
+            else:
+                logger.info(
+                    "[route_dap_command] Workspace socket offline for workspace_id=%s",
+                    workspace_id,
+                )
+            return None, "no_tunnel"
+
+        # Build the full payload, including conversation_id for tracing.
+        # conversation_id is spread last so it always wins over any key in payload.
+        full_payload: Dict[str, Any] = {
+            **payload,
+            "conversation_id": conversation_id,
+        }
+
+        # Socket path: tunnel_url is socket://{workspace_id}
+        if tunnel_url.startswith(SOCKET_TUNNEL_PREFIX):
+            # Endpoint string passed to the socket bridge (not a Socket.IO event name).
+            socket_endpoint = f"/api/debug/{method.replace('_', '-')}"
+            logger.info(
+                "[route_dap_command] Routing debug.%s via Socket.IO (timeout=%.1fs)",
+                method,
+                timeout,
+            )
+            result = _execute_via_socket(
+                user_id=user_id,
+                conversation_id=conversation_id,
+                endpoint=socket_endpoint,
+                payload=full_payload,
+                tunnel_url=tunnel_url,
+                repository=repository,
+                branch=branch,
+                timeout=timeout,
+            )
+            if result is not None:
+                # Extension may signal an unknown-route error in the result body.
+                if isinstance(result, dict) and result.get("error") in (
+                    "unknown_route",
+                    "NOT_IMPLEMENTED",
+                    "route_not_found",
+                ):
+                    logger.info(
+                        "[route_dap_command] Extension returned unknown-route for debug.%s: %s",
+                        method,
+                        result.get("error"),
+                    )
+                    return None, "unknown_route"
+                logger.info("[route_dap_command] debug.%s RPC succeeded", method)
+                return result, None
+            logger.info(
+                "[route_dap_command] Socket call returned None for debug.%s — tunnel unreachable or extension did not respond",
+                method,
+            )
+            return None, "tunnel_unreachable"
+
+        # Legacy HTTP path (direct local URL without socket prefix)
+        http_method = method.replace("_", "-")
+        base = tunnel_url.rstrip("/")
+        url = f"{base}/api/debug/{http_method}"
+        logger.info(
+            "[route_dap_command] Routing debug.%s via HTTP: %s (timeout=%.1fs)",
+            method,
+            url,
+            timeout,
+        )
+        try:
+            with httpx.Client(timeout=timeout) as client:
+                response = client.post(
+                    url,
+                    json=full_payload,
+                    headers={"Content-Type": "application/json"},
+                )
+        except httpx.TimeoutException:
+            logger.warning(
+                "[route_dap_command] HTTP request timed out for debug.%s", method
+            )
+            return None, "timeout"
+        except httpx.ConnectError as e:
+            logger.warning(
+                "[route_dap_command] HTTP connect failed for debug.%s: %s", method, e
+            )
+            return None, "tunnel_unreachable"
+        if response.status_code == 404:
+            logger.info(
+                "[route_dap_command] HTTP 404 — route debug.%s not implemented on extension",
+                method,
+            )
+            return None, "unknown_route"
+        if response.status_code == 200:
+            result = response.json()
+            logger.info("[route_dap_command] HTTP debug.%s RPC succeeded", method)
+            return result, None
+        logger.warning(
+            "[route_dap_command] HTTP %s for debug.%s: %s",
+            response.status_code,
+            method,
+            response.text[:300],
+        )
+        return None, "tunnel_unreachable"
+
+    except Exception as e:
+        logger.exception(
+            "[route_dap_command] Unexpected error dispatching debug.%s: %s", method, e
+        )
         return None, "unknown_error"
 
 

--- a/app/modules/intelligence/tools/local_search_tools/tunnel_utils.py
+++ b/app/modules/intelligence/tools/local_search_tools/tunnel_utils.py
@@ -60,6 +60,19 @@ def _route_socket_error(error_type: Optional[str]) -> str:
     return normalized
 
 
+def _dap_domain_error(result: Any) -> Optional[str]:
+    """Detect extension-level failure envelopes in DAP RPC responses."""
+    if not isinstance(result, dict):
+        return None
+    if result.get("success") is False:
+        return _route_socket_error(
+            _normalize_socket_error(result.get("error") or "extension_error")
+        )
+    if result.get("error") in ("unknown_route", "NOT_IMPLEMENTED", "route_not_found"):
+        return "unknown_route"
+    return None
+
+
 def _socket_result(
     result: Optional[Dict[str, Any]],
     error_type: Optional[str],
@@ -1272,16 +1285,12 @@ def route_dap_command(
             else:
                 result, socket_error = socket_call, None
             if result is not None:
-                # Extension may signal an unknown-route error in the result body.
-                if isinstance(result, dict) and result.get("error") in (
-                    "unknown_route",
-                    "NOT_IMPLEMENTED",
-                    "route_not_found",
-                ):
+                domain_err = _dap_domain_error(result)
+                if domain_err:
                     logger.info(
-                        f"[route_dap_command] Extension returned unknown-route for debug.{method}: {result.get('error')}"
+                        f"[route_dap_command] Extension returned domain error for debug.{method}: {domain_err}"
                     )
-                    return None, "unknown_route"
+                    return None, domain_err
                 logger.info(f"[route_dap_command] debug.{method} RPC succeeded")
                 return result, None
             socket_error = _normalize_socket_error(socket_error)
@@ -1322,10 +1331,33 @@ def route_dap_command(
                 f"[route_dap_command] HTTP 404 — route debug.{method} not implemented on extension"
             )
             return None, "unknown_route"
+        try:
+            body = response.json()
+        except Exception:
+            body = None
         if response.status_code == 200:
-            result = response.json()
+            domain_err = _dap_domain_error(body)
+            if domain_err:
+                logger.info(
+                    f"[route_dap_command] HTTP 200 domain error for debug.{method}: {domain_err}"
+                )
+                return None, domain_err
             logger.info(f"[route_dap_command] HTTP debug.{method} RPC succeeded")
-            return result, None
+            return body, None
+        if isinstance(body, dict):
+            domain_err = _dap_domain_error(body)
+            if domain_err:
+                logger.info(
+                    f"[route_dap_command] HTTP {response.status_code} domain error for debug.{method}: {domain_err}"
+                )
+                return None, domain_err
+            error = body.get("error")
+            if error:
+                routed = _route_socket_error(_normalize_socket_error(error))
+                logger.info(
+                    f"[route_dap_command] HTTP {response.status_code} error for debug.{method}: {routed}"
+                )
+                return None, routed
         logger.warning(
             f"[route_dap_command] HTTP {response.status_code} for debug.{method}: {response.text[:300]}"
         )

--- a/app/modules/intelligence/tools/local_search_tools/tunnel_utils.py
+++ b/app/modules/intelligence/tools/local_search_tools/tunnel_utils.py
@@ -1160,6 +1160,17 @@ def route_workspace_debug_context(
             return None, "unknown_route"
         if response.status_code == 200:
             result = response.json()
+            # Mirror the socket branch: the extension may signal a structured
+            # error (e.g. unknown route) in a 200 body rather than via status code.
+            if isinstance(result, dict) and result.get("error") in (
+                "unknown_route",
+                "NOT_IMPLEMENTED",
+                "route_not_found",
+            ):
+                logger.info(
+                    f"[route_workspace_debug_context] HTTP extension returned unknown-route error: {result.get('error')}"
+                )
+                return None, "unknown_route"
             logger.info("[route_workspace_debug_context] HTTP RPC succeeded")
             return result, None
         logger.warning(

--- a/app/modules/intelligence/tools/parse_failure_signal_tool.py
+++ b/app/modules/intelligence/tools/parse_failure_signal_tool.py
@@ -1,0 +1,499 @@
+"""parse_failure_signal — pure-parsing tool for the debug agent.
+
+Takes a raw failure text (log, stack trace, failed-test output, or natural-language
+symptom) and returns a structured representation: classification, extracted stack
+frames, error type, and a short signature for dedup/grouping.
+
+No I/O, no network, no LLM calls.  Entirely deterministic regex-based extraction.
+"""
+
+import re
+from typing import Dict, Any, List, Literal, Optional
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from app.modules.utils.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+InputTypeHint = Optional[Literal["pasted_log", "nl_symptom", "failed_test"]]
+Classification = Literal["pasted_log", "nl_symptom", "failed_test"]
+Language = Literal["python", "javascript", "typescript", "go", "unknown"]
+
+
+class StackFrame(BaseModel):
+    file: str
+    line: Optional[int] = None
+    symbol: Optional[str] = None
+    language: Language = "unknown"
+
+
+class ParseFailureSignalResult(BaseModel):
+    signature: str
+    classification: Classification
+    stack_frames: List[StackFrame]
+    error_type: Optional[str] = None
+    raw_excerpt: str
+
+
+class ParseFailureSignalInput(BaseModel):
+    raw_text: str = Field(description="Pasted log, stack trace, or failed-test output")
+    input_type_hint: InputTypeHint = Field(
+        default=None,
+        description='Optional classification hint: "pasted_log", "nl_symptom", or "failed_test"',
+    )
+
+
+# ---------------------------------------------------------------------------
+# Language detection helpers
+# ---------------------------------------------------------------------------
+
+def _language_from_file(path: str) -> Language:
+    path_lower = path.lower()
+    if path_lower.endswith(".py"):
+        return "python"
+    if path_lower.endswith(".ts") or path_lower.endswith(".tsx"):
+        return "typescript"
+    if path_lower.endswith(".js") or path_lower.endswith(".jsx") or path_lower.endswith(".mjs"):
+        return "javascript"
+    if path_lower.endswith(".go"):
+        return "go"
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Extractor: Python traceback
+# ---------------------------------------------------------------------------
+# Shape:
+#   File "path/to/file.py", line 42, in function_name
+#   <source line>
+# Error line at end: ErrorClass: message   OR   module.ErrorClass: message
+_PY_FRAME_RE = re.compile(
+    r'^\s{2}File "(?P<file>[^"]+)",\s*line\s+(?P<line>\d+),\s*in\s+(?P<symbol>\S+)',
+    re.MULTILINE,
+)
+_PY_ERROR_RE = re.compile(
+    r'^(?P<error>[\w.]+(?:Error|Exception|Warning|Fault|Timeout|Interrupt|Exit|Stop|KeyboardInterrupt))[:\s]',
+    re.MULTILINE,
+)
+
+
+def _extract_python(text: str) -> Optional[List[StackFrame]]:
+    frames = []
+    for m in _PY_FRAME_RE.finditer(text):
+        frames.append(
+            StackFrame(
+                file=m.group("file"),
+                line=int(m.group("line")),
+                symbol=m.group("symbol"),
+                language=_language_from_file(m.group("file")),
+            )
+        )
+    return frames if frames else None
+
+
+def _python_error_type(text: str) -> Optional[str]:
+    m = _PY_ERROR_RE.search(text)
+    if m:
+        name = m.group("error")
+        # Return the leaf class name (after last dot)
+        return name.split(".")[-1]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Extractor: pytest failure
+# ---------------------------------------------------------------------------
+# Shape:
+#   FAILED tests/foo.py::test_bar - AssertionError: ...
+#   OR inline assertion lines inside the boxed traceback
+_PYTEST_FAILED_RE = re.compile(
+    r'^FAILED\s+(?P<path>[\w/\\.\-]+::[\w.\-]+)\s+-\s+(?P<error>[\w.]+(?:Error|Exception|Warning|Assertion)[^:\n]*)',
+    re.MULTILINE,
+)
+_PYTEST_ASSERT_RE = re.compile(
+    r'^E\s+(?P<error>[\w]+(?:Error|Exception|Assertion))[:\s]',
+    re.MULTILINE,
+)
+
+
+def _extract_pytest(text: str) -> Optional[List[StackFrame]]:
+    """Return frames if this looks like a pytest failure output."""
+    failed_match = _PYTEST_FAILED_RE.search(text)
+    assert_match = _PYTEST_ASSERT_RE.search(text)
+    if not failed_match and not assert_match:
+        return None
+
+    # Also pull Python frames from the traceback section
+    frames = _extract_python(text) or []
+
+    # If no Python frames but we found a FAILED line, synthesise one frame
+    if not frames and failed_match:
+        path_part = failed_match.group("path")
+        file_part = path_part.split("::")[0]
+        frames.append(
+            StackFrame(
+                file=file_part,
+                line=None,
+                symbol=None,
+                language=_language_from_file(file_part),
+            )
+        )
+    return frames if frames else None
+
+
+def _pytest_error_type(text: str) -> Optional[str]:
+    m = _PYTEST_FAILED_RE.search(text)
+    if m:
+        raw = m.group("error").strip()
+        # strip trailing message after ':'
+        cls = raw.split(":")[0].strip()
+        return cls.split(".")[-1]
+    m2 = _PYTEST_ASSERT_RE.search(text)
+    if m2:
+        return m2.group("error").strip()
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Extractor: Node / TypeScript / JavaScript stack
+# ---------------------------------------------------------------------------
+# Shape:
+#   at functionName (path/to/file.ts:42:13)
+#   at path/to/file.js:88:7
+_NODE_AT_FULL_RE = re.compile(
+    r'^\s+at\s+(?P<symbol>[\w.<>$\[\] ]+?)\s+\((?P<file>[^)]+):(?P<line>\d+):\d+\)',
+    re.MULTILINE,
+)
+_NODE_AT_BARE_RE = re.compile(
+    r'^\s+at\s+(?P<file>(?!\s)[\w./\\@\-]+\.[jt]sx?):(?P<line>\d+):\d+',
+    re.MULTILINE,
+)
+# Error class on the first line: "ErrorClass: message"
+_NODE_ERROR_RE = re.compile(
+    r'^(?P<error>[\w]+(?:Error|Exception|Timeout|Fault))[:\s]',
+    re.MULTILINE,
+)
+
+
+def _extract_node(text: str) -> Optional[List[StackFrame]]:
+    frames = []
+    # Combine both patterns in order of appearance
+    hits: List[tuple] = []  # (match_start, frame)
+
+    for m in _NODE_AT_FULL_RE.finditer(text):
+        raw_file = m.group("file")
+        # file may have leading "file://" or similar — strip to path
+        file_path = _FILE_URI_RE.sub('', raw_file)
+        # strip column (already in regex)
+        hits.append(
+            (
+                m.start(),
+                StackFrame(
+                    file=file_path,
+                    line=int(m.group("line")),
+                    symbol=m.group("symbol").strip(),
+                    language=_language_from_file(file_path),
+                ),
+            )
+        )
+
+    for m in _NODE_AT_BARE_RE.finditer(text):
+        file_path = m.group("file")
+        hits.append(
+            (
+                m.start(),
+                StackFrame(
+                    file=file_path,
+                    line=int(m.group("line")),
+                    symbol=None,
+                    language=_language_from_file(file_path),
+                ),
+            )
+        )
+
+    # Sort by position and deduplicate (full match wins over bare if same position)
+    hits.sort(key=lambda x: x[0])
+    seen_pos: set = set()
+    for pos, frame in hits:
+        if pos not in seen_pos:
+            frames.append(frame)
+            seen_pos.add(pos)
+
+    return frames if frames else None
+
+
+def _node_error_type(text: str) -> Optional[str]:
+    m = _NODE_ERROR_RE.search(text)
+    return m.group("error") if m else None
+
+
+# ---------------------------------------------------------------------------
+# Extractor: Jest / Mocha failure
+# ---------------------------------------------------------------------------
+# Shape:
+#   FAIL tests/foo.test.ts
+#   ● Test Suite > test name
+#   Expected: ...  Received: ...
+_JEST_FAIL_RE = re.compile(r'^[\s]*(FAIL|FAILED)\s+[\w/\\.\-]+\.(?:test|spec)\.[jt]sx?', re.MULTILINE)
+_JEST_MOCHA_MARKER_RE = re.compile(r'^[\s]*●\s+', re.MULTILINE)
+
+
+def _extract_jest(text: str) -> Optional[List[StackFrame]]:
+    """Return frames if text looks like Jest/Mocha output."""
+    fail_match = _JEST_FAIL_RE.search(text)
+    mocha_match = _JEST_MOCHA_MARKER_RE.search(text)
+    if not fail_match and not mocha_match:
+        return None
+
+    # Pull any Node-style "at ..." frames from the traceback section
+    frames = _extract_node(text) or []
+
+    # Synthesise a frame from the FAIL file path if no other frames
+    if not frames and fail_match:
+        line_text = fail_match.group(0).strip()
+        # The file path is after FAIL/FAILED token
+        parts = line_text.split(None, 1)
+        if len(parts) == 2:
+            file_part = parts[1].strip()
+            frames.append(
+                StackFrame(
+                    file=file_part,
+                    line=None,
+                    symbol=None,
+                    language=_language_from_file(file_part),
+                )
+            )
+    return frames if frames else None
+
+
+def _jest_error_type(text: str) -> Optional[str]:
+    # Jest usually shows "Expected: N  Received: M" without explicit error class.
+    # Check for explicit thrown errors in "at" lines.
+    return _node_error_type(text)
+
+
+# ---------------------------------------------------------------------------
+# Extractor: Go goroutine dump
+# ---------------------------------------------------------------------------
+# Shape:
+#   goroutine 1 [running]:
+#   main.foo(0xc...)
+#         /path/to/file.go:42 +0x...
+_GO_GOROUTINE_RE = re.compile(r'goroutine\s+\d+\s+\[', re.MULTILINE)
+_GO_SYMBOL_RE = re.compile(r'^(?P<symbol>[\w/.]+)\(', re.MULTILINE)
+_GO_FILE_RE = re.compile(r'^\t(?P<file>[^\s:]+\.go):(?P<line>\d+)', re.MULTILINE)
+
+# Promoted inline patterns (Minor 2)
+_FILE_URI_RE = re.compile(r'^file://')
+_PATH_PREFIX_RE = re.compile(r'^.*?(?:src/|app/|tests/|lib/)')
+
+
+def _extract_go(text: str) -> Optional[List[StackFrame]]:
+    if not _GO_GOROUTINE_RE.search(text):
+        return None
+
+    frames = []
+    # Pair symbol lines with their following file lines
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        sym_m = _GO_SYMBOL_RE.match(line)
+        if sym_m and i + 1 < len(lines):
+            file_m = _GO_FILE_RE.match(lines[i + 1])
+            if file_m:
+                symbol = sym_m.group("symbol")
+                file_path = file_m.group("file")
+                line_no = int(file_m.group("line"))
+                frames.append(
+                    StackFrame(
+                        file=file_path,
+                        line=line_no,
+                        symbol=symbol,
+                        language="go",
+                    )
+                )
+                i += 2
+                continue
+        i += 1
+
+    return frames if frames else None
+
+
+# ---------------------------------------------------------------------------
+# Detection logic with precedence
+# ---------------------------------------------------------------------------
+
+def _is_pytest(text: str) -> bool:
+    return bool(
+        _PYTEST_FAILED_RE.search(text)
+        or (_PY_FRAME_RE.search(text) and _PYTEST_ASSERT_RE.search(text))
+    )
+
+
+def _is_python_traceback(text: str) -> bool:
+    return bool(_PY_FRAME_RE.search(text))
+
+
+def _is_jest(text: str) -> bool:
+    fail_line = bool(_JEST_FAIL_RE.search(text))
+    mocha_marker = bool(_JEST_MOCHA_MARKER_RE.search(text))
+    if mocha_marker and not fail_line:
+        return bool(_NODE_AT_FULL_RE.search(text) or _NODE_AT_BARE_RE.search(text))
+    return fail_line or mocha_marker
+
+
+def _is_node(text: str) -> bool:
+    return bool(_NODE_AT_FULL_RE.search(text) or _NODE_AT_BARE_RE.search(text))
+
+
+def _is_go(text: str) -> bool:
+    return bool(_GO_GOROUTINE_RE.search(text))
+
+
+# ---------------------------------------------------------------------------
+# Signature builder
+# ---------------------------------------------------------------------------
+
+def _build_signature(
+    text: str,
+    classification: Classification,
+    frames: List[StackFrame],
+    error_type: Optional[str],
+) -> str:
+    if classification == "nl_symptom" or not frames:
+        # Use first ~60 chars of raw text
+        cleaned = " ".join(text.split())
+        return cleaned[:60]
+
+    # Build from error_type + first meaningful frame
+    parts = []
+    if error_type:
+        parts.append(error_type)
+    if frames:
+        first = frames[0]
+        # Strip leading path components to keep it short
+        short_file = _PATH_PREFIX_RE.sub('', first.file)
+        short_file = short_file.rstrip("/").replace("/", ".")
+        if short_file.endswith(".py"):
+            short_file = short_file[:-3]
+        elif short_file.endswith(".tsx"):
+            short_file = short_file[:-4]
+        elif short_file.endswith(".ts"):
+            short_file = short_file[:-3]
+        elif short_file.endswith(".jsx"):
+            short_file = short_file[:-4]
+        elif short_file.endswith(".js"):
+            short_file = short_file[:-3]
+        elif short_file.endswith(".go"):
+            short_file = short_file[:-3]
+        if first.symbol:
+            parts.append(f"{short_file}.{first.symbol}")
+        else:
+            parts.append(short_file)
+    sig = ".".join(parts) if parts else " ".join(text.split())[:60]
+    return sig[:80]
+
+
+# ---------------------------------------------------------------------------
+# Core function
+# ---------------------------------------------------------------------------
+
+def parse_failure_signal(
+    raw_text: str,
+    input_type_hint: InputTypeHint = None,
+) -> Dict[str, Any]:
+    """Parse a raw failure signal and return structured debug information.
+
+    Pure parsing — no I/O, no network, no LLM calls.
+    """
+    text = raw_text or ""
+    raw_excerpt = text[:300]
+
+    # --- Auto-detection (ordered by specificity: most specific first) ---
+    # pytest > python_traceback > jest/mocha > node > go > nl_symptom
+
+    detected_classification: Classification = "nl_symptom"
+    frames: Optional[List[StackFrame]] = None
+    error_type: Optional[str] = None
+
+    if _is_pytest(text):
+        detected_classification = "failed_test"
+        frames = _extract_pytest(text)
+        error_type = _pytest_error_type(text)
+    elif _is_python_traceback(text):
+        detected_classification = "pasted_log"
+        frames = _extract_python(text)
+        error_type = _python_error_type(text)
+    elif _is_jest(text):
+        detected_classification = "failed_test"
+        frames = _extract_jest(text)
+        error_type = _jest_error_type(text)
+    elif _is_node(text):
+        detected_classification = "pasted_log"
+        frames = _extract_node(text)
+        error_type = _node_error_type(text)
+    elif _is_go(text):
+        detected_classification = "pasted_log"
+        frames = _extract_go(text)
+        error_type = None
+    else:
+        detected_classification = "nl_symptom"
+        frames = []
+        error_type = None
+
+    # --- Honor hint ---
+    # When a hint is provided, override the classification.
+    # The hint does NOT change frame extraction (we already extracted from the content);
+    # it only affects the final classification label.
+    if input_type_hint is not None:
+        final_classification: Classification = input_type_hint
+    else:
+        final_classification = detected_classification
+
+    # If detected as nl_symptom (no frames), keep frames empty regardless of hint
+    safe_frames: List[StackFrame] = frames or []
+
+    # --- Signature ---
+    signature = _build_signature(text, final_classification, safe_frames, error_type)
+
+    result = ParseFailureSignalResult(
+        signature=signature,
+        classification=final_classification,
+        stack_frames=safe_frames,
+        error_type=error_type,
+        raw_excerpt=raw_excerpt,
+    )
+
+    # Return as dict so existing StructuredTool plumbing serializes it cleanly
+    return result.model_dump()
+
+
+# ---------------------------------------------------------------------------
+# LangChain StructuredTool factory
+# ---------------------------------------------------------------------------
+
+def parse_failure_signal_tool() -> StructuredTool:
+    """Create the parse_failure_signal StructuredTool.
+
+    No db/user_id required — this tool is pure parsing with no I/O.
+    """
+    return StructuredTool.from_function(
+        func=parse_failure_signal,
+        name="parse_failure_signal",
+        description=(
+            "Parse a pasted log, stack trace, or failed-test output and return a "
+            "structured representation: classification (pasted_log | failed_test | nl_symptom), "
+            "extracted stack frames (file, line, symbol, language), error type, and a short "
+            "signature for grouping. Pure parsing — no network, no LLM. "
+            "Use this as the first step in a debugging session to extract candidate source "
+            "locations before forming hypotheses."
+        ),
+        args_schema=ParseFailureSignalInput,
+    )

--- a/app/modules/intelligence/tools/query_context_graph_tool.py
+++ b/app/modules/intelligence/tools/query_context_graph_tool.py
@@ -1,0 +1,138 @@
+"""query_context_graph — stub tool for the debug agent.
+
+Queries the context-graph service for code locations relevant to a
+natural-language description.  The real context-graph service is under
+separate development; this file ships the stub so:
+
+  1. The tool contract (args schema + output schema) is locked in from day one.
+  2. The debug agent's prompt can reference the tool name today.
+  3. The future implementer can replace the stub body with the real service call
+     (and update the factory signature in tool_service.py to take db/user_id if
+     needed) without changing any agent consumers.
+
+When ``available=False``, the agent must fall back to the discovery tools
+listed in ``debug_hypothesis_contract.DISCOVERY_PRIORITY_ORDER`` (e.g.
+``ask_knowledge_graph_queries``, ``search_text``, ``get_code_file_structure``).
+"""
+
+from typing import List, Optional
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from app.modules.utils.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models — output schema
+# ---------------------------------------------------------------------------
+
+
+class ContextGraphResult(BaseModel):
+    """A single result entry returned by the context-graph service."""
+
+    file: str
+    symbol: Optional[str] = None
+    snippet: Optional[str] = None  # a small code excerpt for the agent to read
+    score: float = Field(..., ge=0.0, le=1.0, description="Relevance score, 0.0–1.0.")
+
+
+class QueryContextGraphOutput(BaseModel):
+    """Output shape for query_context_graph.
+
+    ``available`` is ``False`` for the stub; ``True`` once the real service
+    is wired.  ``results`` is always an empty list from the stub.
+    ``message`` is a human-readable hint for the agent when ``available`` is
+    ``False``; ``None`` when the real service returns hits.
+    """
+
+    available: bool
+    results: List[ContextGraphResult]
+    message: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Input schema
+# ---------------------------------------------------------------------------
+
+
+class QueryContextGraphInput(BaseModel):
+    query: str = Field(
+        description=(
+            "Natural-language description of what to find, e.g. "
+            "'where is payment timeout handled'."
+        )
+    )
+    project_id: str = Field(
+        description="Project ID — same value the rest of the agent uses."
+    )
+    limit: int = Field(
+        default=10,
+        description="Maximum number of results to return (default 10).",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stub implementation
+# ---------------------------------------------------------------------------
+
+_STUB_MESSAGE = (
+    "context graph service not yet wired; agent should fall back to "
+    "ask_knowledge_graph_queries / search_text / file structure tools"
+)
+
+
+def query_context_graph(
+    query: str,
+    project_id: str,
+    limit: int = 10,
+) -> dict:
+    """Stub implementation — returns available=False unconditionally.
+
+    Args:
+        query: Natural-language description of what to find.
+        project_id: Project identifier.
+        limit: Maximum results requested (ignored by stub).
+
+    Returns:
+        Serialised ``QueryContextGraphOutput`` with ``available=False``.
+    """
+    logger.debug(
+        "query_context_graph called (stub) query={!r} project_id={!r} limit={}",
+        query,
+        project_id,
+        limit,
+    )
+    return QueryContextGraphOutput(
+        available=False,
+        results=[],
+        message=_STUB_MESSAGE,
+    ).model_dump()
+
+
+# ---------------------------------------------------------------------------
+# LangChain StructuredTool factory
+# ---------------------------------------------------------------------------
+
+
+def query_context_graph_tool() -> StructuredTool:
+    """Create the query_context_graph StructuredTool.
+
+    No db/user_id required — the stub performs no I/O.
+    """
+    return StructuredTool.from_function(
+        func=query_context_graph,
+        name="query_context_graph",
+        description=(
+            "Query the context-graph service for code locations relevant to a "
+            "natural-language description (e.g. 'where is payment timeout handled'). "
+            "Returns a ranked list of file/symbol/snippet results with relevance scores. "
+            "IMPORTANT: the service is not yet wired — the tool returns available=False "
+            "today. When available=False, fall back to ask_knowledge_graph_queries, "
+            "search_text, get_code_file_structure, or fetch_file as directed by the "
+            "discovery priority order."
+        ),
+        args_schema=QueryContextGraphInput,
+    )

--- a/app/modules/intelligence/tools/query_context_graph_tool.py
+++ b/app/modules/intelligence/tools/query_context_graph_tool.py
@@ -80,7 +80,7 @@ class QueryContextGraphInput(BaseModel):
 
 _STUB_MESSAGE = (
     "context graph service not yet wired; agent should fall back to "
-    "ask_knowledge_graph_queries / search_text / file structure tools"
+    "ask_knowledge_graph_queries / search_text / search_bash / file structure tools"
 )
 
 
@@ -131,8 +131,8 @@ def query_context_graph_tool() -> StructuredTool:
             "Returns a ranked list of file/symbol/snippet results with relevance scores. "
             "IMPORTANT: the service is not yet wired — the tool returns available=False "
             "today. When available=False, fall back to ask_knowledge_graph_queries, "
-            "search_text, get_code_file_structure, or fetch_file as directed by the "
-            "discovery priority order."
+            "search_text, search_bash, get_code_file_structure, or fetch_file as "
+            "directed by the discovery priority order."
         ),
         args_schema=QueryContextGraphInput,
     )

--- a/app/modules/intelligence/tools/registry/definitions.py
+++ b/app/modules/intelligence/tools/registry/definitions.py
@@ -218,12 +218,14 @@ TOOL_DEFINITIONS: Dict[str, dict] = {
         "tier": "medium",
         "category": "sandbox",
         "short_description": "View / create / str_replace / insert on worktree files.",
+        "non_local_only": True,
     },
     "sandbox_shell": {
         "tier": "low",
         "category": "sandbox",
         "short_description": "Run a single shell command inside the sandbox.",
         "destructive": True,
+        "non_local_only": True,
     },
     "sandbox_search": {
         "tier": "medium",
@@ -236,6 +238,7 @@ TOOL_DEFINITIONS: Dict[str, dict] = {
         "tier": "medium",
         "category": "sandbox",
         "short_description": "Git status / diff / log / commit / push on the worktree.",
+        "non_local_only": True,
     },
     # ``sandbox_pr`` / ``sandbox_pr_comment`` are the consolidation
     # targets for the four legacy ``code_provider_*`` integration tools.

--- a/app/modules/intelligence/tools/registry/resolver.py
+++ b/app/modules/intelligence/tools/registry/resolver.py
@@ -90,6 +90,11 @@ class ToolResolver:
             len(names),
             len(tools),
         )
+        logger.info(
+            "[DEBUG resolver] execute_terminal_command in resolved names: {} | in returned tools: {}",
+            "execute_terminal_command" in names,
+            any(getattr(t, "name", None) == "execute_terminal_command" for t in tools),
+        )
         # #region agent log
         try:
             _dp = "/Users/nandan/Desktop/Dev/potpie/.cursor/debug-65030d.log"

--- a/app/modules/intelligence/tools/run_validation_tool.py
+++ b/app/modules/intelligence/tools/run_validation_tool.py
@@ -1,0 +1,337 @@
+"""run_validation — structured pass/fail validation tool for the debug agent.
+
+Runs a user-supplied command (typically a test or debug re-run), captures the
+result via the existing execute_terminal_command plumbing, and returns a
+structured pass/fail summary with evidence the agent can use for "before fix /
+after fix" validation (hypo.md §5 Step 9).
+
+This is distinct from generic bash execution: it adds structured outcome
+semantics (status, exit_code, evidence_summary, output_excerpt, wall_time).
+No direct subprocess usage — all execution is delegated to route_terminal_command.
+"""
+
+import re
+import time
+from typing import Literal, Optional
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from app.modules.utils.logger import setup_logger
+from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
+    route_terminal_command,
+    get_context_vars,
+)
+
+logger = setup_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Compiled failure-line patterns (module-level, compiled once at import time).
+# Anchored / left-anchored patterns to avoid catastrophic backtracking.
+# ---------------------------------------------------------------------------
+
+# Matches lines that begin with (or contain after leading whitespace) a
+# recognisable error/failure keyword.
+# Groups of alternatives ordered from most specific to least specific.
+_FAILURE_LINE_RE = re.compile(
+    r"""
+    (?:^|\n)            # start of string or start of new line
+    [^\S\n]*            # optional horizontal whitespace (tabs, spaces)
+    (?:
+        AssertionError  |
+        AssertError     |
+        assert\s+       |   # "assert x == y" lines from pytest
+        Exception       |
+        Error:          |   # "Error: something" (JS/TS style)
+        FAILED(?=[^\S\n]|\n|$)  |   # "FAILED tests/..." pytest; bare "FAILED" jest EOL
+        FAIL(?=[^\S\n]|\n|$)    |   # "FAIL tests/..." jest-style
+        FailError       |
+        Traceback       |   # Python traceback header
+        SyntaxError     |
+        TypeError       |
+        ValueError      |
+        KeyError        |
+        AttributeError  |
+        ImportError     |
+        RuntimeError    |
+        NotImplementedError |
+        PermissionError |
+        TimeoutError    |
+        ConnectionError |
+        OSError         |
+        E\s{5,}         |   # pytest inline error lines (E       AssertionError)
+        panic:          |   # Go panic
+        PANIC           |   # Go PANIC
+        fatal\s+error   |   # Go / C fatal
+        \[FAIL\]        |   # Go test output
+        ● \s            |   # Jest/Mocha bullet marker
+        ✕ \s            |   # Vitest cross marker
+        ✗ \s                # alternative cross marker
+    )
+    """,
+    re.VERBOSE | re.MULTILINE,
+)
+
+# Maximum characters for output_excerpt
+_MAX_EXCERPT_CHARS: int = 800
+# Maximum characters for evidence_summary
+_MAX_EVIDENCE_CHARS: int = 240
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class RunValidationInput(BaseModel):
+    command: str = Field(
+        description=(
+            "The shell command to run for validation, e.g. "
+            "'npm test -- src/checkout/createOrder.test.ts' or "
+            "'pytest tests/test_checkout.py -k payment_timeout'"
+        )
+    )
+    working_directory: Optional[str] = Field(
+        default=None,
+        description=(
+            "Working directory relative to workspace root (optional). "
+            "Defaults to the project root via the existing terminal-command convention."
+        ),
+    )
+    timeout_seconds: int = Field(
+        default=120,
+        description="Wall-clock cap in seconds before the process is killed (default: 120).",
+    )
+
+
+class RunValidationResult(BaseModel):
+    status: Literal["passed", "failed", "timed_out", "error"]
+    exit_code: Optional[int]
+    evidence_summary: str
+    output_excerpt: str
+    wall_time_seconds: float
+    command: str
+
+
+# ---------------------------------------------------------------------------
+# Evidence-summary helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_last_error_line(output: str) -> Optional[str]:
+    """Scan *output* bottom-up for the last line matching a failure pattern.
+
+    Returns the stripped matching line, or None if nothing matches.
+    """
+    if not output:
+        return None
+
+    # Collect all match positions
+    matches = list(_FAILURE_LINE_RE.finditer(output))
+    if not matches:
+        return None
+
+    # Take the LAST match (bottom-up scan gives us the most relevant line,
+    # typically the final error before the summary)
+    match = matches[-1]
+
+    # The regex may include a leading `\n` (or `(?:^|\n)`) in the match.
+    # Use match.end() as the anchor: it points past the keyword.  Then find
+    # the full line by searching backwards for the preceding newline and
+    # forwards for the next newline.
+    anchor = match.end()
+    # Find the start of the line that contains the keyword
+    line_start = output.rfind("\n", 0, anchor) + 1  # +1 skips the \n itself
+    line_end = output.find("\n", anchor)
+    if line_end == -1:
+        line_end = len(output)
+    return output[line_start:line_end].strip()
+
+
+def _last_nonempty_line(output: str) -> str:
+    """Return the last non-empty stripped line, or empty string."""
+    for line in reversed(output.splitlines()):
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def _build_evidence_summary(
+    status: str,
+    wall_time: float,
+    output: str,
+    timeout_seconds: int,
+    error_msg: str = "",
+) -> str:
+    """Construct a ≤240-char human-readable evidence summary."""
+    if status == "passed":
+        summary = f"Command passed in {wall_time:.1f}s"
+
+    elif status == "failed":
+        error_line = _find_last_error_line(output)
+        if not error_line:
+            error_line = _last_nonempty_line(output)
+        if error_line:
+            summary = f"failed — {error_line}"
+        else:
+            summary = f"failed — exit code non-zero in {wall_time:.1f}s"
+
+    elif status == "timed_out":
+        summary = f"Timed out after {timeout_seconds}s (limit reached)"
+
+    else:  # error
+        if error_msg:
+            summary = f"Could not run: {error_msg}"
+        else:
+            summary = "Could not run: unknown execution error"
+
+    return summary[:_MAX_EVIDENCE_CHARS]
+
+
+# ---------------------------------------------------------------------------
+# Core implementation
+# ---------------------------------------------------------------------------
+
+
+def run_validation(
+    command: str,
+    working_directory: Optional[str] = None,
+    timeout_seconds: int = 120,
+) -> dict:
+    """Run *command* and return a structured pass/fail result.
+
+    Delegates execution to route_terminal_command (the same underlying
+    executor used by execute_terminal_command_tool) — no direct subprocess.
+    """
+    user_id, conversation_id = get_context_vars()
+
+    # Convert timeout_seconds → milliseconds for route_terminal_command
+    timeout_ms = timeout_seconds * 1000
+
+    t_start = time.monotonic()
+
+    try:
+        result, error_type = route_terminal_command(
+            command=command,
+            working_directory=working_directory,
+            timeout=timeout_ms,
+            mode="sync",
+            user_id=user_id,
+            conversation_id=conversation_id,
+        )
+    except Exception as exc:
+        wall_time = time.monotonic() - t_start
+        err_msg = str(exc)
+        logger.warning(f"[run_validation] Unexpected exception executing command: {exc}")
+        summary = _build_evidence_summary("error", wall_time, "", timeout_seconds, err_msg)
+        return RunValidationResult(
+            status="error",
+            exit_code=None,
+            evidence_summary=summary,
+            output_excerpt=err_msg[:_MAX_EXCERPT_CHARS],
+            wall_time_seconds=round(wall_time, 3),
+            command=command,
+        ).model_dump()
+
+    wall_time = time.monotonic() - t_start
+
+    # If route_terminal_command used duration_ms from the remote executor, prefer it
+    if result and result.get("duration_ms") is not None:
+        wall_time = result["duration_ms"] / 1000.0
+
+    # -----------------------------------------------------------------------
+    # Determine status
+    # -----------------------------------------------------------------------
+
+    if error_type == "timeout" or (result and result.get("timed_out")):
+        # Timed out
+        status: Literal["passed", "failed", "timed_out", "error"] = "timed_out"
+        exit_code: Optional[int] = None
+        combined_output = ""
+        if result:
+            combined_output = (result.get("output") or "") + (result.get("error") or "")
+        output_excerpt = combined_output[:_MAX_EXCERPT_CHARS]
+        summary = _build_evidence_summary("timed_out", wall_time, "", timeout_seconds)
+
+    # Invariant: route_terminal_command returns result=None whenever error_type is set,
+    # so the fall-through "result is None" branch catches any future unrecognized error types.
+    elif result is None or error_type in (
+        "no_tunnel",
+        "no_user_id",
+        "tunnel_unreachable",
+        "tunnel_expired",
+        "connection_error",
+        "unknown_error",
+    ):
+        # Could not run at all
+        status = "error"
+        exit_code = None
+        err_msg = error_type or "no result returned"
+        output_excerpt = err_msg[:_MAX_EXCERPT_CHARS]
+        summary = _build_evidence_summary("error", wall_time, "", timeout_seconds, err_msg)
+
+    else:
+        # Command ran to completion (success or failure)
+        raw_exit = result.get("exit_code")
+        # The extension may report -1 for "blocked" commands
+        if raw_exit == -1 and not result.get("success", True):
+            # Blocked by security policy → treat as error
+            status = "error"
+            exit_code = None
+            err_msg = result.get("error", "command blocked by security policy")
+            combined_output = (result.get("output") or "") + (result.get("error") or "")
+            output_excerpt = combined_output[:_MAX_EXCERPT_CHARS]
+            summary = _build_evidence_summary("error", wall_time, combined_output, timeout_seconds, err_msg)
+        elif raw_exit == 0:
+            status = "passed"
+            exit_code = 0
+            combined_output = (result.get("output") or "") + (result.get("error") or "")
+            output_excerpt = combined_output[:_MAX_EXCERPT_CHARS]
+            summary = _build_evidence_summary("passed", wall_time, combined_output, timeout_seconds)
+        else:
+            status = "failed"
+            exit_code = raw_exit if raw_exit is not None else 1
+            combined_output = (result.get("output") or "") + (result.get("error") or "")
+            output_excerpt = combined_output[:_MAX_EXCERPT_CHARS]
+            summary = _build_evidence_summary("failed", wall_time, combined_output, timeout_seconds)
+
+    return RunValidationResult(
+        status=status,
+        exit_code=exit_code,
+        evidence_summary=summary,
+        output_excerpt=output_excerpt,
+        wall_time_seconds=round(wall_time, 3),
+        command=command,
+    ).model_dump()
+
+
+# ---------------------------------------------------------------------------
+# LangChain StructuredTool factory
+# ---------------------------------------------------------------------------
+
+
+def run_validation_tool() -> StructuredTool:
+    """Create the run_validation StructuredTool.
+
+    No db/user_id required — context vars are read inside run_validation.
+    Mirrors the parse_failure_signal_tool() factory signature.
+    """
+    return StructuredTool.from_function(
+        func=run_validation,
+        name="run_validation",
+        description=(
+            "Run a shell command (typically a test suite or a debug re-run) and "
+            "return a structured pass/fail summary. "
+            "Use this tool for the 'before fix / after fix' validation step to "
+            "produce machine-readable evidence that a fix worked. "
+            "Unlike generic bash execution, this tool returns a structured result "
+            "with status ('passed' | 'failed' | 'timed_out' | 'error'), exit_code, "
+            "a short evidence_summary (≤240 chars) suitable for inline display, "
+            "an output_excerpt (≤800 chars) for deeper inspection, and wall_time_seconds. "
+            "Examples: 'npm test -- src/checkout/createOrder.test.ts', "
+            "'pytest tests/test_checkout.py -k payment_timeout', "
+            "'go test ./pkg/payments/... -run TestChargeTimeout'."
+        ),
+        args_schema=RunValidationInput,
+    )

--- a/app/modules/intelligence/tools/run_validation_tool.py
+++ b/app/modules/intelligence/tools/run_validation_tool.py
@@ -157,6 +157,13 @@ def _last_nonempty_line(output: str) -> str:
     return ""
 
 
+def _combine_output(result: dict) -> str:
+    """Join stdout and stderr with a newline so unrelated lines don't fuse into
+    one token (which would make _find_last_error_line miss the real failure line)."""
+    parts = [result.get("output") or "", result.get("error") or ""]
+    return "\n".join(part for part in parts if part)
+
+
 def _build_evidence_summary(
     status: str,
     wall_time: float,
@@ -250,7 +257,7 @@ def run_validation(
         exit_code: Optional[int] = None
         combined_output = ""
         if result:
-            combined_output = (result.get("output") or "") + (result.get("error") or "")
+            combined_output = _combine_output(result)
         output_excerpt = combined_output[:_MAX_EXCERPT_CHARS]
         summary = _build_evidence_summary("timed_out", wall_time, "", timeout_seconds)
 
@@ -280,19 +287,19 @@ def run_validation(
             status = "error"
             exit_code = None
             err_msg = result.get("error", "command blocked by security policy")
-            combined_output = (result.get("output") or "") + (result.get("error") or "")
+            combined_output = _combine_output(result)
             output_excerpt = combined_output[:_MAX_EXCERPT_CHARS]
             summary = _build_evidence_summary("error", wall_time, combined_output, timeout_seconds, err_msg)
         elif raw_exit == 0:
             status = "passed"
             exit_code = 0
-            combined_output = (result.get("output") or "") + (result.get("error") or "")
+            combined_output = _combine_output(result)
             output_excerpt = combined_output[:_MAX_EXCERPT_CHARS]
             summary = _build_evidence_summary("passed", wall_time, combined_output, timeout_seconds)
         else:
             status = "failed"
             exit_code = raw_exit if raw_exit is not None else 1
-            combined_output = (result.get("output") or "") + (result.get("error") or "")
+            combined_output = _combine_output(result)
             output_excerpt = combined_output[:_MAX_EXCERPT_CHARS]
             summary = _build_evidence_summary("failed", wall_time, combined_output, timeout_seconds)
 

--- a/app/modules/intelligence/tools/tool_service.py
+++ b/app/modules/intelligence/tools/tool_service.py
@@ -95,6 +95,23 @@ from langchain_core.tools import StructuredTool
 from .todo_management_tool import create_todo_management_tools
 from .requirement_verification_tool import create_requirement_verification_tools
 from .sandbox.tools import create_sandbox_tools
+from .parse_failure_signal_tool import parse_failure_signal_tool
+from .query_context_graph_tool import query_context_graph_tool
+from .hypothesis_state_tool import create_hypothesis_state_tools
+from .run_validation_tool import run_validation_tool
+from .get_workspace_debug_context_tool import get_workspace_debug_context_tool
+from .dap_tools import (
+    start_debug_session_tool,
+    set_breakpoints_tool,
+    take_debug_snapshot_tool,
+    step_over_tool,
+    step_into_tool,
+    step_out_tool,
+    continue_execution_tool,
+    evaluate_expression_tool,
+    list_debug_sessions_tool,
+    stop_debug_session_tool,
+)
 
 
 logger = get_logger(__name__)
@@ -182,6 +199,7 @@ class ToolService:
             "get_code_from_multiple_node_ids": get_code_from_multiple_node_ids_tool(
                 self.db, self.user_id
             ),
+            "query_context_graph": query_context_graph_tool(),
             "ask_knowledge_graph_queries": get_ask_knowledge_graph_queries_tool(
                 self.db, self.user_id
             ),
@@ -189,6 +207,20 @@ class ToolService:
             "get_code_graph_from_node_id": get_code_graph_from_node_id_tool(self.db),
             "change_detection": get_change_detection_tool(self.user_id),
             "get_code_file_structure": get_code_file_structure_tool(self.db),
+            "parse_failure_signal": parse_failure_signal_tool(),
+            "run_validation": run_validation_tool(),
+            "get_workspace_debug_context": get_workspace_debug_context_tool(),
+            # DAP debugger tools (A3) — dispatched via tunnel to DebugSessionManager
+            "start_debug_session": start_debug_session_tool(),
+            "set_breakpoints": set_breakpoints_tool(),
+            "take_debug_snapshot": take_debug_snapshot_tool(),
+            "step_over": step_over_tool(),
+            "step_into": step_into_tool(),
+            "step_out": step_out_tool(),
+            "continue_execution": continue_execution_tool(),
+            "evaluate_expression": evaluate_expression_tool(),
+            "list_debug_sessions": list_debug_sessions_tool(),
+            "stop_debug_session": stop_debug_session_tool(),
             "get_node_neighbours_from_node_id": get_node_neighbours_from_node_id_tool(
                 self.db
             ),
@@ -245,6 +277,11 @@ class ToolService:
         # Add todo management tools
         todo_tools = create_todo_management_tools()
         for tool in todo_tools:
+            tools[tool.name] = tool
+
+        # Add hypothesis state tools (debug agent — A5)
+        hypothesis_tools = create_hypothesis_state_tools()
+        for tool in hypothesis_tools:
             tools[tool.name] = tool
 
         # Sandbox-backed tools replace the legacy code_changes_manager staging

--- a/app/modules/intelligence/tools/tool_service.py
+++ b/app/modules/intelligence/tools/tool_service.py
@@ -92,6 +92,7 @@ from app.modules.intelligence.tools.confluence_tools import (
 from app.modules.intelligence.tools.web_tools.web_search_tool import web_search_tool
 from app.modules.intelligence.provider.provider_service import ProviderService
 from langchain_core.tools import StructuredTool
+from .local_search_tools.tools import create_local_search_tools
 from .todo_management_tool import create_todo_management_tools
 from .requirement_verification_tool import create_requirement_verification_tools
 from .sandbox.tools import create_sandbox_tools
@@ -269,6 +270,20 @@ class ToolService:
 
         for tool in create_agent_context_tools(self.db, self.user_id):
             tools[tool.name] = tool
+
+        # Local workspace search tools routed through the VS Code tunnel. They
+        # fail gracefully when no tunnel is attached, but must still be
+        # registered so agents can choose them when local mode is available.
+        for tool in create_local_search_tools():
+            tools[tool.name] = tool
+
+        logger.info(
+            "[DEBUG tool_service] execute_terminal_command registered: {} | "
+            "terminal_session_output registered: {} | terminal_session_signal registered: {}",
+            "execute_terminal_command" in tools,
+            "terminal_session_output" in tools,
+            "terminal_session_signal" in tools,
+        )
 
         # bash_command, apply_changes, git_commit, git_push, create_pr_workflow,
         # checkout_worktree_branch — all removed during the sandbox migration.

--- a/app/modules/intelligence/tracing/logfire_tracer.py
+++ b/app/modules/intelligence/tracing/logfire_tracer.py
@@ -163,6 +163,13 @@ def initialize_logfire_tracing(
             environment=env,
             send_to_logfire=send_to_logfire,
         )
+        # Logfire mirrors every span to the console by default. With an agent emitting
+        # a span per token/tool call that floods local dev terminals (and the worker
+        # prints them too). Cloud tracing still captures everything (Logfire UI), so
+        # keep console off unless explicitly opted in with LOGFIRE_CONSOLE=true.
+        if os.getenv("LOGFIRE_CONSOLE", "false").lower() not in ("true", "1", "yes"):
+            config_kwargs["console"] = False
+
         logfire.configure(**config_kwargs)
 
         if instrument_pydantic_ai:

--- a/app/modules/tunnel/socket_service.py
+++ b/app/modules/tunnel/socket_service.py
@@ -63,13 +63,57 @@ def _workspace_socket_key(workspace_id: str) -> str:
 
 _socket_service_instance: Optional["WorkspaceSocketService"] = None
 _executor: Optional[ThreadPoolExecutor] = None
+# Reuse one event loop per executor thread — creating/closing a loop on every RPC
+# breaks AsyncRedisManager cross-process emits (Hatchet worker / Celery).
+_rpc_loop_local = threading.local()
 
 
 def _get_executor() -> ThreadPoolExecutor:
     global _executor
     if _executor is None:
-        _executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="socket_rpc")
+        # Socket.IO / redis.asyncio objects are event-loop-bound. Keep sync RPCs on
+        # one dedicated loop thread so sequential tool calls do not hop between
+        # loops and reuse async state from the wrong loop.
+        _executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="socket_rpc")
     return _executor
+
+
+def _get_rpc_event_loop() -> asyncio.AbstractEventLoop:
+    """Return a persistent event loop for the current executor thread."""
+    loop = getattr(_rpc_loop_local, "loop", None)
+    if loop is None or loop.is_closed():
+        loop = asyncio.new_event_loop()
+        _rpc_loop_local.loop = loop
+    asyncio.set_event_loop(loop)
+    return loop
+
+
+def _invalidate_workspace_after_rpc_failure(
+    workspace_id: str, reason: str, socket_id: Optional[str] = None
+) -> None:
+    """Drop stale Redis socket mapping so get_tunnel_url stops lying 'online'."""
+    try:
+        from app.modules.tunnel.tunnel_service import get_tunnel_service
+
+        get_tunnel_service().invalidate_workspace_socket(workspace_id)
+        logger.info(
+            "[WorkspaceSocketService] Cleared stale socket for workspace_id={} "
+            "(reason={}, socket_id={})",
+            workspace_id,
+            reason,
+            socket_id,
+        )
+    except Exception as exc:
+        logger.warning(
+            "[WorkspaceSocketService] Could not invalidate workspace_id={}: {}",
+            workspace_id,
+            exc,
+        )
+
+
+def _is_async_loop_mismatch(exc: Exception) -> bool:
+    message = str(exc)
+    return "attached to a different loop" in message or "bound to a different event loop" in message
 
 
 class WorkspaceSocketService:
@@ -116,6 +160,58 @@ class WorkspaceSocketService:
             logger.warning("[WorkspaceSocketService] Async Redis unavailable: %s", e)
             self._async_redis = None
             return None
+
+    async def _publish_tool_call(
+        self,
+        socket_id: str,
+        event_payload: Dict[str, Any],
+    ) -> None:
+        """Publish a Socket.IO emit command without reusing AsyncRedisManager state.
+
+        The Hatchet/debug tool path runs from sync code on a worker-thread event
+        loop. Calling ``sio.emit`` there can reuse the global AsyncRedisManager's
+        loop-bound Redis connection from another loop, which intermittently raises
+        "Future attached to a different loop" and causes false socket invalidation.
+        Publishing the manager message with a fresh loop-local Redis client keeps
+        the RPC cross-process behavior without touching the shared manager client.
+        """
+        manager = getattr(sio, "manager", None)
+        redis_url = getattr(manager, "redis_url", None)
+        channel = getattr(manager, "channel", None)
+        if not redis_url or not channel:
+            await sio.emit(
+                "tool_call",
+                event_payload,
+                room=socket_id,
+                namespace=WORKSPACE_NAMESPACE,
+            )
+            return
+
+        message = {
+            "method": "emit",
+            "event": "tool_call",
+            "data": [event_payload],
+            "binary": False,
+            "namespace": WORKSPACE_NAMESPACE,
+            "room": socket_id,
+            "skip_sid": None,
+            "callback": None,
+            # Do not use manager.host_id here. If this code runs in the same
+            # process as the Socket.IO server, the listener ignores messages from
+            # its own host_id. A distinct host_id makes the message deliverable.
+            "host_id": f"workspace-rpc:{uuid4()}",
+        }
+        json_module = getattr(manager, "json", json)
+        redis_options = getattr(manager, "redis_options", {}) or {}
+        publisher = aioredis.from_url(redis_url, **redis_options)
+        try:
+            await publisher.publish(channel, json_module.dumps(message))
+        finally:
+            close = getattr(publisher, "aclose", None)
+            if close is not None:
+                await close()
+            else:  # pragma: no cover - compatibility with older redis clients
+                await publisher.close()
 
     async def _get_socket_id(self, workspace_id: str) -> Optional[str]:
         """Resolve workspace_id to socket id from Redis."""
@@ -188,19 +284,30 @@ class WorkspaceSocketService:
         await pubsub.subscribe(channel)
 
         try:
-            await sio.emit(
-                "tool_call",
-                event_payload,
-                room=socket_id,
-                namespace=WORKSPACE_NAMESPACE,
-            )
+            await self._publish_tool_call(socket_id, event_payload)
         except Exception as e:
             await pubsub.unsubscribe(channel)
             await pubsub.close()
-            logger.warning("[WorkspaceSocketService] emit failed: %s", e)
+            loop_mismatch = _is_async_loop_mismatch(e)
+            logger.warning(
+                "[WorkspaceSocketService] emit failed for workspace_id={} socket_id={}: {}",
+                workspace_id,
+                socket_id,
+                e,
+            )
+            if loop_mismatch:
+                logger.warning(
+                    "[WorkspaceSocketService] Not invalidating workspace_id={} "
+                    "for backend async loop mismatch",
+                    workspace_id,
+                )
+            else:
+                _invalidate_workspace_after_rpc_failure(
+                    workspace_id, reason="emit_failed", socket_id=socket_id
+                )
             raise TunnelConnectionError(
                 f"Failed to send tool call to workspace {workspace_id}: {e}",
-                last_error=str(e),
+                last_error="backend_loop_mismatch" if loop_mismatch else "emit_failed",
             )
 
         async def _wait_one_response():
@@ -226,6 +333,15 @@ class WorkspaceSocketService:
         try:
             return await asyncio.wait_for(_wait_one_response(), timeout=timeout + 2.0)
         except asyncio.TimeoutError:
+            logger.warning(
+                "[WorkspaceSocketService] RPC timed out for workspace_id={} socket_id={} "
+                "endpoint={} after {:.1f}s; keeping socket registration because timeout "
+                "does not prove the extension disconnected",
+                workspace_id,
+                socket_id,
+                endpoint,
+                timeout,
+            )
             raise TunnelConnectionError(
                 f"Tool call timed out for workspace_id={workspace_id} (endpoint={endpoint})",
                 last_error="timeout",
@@ -313,16 +429,12 @@ class WorkspaceSocketService:
         dedicated thread with a new event loop. Use from sync tool code.
         """
         def _run() -> Dict[str, Any]:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            try:
-                return loop.run_until_complete(
-                    self._execute_tool_call_with_timeout(
-                        workspace_id, endpoint, payload, timeout
-                    )
+            loop = _get_rpc_event_loop()
+            return loop.run_until_complete(
+                self._execute_tool_call_with_timeout(
+                    workspace_id, endpoint, payload, timeout
                 )
-            finally:
-                loop.close()
+            )
 
         future = _get_executor().submit(_run)
         try:

--- a/app/modules/tunnel/tunnel_service.py
+++ b/app/modules/tunnel/tunnel_service.py
@@ -63,7 +63,8 @@ def _get_local_tunnel_server_url() -> Optional[str]:
 def normalise_repo_url(repository: str) -> str:
     """
     Normalise repo identifier to a single form for workspace_id hashing.
-    Backend and extension must use the same rule: lowercase, strip protocol, strip .git, rstrip /.
+    Backend and extension must use the same rule: lowercase, strip protocol,
+    strip git host, strip .git, rstrip /.
     Accepts owner/repo or full URL (https://github.com/owner/repo or github.com/owner/repo).
     """
     if not repository or not isinstance(repository, str):
@@ -79,6 +80,11 @@ def normalise_repo_url(repository: str) -> str:
         s = s.replace(":", "/", 1)
     if s.endswith(".git"):
         s = s[: -len(".git")]
+    # Strip git host so "github.com/owner/repo" and "owner/repo" hash identically
+    for host in ("github.com/", "gitlab.com/", "bitbucket.org/"):
+        if s.startswith(host):
+            s = s[len(host):]
+            break
     return s
 
 
@@ -503,6 +509,54 @@ class TunnelService:
         """Check if a socket is connected for this workspace_id."""
         from app.modules.tunnel.socket_service import get_socket_service
         return get_socket_service().is_workspace_online(workspace_id)
+
+    def invalidate_workspace_socket(self, workspace_id: str) -> bool:
+        """Remove stale workspace socket registration when RPC cannot reach the extension.
+
+        Called when Socket.IO emit fails or the mapped socket_id is dead but Redis
+        still has workspace:socket:{id} (e.g. extension disconnected without cleanup).
+        """
+        if not workspace_id:
+            return False
+        try:
+            from app.modules.tunnel.socket_server import (
+                SOCKET_WORKSPACE_KEY_PREFIX,
+                WORKSPACE_SOCKET_KEY_PREFIX,
+            )
+
+            fwd_key = f"{WORKSPACE_SOCKET_KEY_PREFIX}{workspace_id}"
+            removed = False
+            sid = None
+            if self.redis_client:
+                sid = self.redis_client.get(fwd_key)
+                if sid:
+                    rev_key = f"{SOCKET_WORKSPACE_KEY_PREFIX}{sid}"
+                    self.redis_client.delete(rev_key)
+                removed = self.redis_client.delete(fwd_key) > 0
+            else:
+                removed = False
+            record = self.get_workspace_tunnel_record(workspace_id)
+            if record and record.get("user_id") and record.get("repo_url"):
+                self.set_workspace_tunnel_record(
+                    workspace_id=workspace_id,
+                    user_id=record["user_id"],
+                    repo_url=record["repo_url"],
+                    status="disconnected",
+                )
+            if removed:
+                logger.info(
+                    "[TunnelService] Invalidated stale workspace socket workspace_id={} sid={}",
+                    workspace_id,
+                    sid,
+                )
+            return removed
+        except Exception as e:
+            logger.warning(
+                "[TunnelService] Failed to invalidate workspace socket {}: {}",
+                workspace_id,
+                e,
+            )
+            return False
 
     def is_tunnel_available(
         self, user_id: str, conversation_id: Optional[str] = None,

--- a/docs/vscode-extension-debug-handoff.md
+++ b/docs/vscode-extension-debug-handoff.md
@@ -1,0 +1,264 @@
+# VS Code Extension Debug/DAP Handoff
+
+Date: 2026-05-25
+
+## Context
+
+The debug agent can reach the local workspace over the Socket.IO tunnel, but C/C++
+debugging currently fails or degrades in two ways:
+
+1. Terminal commands such as `gcc -g ...` and `mkdir ...` can complete locally while
+   the backend waits until the RPC timeout because no `tool_response` is observed.
+2. `get_workspace_debug_context` reports `debug_adapters: ["python", "node"]` even
+   on a macOS machine where LLDB and `lldb-dap` are installed. This blocks C/C++
+   debug session setup from the agent's point of view.
+
+This is not expected to be a local network or WebSocket reliability problem. The
+backend timeout means: `tool_call` was emitted, but no matching `tool_response`
+arrived on Redis pub/sub before the timeout.
+
+Latest isolated harness verification after the extension-side terminal fix:
+
+- `/api/terminal/execute` for `cc -g -o add_numbers add_numbers.c` returned in
+  roughly 400ms with `success=true`, `exit_code=0`, empty stdout/stderr, and
+  `timed_out=false`.
+- `/api/workspace/debug-context` returned C/C++-relevant adapters:
+  `["python", "node", "lldb", "lldb-dap"]`.
+- `/api/debug/start-session` with `lldb-dap` succeeded and returned a session id.
+- `/api/debug/set-breakpoints` at `add_numbers.c:4` returned a verified
+  breakpoint.
+- `/api/debug/snapshot` after continue still failed with
+  `Cannot take snapshot: session is running, expected paused`.
+
+That harness run was a smoke test, not a full DAP tool matrix. It did not cover
+`step-over`, `step-into`, `step-out`, `evaluate`, `list-sessions`, or a clean
+`stop-session` path.
+
+## Backend Contract
+
+Socket event from backend to extension:
+
+```json
+{
+  "correlation_id": "<uuid>",
+  "endpoint": "/api/terminal/execute",
+  "payload": {},
+  "timeout": 35.0
+}
+```
+
+The extension must always respond with:
+
+```json
+{
+  "correlation_id": "<same uuid>",
+  "success": true,
+  "result": {}
+}
+```
+
+or:
+
+```json
+{
+  "correlation_id": "<same uuid>",
+  "success": false,
+  "error": "..."
+}
+```
+
+Important backend routes used by the debug agent:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `/api/workspace/debug-context` | Return launch configs, available debug adapters, inferred commands |
+| `/api/terminal/execute` | Run shell commands in sync or async mode |
+| `/api/terminal/sessions/{session_id}/output` | Poll async terminal output |
+| `/api/terminal/sessions/{session_id}/signal` | Stop async terminal process |
+| `/api/debug/start-session` | Start DAP debug session |
+| `/api/debug/set-breakpoints` | Set breakpoints |
+| `/api/debug/snapshot` | Capture stack/locals/expressions |
+| `/api/debug/list-sessions` | List debug sessions |
+| `/api/debug/stop-session` | Stop debug session |
+
+## Required Extension Changes
+
+### 1. Always Emit `tool_response`
+
+Every extension route handler must emit a response for every received
+`correlation_id`, including:
+
+- success with empty stdout
+- non-zero exit
+- thrown exception
+- timeout
+- unknown route
+- debug adapter launch failure
+
+This should be implemented with a top-level `try/catch/finally` around dispatch so
+no handler can accidentally leave the backend waiting.
+
+### 2. Fix Terminal Completion For Silent Commands
+
+The terminal executor must not infer completion from visible terminal output.
+Commands like these are valid and often produce no stdout:
+
+```bash
+gcc -g -o add_numbers add_numbers.c
+mkdir -p .vscode
+true
+```
+
+The user-facing contract is that terminal commands should be visible in a VS Code
+integrated terminal by default. A hidden `child_process` result is acceptable only
+for an explicitly hidden/internal mode; it is not acceptable for normal debug-agent
+terminal commands because users must be able to see what the agent ran.
+
+Recommended behavior:
+
+- Open or reuse a named integrated terminal such as `Potpie`.
+- Show the command in that terminal before execution.
+- Capture stdout, stderr, exit code, duration, and timeout for the RPC response.
+- Append an internal sentinel to detect completion reliably when the command is
+  silent.
+- Keep the terminal visible unless the payload explicitly requests hidden
+  execution.
+
+Implementation options:
+
+- If using an integrated terminal/PTY, append an explicit sentinel that includes
+  exit code, then parse that sentinel, e.g. `printf "\n__POTPIE_EXIT:$?__\n"`.
+- If using `child_process.spawn` / `execFile`, wire it only to an explicit hidden
+  mode or mirror the command/output into the visible terminal.
+
+Expected sync result shape:
+
+```json
+{
+  "success": true,
+  "command": "gcc -g -o add_numbers add_numbers.c",
+  "output": "",
+  "error": "",
+  "exit_code": 0,
+  "duration_ms": 1234
+}
+```
+
+### 3. Return Accurate `debug_adapters`
+
+`debug_adapters` should represent debug adapter types that the extension can
+actually launch in the current VS Code/Cursor session.
+
+For C/C++ on macOS, include at least one of:
+
+- `lldb` when CodeLLDB (`vadimcn.vscode-lldb`) is available
+- `cppdbg` when Microsoft C/C++ (`ms-vscode.cpptools`) is available
+- `lldb-dap` or another explicit adapter id only if the extension start-session
+  handler can launch it directly
+
+Do not infer this only from binaries on disk. `/usr/bin/lldb` and
+`/Library/Developer/CommandLineTools/usr/bin/lldb-dap` prove the machine has LLDB,
+but they do not prove VS Code has a registered adapter type unless the extension can
+use them.
+
+If the extension can launch `/Library/Developer/CommandLineTools/usr/bin/lldb-dap`
+directly without a marketplace extension, return a capability that makes that
+explicit, for example:
+
+```json
+{
+  "debug_adapters": ["python", "node", "lldb-dap"],
+  "native_debuggers": {
+    "lldb": "/usr/bin/lldb",
+    "lldb_dap": "/Library/Developer/CommandLineTools/usr/bin/lldb-dap"
+  }
+}
+```
+
+### 4. Support C/C++ Launch Configs
+
+The extension should accept launch configs from `.vscode/launch.json` and start
+sessions for C/C++ configs such as:
+
+```json
+{
+  "type": "cppdbg",
+  "request": "launch",
+  "name": "Debug add_numbers",
+  "program": "/Users/deepesh/work/valkey/add_numbers",
+  "cwd": "/Users/deepesh/work/valkey",
+  "MIMode": "lldb"
+}
+```
+
+and/or CodeLLDB style:
+
+```json
+{
+  "type": "lldb",
+  "request": "launch",
+  "name": "Debug add_numbers",
+  "program": "/Users/deepesh/work/valkey/add_numbers",
+  "cwd": "/Users/deepesh/work/valkey"
+}
+```
+
+If an adapter is missing, return a structured failure response instead of timing
+out:
+
+```json
+{
+  "success": false,
+  "error": "debug_adapter_unavailable",
+  "message": "No registered debug adapter for type 'cppdbg'. Install ms-vscode.cpptools or use lldb."
+}
+```
+
+### 5. Add Correlation-ID Tracing
+
+Log these lifecycle points with `correlation_id`, `endpoint`, and `workspace_id`:
+
+- received `tool_call`
+- selected handler
+- handler started
+- handler completed
+- emitted `tool_response`
+- handler exception
+- handler timeout
+
+This is the fastest way to distinguish:
+
+- backend emitted to stale socket id
+- extension received but handler did not respond
+- extension responded but socket server did not publish to Redis
+- backend worker did not receive Redis pub/sub message
+
+## Acceptance Checks
+
+With the extension connected to the workspace:
+
+1. `execute_terminal_command("true")` returns exit code 0 without timeout.
+2. `execute_terminal_command("mkdir -p .vscode")` returns exit code 0 without timeout.
+3. `execute_terminal_command("gcc -g -o add_numbers add_numbers.c")` returns exit
+   code 0 without timeout, even with empty stdout.
+4. `get_workspace_debug_context` includes the C/C++ adapter that the extension can
+   actually launch (`lldb`, `cppdbg`, or `lldb-dap`).
+5. `start_debug_session` for the compiled `add_numbers` binary returns a session id
+   or a structured adapter-unavailable error; it must not time out silently.
+6. `set_breakpoints` at `add_numbers.c:4` and `take_debug_snapshot` return locals
+   when the program pauses.
+7. User-facing terminal commands visibly open or reuse an integrated terminal and
+   show the command being run; the RPC response must not be produced only by a
+   hidden process in normal mode.
+
+## Backend Follow-Up Needed
+
+The backend currently models `start_debug_session.language` as:
+
+```python
+Literal["python", "node", "go", "unknown"]
+```
+
+To make C/C++ first-class, backend should add `c`, `cpp`, or a direct launch-config
+type field and pass through adapter-specific launch configs without forcing them
+through language-only routing.

--- a/tests/smoke/test_debug_agent_smoke.py
+++ b/tests/smoke/test_debug_agent_smoke.py
@@ -1,0 +1,580 @@
+#!/usr/bin/env python3
+"""Smoke test — DebugAgent hypothesis creation via real LLM.
+
+Runs the actual debug_task_prompt against a real LLM and measures whether the
+agent follows the hypothesis-driven debugging protocol.
+
+Usage
+-----
+Standalone:
+    python tests/smoke/test_debug_agent_smoke.py [--model MODEL]
+
+Pytest:
+    pytest tests/smoke/test_debug_agent_smoke.py -s -v -m smoke
+
+Required env var:
+    ANTHROPIC_API_KEY   (preferred — claude supports tool calling reliably)
+  or
+    OPENAI_API_KEY / GOOGLE_API_KEY / GEMINI_API_KEY
+
+Optional env vars:
+    SMOKE_MODEL   model name override (default: claude-haiku-4-5-20251001)
+    SMOKE_TIMEOUT maximum seconds to wait for the agent (default: 120)
+
+What is checked
+---------------
+The checks mirror the OUTPUT CONTRACT in debug_task_prompt:
+
+  phase1_parse_failure_signal_called  — Phase 1: REQUIRED tool call
+  phase2_debugger_status_emitted      — Phase 2: **Debugger:** line emitted
+  phase4_hypothesis_markdown_emitted  — Phase 4: ## Hypothesis N: block present
+  phase4_record_hypothesis_called     — Phase 4: persistence tool called
+  phase4_hypothesis_store_populated   — Phase 4: store has ≥1 record
+  phase4_card_terminator_present      — Phase 4: '---' card terminator present
+  forbidden_output_absent             — FORBIDDEN OUTPUT: no standalone conclusions
+  phase4_pause_question_present       — MULTI-TURN: response ends with pause question
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+import time
+import types
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — works whether called as a module or directly
+# ---------------------------------------------------------------------------
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+# ---------------------------------------------------------------------------
+# Env vars that app modules read at import time
+# ---------------------------------------------------------------------------
+os.environ.setdefault("POSTGRES_SERVER", "postgresql://test:test@localhost:5432/testdb")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+
+# ---------------------------------------------------------------------------
+# Stub heavy ML packages pulled in transitively (same pattern as unit tests)
+# ---------------------------------------------------------------------------
+def _stub(name: str, **attrs: Any) -> types.ModuleType:
+    mod = sys.modules.get(name) or types.ModuleType(name)
+    sys.modules[name] = mod
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    return mod
+
+_t = _stub("torch")
+_stub("torch.nn", functional=MagicMock())
+_stub("torch.nn.functional")
+_stub("torch.nn.modules")
+_stub("torch._jit_internal")
+_stub("torch._sources")
+_stub("torch._VF")
+_t._VF = MagicMock()
+_t.functional = MagicMock()
+_t.nn = sys.modules["torch.nn"]
+_st = _stub("sentence_transformers")
+_st.SentenceTransformer = MagicMock(name="SentenceTransformer")
+
+# ---------------------------------------------------------------------------
+# App imports (after stubs)
+# ---------------------------------------------------------------------------
+from pydantic_ai import Agent, Tool  # noqa: E402
+from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart  # noqa: E402
+
+from app.modules.intelligence.agents.chat_agents.system_agents.debug_agent_prompt import (  # noqa: E402
+    debug_task_prompt,
+)
+from app.modules.intelligence.tools.hypothesis_state_tool import (  # noqa: E402
+    HypothesisStore,
+    _hypothesis_store_ctx,
+    create_hypothesis_state_tools,
+)
+from app.modules.intelligence.agents.chat_agents.multi_agent.utils.tool_utils import (  # noqa: E402
+    wrap_structured_tools,
+)
+
+# ---------------------------------------------------------------------------
+# Performance contract — assertions written first (TDD RED)
+# ---------------------------------------------------------------------------
+
+# Output sections that violate the FORBIDDEN OUTPUT clause
+_FORBIDDEN_SECTIONS = [
+    "## Root Cause Analysis",
+    "## Analysis Summary",
+    "## Final Summary",
+    "## Vulnerability Overview",
+    "## Security Impact",
+    "## Recommended Fix",
+    "## Bug Analysis",
+    "## Detailed Analysis",
+    "## Refined Analysis",
+    "## Conclusion",
+]
+
+# Phrases the model must include at Phase 4 exit to satisfy the MULTI-TURN STOP
+_PAUSE_PHRASES = [
+    "which hypothesis",
+    "Which hypothesis",
+    "H1",
+    "H2",
+    "all of them",
+    "start with",
+    "pick",
+    "validate",
+]
+
+
+def check_protocol_compliance(
+    full_text: str,
+    tool_calls: list[str],
+    hypotheses: list[dict],
+) -> dict[str, bool]:
+    """Evaluate agent output against every requirement in debug_task_prompt.
+
+    Arguments
+    ---------
+    full_text  : ALL text emitted across every LLM turn (not just the final turn).
+                 The **Debugger:** line is emitted in an intermediate turn; checking
+                 only result.output would miss it.
+    tool_calls : Ordered list of tool names called during the run.
+    hypotheses : Snapshot of the hypothesis store captured INSIDE the async run
+                 (the ContextVar goes out of scope after asyncio.run() returns).
+
+    Returns
+    -------
+    Mapping of requirement_name → passed.  All must be True for the smoke test
+    to pass.
+    """
+    return {
+        # --- Phase 1 (REQUIRED — never skip) ---
+        "phase1_parse_failure_signal_called": (
+            "parse_failure_signal" in tool_calls
+        ),
+        # --- Phase 2 (Debugger status line) ---
+        "phase2_debugger_status_emitted": (
+            "**Debugger:**" in full_text
+        ),
+        # --- Phase 4 (Hypothesis generation) ---
+        "phase4_hypothesis_markdown_emitted": (
+            "## Hypothesis" in full_text
+        ),
+        "phase4_record_hypothesis_called": (
+            "record_hypothesis" in tool_calls
+        ),
+        "phase4_hypothesis_store_populated": (
+            len(hypotheses) >= 1
+        ),
+        "phase4_card_terminator_present": (
+            "---" in full_text
+        ),
+        # --- FORBIDDEN OUTPUT contract ---
+        "forbidden_output_absent": (
+            not any(s in full_text for s in _FORBIDDEN_SECTIONS)
+        ),
+        # --- MULTI-TURN FLOW (pause after Phase 4) ---
+        "phase4_pause_question_present": (
+            any(p in full_text for p in _PAUSE_PHRASES)
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Debugging signal — real-world ASan heap-buffer-overflow from valkey-io/valkey
+# This is the same signal used in the two production traces that failed.
+# ---------------------------------------------------------------------------
+DEBUGGING_SIGNAL = """\
+AddressSanitizer: heap-buffer-overflow on address 0x602000000631 READ of size 1
+    #0 0x555b4a1c2340 in zipmapNext zipmap.c:240
+    #1 0x555b4a1c3b20 in rdbLoadObject rdb.c:2408
+    #2 0x555b4a1c4100 in restoreCommand t_string.c:462
+
+Internal error in RDB reading offset 0, function at rdb.c:2408 -> Hash zipmap \
+with dup elements, or big length (0)
+"""
+
+# ---------------------------------------------------------------------------
+# Mock tools — controlled responses for all infrastructure tools the agent
+# may call, so the smoke test runs without a real VS Code / sandbox / DB.
+# DAP tools return error_type="no_tunnel" so the agent takes the Case C path.
+# ---------------------------------------------------------------------------
+def _mock(name: str, description: str, returns: Any) -> Tool:
+    async def _fn(**kwargs: Any) -> Any:  # noqa: ANN401
+        return returns
+    return Tool(name=name, description=description, function=_fn)
+
+
+_MOCK_TOOLS: list[Tool] = [
+    _mock(
+        "parse_failure_signal",
+        "Parse and structure a raw failure signal.",
+        {
+            "classification": "pasted_log",
+            "signature": "heap-buffer-overflow in zipmapNext",
+            "error_type": "HeapBufferOverflow",
+            "stack_frames": [
+                {"file": "src/zipmap.c", "line": 240, "symbol": "zipmapNext"},
+                {"file": "src/rdb.c", "line": 2408, "symbol": "rdbLoadObject"},
+            ],
+            "raw_excerpt": (
+                "AddressSanitizer: heap-buffer-overflow READ of size 1\n"
+                "#0 zipmapNext zipmap.c:240\n"
+                "#1 rdbLoadObject rdb.c:2408\n"
+            ),
+        },
+    ),
+    _mock(
+        "get_workspace_debug_context",
+        "Return debug capabilities: launch configs, adapters, recent git changes.",
+        {
+            "available": False,
+            "launch_configs": [],
+            "inferred_commands": [],
+            "recent_changes": [],
+            "related_tests": [],
+            "message": "No workspace attached in smoke-test mode.",
+        },
+    ),
+    _mock(
+        "query_context_graph",
+        "Query the context graph for relevant code entities.",
+        {"available": False, "results": [], "message": "Context graph not wired."},
+    ),
+    _mock(
+        "ask_knowledge_graph_queries",
+        "Semantic search over the embedded knowledge graph.",
+        {
+            "results": [
+                {
+                    "file": "src/zipmap.c",
+                    "symbol": "zipmapValidateIntegrity",
+                    "snippet": (
+                        "int zipmapValidateIntegrity(unsigned char *p, "
+                        "size_t len, int deep)"
+                    ),
+                    "score": 0.93,
+                },
+                {
+                    "file": "src/zipmap.c",
+                    "symbol": "zipmapNext",
+                    "snippet": (
+                        "unsigned char *zipmapNext(unsigned char *zm, "
+                        "unsigned char **key, unsigned int *klen, "
+                        "unsigned char **value, unsigned int *vlen)"
+                    ),
+                    "score": 0.88,
+                },
+                {
+                    "file": "src/zipmap.c",
+                    "symbol": "zipmapDecodeLength",
+                    "snippet": (
+                        "static unsigned int zipmapDecodeLength(unsigned char *p)"
+                    ),
+                    "score": 0.81,
+                },
+            ]
+        },
+    ),
+    _mock(
+        "search_text",
+        "Ripgrep-style text search over the repository.",
+        {
+            "results": [
+                {"file": "src/zipmap.c", "line": 196, "text": "l = zipmapDecodeLength(p);"},
+                {
+                    "file": "src/zipmap.c",
+                    "line": 200,
+                    "text": "if (l < ZIPMAP_BIGLEN && s != 1) return 0;  /* no l==0 check */",
+                },
+                {
+                    "file": "src/zipmap.c",
+                    "line": 240,
+                    "text": "l = zipmapDecodeLength(p); p += l + ZIPMAP_LEN_BYTES(l) + ...;",
+                },
+                {
+                    "file": "src/rdb.c",
+                    "line": 2408,
+                    "text": 'serverLog(LL_WARNING,"Hash zipmap with dup elements, or big length (%d)",zm_len);',
+                },
+            ]
+        },
+    ),
+    _mock(
+        "search_bash",
+        "Read-only rg/bash search over source and tests.",
+        {
+            "output": (
+                "src/zipmap.c:196:s = zipmapGetEncodedLengthSize(p);\n"
+                "src/zipmap.c:197:l = zipmapDecodeLength(p);\n"
+                "src/zipmap.c:240:return zipmapEncodeLength(NULL, l) + l;\n"
+                "tests/unit/dump.tcl:123:set payload {fe 03 00 00 00}\n"
+            )
+        },
+    ),
+    _mock(
+        "get_code_file_structure",
+        "Return the directory/file tree for a project path.",
+        {"files": ["src/zipmap.c", "src/zipmap.h", "src/rdb.c", "src/rdb.h"]},
+    ),
+    _mock(
+        "fetch_file",
+        "Fetch raw file content by path.",
+        {
+            "content": (
+                "/* zipmapValidateIntegrity: validates a raw zipmap blob. */\n"
+                "int zipmapValidateIntegrity(unsigned char *p, size_t len, int deep) {\n"
+                "    unsigned int l;\n"
+                "    unsigned char *e = p + len;\n"
+                "    while (p < e) {\n"
+                "        l = zipmapDecodeLength(p);  /* returns 0 for crafted input */\n"
+                "        /* BUG: no check for l == 0 */\n"
+                "        if (l < ZIPMAP_BIGLEN && p[0] != l) return 0;\n"
+                "        p += zipmapRawKeyLength(p);\n"
+                "        /* value */\n"
+                "        l = zipmapDecodeLength(p);\n"
+                "        /* BUG: no check for l == 0 here either */\n"
+                "        p += zipmapRawValueLength(p);\n"
+                "    }\n"
+                "    return 1;\n"
+                "}\n"
+            )
+        },
+    ),
+    # DAP tools — all return no_tunnel so Phase 5 is skipped (expected in smoke)
+    *[
+        _mock(name, f"DAP: {name}", {"error_type": "no_tunnel", "available": False})
+        for name in [
+            "set_breakpoints",
+            "start_debug_session",
+            "take_debug_snapshot",
+            "step_over",
+            "step_into",
+            "step_out",
+            "continue_execution",
+            "evaluate_expression",
+            "list_debug_sessions",
+            "stop_debug_session",
+        ]
+    ],
+    _mock(
+        "run_validation",
+        "Run a validation command and return pass/fail with evidence.",
+        {
+            "status": "error",
+            "exit_code": 1,
+            "evidence_summary": "Command not available in smoke-test mode.",
+        },
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# LLM model builder
+# ---------------------------------------------------------------------------
+def _build_llm(model_name: str) -> Any:
+    """Return a pydantic_ai model from whichever provider API key is set."""
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        from pydantic_ai.models.anthropic import AnthropicModel
+        return AnthropicModel(model_name)
+    if os.environ.get("OPENAI_API_KEY"):
+        from pydantic_ai.models.openai import OpenAIModel
+        return OpenAIModel(model_name or "gpt-4o-mini")
+    if os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY"):
+        from pydantic_ai.models.gemini import GeminiModel
+        return GeminiModel(model_name or "gemini-2.0-flash")
+    raise RuntimeError(
+        "No LLM API key found. Set ANTHROPIC_API_KEY (or OPENAI_API_KEY / GOOGLE_API_KEY)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core runner
+# ---------------------------------------------------------------------------
+async def run_smoke(model_name: str) -> tuple[str, str, list[str], list[dict], float]:
+    """Run the debug agent against DEBUGGING_SIGNAL.
+
+    Returns
+    -------
+    (final_output, full_text, tool_call_names, hypotheses, elapsed_seconds)
+
+    full_text   — ALL text across every LLM turn, joined with newlines.  The
+                  **Debugger:** status line is emitted in an intermediate turn
+                  and would be missed if we checked result.output alone.
+    hypotheses  — Snapshot taken INSIDE the async context (ContextVar goes out
+                  of scope after asyncio.run() returns).
+    """
+    store = HypothesisStore(conversation_id="smoke-test")
+    _hypothesis_store_ctx.set(store)
+
+    real_hyp_tools = wrap_structured_tools(create_hypothesis_state_tools())
+    all_tools = real_hyp_tools + _MOCK_TOOLS
+
+    agent = Agent(
+        model=_build_llm(model_name),
+        tools=all_tools,
+        system_prompt=debug_task_prompt,
+    )
+
+    t0 = time.perf_counter()
+    result = await asyncio.wait_for(
+        agent.run(DEBUGGING_SIGNAL),
+        timeout=float(os.environ.get("SMOKE_TIMEOUT", "120")),
+    )
+    elapsed = time.perf_counter() - t0
+
+    # Collect ALL text and tool calls from the full conversation history
+    tool_calls: list[str] = []
+    text_parts: list[str] = []
+    for msg in result.all_messages():
+        if isinstance(msg, ModelResponse):
+            for part in msg.parts:
+                if isinstance(part, ToolCallPart):
+                    tool_calls.append(part.tool_name)
+                elif isinstance(part, TextPart) and part.content:
+                    text_parts.append(part.content)
+
+    full_text = "\n".join(text_parts)
+
+    # Snapshot the store BEFORE leaving this async context
+    hypotheses = [r.model_dump(mode="json") for r in store.list_all()]
+
+    return result.output, full_text, tool_calls, hypotheses, elapsed
+
+
+# ---------------------------------------------------------------------------
+# Report printer
+# ---------------------------------------------------------------------------
+def print_report(
+    model_name: str,
+    final_output: str,
+    full_text: str,
+    tool_calls: list[str],
+    hypotheses: list[dict],
+    checks: dict[str, bool],
+    elapsed: float,
+) -> bool:
+    """Print a human-readable smoke-test report. Returns True if all checks pass."""
+    tty = sys.stdout.isatty()
+    G = "\033[92m" if tty else ""
+    R = "\033[91m" if tty else ""
+    Y = "\033[93m" if tty else ""
+    B = "\033[1m" if tty else ""
+    E = "\033[0m" if tty else ""
+
+    all_passed = all(checks.values())
+    status = f"{G}PASSED{E}" if all_passed else f"{R}FAILED{E}"
+
+    print(f"\n{B}{'='*60}{E}")
+    print(f"{B}  Debug Agent Smoke Test{E}")
+    print(f"{B}{'='*60}{E}")
+    print(f"  Model   : {model_name}")
+    print(f"  Elapsed : {elapsed:.1f}s")
+    print(f"  Status  : {status}")
+    print()
+
+    print(f"{B}  Tool Call Sequence ({len(tool_calls)} calls):{E}")
+    for i, name in enumerate(tool_calls, 1):
+        print(f"    {i:2}. {name}")
+    print()
+
+    print(f"{B}  Protocol Compliance:{E}")
+    for name, passed in checks.items():
+        icon = f"{G}✓{E}" if passed else f"{R}✗{E}"
+        label = name.replace("_", " ")
+        print(f"    {icon}  {label}")
+    print()
+
+    print(f"{B}  Recorded Hypotheses ({len(hypotheses)}):{E}")
+    if hypotheses:
+        for h in hypotheses:
+            evidence_count = len(h.get("evidence", []))
+            print(
+                f"    [{h['id']}] {h['title'][:65]}"
+                f"\n           status={h['status']}, evidence_items={evidence_count}"
+            )
+    else:
+        print(f"    {R}(none — record_hypothesis was not called or failed){E}")
+    print()
+
+    print(f"{B}  Full Conversation Text (first 1000 chars):{E}")
+    preview = full_text[:1000]
+    print(f"{Y}{preview}{E}")
+    if len(full_text) > 1000:
+        print(f"  ... [{len(full_text) - 1000} more chars]")
+    print()
+
+    failed_checks = [k for k, v in checks.items() if not v]
+    if failed_checks:
+        print(f"{R}{B}  Failed checks:{E}")
+        for name in failed_checks:
+            print(f"  {R}  ✗  {name.replace('_', ' ')}{E}")
+        print()
+
+    print(f"{B}{'='*60}{E}\n")
+    return all_passed
+
+
+# ---------------------------------------------------------------------------
+# Pytest entry point
+# ---------------------------------------------------------------------------
+_has_api_key = bool(
+    os.environ.get("ANTHROPIC_API_KEY")
+    or os.environ.get("OPENAI_API_KEY")
+    or os.environ.get("GOOGLE_API_KEY")
+    or os.environ.get("GEMINI_API_KEY")
+)
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not _has_api_key, reason="No LLM API key — set ANTHROPIC_API_KEY")
+def test_debug_agent_follows_hypothesis_protocol() -> None:
+    """Smoke: real LLM must follow the hypothesis-driven debugging protocol.
+
+    Feeds the ASan heap-buffer-overflow signal from valkey-io/valkey and
+    asserts all OUTPUT CONTRACT requirements from debug_task_prompt are met.
+
+    Skipped automatically when no LLM API key is in the environment.
+    """
+    model_name = os.environ.get("SMOKE_MODEL", "claude-haiku-4-5-20251001")
+    final_output, full_text, tool_calls, hypotheses, elapsed = asyncio.run(run_smoke(model_name))
+    checks = check_protocol_compliance(full_text, tool_calls, hypotheses)
+    print_report(model_name, final_output, full_text, tool_calls, hypotheses, checks, elapsed)
+
+    failed = {k for k, v in checks.items() if not v}
+    assert not failed, (
+        f"Agent failed {len(failed)} protocol check(s):\n"
+        + "\n".join(f"  ✗ {c.replace('_', ' ')}" for c in sorted(failed))
+    )
+
+
+# ---------------------------------------------------------------------------
+# Standalone entry point
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Debug agent smoke test")
+    parser.add_argument(
+        "--model",
+        default=os.environ.get("SMOKE_MODEL", "claude-haiku-4-5-20251001"),
+        help="LLM model name override",
+    )
+    args = parser.parse_args()
+
+    if not _has_api_key:
+        print(
+            "ERROR: No LLM API key found.\n"
+            "Set ANTHROPIC_API_KEY (or OPENAI_API_KEY / GOOGLE_API_KEY) and retry.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    final_output, full_text, tool_calls, hypotheses, elapsed = asyncio.run(run_smoke(args.model))
+    checks = check_protocol_compliance(full_text, tool_calls, hypotheses)
+    passed = print_report(args.model, final_output, full_text, tool_calls, hypotheses, checks, elapsed)
+    sys.exit(0 if passed else 1)

--- a/tests/unit/intelligence/test_agent_dispatch_routing.py
+++ b/tests/unit/intelligence/test_agent_dispatch_routing.py
@@ -141,3 +141,114 @@ async def test_resolve_conversation_agent_id_reads_agent_ids(monkeypatch):
 async def test_resolve_conversation_agent_id_none_when_missing(monkeypatch):
     _patch_store(monkeypatch, None)
     assert await cr.resolve_conversation_agent_id("c1", None, None) is None
+
+
+class _RecordingAsyncRedis:
+    """Async redis stub that records which lifecycle calls were made."""
+
+    def __init__(self):
+        self.calls = []
+
+    async def set_task_status(self, conversation_id, run_id, status):
+        self.calls.append(("set_task_status", status))
+
+    async def publish_event(self, conversation_id, run_id, event_type, payload):
+        self.calls.append(("publish_event", event_type))
+
+    async def wait_for_task_start(
+        self, conversation_id, run_id, timeout=30, require_running=False
+    ):
+        self.calls.append(("wait_for_task_start",))
+        return True
+
+    async def get_task_status(self, conversation_id, run_id):
+        return None
+
+    def stream_key(self, conversation_id, run_id):
+        return f"chat:stream:{conversation_id}:{run_id}"
+
+
+def _patch_dispatch_recorder(monkeypatch):
+    dispatched = []
+
+    async def _fake_dispatch(**kwargs):
+        dispatched.append(kwargs)
+        return None
+
+    monkeypatch.setattr(cr, "_dispatch_agent_run", _fake_dispatch)
+    return dispatched
+
+
+async def test_stream_with_cursor_does_not_redispatch(monkeypatch):
+    """Reconnect (cursor set) must attach to the existing run, never start a new one.
+
+    A durable backend (Hatchet) keeps orphaned runs alive, so re-dispatching on
+    reconnect spawns duplicate tasks that interleave into the same Redis stream.
+    """
+    from fastapi.responses import StreamingResponse
+
+    dispatched = _patch_dispatch_recorder(monkeypatch)
+    redis = _RecordingAsyncRedis()
+
+    resp = await cr.start_celery_task_and_stream(
+        conversation_id="c1",
+        run_id="r1",
+        user_id="u1",
+        query="q",
+        agent_id="debugging_agent",
+        node_ids=[],
+        attachment_ids=[],
+        async_redis_manager=redis,
+        cursor="5-0",
+        local_mode=False,
+        tunnel_url=None,
+    )
+
+    assert dispatched == []  # reconnect must NOT enqueue another run
+    # And it must not clobber the live run's status or inject a fresh queued event.
+    assert all(name != "set_task_status" for name, *_ in redis.calls)
+    assert all(name != "publish_event" for name, *_ in redis.calls)
+    assert isinstance(resp, StreamingResponse)
+
+
+async def test_stream_without_cursor_dispatches_once(monkeypatch):
+    """A fresh request (no cursor) still dispatches exactly one run."""
+    dispatched = _patch_dispatch_recorder(monkeypatch)
+    redis = _RecordingAsyncRedis()
+
+    await cr.start_celery_task_and_stream(
+        conversation_id="c1",
+        run_id="r1",
+        user_id="u1",
+        query="q",
+        agent_id="debugging_agent",
+        node_ids=[],
+        attachment_ids=[],
+        async_redis_manager=redis,
+        cursor=None,
+        local_mode=False,
+        tunnel_url=None,
+    )
+
+    assert len(dispatched) == 1
+    assert ("set_task_status", "queued") in redis.calls
+
+
+async def test_regenerate_stream_with_cursor_does_not_redispatch(monkeypatch):
+    """Regenerate reconnect path must also attach rather than re-dispatch."""
+    dispatched = _patch_dispatch_recorder(monkeypatch)
+    redis = _RecordingAsyncRedis()
+
+    await cr.start_regenerate_task_and_stream(
+        conversation_id="c1",
+        run_id="r1",
+        user_id="u1",
+        agent_id="debugging_agent",
+        node_ids=[],
+        attachment_ids=[],
+        async_redis_manager=redis,
+        cursor="5-0",
+        local_mode=False,
+    )
+
+    assert dispatched == []

--- a/tests/unit/intelligence/test_agent_execution_service.py
+++ b/tests/unit/intelligence/test_agent_execution_service.py
@@ -7,6 +7,7 @@ This is the shared logic both the Celery and Hatchet backends drive.
 from app.modules.conversations.exceptions import GenerationCancelled
 from app.modules.intelligence.agents.runtime.agent_execution_service import (
     run_agent_turn,
+    serialize_tool_calls,
 )
 from app.modules.intelligence.agents.runtime.redis_sink import RedisStreamSink
 
@@ -41,10 +42,11 @@ class FakeToolCall:
 
 
 class FakeChunk:
-    def __init__(self, message="", citations=None, tool_calls=None):
+    def __init__(self, message="", citations=None, tool_calls=None, thinking=None):
         self.message = message
         self.citations = citations
         self.tool_calls = tool_calls
+        self.thinking = thinking
 
 
 async def _agen(items):
@@ -72,6 +74,25 @@ async def test_emits_start_then_chunks_then_returns_completed():
     assert first_chunk["tool_calls_json"] == [{"name": "search"}]
     second_chunk = sink.events[2][1]
     assert second_chunk["citations_json"] == ["c1"]
+
+
+async def test_chunk_emits_thinking_when_present():
+    sink = FakeSink()
+    completed = await run_agent_turn(
+        start_payload={},
+        chunk_stream=_agen([FakeChunk(message="hi", thinking="step 1")]),
+        sink=sink,
+        flush_partial=lambda: None,
+    )
+    assert completed is True
+    assert sink.events[1][1]["thinking"] == "step 1"
+
+
+def test_serialize_tool_calls_parses_json_strings():
+    raw = '{"call_id": "c1", "tool_name": "search"}'
+    assert serialize_tool_calls([raw]) == [
+        {"call_id": "c1", "tool_name": "search"}
+    ]
 
 
 async def test_cancellation_mid_stream_flushes_and_emits_cancelled_end():

--- a/tests/unit/intelligence/test_anthropic_caching_model.py
+++ b/tests/unit/intelligence/test_anthropic_caching_model.py
@@ -1,0 +1,84 @@
+import pytest
+
+from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserPromptPart
+from pydantic_ai.models import ModelRequestParameters
+from pydantic_ai.providers.anthropic import AnthropicProvider
+
+from app.modules.intelligence.provider.anthropic_caching_model import (
+    CachingAnthropicModel,
+)
+
+
+def _model() -> CachingAnthropicModel:
+    return CachingAnthropicModel(
+        model_name="claude-sonnet-4-20250514",
+        provider=AnthropicProvider(api_key="test-key"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_request_accepts_current_pydantic_ai_request_parameters(monkeypatch):
+    model = _model()
+    parameters = ModelRequestParameters()
+    expected_response = ModelResponse(parts=[TextPart(content="ok")])
+    captured = {}
+
+    async def fake_messages_create(
+        messages,
+        stream,
+        model_settings,
+        model_request_parameters,
+    ):
+        captured["messages"] = messages
+        captured["stream"] = stream
+        captured["model_settings"] = model_settings
+        captured["model_request_parameters"] = model_request_parameters
+        return object()
+
+    monkeypatch.setattr(model, "_messages_create", fake_messages_create)
+    monkeypatch.setattr(model, "_process_response", lambda _: expected_response)
+
+    result = await model.request(
+        [ModelRequest(parts=[UserPromptPart(content="hi")])],
+        {},
+        parameters,
+    )
+
+    assert result is expected_response
+    assert captured["stream"] is False
+    assert isinstance(captured["model_request_parameters"], ModelRequestParameters)
+    assert captured["model_request_parameters"].allow_text_output is True
+
+
+@pytest.mark.asyncio
+async def test_messages_create_preserves_structured_system_prompt(monkeypatch):
+    model = _model()
+    captured = {}
+
+    async def fake_map_message(*_args, **_kwargs):
+        return (
+            [{"type": "text", "text": "structured system prompt"}],
+            [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+        )
+
+    async def fake_create(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(model, "_map_message", fake_map_message)
+    model.client.beta.messages.create = fake_create
+
+    await model._messages_create(
+        [ModelRequest(parts=[UserPromptPart(content="hi")])],
+        False,
+        {},
+        ModelRequestParameters(),
+    )
+
+    assert captured["system"] == [
+        {
+            "type": "text",
+            "text": "structured system prompt",
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]

--- a/tests/unit/intelligence/test_dap_tools.py
+++ b/tests/unit/intelligence/test_dap_tools.py
@@ -162,6 +162,13 @@ class TestStartDebugSessionInputSchema:
         with pytest.raises(ValidationError):
             StartDebugSessionInput(program="/a.py", args=["--flag"])  # type: ignore[arg-type]
 
+    @pytest.mark.parametrize("lang", ["c", "cpp", "c++", "lldb", "cppdbg", "lldb-dap"])
+    def test_native_language_values_accepted(self, lang):
+        from app.modules.intelligence.tools.dap_tools import StartDebugSessionInput
+
+        inp = StartDebugSessionInput(program="/bin/a.out", language=lang)
+        assert inp.language == lang
+
 
 class TestSetBreakpointsResultSchema:
     def test_round_trip(self):
@@ -340,7 +347,28 @@ class TestMakeDapError:
         assert err["error"] == "debug adapter not available"
         assert err["error_type"] == "extension_error"
         assert "debug adapter" in err["message"]
+        assert "NOT a tunnel/connection problem" in err["message"]
         assert "Reconnect and retry" not in err["message"]
+
+    def test_dap_error_timeout_not_reported_as_tunnel_drop(self):
+        from app.modules.intelligence.tools.dap_tools import _make_dap_error
+
+        err = _make_dap_error(error_type="timeout", context="start_session").model_dump(mode="json")
+
+        assert err["error_type"] == "timeout"
+        assert "not evidence" in err["message"]
+        assert "Reconnect and retry" not in err["message"]
+
+    def test_dap_error_debug_adapter_unavailable_includes_install_guidance(self):
+        from app.modules.intelligence.tools.dap_tools import _make_dap_error
+
+        err = _make_dap_error(
+            error_type="debug_adapter_unavailable: No registered debug adapter",
+            context="start_session",
+        ).model_dump(mode="json")
+
+        assert err["error_type"] == "extension_error"
+        assert "not installed" in err["message"].lower()
 
 
 # ===========================================================================
@@ -536,6 +564,86 @@ class TestRouteDapCommand:
         assert result is None
         assert err == "unknown_route"
 
+    def test_http_200_domain_failure_returns_extension_error(self):
+        import httpx
+        from unittest.mock import patch as _patch, MagicMock
+        from app.modules.intelligence.tools.local_search_tools.tunnel_utils import route_dap_command
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "success": False,
+            "error": "debug_adapter_unavailable",
+        }
+
+        with _patch(
+            "app.modules.tunnel.tunnel_service.get_tunnel_service",
+            return_value=self._mock_tunnel_service(),
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_tunnel_url",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_repository",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_branch",
+            return_value=None,
+        ), _patch.object(
+            httpx.Client,
+            "post",
+            return_value=mock_resp,
+        ):
+            result, err = route_dap_command(
+                method="start_session",
+                payload={"program": "a.py"},
+                user_id="u1",
+                conversation_id="c1",
+            )
+
+        assert result is None
+        assert err == "debug_adapter_unavailable"
+
+    def test_http_422_returns_domain_error_not_tunnel_unreachable(self):
+        import httpx
+        from unittest.mock import patch as _patch, MagicMock
+        from app.modules.intelligence.tools.local_search_tools.tunnel_utils import route_dap_command
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 422
+        mock_resp.json.return_value = {
+            "error": "debug_adapter_unavailable: adapter missing",
+            "adapter_type": "cppdbg",
+        }
+        mock_resp.text = "debug_adapter_unavailable: adapter missing"
+
+        with _patch(
+            "app.modules.tunnel.tunnel_service.get_tunnel_service",
+            return_value=self._mock_tunnel_service(),
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_tunnel_url",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_repository",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_branch",
+            return_value=None,
+        ), _patch.object(
+            httpx.Client,
+            "post",
+            return_value=mock_resp,
+        ):
+            result, err = route_dap_command(
+                method="start_session",
+                payload={"program": "a.py"},
+                user_id="u1",
+                conversation_id="c1",
+            )
+
+        assert result is None
+        assert err == "debug_adapter_unavailable: adapter missing"
+        assert err != "tunnel_unreachable"
+
     def test_socket_route_hyphenizes_method_endpoint(self):
         from unittest.mock import patch as _patch
         from app.modules.intelligence.tools.local_search_tools.tunnel_utils import route_dap_command
@@ -639,6 +747,40 @@ class TestRouteDapCommand:
         assert result is None
         assert err == "debug adapter not available"
 
+    def test_socket_domain_failure_body_returns_extension_error(self):
+        from unittest.mock import patch as _patch
+        from app.modules.intelligence.tools.local_search_tools.tunnel_utils import route_dap_command
+
+        mock_svc = MagicMock()
+        mock_svc.get_tunnel_url.return_value = "socket://workspace-1"
+        mock_svc.get_workspace_id.return_value = "workspace-1"
+
+        with _patch(
+            "app.modules.tunnel.tunnel_service.get_tunnel_service",
+            return_value=mock_svc,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_tunnel_url",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_repository",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_branch",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.local_search_tools.tunnel_utils._execute_via_socket",
+            return_value=({"success": False, "error": "debug_adapter_unavailable"}, None),
+        ):
+            result, err = route_dap_command(
+                method="start_session",
+                payload={"program": "a.py"},
+                user_id="u1",
+                conversation_id="c1",
+            )
+
+        assert result is None
+        assert err == "debug_adapter_unavailable"
+
 
 # ===========================================================================
 # A3.3 — Per-tool tests
@@ -694,6 +836,27 @@ class TestStartDebugSession:
         assert payload_val["program"] == "/a.py"
         assert payload_val["port"] == 5678
         assert payload_val["args"] == {"stopOnEntry": True}
+        assert kwargs.get("timeout") == 65.0
+
+    def test_empty_session_id_returns_extension_error(self):
+        from app.modules.intelligence.tools.dap_tools import start_debug_session
+
+        with patch(_DISPATCH, return_value=({"success": False, "error": "launch_failed"}, None)), \
+             patch(_CTX, return_value=_CTX_RETURN):
+            result = start_debug_session(program="/a.py")
+        assert result["error_type"] == "extension_error"
+        assert "session_id" in result["message"]
+
+    def test_domain_failure_body_returns_extension_error(self):
+        from app.modules.intelligence.tools.dap_tools import start_debug_session
+
+        with patch(
+            _DISPATCH,
+            return_value=(None, "debug_adapter_unavailable"),
+        ), patch(_CTX, return_value=_CTX_RETURN):
+            result = start_debug_session(program="/a.py")
+        assert result["error_type"] == "extension_error"
+        assert "not installed" in result["message"].lower()
 
     def test_legacy_argv_list_is_wrapped_as_launch_config_args(self):
         from app.modules.intelligence.tools.dap_tools import start_debug_session
@@ -837,6 +1000,7 @@ class TestStepTools:
         assert kwargs["method"] == expected_method
         assert kwargs["payload"].get("session_id") == "s1"
         assert kwargs["payload"].get("expressions") == ["x"]
+        assert kwargs.get("timeout") == 40.0
 
 
 class TestContinueExecution:

--- a/tests/unit/intelligence/test_dap_tools.py
+++ b/tests/unit/intelligence/test_dap_tools.py
@@ -1,0 +1,984 @@
+"""Unit tests for the DAP tool family (A3).
+
+Coverage:
+  - A3.1: Schema round-trips, optional-field defaults, Literal enum rejection
+  - A3.2: route_dap_command — success, HTTP timeout, HTTP ConnectError
+  - A3.3: Each of the 10 tools — success path, no_tunnel failure, unknown_route failure,
+           and one arg-forwarding assertion (method= and payload=)
+  - The 4 step_* tools are parametrized together (same shape)
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("POSTGRES_SERVER", "postgresql://test:test@localhost:5432/testdb")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+
+import pytest
+from unittest.mock import MagicMock, patch
+from pydantic import ValidationError
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Patch targets
+# ---------------------------------------------------------------------------
+
+_DISPATCH = "app.modules.intelligence.tools.dap_tools.route_dap_command"
+_CTX = "app.modules.intelligence.tools.dap_tools.get_context_vars"
+_CTX_RETURN = ("user1", "conv1")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _snapshot_payload(**extra) -> dict:
+    return {
+        "session_id": "sess-abc",
+        "status": "paused",
+        "paused_at": {"file": "/app/main.py", "line": 10, "function": "run"},
+        "call_stack": [
+            {"frame_id": 1, "function": "run", "file": "/app/main.py", "line": 10}
+        ],
+        "locals": {"x": "42"},
+        "expression_results": [],
+        **extra,
+    }
+
+
+# ===========================================================================
+# A3.1 — Schema tests
+# ===========================================================================
+
+
+class TestDebugCallFrameSchema:
+    def test_round_trip(self):
+        from app.modules.intelligence.tools.dap_schemas import DebugCallFrame
+
+        frame = DebugCallFrame(frame_id=1, name="main", source_path="/a.py", line=5, column=3)
+        restored = DebugCallFrame.model_validate_json(frame.model_dump_json())
+        assert restored.frame_id == 1
+        assert restored.name == "main"
+        assert restored.source_path == "/a.py"
+        assert restored.line == 5
+        assert restored.column == 3
+
+    def test_optional_fields_default_none(self):
+        from app.modules.intelligence.tools.dap_schemas import DebugCallFrame
+
+        frame = DebugCallFrame(frame_id=0, name="<top>")
+        assert frame.source_path is None
+        assert frame.line is None
+        assert frame.column is None
+
+    def test_debug_call_frame_accepts_ts_field_names_via_aliases(self):
+        from app.modules.intelligence.tools.dap_schemas import DebugCallFrame
+
+        frame = DebugCallFrame.model_validate({
+            "frame_id": 1,
+            "function": "createOrder",
+            "file": "/src/checkout/createOrder.ts",
+            "line": 88,
+        })
+        assert frame.name == "createOrder"
+        assert frame.source_path == "/src/checkout/createOrder.ts"
+
+    def test_debug_call_frame_accepts_python_field_names(self):
+        from app.modules.intelligence.tools.dap_schemas import DebugCallFrame
+
+        frame = DebugCallFrame(
+            frame_id=1,
+            name="createOrder",
+            source_path="/src/checkout/createOrder.ts",
+            line=88,
+        )
+        assert frame.name == "createOrder"
+
+
+class TestDebugSnapshotSchema:
+    def test_round_trip_full(self):
+        from app.modules.intelligence.tools.dap_schemas import DebugSnapshot, DebugCallFrame
+
+        snap = DebugSnapshot(
+            session_id="s1",
+            status="paused",
+            paused_at={"file": "/a.py", "line": 1, "function": "f"},
+            call_stack=[DebugCallFrame(frame_id=1, name="f", source_path="/a.py", line=1)],
+            locals={"x": "1"},
+            expression_results=[{"expression": "x+1", "result": "2"}],
+            output="hello",
+        )
+        restored = DebugSnapshot.model_validate_json(snap.model_dump_json())
+        assert restored.session_id == "s1"
+        assert restored.status == "paused"
+        assert restored.locals == {"x": "1"}
+        assert len(restored.call_stack) == 1
+        assert restored.output == "hello"
+
+    def test_defaults(self):
+        from app.modules.intelligence.tools.dap_schemas import DebugSnapshot
+
+        snap = DebugSnapshot(session_id="s", status="running")
+        assert snap.call_stack == []
+        assert snap.locals == {}
+        assert snap.expression_results == []
+        assert snap.paused_at is None
+        assert snap.output is None
+
+
+class TestStartSessionResultSchema:
+    def test_round_trip(self):
+        from app.modules.intelligence.tools.dap_schemas import StartSessionResult
+
+        r = StartSessionResult(session_id="s1", program="/a.py", language="python", status="initialized")
+        restored = StartSessionResult.model_validate_json(r.model_dump_json())
+        assert restored.session_id == "s1"
+        assert restored.language == "python"
+
+    def test_optional_fields_default_none(self):
+        from app.modules.intelligence.tools.dap_schemas import StartSessionResult
+
+        r = StartSessionResult(session_id="s1", status="failed")
+        assert r.program is None
+        assert r.language is None
+        assert r.message is None
+
+
+class TestSetBreakpointsResultSchema:
+    def test_round_trip(self):
+        from app.modules.intelligence.tools.dap_schemas import SetBreakpointsResult
+
+        r = SetBreakpointsResult(
+            session_id="s1",
+            file="/a.py",
+            breakpoints=[{"line": 10, "verified": True}],
+        )
+        restored = SetBreakpointsResult.model_validate_json(r.model_dump_json())
+        assert restored.file == "/a.py"
+        assert restored.breakpoints[0]["verified"] is True
+
+    def test_optional_fields_default(self):
+        from app.modules.intelligence.tools.dap_schemas import SetBreakpointsResult
+
+        r = SetBreakpointsResult(file="/b.py")
+        assert r.breakpoints == []
+        assert r.session_id is None
+        assert r.message is None
+
+
+class TestTrackedDebugSessionSchema:
+    def test_round_trip(self):
+        from app.modules.intelligence.tools.dap_schemas import TrackedDebugSession
+
+        s = TrackedDebugSession(session_id="s1", program="/a.py", language="python", status="paused")
+        restored = TrackedDebugSession.model_validate_json(s.model_dump_json())
+        assert restored.status == "paused"
+
+    def test_optional_fields_default_none(self):
+        from app.modules.intelligence.tools.dap_schemas import TrackedDebugSession
+
+        s = TrackedDebugSession(session_id="s1", status="running")
+        assert s.program is None
+        assert s.language is None
+        assert s.created_at is None
+
+    def test_tracked_debug_session_accepts_ts_field_names_via_alias(self):
+        from app.modules.intelligence.tools.dap_schemas import TrackedDebugSession
+
+        s = TrackedDebugSession.model_validate({
+            "session_id": "sess_1",
+            "status": "running",
+            "createdAt": "2026-05-19T10:00:00Z",
+        })
+        assert s.created_at == "2026-05-19T10:00:00Z"
+
+    def test_tracked_debug_session_accepts_python_field_name(self):
+        from app.modules.intelligence.tools.dap_schemas import TrackedDebugSession
+
+        s = TrackedDebugSession(session_id="sess_1", status="running", created_at="2026-05-19T10:00:00Z")
+        assert s.created_at == "2026-05-19T10:00:00Z"
+
+
+class TestListSessionsResultSchema:
+    def test_round_trip_empty(self):
+        from app.modules.intelligence.tools.dap_schemas import ListSessionsResult
+
+        r = ListSessionsResult()
+        restored = ListSessionsResult.model_validate_json(r.model_dump_json())
+        assert restored.sessions == []
+
+    def test_round_trip_with_sessions(self):
+        from app.modules.intelligence.tools.dap_schemas import ListSessionsResult, TrackedDebugSession
+
+        r = ListSessionsResult(
+            sessions=[TrackedDebugSession(session_id="s1", status="paused")]
+        )
+        restored = ListSessionsResult.model_validate_json(r.model_dump_json())
+        assert len(restored.sessions) == 1
+        assert restored.sessions[0].session_id == "s1"
+
+
+class TestEvaluateResultSchema:
+    def test_round_trip(self):
+        from app.modules.intelligence.tools.dap_schemas import EvaluateResult
+
+        r = EvaluateResult(session_id="s1", expression="x+1", value="42", type="int")
+        restored = EvaluateResult.model_validate_json(r.model_dump_json())
+        assert restored.value == "42"
+        assert restored.type == "int"
+
+    def test_type_optional(self):
+        from app.modules.intelligence.tools.dap_schemas import EvaluateResult
+
+        r = EvaluateResult(session_id="s1", expression="x", value="1")
+        assert r.type is None
+
+
+class TestStopSessionResultSchema:
+    def test_round_trip_terminated(self):
+        from app.modules.intelligence.tools.dap_schemas import StopSessionResult
+
+        r = StopSessionResult(session_id="s1", status="terminated")
+        restored = StopSessionResult.model_validate_json(r.model_dump_json())
+        assert restored.status == "terminated"
+
+    def test_invalid_status_raises(self):
+        from app.modules.intelligence.tools.dap_schemas import StopSessionResult
+
+        with pytest.raises(ValidationError):
+            StopSessionResult(session_id="s1", status="running")  # type: ignore
+
+    def test_message_optional(self):
+        from app.modules.intelligence.tools.dap_schemas import StopSessionResult
+
+        r = StopSessionResult(session_id="s1", status="not_found")
+        assert r.message is None
+
+
+class TestDapErrorSchema:
+    def test_round_trip(self):
+        from app.modules.intelligence.tools.dap_schemas import DapError
+
+        e = DapError(available=False, error="no_tunnel", error_type="no_tunnel", message="not connected")
+        restored = DapError.model_validate_json(e.model_dump_json())
+        assert restored.error_type == "no_tunnel"
+        assert restored.available is False
+
+    def test_available_default_false(self):
+        from app.modules.intelligence.tools.dap_schemas import DapError
+
+        e = DapError(error="x", error_type="unknown_error", message="oops")
+        assert e.available is False
+
+    def test_invalid_error_type_raises(self):
+        from app.modules.intelligence.tools.dap_schemas import DapError
+
+        with pytest.raises(ValidationError):
+            DapError(error="x", error_type="bad_type", message="oops")  # type: ignore
+
+    @pytest.mark.parametrize("etype", [
+        "no_tunnel", "unknown_route", "timeout",
+        "tunnel_unreachable", "no_user_id", "unknown_error",
+    ])
+    def test_all_valid_error_types(self, etype):
+        from app.modules.intelligence.tools.dap_schemas import DapError
+
+        e = DapError(error=etype, error_type=etype, message="msg")
+        assert e.error_type == etype
+
+    def test_no_session_is_rejected(self):
+        from app.modules.intelligence.tools.dap_schemas import DapError
+
+        with pytest.raises(ValidationError):
+            DapError(error="no_session", error_type="no_session", message="msg")  # type: ignore
+
+
+class TestMakeDapError:
+    def test_dap_error_no_user_id_message_distinct_from_no_tunnel(self):
+        from app.modules.intelligence.tools.dap_tools import _make_dap_error, _NO_TUNNEL_MSG
+
+        err = _make_dap_error(error_type="no_user_id", context="test").model_dump(mode="json")
+        assert err["error_type"] == "no_user_id"
+        assert "user" in err["message"].lower()
+        assert err["message"] != _NO_TUNNEL_MSG
+
+
+# ===========================================================================
+# A3.2 — route_dap_command dispatcher tests
+# ===========================================================================
+
+
+class TestRouteDapCommand:
+    """Tests for the generic HTTP path of route_dap_command.
+
+    Uses the same mocking strategy as test_get_workspace_debug_context_tool.py.
+    """
+
+    _http_tunnel_url = "http://localhost:49152"
+
+    def _mock_tunnel_service(self):
+        svc = MagicMock()
+        svc.get_tunnel_url.return_value = self._http_tunnel_url
+        svc.get_workspace_id.return_value = None
+        return svc
+
+    def test_http_success_returns_result(self):
+        import httpx
+        from unittest.mock import patch as _patch, MagicMock
+        from app.modules.intelligence.tools.local_search_tools.tunnel_utils import route_dap_command
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"session_id": "s1", "status": "paused"}
+
+        with _patch(
+            "app.modules.tunnel.tunnel_service.get_tunnel_service",
+            return_value=self._mock_tunnel_service(),
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_tunnel_url",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_repository",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_branch",
+            return_value=None,
+        ), _patch.object(
+            httpx.Client,
+            "post",
+            return_value=mock_resp,
+        ):
+            result, err = route_dap_command(
+                method="snapshot",
+                payload={},
+                user_id="u1",
+                conversation_id="c1",
+                timeout=5.0,
+            )
+
+        assert err is None
+        assert result is not None
+        assert result["session_id"] == "s1"
+
+    def test_http_timeout_returns_timeout_code(self):
+        import httpx
+        from unittest.mock import patch as _patch
+        from app.modules.intelligence.tools.local_search_tools.tunnel_utils import route_dap_command
+
+        with _patch(
+            "app.modules.tunnel.tunnel_service.get_tunnel_service",
+            return_value=self._mock_tunnel_service(),
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_tunnel_url",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_repository",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_branch",
+            return_value=None,
+        ), _patch.object(
+            httpx.Client,
+            "post",
+            side_effect=httpx.TimeoutException("timed out"),
+        ):
+            result, err = route_dap_command(
+                method="start_session",
+                payload={"program": "a.py"},
+                user_id="u1",
+                conversation_id="c1",
+                timeout=1.0,
+            )
+
+        assert result is None
+        assert err == "timeout"
+
+    def test_http_connect_error_returns_tunnel_unreachable(self):
+        import httpx
+        from unittest.mock import patch as _patch
+        from app.modules.intelligence.tools.local_search_tools.tunnel_utils import route_dap_command
+
+        with _patch(
+            "app.modules.tunnel.tunnel_service.get_tunnel_service",
+            return_value=self._mock_tunnel_service(),
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_tunnel_url",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_repository",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_branch",
+            return_value=None,
+        ), _patch.object(
+            httpx.Client,
+            "post",
+            side_effect=httpx.ConnectError("dns failure"),
+        ):
+            result, err = route_dap_command(
+                method="list_sessions",
+                payload={},
+                user_id="u1",
+                conversation_id="c1",
+                timeout=1.0,
+            )
+
+        assert result is None
+        assert err == "tunnel_unreachable"
+
+    def test_no_user_id_returns_no_user_id(self):
+        from app.modules.intelligence.tools.local_search_tools.tunnel_utils import route_dap_command
+
+        result, err = route_dap_command(method="snapshot", payload={}, user_id="")
+        assert result is None
+        assert err == "no_user_id"
+
+    def test_no_tunnel_returns_no_tunnel(self):
+        from unittest.mock import patch as _patch
+        from app.modules.intelligence.tools.local_search_tools.tunnel_utils import route_dap_command
+
+        mock_svc = MagicMock()
+        mock_svc.get_tunnel_url.return_value = None
+        mock_svc.get_workspace_id.return_value = None
+
+        with _patch(
+            "app.modules.tunnel.tunnel_service.get_tunnel_service",
+            return_value=mock_svc,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_tunnel_url",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_repository",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_branch",
+            return_value=None,
+        ):
+            result, err = route_dap_command(method="snapshot", payload={}, user_id="u1")
+
+        assert result is None
+        assert err == "no_tunnel"
+
+    def test_http_404_returns_unknown_route(self):
+        import httpx
+        from unittest.mock import patch as _patch, MagicMock
+        from app.modules.intelligence.tools.local_search_tools.tunnel_utils import route_dap_command
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        mock_resp.text = "Not Found"
+
+        with _patch(
+            "app.modules.tunnel.tunnel_service.get_tunnel_service",
+            return_value=self._mock_tunnel_service(),
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_tunnel_url",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_repository",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_branch",
+            return_value=None,
+        ), _patch.object(
+            httpx.Client,
+            "post",
+            return_value=mock_resp,
+        ):
+            result, err = route_dap_command(
+                method="snapshot",
+                payload={},
+                user_id="u1",
+                conversation_id="c1",
+                timeout=5.0,
+            )
+
+        assert result is None
+        assert err == "unknown_route"
+
+
+# ===========================================================================
+# A3.3 — Per-tool tests
+# ===========================================================================
+
+
+class TestStartDebugSession:
+    def test_success_returns_start_session_result(self):
+        from app.modules.intelligence.tools.dap_tools import start_debug_session
+
+        payload = {"session_id": "s1", "program": "/a.py", "language": "python", "status": "initialized"}
+        with patch(_DISPATCH, return_value=(payload, None)), patch(_CTX, return_value=_CTX_RETURN):
+            result = start_debug_session(program="/a.py")
+        assert result["session_id"] == "s1"
+        assert result["status"] == "initialized"
+
+    def test_no_tunnel_returns_dap_error(self):
+        from app.modules.intelligence.tools.dap_tools import start_debug_session
+
+        with patch(_DISPATCH, return_value=(None, "no_tunnel")), patch(_CTX, return_value=_CTX_RETURN):
+            result = start_debug_session(program="/a.py")
+        assert result["error_type"] == "no_tunnel"
+        assert result["available"] is False
+
+    def test_unknown_route_returns_dap_error(self):
+        from app.modules.intelligence.tools.dap_tools import start_debug_session
+
+        with patch(_DISPATCH, return_value=(None, "unknown_route")), patch(_CTX, return_value=_CTX_RETURN):
+            result = start_debug_session(program="/a.py")
+        assert result["error_type"] == "unknown_route"
+
+    def test_forwards_correct_method_and_payload(self):
+        from app.modules.intelligence.tools.dap_tools import start_debug_session
+
+        with patch(_DISPATCH, return_value=(None, "no_tunnel")) as mock_d, \
+             patch(_CTX, return_value=_CTX_RETURN):
+            start_debug_session(program="/a.py", language="python", mode="launch", port=5678)
+
+        mock_d.assert_called_once()
+        kwargs = mock_d.call_args.kwargs if mock_d.call_args.kwargs else {}
+        args = mock_d.call_args.args if mock_d.call_args.args else ()
+        # method should be "start_session"
+        method_val = kwargs.get("method") or (args[0] if args else None)
+        assert method_val == "start_session"
+        # payload should contain program and port
+        payload_val = kwargs.get("payload") or (args[1] if len(args) > 1 else None)
+        assert payload_val["program"] == "/a.py"
+        assert payload_val["port"] == 5678
+
+    def test_does_not_raise_on_exception(self):
+        from app.modules.intelligence.tools.dap_tools import start_debug_session
+
+        with patch(_DISPATCH, side_effect=RuntimeError("boom")), patch(_CTX, return_value=_CTX_RETURN):
+            result = start_debug_session(program="/a.py")
+        assert result["available"] is False
+        assert result["error_type"] == "unknown_error"
+
+
+class TestSetBreakpoints:
+    def test_success_returns_set_breakpoints_result(self):
+        from app.modules.intelligence.tools.dap_tools import set_breakpoints
+
+        payload = {"file": "/a.py", "breakpoints": [{"line": 5, "verified": True}]}
+        with patch(_DISPATCH, return_value=(payload, None)), patch(_CTX, return_value=_CTX_RETURN):
+            result = set_breakpoints(file="/a.py", lines=[5])
+        assert result["file"] == "/a.py"
+        assert result["breakpoints"][0]["verified"] is True
+
+    def test_no_tunnel_returns_dap_error(self):
+        from app.modules.intelligence.tools.dap_tools import set_breakpoints
+
+        with patch(_DISPATCH, return_value=(None, "no_tunnel")), patch(_CTX, return_value=_CTX_RETURN):
+            result = set_breakpoints(file="/a.py", lines=[5])
+        assert result["error_type"] == "no_tunnel"
+
+    def test_unknown_route_returns_dap_error(self):
+        from app.modules.intelligence.tools.dap_tools import set_breakpoints
+
+        with patch(_DISPATCH, return_value=(None, "unknown_route")), patch(_CTX, return_value=_CTX_RETURN):
+            result = set_breakpoints(file="/a.py", lines=[5])
+        assert result["error_type"] == "unknown_route"
+
+    def test_forwards_correct_method_and_payload(self):
+        from app.modules.intelligence.tools.dap_tools import set_breakpoints
+
+        with patch(_DISPATCH, return_value=(None, "no_tunnel")) as mock_d, \
+             patch(_CTX, return_value=_CTX_RETURN):
+            set_breakpoints(file="/a.py", lines=[10, 20], condition="x > 5")
+
+        kwargs = mock_d.call_args.kwargs
+        assert kwargs["method"] == "set_breakpoints"
+        assert kwargs["payload"]["file"] == "/a.py"
+        assert kwargs["payload"]["lines"] == [10, 20]
+        assert kwargs["payload"]["condition"] == "x > 5"
+
+
+class TestTakeDebugSnapshot:
+    def test_success_returns_debug_snapshot(self):
+        from app.modules.intelligence.tools.dap_tools import take_debug_snapshot
+
+        with patch(_DISPATCH, return_value=(_snapshot_payload(), None)), \
+             patch(_CTX, return_value=_CTX_RETURN):
+            result = take_debug_snapshot()
+        assert result["session_id"] == "sess-abc"
+        assert result["status"] == "paused"
+        assert result["locals"] == {"x": "42"}
+
+    def test_no_tunnel_returns_dap_error(self):
+        from app.modules.intelligence.tools.dap_tools import take_debug_snapshot
+
+        with patch(_DISPATCH, return_value=(None, "no_tunnel")), patch(_CTX, return_value=_CTX_RETURN):
+            result = take_debug_snapshot()
+        assert result["error_type"] == "no_tunnel"
+
+    def test_unknown_route_returns_dap_error(self):
+        from app.modules.intelligence.tools.dap_tools import take_debug_snapshot
+
+        with patch(_DISPATCH, return_value=(None, "unknown_route")), patch(_CTX, return_value=_CTX_RETURN):
+            result = take_debug_snapshot()
+        assert result["error_type"] == "unknown_route"
+
+    def test_forwards_correct_method_and_payload(self):
+        from app.modules.intelligence.tools.dap_tools import take_debug_snapshot
+
+        with patch(_DISPATCH, return_value=(None, "no_tunnel")) as mock_d, \
+             patch(_CTX, return_value=_CTX_RETURN):
+            take_debug_snapshot(session_id="s1", expressions=["x+1"], wait_for_stop=True)
+
+        kwargs = mock_d.call_args.kwargs
+        assert kwargs["method"] == "snapshot"
+        assert kwargs["payload"]["session_id"] == "s1"
+        assert kwargs["payload"]["expressions"] == ["x+1"]
+        assert kwargs["payload"]["wait"] is True
+
+
+# ---------------------------------------------------------------------------
+# Parametrized step_* tests
+# ---------------------------------------------------------------------------
+
+_STEP_TOOLS = [
+    ("step_over", "step_over"),
+    ("step_into", "step_into"),
+    ("step_out", "step_out"),
+]
+
+
+@pytest.mark.parametrize("tool_name,expected_method", _STEP_TOOLS)
+class TestStepTools:
+    def _get_tool_fn(self, tool_name):
+        import app.modules.intelligence.tools.dap_tools as dap
+        return getattr(dap, tool_name)
+
+    def test_success_returns_debug_snapshot(self, tool_name, expected_method):
+        fn = self._get_tool_fn(tool_name)
+        with patch(_DISPATCH, return_value=(_snapshot_payload(), None)), \
+             patch(_CTX, return_value=_CTX_RETURN):
+            result = fn()
+        assert result["session_id"] == "sess-abc"
+        assert result["status"] == "paused"
+
+    def test_no_tunnel_returns_dap_error(self, tool_name, expected_method):
+        fn = self._get_tool_fn(tool_name)
+        with patch(_DISPATCH, return_value=(None, "no_tunnel")), patch(_CTX, return_value=_CTX_RETURN):
+            result = fn()
+        assert result["error_type"] == "no_tunnel"
+
+    def test_unknown_route_returns_dap_error(self, tool_name, expected_method):
+        fn = self._get_tool_fn(tool_name)
+        with patch(_DISPATCH, return_value=(None, "unknown_route")), patch(_CTX, return_value=_CTX_RETURN):
+            result = fn()
+        assert result["error_type"] == "unknown_route"
+
+    def test_forwards_correct_method(self, tool_name, expected_method):
+        fn = self._get_tool_fn(tool_name)
+        with patch(_DISPATCH, return_value=(None, "no_tunnel")) as mock_d, \
+             patch(_CTX, return_value=_CTX_RETURN):
+            fn(session_id="s1", expressions=["x"])
+        kwargs = mock_d.call_args.kwargs
+        assert kwargs["method"] == expected_method
+        assert kwargs["payload"].get("session_id") == "s1"
+        assert kwargs["payload"].get("expressions") == ["x"]
+
+
+class TestContinueExecution:
+    def test_success_returns_running_snapshot(self):
+        from app.modules.intelligence.tools.dap_tools import continue_execution
+
+        with patch(_DISPATCH, return_value=({"session_id": "s1", "status": "running"}, None)), \
+             patch(_CTX, return_value=_CTX_RETURN):
+            result = continue_execution()
+        assert result["status"] == "running"
+        assert result["session_id"] == "s1"
+
+    def test_no_tunnel_returns_dap_error(self):
+        from app.modules.intelligence.tools.dap_tools import continue_execution
+
+        with patch(_DISPATCH, return_value=(None, "no_tunnel")), patch(_CTX, return_value=_CTX_RETURN):
+            result = continue_execution()
+        assert result["error_type"] == "no_tunnel"
+
+    def test_unknown_route_returns_dap_error(self):
+        from app.modules.intelligence.tools.dap_tools import continue_execution
+
+        with patch(_DISPATCH, return_value=(None, "unknown_route")), patch(_CTX, return_value=_CTX_RETURN):
+            result = continue_execution()
+        assert result["error_type"] == "unknown_route"
+
+    def test_forwards_correct_method_and_payload(self):
+        from app.modules.intelligence.tools.dap_tools import continue_execution
+
+        with patch(_DISPATCH, return_value=(None, "no_tunnel")) as mock_d, \
+             patch(_CTX, return_value=_CTX_RETURN):
+            continue_execution(session_id="s1")
+        kwargs = mock_d.call_args.kwargs
+        assert kwargs["method"] == "continue_execution"
+        assert kwargs["payload"].get("session_id") == "s1"
+
+
+class TestEvaluateExpression:
+    def test_success_returns_evaluate_result(self):
+        from app.modules.intelligence.tools.dap_tools import evaluate_expression
+
+        with patch(_DISPATCH, return_value=({"session_id": "s1", "expression": "x+1", "result": "43", "type": "int"}, None)), \
+             patch(_CTX, return_value=_CTX_RETURN):
+            result = evaluate_expression(expression="x+1")
+        assert result["value"] == "43"
+        assert result["type"] == "int"
+        assert result["expression"] == "x+1"
+
+    def test_no_tunnel_returns_dap_error(self):
+        from app.modules.intelligence.tools.dap_tools import evaluate_expression
+
+        with patch(_DISPATCH, return_value=(None, "no_tunnel")), patch(_CTX, return_value=_CTX_RETURN):
+            result = evaluate_expression(expression="x")
+        assert result["error_type"] == "no_tunnel"
+
+    def test_unknown_route_returns_dap_error(self):
+        from app.modules.intelligence.tools.dap_tools import evaluate_expression
+
+        with patch(_DISPATCH, return_value=(None, "unknown_route")), patch(_CTX, return_value=_CTX_RETURN):
+            result = evaluate_expression(expression="x")
+        assert result["error_type"] == "unknown_route"
+
+    def test_forwards_correct_method_and_payload(self):
+        from app.modules.intelligence.tools.dap_tools import evaluate_expression
+
+        with patch(_DISPATCH, return_value=(None, "no_tunnel")) as mock_d, \
+             patch(_CTX, return_value=_CTX_RETURN):
+            evaluate_expression(expression="y*2", session_id="s1", frame_id=3)
+        kwargs = mock_d.call_args.kwargs
+        assert kwargs["method"] == "evaluate"
+        assert kwargs["payload"]["expression"] == "y*2"
+        assert kwargs["payload"]["frame_id"] == 3
+        assert kwargs["payload"]["session_id"] == "s1"
+
+
+class TestListDebugSessions:
+    def test_success_returns_list_sessions_result(self):
+        from app.modules.intelligence.tools.dap_tools import list_debug_sessions
+
+        raw = [{"session_id": "s1", "program": "/a.py", "language": "python", "status": "paused"}]
+        with patch(_DISPATCH, return_value=(raw, None)), patch(_CTX, return_value=_CTX_RETURN):
+            result = list_debug_sessions()
+        assert "sessions" in result
+        assert result["sessions"][0]["session_id"] == "s1"
+
+    def test_success_with_sessions_key_in_result(self):
+        from app.modules.intelligence.tools.dap_tools import list_debug_sessions
+
+        raw = {"sessions": [{"session_id": "s2", "status": "running"}]}
+        with patch(_DISPATCH, return_value=(raw, None)), patch(_CTX, return_value=_CTX_RETURN):
+            result = list_debug_sessions()
+        assert result["sessions"][0]["session_id"] == "s2"
+
+    def test_no_tunnel_returns_dap_error(self):
+        from app.modules.intelligence.tools.dap_tools import list_debug_sessions
+
+        with patch(_DISPATCH, return_value=(None, "no_tunnel")), patch(_CTX, return_value=_CTX_RETURN):
+            result = list_debug_sessions()
+        assert result["error_type"] == "no_tunnel"
+
+    def test_unknown_route_returns_dap_error(self):
+        from app.modules.intelligence.tools.dap_tools import list_debug_sessions
+
+        with patch(_DISPATCH, return_value=(None, "unknown_route")), patch(_CTX, return_value=_CTX_RETURN):
+            result = list_debug_sessions()
+        assert result["error_type"] == "unknown_route"
+
+    def test_forwards_correct_method(self):
+        from app.modules.intelligence.tools.dap_tools import list_debug_sessions
+
+        with patch(_DISPATCH, return_value=(None, "no_tunnel")) as mock_d, \
+             patch(_CTX, return_value=_CTX_RETURN):
+            list_debug_sessions()
+        kwargs = mock_d.call_args.kwargs
+        assert kwargs["method"] == "list_sessions"
+
+
+class TestStopDebugSession:
+    def test_success_returns_stop_session_result(self):
+        from app.modules.intelligence.tools.dap_tools import stop_debug_session
+
+        with patch(_DISPATCH, return_value=({"session_id": "s1", "stopped": True}, None)), \
+             patch(_CTX, return_value=_CTX_RETURN):
+            result = stop_debug_session(session_id="s1")
+        assert result["session_id"] == "s1"
+        assert result["status"] == "terminated"
+
+    def test_not_found_maps_to_not_found(self):
+        from app.modules.intelligence.tools.dap_tools import stop_debug_session
+
+        with patch(_DISPATCH, return_value=({"session_id": "s1", "stopped": False}, None)), \
+             patch(_CTX, return_value=_CTX_RETURN):
+            result = stop_debug_session(session_id="s1")
+        assert result["status"] == "not_found"
+
+    def test_no_tunnel_returns_dap_error(self):
+        from app.modules.intelligence.tools.dap_tools import stop_debug_session
+
+        with patch(_DISPATCH, return_value=(None, "no_tunnel")), patch(_CTX, return_value=_CTX_RETURN):
+            result = stop_debug_session()
+        assert result["error_type"] == "no_tunnel"
+
+    def test_unknown_route_returns_dap_error(self):
+        from app.modules.intelligence.tools.dap_tools import stop_debug_session
+
+        with patch(_DISPATCH, return_value=(None, "unknown_route")), patch(_CTX, return_value=_CTX_RETURN):
+            result = stop_debug_session()
+        assert result["error_type"] == "unknown_route"
+
+    def test_forwards_correct_method_and_payload(self):
+        from app.modules.intelligence.tools.dap_tools import stop_debug_session
+
+        with patch(_DISPATCH, return_value=(None, "no_tunnel")) as mock_d, \
+             patch(_CTX, return_value=_CTX_RETURN):
+            stop_debug_session(session_id="s1")
+        kwargs = mock_d.call_args.kwargs
+        assert kwargs["method"] == "stop_session"
+        assert kwargs["payload"]["session_id"] == "s1"
+
+
+# ===========================================================================
+# A3.5 — Registration checks (source text inspection, same pattern as A4 tests)
+# ===========================================================================
+
+
+class TestRegistration:
+    def test_all_dap_tools_registered_in_tool_service(self):
+        import pathlib
+
+        tools_dir = (
+            pathlib.Path(__file__).parents[3]
+            / "app"
+            / "modules"
+            / "intelligence"
+            / "tools"
+        )
+        source = (tools_dir / "tool_service.py").read_text(encoding="utf-8")
+
+        expected_keys = [
+            "start_debug_session",
+            "set_breakpoints",
+            "take_debug_snapshot",
+            "step_over",
+            "step_into",
+            "step_out",
+            "continue_execution",
+            "evaluate_expression",
+            "list_debug_sessions",
+            "stop_debug_session",
+        ]
+        for key in expected_keys:
+            assert f'"{key}"' in source or f"'{key}'" in source, (
+                f"tool_service.py is missing registration for '{key}'"
+            )
+
+    def test_all_dap_tools_in_debug_agent_get_tools(self):
+        import ast
+        import pathlib
+
+        src_path = (
+            pathlib.Path(__file__).parents[3]
+            / "app"
+            / "modules"
+            / "intelligence"
+            / "agents"
+            / "chat_agents"
+            / "system_agents"
+            / "debug_agent.py"
+        )
+        source = src_path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        tool_list: list[str] = []
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "get_tools"
+                and node.args
+                and isinstance(node.args[0], ast.List)
+            ):
+                for elt in node.args[0].elts:
+                    if isinstance(elt, ast.Constant):
+                        tool_list.append(elt.value)
+
+        assert tool_list, "Could not find get_tools([...]) call in debug_agent.py"
+
+        expected_keys = [
+            "start_debug_session",
+            "set_breakpoints",
+            "take_debug_snapshot",
+            "step_over",
+            "step_into",
+            "step_out",
+            "continue_execution",
+            "evaluate_expression",
+            "list_debug_sessions",
+            "stop_debug_session",
+        ]
+        for key in expected_keys:
+            assert key in tool_list, (
+                f"'{key}' not found in DebugAgent's get_tools([...]) call. Found: {tool_list}"
+            )
+
+    def test_dap_tools_not_in_embedding_dependent_tools(self):
+        """Verify none of the DAP tools appear in EMBEDDING_DEPENDENT_TOOLS via source text."""
+        import pathlib
+
+        tools_dir = (
+            pathlib.Path(__file__).parents[3]
+            / "app"
+            / "modules"
+            / "intelligence"
+            / "tools"
+        )
+        source = (tools_dir / "tool_service.py").read_text(encoding="utf-8")
+
+        # Find the EMBEDDING_DEPENDENT_TOOLS block
+        start = source.find("EMBEDDING_DEPENDENT_TOOLS")
+        assert start != -1, "Could not find EMBEDDING_DEPENDENT_TOOLS in tool_service.py"
+        # Extract the set literal (up to its closing brace)
+        block_start = source.find("{", start)
+        block_end = source.find("}", block_start)
+        assert block_start != -1 and block_end != -1
+        embedding_block = source[block_start : block_end + 1]
+
+        dap_tools = [
+            "start_debug_session", "set_breakpoints", "take_debug_snapshot",
+            "step_over", "step_into", "step_out", "continue_execution",
+            "evaluate_expression", "list_debug_sessions", "stop_debug_session",
+        ]
+        for tool in dap_tools:
+            assert tool not in embedding_block, (
+                f"DAP tool '{tool}' should NOT be in EMBEDDING_DEPENDENT_TOOLS"
+            )
+
+
+# ===========================================================================
+# A3.5 — StructuredTool factory sanity checks
+# ===========================================================================
+
+
+class TestToolFactories:
+    @pytest.mark.parametrize("factory_name,expected_tool_name", [
+        ("start_debug_session_tool", "start_debug_session"),
+        ("set_breakpoints_tool", "set_breakpoints"),
+        ("take_debug_snapshot_tool", "take_debug_snapshot"),
+        ("step_over_tool", "step_over"),
+        ("step_into_tool", "step_into"),
+        ("step_out_tool", "step_out"),
+        ("continue_execution_tool", "continue_execution"),
+        ("evaluate_expression_tool", "evaluate_expression"),
+        ("list_debug_sessions_tool", "list_debug_sessions"),
+        ("stop_debug_session_tool", "stop_debug_session"),
+    ])
+    def test_factory_returns_structured_tool_with_correct_name(self, factory_name, expected_tool_name):
+        from langchain_core.tools import StructuredTool
+        import app.modules.intelligence.tools.dap_tools as dap
+
+        factory = getattr(dap, factory_name)
+        tool = factory()
+        assert isinstance(tool, StructuredTool)
+        assert tool.name == expected_tool_name

--- a/tests/unit/intelligence/test_dap_tools.py
+++ b/tests/unit/intelligence/test_dap_tools.py
@@ -146,6 +146,23 @@ class TestStartSessionResultSchema:
         assert r.message is None
 
 
+class TestStartDebugSessionInputSchema:
+    def test_args_is_launch_config_object(self):
+        from app.modules.intelligence.tools.dap_tools import StartDebugSessionInput
+
+        inp = StartDebugSessionInput(
+            program="/a.py",
+            args={"args": ["--flag"], "stopOnEntry": True},
+        )
+        assert inp.args == {"args": ["--flag"], "stopOnEntry": True}
+
+    def test_args_rejects_raw_list_in_tool_schema(self):
+        from app.modules.intelligence.tools.dap_tools import StartDebugSessionInput
+
+        with pytest.raises(ValidationError):
+            StartDebugSessionInput(program="/a.py", args=["--flag"])  # type: ignore[arg-type]
+
+
 class TestSetBreakpointsResultSchema:
     def test_round_trip(self):
         from app.modules.intelligence.tools.dap_schemas import SetBreakpointsResult
@@ -280,7 +297,8 @@ class TestDapErrorSchema:
 
     @pytest.mark.parametrize("etype", [
         "no_tunnel", "unknown_route", "timeout",
-        "tunnel_unreachable", "no_user_id", "unknown_error",
+        "tunnel_unreachable", "backend_socket_error", "extension_error",
+        "no_user_id", "unknown_error",
     ])
     def test_all_valid_error_types(self, etype):
         from app.modules.intelligence.tools.dap_schemas import DapError
@@ -303,6 +321,26 @@ class TestMakeDapError:
         assert err["error_type"] == "no_user_id"
         assert "user" in err["message"].lower()
         assert err["message"] != _NO_TUNNEL_MSG
+
+    def test_dap_error_backend_loop_mismatch_not_reported_as_tunnel_drop(self):
+        from app.modules.intelligence.tools.dap_tools import _make_dap_error
+
+        err = _make_dap_error(error_type="backend_loop_mismatch", context="snapshot").model_dump(mode="json")
+
+        assert err["error"] == "backend_loop_mismatch"
+        assert err["error_type"] == "backend_socket_error"
+        assert "not evidence" in err["message"]
+        assert "disconnected" in err["message"]
+
+    def test_dap_error_extension_error_not_reported_as_tunnel_drop(self):
+        from app.modules.intelligence.tools.dap_tools import _make_dap_error
+
+        err = _make_dap_error(error_type="debug adapter not available", context="start_session").model_dump(mode="json")
+
+        assert err["error"] == "debug adapter not available"
+        assert err["error_type"] == "extension_error"
+        assert "debug adapter" in err["message"]
+        assert "Reconnect and retry" not in err["message"]
 
 
 # ===========================================================================
@@ -498,6 +536,109 @@ class TestRouteDapCommand:
         assert result is None
         assert err == "unknown_route"
 
+    def test_socket_route_hyphenizes_method_endpoint(self):
+        from unittest.mock import patch as _patch
+        from app.modules.intelligence.tools.local_search_tools.tunnel_utils import route_dap_command
+
+        mock_svc = MagicMock()
+        mock_svc.get_tunnel_url.return_value = "socket://workspace-1"
+        mock_svc.get_workspace_id.return_value = "workspace-1"
+
+        with _patch(
+            "app.modules.tunnel.tunnel_service.get_tunnel_service",
+            return_value=mock_svc,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_tunnel_url",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_repository",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_branch",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.local_search_tools.tunnel_utils._execute_via_socket",
+            return_value={"session_id": "s1", "status": "paused"},
+        ) as mock_socket:
+            result, err = route_dap_command(
+                method="continue_execution",
+                payload={},
+                user_id="u1",
+                conversation_id="c1",
+            )
+
+        assert err is None
+        assert result["session_id"] == "s1"
+        assert mock_socket.call_args.kwargs["endpoint"] == "/api/debug/continue-execution"
+
+    def test_socket_timeout_returns_timeout_code(self):
+        from unittest.mock import patch as _patch
+        from app.modules.intelligence.tools.local_search_tools.tunnel_utils import route_dap_command
+
+        mock_svc = MagicMock()
+        mock_svc.get_tunnel_url.return_value = "socket://workspace-1"
+        mock_svc.get_workspace_id.return_value = "workspace-1"
+
+        with _patch(
+            "app.modules.tunnel.tunnel_service.get_tunnel_service",
+            return_value=mock_svc,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_tunnel_url",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_repository",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_branch",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.local_search_tools.tunnel_utils._execute_via_socket",
+            return_value=(None, "timeout"),
+        ):
+            result, err = route_dap_command(
+                method="start_session",
+                payload={"program": "a.py"},
+                user_id="u1",
+                conversation_id="c1",
+            )
+
+        assert result is None
+        assert err == "timeout"
+
+    def test_socket_extension_error_is_preserved(self):
+        from unittest.mock import patch as _patch
+        from app.modules.intelligence.tools.local_search_tools.tunnel_utils import route_dap_command
+
+        mock_svc = MagicMock()
+        mock_svc.get_tunnel_url.return_value = "socket://workspace-1"
+        mock_svc.get_workspace_id.return_value = "workspace-1"
+
+        with _patch(
+            "app.modules.tunnel.tunnel_service.get_tunnel_service",
+            return_value=mock_svc,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_tunnel_url",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_repository",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_branch",
+            return_value=None,
+        ), _patch(
+            "app.modules.intelligence.tools.local_search_tools.tunnel_utils._execute_via_socket",
+            return_value=(None, "debug adapter not available"),
+        ):
+            result, err = route_dap_command(
+                method="start_session",
+                payload={"program": "a.py"},
+                user_id="u1",
+                conversation_id="c1",
+            )
+
+        assert result is None
+        assert err == "debug adapter not available"
+
 
 # ===========================================================================
 # A3.3 — Per-tool tests
@@ -534,7 +675,13 @@ class TestStartDebugSession:
 
         with patch(_DISPATCH, return_value=(None, "no_tunnel")) as mock_d, \
              patch(_CTX, return_value=_CTX_RETURN):
-            start_debug_session(program="/a.py", language="python", mode="launch", port=5678)
+            start_debug_session(
+                program="/a.py",
+                language="python",
+                mode="launch",
+                port=5678,
+                args={"stopOnEntry": True},
+            )
 
         mock_d.assert_called_once()
         kwargs = mock_d.call_args.kwargs if mock_d.call_args.kwargs else {}
@@ -546,6 +693,17 @@ class TestStartDebugSession:
         payload_val = kwargs.get("payload") or (args[1] if len(args) > 1 else None)
         assert payload_val["program"] == "/a.py"
         assert payload_val["port"] == 5678
+        assert payload_val["args"] == {"stopOnEntry": True}
+
+    def test_legacy_argv_list_is_wrapped_as_launch_config_args(self):
+        from app.modules.intelligence.tools.dap_tools import start_debug_session
+
+        with patch(_DISPATCH, return_value=(None, "no_tunnel")) as mock_d, \
+             patch(_CTX, return_value=_CTX_RETURN):
+            start_debug_session(program="/a.py", args=["--flag"])
+
+        payload = mock_d.call_args.kwargs["payload"]
+        assert payload["args"] == {"args": ["--flag"]}
 
     def test_does_not_raise_on_exception(self):
         from app.modules.intelligence.tools.dap_tools import start_debug_session
@@ -727,6 +885,14 @@ class TestEvaluateExpression:
         assert result["type"] == "int"
         assert result["expression"] == "x+1"
 
+    def test_preserves_falsy_extension_result_values(self):
+        from app.modules.intelligence.tools.dap_tools import evaluate_expression
+
+        with patch(_DISPATCH, return_value=({"session_id": "s1", "expression": "x", "result": 0}, None)), \
+             patch(_CTX, return_value=_CTX_RETURN):
+            result = evaluate_expression(expression="x")
+        assert result["value"] == "0"
+
     def test_no_tunnel_returns_dap_error(self):
         from app.modules.intelligence.tools.dap_tools import evaluate_expression
 
@@ -840,6 +1006,102 @@ class TestStopDebugSession:
 
 
 # ===========================================================================
+# A3.6 — Extension contract parsing with stubbed responder shapes
+# ===========================================================================
+
+
+class TestExtensionContractShapes:
+    def test_each_dap_tool_parses_extension_json_shapes(self):
+        import app.modules.intelligence.tools.dap_tools as dap
+
+        def fake_dispatch(method, payload, user_id, conversation_id=None, timeout=30.0):
+            assert user_id == _CTX_RETURN[0]
+            if method == "start_session":
+                return {
+                    "session_id": "sess-1",
+                    "program": payload["program"],
+                    "language": payload["language"],
+                    "status": "initialized",
+                }, None
+            if method == "set_breakpoints":
+                return {
+                    "session_id": "sess-1",
+                    "file": payload["file"],
+                    "breakpoints": [{"line": 25, "verified": True}],
+                }, None
+            if method in {"snapshot", "step_over", "step_into", "step_out"}:
+                return {
+                    "session_id": "sess-1",
+                    "status": "paused",
+                    "paused_at": {"file": "/repo/app.py", "line": 25, "function": "main"},
+                    "call_stack": [
+                        {"frame_id": 1, "function": "main", "file": "/repo/app.py", "line": 25}
+                    ],
+                    "locals": {"x": "10", "y": "20"},
+                    "expression_results": [
+                        {"expression": "x + y", "result": "30"}
+                    ],
+                }, None
+            if method == "continue_execution":
+                return {"session_id": "sess-1", "status": "running"}, None
+            if method == "evaluate":
+                return {
+                    "session_id": "sess-1",
+                    "expression": payload["expression"],
+                    "result": "30",
+                }, None
+            if method == "list_sessions":
+                return {
+                    "sessions": [
+                        {
+                            "session_id": "sess-1",
+                            "program": "/repo/app.py",
+                            "language": "python",
+                            "status": "paused",
+                            "createdAt": "2026-05-21T00:00:00Z",
+                        }
+                    ]
+                }, None
+            if method == "stop_session":
+                return {"session_id": "sess-1", "stopped": True}, None
+            raise AssertionError(f"Unexpected method: {method}")
+
+        with patch(_DISPATCH, side_effect=fake_dispatch), patch(_CTX, return_value=_CTX_RETURN):
+            start = dap.start_debug_session(
+                program="/repo/app.py",
+                language="python",
+                args={"stopOnEntry": True},
+            )
+            bps = dap.set_breakpoints(file="/repo/app.py", lines=[25])
+            snapshot = dap.take_debug_snapshot(
+                session_id="sess-1",
+                expressions=["x + y"],
+                wait_for_stop=True,
+            )
+            step = dap.step_over(session_id="sess-1", expressions=["x + y"])
+            continued = dap.continue_execution(session_id="sess-1")
+            evaluated = dap.evaluate_expression(
+                expression="x + y",
+                session_id="sess-1",
+                frame_id=1,
+            )
+            sessions = dap.list_debug_sessions()
+            stopped = dap.stop_debug_session(session_id="sess-1")
+
+        assert start["status"] == "initialized"
+        assert bps["breakpoints"][0]["verified"] is True
+        assert snapshot["call_stack"][0]["name"] == "main"
+        assert snapshot["call_stack"][0]["source_path"] == "/repo/app.py"
+        assert snapshot["locals"] == {"x": "10", "y": "20"}
+        assert snapshot["expression_results"][0]["result"] == "30"
+        assert step["expression_results"][0]["expression"] == "x + y"
+        assert continued["status"] == "running"
+        assert evaluated["value"] == "30"
+        assert sessions["sessions"][0]["created_at"] == "2026-05-21T00:00:00Z"
+        assert stopped["status"] == "terminated"
+
+
+# ===========================================================================
 # A3.5 — Registration checks (source text inspection, same pattern as A4 tests)
 # ===========================================================================
 
@@ -875,36 +1137,17 @@ class TestRegistration:
             )
 
     def test_all_dap_tools_in_debug_agent_get_tools(self):
-        import ast
-        import pathlib
-
-        src_path = (
-            pathlib.Path(__file__).parents[3]
-            / "app"
-            / "modules"
-            / "intelligence"
-            / "agents"
-            / "chat_agents"
-            / "system_agents"
-            / "debug_agent.py"
+        from app.modules.intelligence.agents.chat_agents.system_agents.debug_agent import (
+            DEBUG_AGENT_BASE_TOOLS,
+            DEBUG_AGENT_DAP_TOOLS,
+            DEBUG_AGENT_TERMINAL_TOOLS,
         )
-        source = src_path.read_text(encoding="utf-8")
-        tree = ast.parse(source)
 
-        tool_list: list[str] = []
-        for node in ast.walk(tree):
-            if (
-                isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Attribute)
-                and node.func.attr == "get_tools"
-                and node.args
-                and isinstance(node.args[0], ast.List)
-            ):
-                for elt in node.args[0].elts:
-                    if isinstance(elt, ast.Constant):
-                        tool_list.append(elt.value)
-
-        assert tool_list, "Could not find get_tools([...]) call in debug_agent.py"
+        tool_list = (
+            list(DEBUG_AGENT_BASE_TOOLS)
+            + list(DEBUG_AGENT_DAP_TOOLS)
+            + list(DEBUG_AGENT_TERMINAL_TOOLS)
+        )
 
         expected_keys = [
             "start_debug_session",
@@ -920,7 +1163,7 @@ class TestRegistration:
         ]
         for key in expected_keys:
             assert key in tool_list, (
-                f"'{key}' not found in DebugAgent's get_tools([...]) call. Found: {tool_list}"
+                f"'{key}' not found in DebugAgent's tool allow-list. Found: {tool_list}"
             )
 
     def test_dap_tools_not_in_embedding_dependent_tools(self):

--- a/tests/unit/intelligence/test_debug_agent_end_to_end.py
+++ b/tests/unit/intelligence/test_debug_agent_end_to_end.py
@@ -1,0 +1,1165 @@
+"""End-to-end integration tests — DebugAgent hypothesis creation.
+
+These tests verify that the agent machinery (wrap_structured_tools →
+RecordHypothesisInput validation → record_hypothesis → HypothesisStore)
+works correctly in the complete tool-call pipeline.
+
+Two levels:
+
+A. Tool-pipeline tests
+   Uses pydantic_ai's FunctionModel (no real LLM API) to drive the agent.
+   FunctionModel emits controlled tool calls; we verify the hypothesis
+   store is populated correctly after the run.
+
+B. Prompt-format consistency tests
+   Confirm that the prompt's record_hypothesis example shows list syntax
+   rather than string syntax — the mismatch is what caused the bug in
+   production traces 019e44e1... and 019e44dc...
+
+Design rationale
+----------------
+Production traces 019e44e1... and 019e44dc... showed two consistency failures:
+
+  1. Both agents called record_hypothesis with evidence/validation_plan as
+     multi-line strings (matching the prompt example), but RecordHypothesisInput
+     expects List[str]. This caused pydantic ValidationError → handle_exception
+     returned "An internal error occurred." → hypothesis store stayed empty →
+     the agent fell back to prose analysis, skipping Phases 5-7 entirely.
+
+  2. The Gemini trace grew to 112 K tokens in Phase 3 before completing Phase 4,
+     hitting the model's max_tokens limit mid-analysis.
+
+These tests guard against regression of failure (1).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Env vars required before any app import (same pattern as test_debug_agent_routing.py)
+# ---------------------------------------------------------------------------
+os.environ.setdefault("POSTGRES_SERVER", "postgresql://test:test@localhost:5432/testdb")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+
+
+# ---------------------------------------------------------------------------
+# Stub out heavy ML packages that are pulled in through the import chain.
+# Only stubs if the real package isn't already loaded in this environment.
+# ---------------------------------------------------------------------------
+def _register_stub(name: str, **attrs: object) -> types.ModuleType:
+    mod = sys.modules.get(name)
+    if mod is None:
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    return mod
+
+
+_torch_stub = _register_stub("torch")
+_register_stub("torch.nn", functional=MagicMock())
+_register_stub("torch.nn.functional")
+_register_stub("torch.nn.modules")
+_register_stub("torch._jit_internal")
+_register_stub("torch._sources")
+_register_stub("torch._VF")
+_torch_stub._VF = MagicMock()  # type: ignore[attr-defined]
+_torch_stub.functional = MagicMock()  # type: ignore[attr-defined]
+_torch_stub.nn = sys.modules["torch.nn"]  # type: ignore[attr-defined]
+_st_stub = _register_stub("sentence_transformers")
+_st_stub.SentenceTransformer = MagicMock(name="SentenceTransformer")  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Shared imports (deferred until after stubs are in place)
+# ---------------------------------------------------------------------------
+from pydantic_ai import Agent  # noqa: E402
+from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart  # noqa: E402
+from pydantic_ai.models.function import FunctionModel  # noqa: E402
+
+from app.modules.intelligence.agents.chat_agents.multi_agent.utils.tool_utils import (  # noqa: E402
+    wrap_structured_tools,
+)
+from app.modules.intelligence.tools.hypothesis_state_tool import (  # noqa: E402
+    HypothesisStore,
+    _hypothesis_store_ctx,
+    create_hypothesis_state_tools,
+    list_hypotheses,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def fresh_hypothesis_store():
+    """Each test gets its own isolated HypothesisStore."""
+    store = HypothesisStore(conversation_id="end-to-end-test")
+    _hypothesis_store_ctx.set(store)
+    yield store
+    _hypothesis_store_ctx.set(None)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_function_model(tool_calls: list[dict], final_text: str) -> FunctionModel:
+    """Return a FunctionModel that emits *tool_calls* sequentially, then *final_text*.
+
+    tool_calls: list of dicts with keys 'name' and 'args' (dict).
+    """
+    state = {"index": 0}
+
+    def model_fn(messages: list, info: object) -> ModelResponse:
+        idx = state["index"]
+        state["index"] += 1
+        if idx < len(tool_calls):
+            tc = tool_calls[idx]
+            return ModelResponse(
+                parts=[ToolCallPart(tool_name=tc["name"], args=tc["args"])]
+            )
+        return ModelResponse(parts=[TextPart(content=final_text)])
+
+    return FunctionModel(model_fn)
+
+
+def _run_agent(model: FunctionModel, user_message: str) -> str:
+    """Run a pydantic_ai Agent with the real hypothesis tools and return its output."""
+    hypothesis_tools = create_hypothesis_state_tools()
+    wrapped = wrap_structured_tools(hypothesis_tools)
+    agent = Agent(
+        model=model,
+        tools=wrapped,
+        system_prompt="You are a hypothesis-driven debugging agent.",
+    )
+
+    async def _run():
+        result = await agent.run(user_message)
+        return result.output
+
+    return asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# A1. Happy path — list evidence flows through to the store
+# ---------------------------------------------------------------------------
+
+
+def test_agent_creates_hypothesis_with_list_evidence():
+    """The pipeline must populate the hypothesis store when the LLM passes list evidence.
+
+    This is the 'works correctly' baseline. If this test fails, the tool
+    registration or wrap_structured_tools machinery is broken.
+    """
+    model = _make_function_model(
+        tool_calls=[
+            {
+                "name": "record_hypothesis",
+                "args": {
+                    "title": "Zero-length check missing in zipmapValidateIntegrity",
+                    "status": "proposed",
+                    "evidence": [
+                        "ASan shows heap-buffer-overflow in zipmapNext at rdb.c:2408",
+                        "Error message: Hash zipmap with big length (0)",
+                    ],
+                    "validation_plan": [
+                        "Set breakpoint at zipmapValidateIntegrity",
+                        "Verify length == 0 is not rejected by validation",
+                    ],
+                },
+            }
+        ],
+        final_text=(
+            "## Hypothesis 1: Zero-length check missing in zipmapValidateIntegrity\n\n"
+            "### Status: proposed\n\n"
+            "### Evidence\n\n"
+            "- ASan shows heap-buffer-overflow in zipmapNext at rdb.c:2408\n\n"
+            "---"
+        ),
+    )
+
+    _run_agent(model, "AddressSanitizer: heap-buffer-overflow in zipmapNext")
+
+    stored = list_hypotheses()["hypotheses"]
+    assert len(stored) == 1, f"Expected 1 hypothesis in store, got {len(stored)}"
+    assert stored[0]["id"] == "hyp_1"
+    assert stored[0]["status"] == "proposed"
+    assert len(stored[0]["evidence"]) == 2
+
+
+def test_agent_creates_multiple_hypotheses_in_order():
+    """The store must hold all hypotheses in creation order with sequential ids."""
+    model = _make_function_model(
+        tool_calls=[
+            {
+                "name": "record_hypothesis",
+                "args": {
+                    "title": "Hypothesis A: primary root cause",
+                    "evidence": ["Frame rdb.c:2408 in zipmapNext"],
+                    "validation_plan": ["Breakpoint at zipmapValidateIntegrity"],
+                },
+            },
+            {
+                "name": "record_hypothesis",
+                "args": {
+                    "title": "Hypothesis B: secondary candidate",
+                    "evidence": ["Frame rdb.c:2401 in rdbLoadObject"],
+                    "validation_plan": ["Breakpoint at rdbLoadObject"],
+                },
+            },
+        ],
+        final_text=(
+            "## Hypothesis 1: Hypothesis A ...\n---\n"
+            "## Hypothesis 2: Hypothesis B ...\n---"
+        ),
+    )
+
+    _run_agent(model, "heap-buffer-overflow")
+
+    stored = list_hypotheses()["hypotheses"]
+    assert len(stored) == 2
+    assert stored[0]["id"] == "hyp_1"
+    assert stored[1]["id"] == "hyp_2"
+    assert "primary" in stored[0]["title"]
+    assert "secondary" in stored[1]["title"]
+
+
+# ---------------------------------------------------------------------------
+# A2. String-evidence path — the production bug from traces 019e44e1 / 019e44dc
+# ---------------------------------------------------------------------------
+
+
+def test_agent_creates_hypothesis_with_string_evidence():
+    """The pipeline must NOT silently drop the hypothesis when the LLM passes
+    evidence as a multi-line string instead of a list.
+
+    Root-cause reproduction: both production traces showed the LLM following the
+    prompt example and passing evidence as a string. Without schema coercion,
+    RecordHypothesisInput raised ValidationError → handle_exception returned
+    'An internal error occurred.' → hypothesis store stayed empty.
+
+    After the fix (field_validator coercing str to List[str]), the hypothesis
+    must land in the store.
+    """
+    model = _make_function_model(
+        tool_calls=[
+            {
+                "name": "record_hypothesis",
+                "args": {
+                    "title": "Zero-length check missing in zipmapValidateIntegrity",
+                    "status": "proposed",
+                    "evidence": (
+                        "- ASan shows heap-buffer-overflow in zipmapNext at rdb.c:2408\n"
+                        "- Error message: Hash zipmap with big length (0)"
+                    ),
+                    "validation_plan": (
+                        "- Set breakpoint at zipmapValidateIntegrity\n"
+                        "- Verify length == 0 is not rejected"
+                    ),
+                },
+            }
+        ],
+        final_text="## Hypothesis 1: ...\n---",
+    )
+
+    _run_agent(model, "heap-buffer-overflow in zipmapNext")
+
+    stored = list_hypotheses()["hypotheses"]
+    assert len(stored) == 1, (
+        f"Expected 1 hypothesis in store after string-evidence call, got {len(stored)}. "
+        "This indicates RecordHypothesisInput is still rejecting string evidence — "
+        "the field_validator coercion fix is missing."
+    )
+    assert stored[0]["status"] == "proposed"
+    # Coerced evidence must be a non-empty list, not a raw string
+    assert isinstance(stored[0]["evidence"], list)
+    assert len(stored[0]["evidence"]) >= 1
+
+
+def test_agent_creates_hypothesis_with_mixed_format_evidence():
+    """Validate that a mix of list items for one field and string for another both work."""
+    model = _make_function_model(
+        tool_calls=[
+            {
+                "name": "record_hypothesis",
+                "args": {
+                    "title": "Mixed format test",
+                    "evidence": ["Proper list item"],  # list — no coercion needed
+                    "validation_plan": "- Step A\n- Step B",  # string — needs coercion
+                },
+            }
+        ],
+        final_text="Done",
+    )
+
+    _run_agent(model, "some error")
+
+    stored = list_hypotheses()["hypotheses"]
+    assert len(stored) == 1
+    assert stored[0]["evidence"] == ["Proper list item"]
+    assert isinstance(stored[0]["validation_plan"], list)
+    assert len(stored[0]["validation_plan"]) >= 1
+
+
+# ---------------------------------------------------------------------------
+# A3. Post-creation tool interactions — update_hypothesis_status + list_hypotheses
+# ---------------------------------------------------------------------------
+
+
+def test_agent_can_update_hypothesis_status_after_recording():
+    """After record_hypothesis succeeds, update_hypothesis_status must find the record."""
+    model = _make_function_model(
+        tool_calls=[
+            {
+                "name": "record_hypothesis",
+                "args": {
+                    "title": "Status update test",
+                    "evidence": ["Initial observation"],
+                    "validation_plan": ["Step 1"],
+                },
+            },
+            {
+                "name": "update_hypothesis_status",
+                "args": {"hypothesis_id": "hyp_1", "status": "debugging"},
+            },
+        ],
+        final_text="### Status: debugging",
+    )
+
+    _run_agent(model, "testing status update")
+
+    stored = list_hypotheses()["hypotheses"]
+    assert len(stored) == 1
+    assert stored[0]["status"] == "debugging"
+
+
+def test_agent_list_hypotheses_returns_all_created():
+    """list_hypotheses tool call must reflect all hypotheses in the store."""
+    model = _make_function_model(
+        tool_calls=[
+            {
+                "name": "record_hypothesis",
+                "args": {"title": "H1", "evidence": ["e1"], "validation_plan": ["p1"]},
+            },
+            {
+                "name": "record_hypothesis",
+                "args": {"title": "H2", "evidence": ["e2"], "validation_plan": ["p2"]},
+            },
+            {"name": "list_hypotheses", "args": {}},
+        ],
+        final_text="Listed all hypotheses.",
+    )
+
+    _run_agent(model, "list all hypotheses")
+
+    stored = list_hypotheses()["hypotheses"]
+    assert len(stored) == 2
+    titles = {h["title"] for h in stored}
+    assert titles == {"H1", "H2"}
+
+
+# ---------------------------------------------------------------------------
+# B. Prompt-format consistency — guard against the prompt reverting to string example
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_record_hypothesis_example_shows_list_evidence():
+    """The prompt's record_hypothesis example must show evidence as a Python list,
+    not as a string literal.
+
+    When the example shows evidence="<string>", the LLM follows it and passes a
+    string, which (without schema coercion) causes ValidationError.
+    """
+    from app.modules.intelligence.agents.chat_agents.system_agents.debug_agent_prompt import (
+        debug_task_prompt,
+    )
+
+    # Find the record_hypothesis code block in the prompt
+    assert "record_hypothesis(" in debug_task_prompt, (
+        "Prompt must contain a record_hypothesis() call example"
+    )
+
+    rh_start = debug_task_prompt.find("record_hypothesis(")
+    rh_end = debug_task_prompt.find(")", rh_start) + 1
+    # Extend to include multi-line block (find matching closing paren)
+    depth = 0
+    for i, ch in enumerate(debug_task_prompt[rh_start:], start=rh_start):
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                rh_end = i + 1
+                break
+    rh_block = debug_task_prompt[rh_start:rh_end]
+
+    # The evidence argument must use list syntax [...] not string syntax "..."
+    assert "evidence=[" in rh_block, (
+        "The record_hypothesis() example in the prompt must use "
+        "evidence=[...] (list syntax) rather than evidence='...' (string syntax). "
+        "String syntax causes the LLM to pass a string, which fails pydantic "
+        "validation and returns 'An internal error occurred.'\n\n"
+        f"Found block:\n{rh_block}"
+    )
+    assert "validation_plan=[" in rh_block, (
+        "The record_hypothesis() example in the prompt must use "
+        "validation_plan=[...] (list syntax) rather than validation_plan='...' (string syntax).\n\n"
+        f"Found block:\n{rh_block}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# C. PydanticDeepDebugAgent — streaming + Logfire instrumentation
+# ---------------------------------------------------------------------------
+#
+# These tests mock `pydantic_deep.create_deep_agent` so we can drive the
+# adapter without a real LLM. We synthesize the node/event stream that
+# PydanticDeepDebugAgent.run_stream consumes and assert the shape of the
+# yielded ChatAgentResponse / ToolCallResponse objects.
+# ---------------------------------------------------------------------------
+
+from contextlib import asynccontextmanager  # noqa: E402
+from dataclasses import dataclass  # noqa: E402
+from typing import Any, Iterable, List as _List  # noqa: E402
+from unittest.mock import patch  # noqa: E402
+
+from pydantic_ai.messages import (  # noqa: E402
+    FunctionToolCallEvent,
+    FunctionToolResultEvent,
+    PartDeltaEvent,
+    PartStartEvent,
+    TextPartDelta,
+    ToolReturnPart,
+)
+
+from app.modules.intelligence.agents.chat_agent import (  # noqa: E402
+    ChatContext,
+    ToolCallEventType,
+)
+from app.modules.intelligence.agents.chat_agents.agent_config import (  # noqa: E402
+    AgentConfig,
+    TaskConfig,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — fake pydantic-deep agent that synthesizes node events
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ModelRequestNodeStub:
+    """Marker node yielded by the fake run, treated as a model-request node."""
+
+    events: _List[Any]
+
+
+@dataclass
+class _CallToolsNodeStub:
+    """Marker node yielded by the fake run, treated as a call-tools node."""
+
+    events: _List[Any]
+
+
+@dataclass
+class _EndNodeStub:
+    """Marker node yielded by the fake run, treated as the end node."""
+
+
+class _FakeAgentRun:
+    """Mimics the async iterator returned by ``agent.iter().__aenter__()``."""
+
+    def __init__(self, nodes: Iterable[Any]):
+        self._nodes = list(nodes)
+        self.ctx = MagicMock(name="run_ctx")
+
+    def __aiter__(self):
+        return self._iter()
+
+    async def _iter(self):
+        for node in self._nodes:
+            # Wire the per-node stream() helper used by the adapter
+            events = getattr(node, "events", [])
+            node.stream = lambda _ctx, events=events: _stream_cm(events)
+            yield node
+
+
+@asynccontextmanager
+async def _stream_cm(events: _List[Any]):
+    async def _gen():
+        for ev in events:
+            yield ev
+
+    yield _gen()
+
+
+def _make_fake_agent(nodes: Iterable[Any]):
+    """Return a fake pydantic-deep Agent whose .iter() yields *nodes*."""
+    fake_agent = MagicMock(name="FakeDeepAgent")
+
+    @asynccontextmanager
+    async def _iter_cm(*args: Any, **kwargs: Any):
+        yield _FakeAgentRun(nodes)
+
+    fake_agent.iter = lambda *args, **kwargs: _iter_cm(*args, **kwargs)
+    # `run` is used by the non-stream path; default to AsyncMock-style coroutine.
+    async def _run(*args: Any, **kwargs: Any):
+        result = MagicMock()
+        result.output = "fake-non-stream-output"
+        return result
+
+    fake_agent.run = _run
+    return fake_agent
+
+
+def _patch_node_type_checks():
+    """Patch pydantic_ai.Agent.is_*_node so they recognize our marker stubs.
+
+    Returns a context-manager helper that may be used with ``with``."""
+    from app.modules.intelligence.agents.chat_agents import pydantic_deep_debug_agent
+
+    return patch.multiple(
+        pydantic_deep_debug_agent.Agent,
+        is_model_request_node=staticmethod(
+            lambda node: isinstance(node, _ModelRequestNodeStub)
+        ),
+        is_call_tools_node=staticmethod(
+            lambda node: isinstance(node, _CallToolsNodeStub)
+        ),
+        is_end_node=staticmethod(lambda node: isinstance(node, _EndNodeStub)),
+    )
+
+
+def _make_agent_config() -> AgentConfig:
+    return AgentConfig(
+        role="DebugAgent",
+        goal="Diagnose failures.",
+        backstory="A focused debugger.",
+        tasks=[
+            TaskConfig(
+                description="Debug the user's issue.",
+                expected_output="Markdown response",
+            )
+        ],
+    )
+
+
+def _make_chat_context(**overrides: Any) -> ChatContext:
+    kwargs: dict[str, Any] = dict(
+        project_id="proj-debug",
+        project_name="potpie",
+        curr_agent_id="debug_agent",
+        history=[],
+        query="my code is broken",
+        user_id="user-123",
+        conversation_id="conv-456",
+        local_mode=False,
+    )
+    kwargs.update(overrides)
+    return ChatContext(**kwargs)
+
+
+def _build_debug_agent(tools=None):
+    """Construct a PydanticDeepDebugAgent with mocks for llm/tools."""
+    from app.modules.intelligence.agents.chat_agents.pydantic_deep_debug_agent import (
+        PydanticDeepDebugAgent,
+    )
+
+    llm_provider = MagicMock(name="llm_provider")
+    llm_provider.get_pydantic_model.return_value = MagicMock(name="pydantic_model")
+    return PydanticDeepDebugAgent(
+        llm_provider=llm_provider,
+        config=_make_agent_config(),
+        tools=tools or [],
+    )
+
+
+def _make_part_start_event(content: str) -> PartStartEvent:
+    return PartStartEvent(index=0, part=TextPart(content=content))
+
+
+def _make_part_delta_event(content_delta: str) -> PartDeltaEvent:
+    return PartDeltaEvent(index=0, delta=TextPartDelta(content_delta=content_delta))
+
+
+def _make_tool_call_event(name: str, call_id: str, args: dict) -> FunctionToolCallEvent:
+    return FunctionToolCallEvent(
+        part=ToolCallPart(tool_name=name, tool_call_id=call_id, args=args)
+    )
+
+
+def _make_tool_result_event(name: str, call_id: str, result: str) -> FunctionToolResultEvent:
+    return FunctionToolResultEvent(
+        result=ToolReturnPart(
+            tool_name=name,
+            tool_call_id=call_id,
+            content=result,
+        )
+    )
+
+
+async def _collect_stream(agent, ctx):
+    out: list = []
+    async for chunk in agent.run_stream(ctx):
+        out.append(chunk)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# C1. Smoke test for text streaming
+# ---------------------------------------------------------------------------
+
+
+def test_pydantic_deep_debug_agent_streams_text_deltas():
+    """Text from PartStartEvent + PartDeltaEvent should reach the consumer.
+
+    Validates the core streaming contract: each text event becomes a
+    ChatAgentResponse with that text in ``response``."""
+    agent = _build_debug_agent()
+
+    fake_pd = _make_fake_agent(
+        nodes=[
+            _ModelRequestNodeStub(
+                events=[
+                    _make_part_start_event("Hello "),
+                    _make_part_delta_event("world"),
+                    _make_part_delta_event("!"),
+                ]
+            ),
+            _EndNodeStub(),
+        ]
+    )
+
+    captured: dict[str, Any] = {}
+
+    def _capture_create_deep_agent(*args: Any, **kwargs: Any):
+        captured["instrument"] = kwargs.get("instrument")
+        return fake_pd
+
+    ctx = _make_chat_context()
+
+    with patch(
+        "pydantic_deep.create_deep_agent", side_effect=_capture_create_deep_agent
+    ), _patch_node_type_checks():
+        chunks = asyncio.run(_collect_stream(agent, ctx))
+
+    text_chunks = [c.response for c in chunks if c.response]
+    assert text_chunks == ["Hello ", "world", "!"], (
+        f"Expected text deltas in order, got {text_chunks!r}"
+    )
+    # No tool call responses in this scenario
+    assert all(c.tool_calls == [] for c in chunks)
+
+
+# ---------------------------------------------------------------------------
+# C2. Tool-call streaming — CALL + RESULT event shapes
+# ---------------------------------------------------------------------------
+
+
+def test_pydantic_deep_debug_agent_streams_tool_call_events():
+    """FunctionToolCallEvent + FunctionToolResultEvent should produce
+    ToolCallResponse entries with CALL and RESULT event types respectively."""
+    agent = _build_debug_agent()
+
+    fake_pd = _make_fake_agent(
+        nodes=[
+            _CallToolsNodeStub(
+                events=[
+                    _make_tool_call_event(
+                        "fetch_file", "call-1", {"file_path": "src/app.py"}
+                    ),
+                    _make_tool_result_event(
+                        "fetch_file", "call-1", "def main(): pass"
+                    ),
+                ]
+            ),
+            _EndNodeStub(),
+        ]
+    )
+
+    ctx = _make_chat_context()
+
+    with patch(
+        "pydantic_deep.create_deep_agent", return_value=fake_pd
+    ), _patch_node_type_checks():
+        chunks = asyncio.run(_collect_stream(agent, ctx))
+
+    tool_calls = [tc for c in chunks for tc in c.tool_calls]
+    assert len(tool_calls) == 2, (
+        f"Expected two tool-call chunks (CALL + RESULT), got {len(tool_calls)}"
+    )
+
+    call_evt = tool_calls[0]
+    assert call_evt.tool_name == "fetch_file"
+    assert call_evt.call_id == "call-1"
+    assert call_evt.event_type == ToolCallEventType.CALL.value
+
+    result_evt = tool_calls[1]
+    assert result_evt.tool_name == "fetch_file"
+    assert result_evt.call_id == "call-1"
+    assert result_evt.event_type == ToolCallEventType.RESULT.value
+
+
+# ---------------------------------------------------------------------------
+# C3. Logfire ``instrument`` flag is wired through to create_deep_agent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("instrument_flag", [True, False])
+def test_pydantic_deep_debug_agent_passes_instrument_flag(monkeypatch, instrument_flag):
+    """should_instrument_pydantic_ai() value must be forwarded to create_deep_agent."""
+    from app.modules.intelligence.agents.chat_agents import pydantic_deep_debug_agent
+
+    monkeypatch.setattr(
+        pydantic_deep_debug_agent,
+        "should_instrument_pydantic_ai",
+        lambda: instrument_flag,
+    )
+
+    agent = _build_debug_agent()
+    captured: dict[str, Any] = {}
+
+    fake_pd = _make_fake_agent(nodes=[_EndNodeStub()])
+
+    def _capture(*args: Any, **kwargs: Any):
+        captured.update(kwargs)
+        return fake_pd
+
+    ctx = _make_chat_context()
+
+    with patch(
+        "pydantic_deep.create_deep_agent", side_effect=_capture
+    ), _patch_node_type_checks():
+        asyncio.run(_collect_stream(agent, ctx))
+
+    assert captured.get("instrument") is instrument_flag, (
+        f"Expected instrument={instrument_flag!r} in create_deep_agent kwargs, "
+        f"got {captured.get('instrument')!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# C4. Logfire failures are non-fatal — agent still produces output
+# ---------------------------------------------------------------------------
+
+
+def test_pydantic_deep_debug_agent_runs_when_logfire_trace_metadata_raises(monkeypatch):
+    """If logfire_trace_metadata blows up on entry, run_stream must still yield."""
+    from contextlib import contextmanager
+
+    from app.modules.intelligence.agents.chat_agents import pydantic_deep_debug_agent
+
+    @contextmanager
+    def _boom(**_kwargs):
+        raise RuntimeError("logfire exploded")
+        yield  # pragma: no cover — unreachable
+
+    monkeypatch.setattr(
+        pydantic_deep_debug_agent, "logfire_trace_metadata", _boom
+    )
+
+    agent = _build_debug_agent()
+    fake_pd = _make_fake_agent(
+        nodes=[
+            _ModelRequestNodeStub(
+                events=[_make_part_start_event("alive")],
+            ),
+            _EndNodeStub(),
+        ]
+    )
+
+    ctx = _make_chat_context()
+
+    with patch(
+        "pydantic_deep.create_deep_agent", return_value=fake_pd
+    ), _patch_node_type_checks():
+        chunks = asyncio.run(_collect_stream(agent, ctx))
+
+    assert any(c.response == "alive" for c in chunks), (
+        "run_stream should still yield agent output when logfire_trace_metadata fails"
+    )
+
+
+def test_pydantic_deep_debug_agent_runs_when_logfire_span_raises(monkeypatch):
+    """If is_logfire_enabled() is True but logfire.span raises, run_stream must
+    still yield output (span failure is non-fatal)."""
+    from app.modules.intelligence.agents.chat_agents import pydantic_deep_debug_agent
+
+    monkeypatch.setattr(
+        pydantic_deep_debug_agent, "is_logfire_enabled", lambda: True
+    )
+
+    fake_logfire = types.ModuleType("logfire")
+
+    def _bad_span(*_a, **_k):
+        raise RuntimeError("span exploded")
+
+    fake_logfire.span = _bad_span  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "logfire", fake_logfire)
+
+    agent = _build_debug_agent()
+    fake_pd = _make_fake_agent(
+        nodes=[
+            _ModelRequestNodeStub(events=[_make_part_start_event("still-alive")]),
+            _EndNodeStub(),
+        ]
+    )
+
+    ctx = _make_chat_context()
+
+    with patch(
+        "pydantic_deep.create_deep_agent", return_value=fake_pd
+    ), _patch_node_type_checks():
+        chunks = asyncio.run(_collect_stream(agent, ctx))
+
+    assert any(c.response == "still-alive" for c in chunks), (
+        "run_stream should still yield agent output when logfire.span raises"
+    )
+
+
+# ---------------------------------------------------------------------------
+# C5. Non-streaming run() also passes instrument and survives logfire failures
+# ---------------------------------------------------------------------------
+
+
+def test_pydantic_deep_debug_agent_run_returns_output(monkeypatch):
+    """The synchronous run() path must return the agent's output and pass
+    instrument= into create_deep_agent (parity with run_stream)."""
+    captured: dict[str, Any] = {}
+
+    fake_agent = MagicMock(name="FakeAgent")
+
+    async def _agent_run(*args: Any, **kwargs: Any):
+        result = MagicMock()
+        result.output = "diagnosis: cosmic rays"
+        return result
+
+    fake_agent.run = _agent_run
+
+    def _capture(*args: Any, **kwargs: Any):
+        captured.update(kwargs)
+        return fake_agent
+
+    debug_agent = _build_debug_agent()
+    ctx = _make_chat_context()
+
+    with patch("pydantic_deep.create_deep_agent", side_effect=_capture):
+        resp = asyncio.run(debug_agent.run(ctx))
+
+    assert resp.response == "diagnosis: cosmic rays"
+    assert "instrument" in captured, "instrument flag must reach create_deep_agent"
+
+
+def test_pydantic_deep_debug_agent_run_survives_logfire_failure(monkeypatch):
+    """run() should still produce a response when logfire_trace_metadata fails."""
+    from contextlib import contextmanager
+
+    from app.modules.intelligence.agents.chat_agents import pydantic_deep_debug_agent
+
+    @contextmanager
+    def _boom(**_kwargs):
+        raise RuntimeError("logfire exploded")
+        yield  # pragma: no cover — unreachable
+
+    monkeypatch.setattr(
+        pydantic_deep_debug_agent, "logfire_trace_metadata", _boom
+    )
+
+    fake_agent = MagicMock(name="FakeAgent")
+
+    async def _agent_run(*args: Any, **kwargs: Any):
+        result = MagicMock()
+        result.output = "ok"
+        return result
+
+    fake_agent.run = _agent_run
+
+    debug_agent = _build_debug_agent()
+    ctx = _make_chat_context()
+
+    with patch("pydantic_deep.create_deep_agent", return_value=fake_agent):
+        resp = asyncio.run(debug_agent.run(ctx))
+
+    assert resp.response == "ok"
+
+
+# ---------------------------------------------------------------------------
+# C6. Logfire metadata keys are forwarded correctly
+# ---------------------------------------------------------------------------
+
+
+def _expected_metadata_from_ctx(ctx: ChatContext) -> dict[str, Any]:
+    """Mirror _build_logfire_metadata in the agent: the precise set of keys the
+    helper is contractually required to populate. Re-deriving it here lets the
+    test assert exact-key parity (no extras, no omissions)."""
+    return {
+        "user_id": ctx.user_id,
+        "conversation_id": ctx.conversation_id,
+        "agent_id": ctx.curr_agent_id or "debug_agent",
+        "project_id": ctx.project_id,
+        "project_name": ctx.project_name,
+        "repository": getattr(ctx, "repository", None),
+        "branch": getattr(ctx, "branch", None),
+        "local_mode": ctx.local_mode,
+        "runtime": "pydantic_deep_debug_agent",
+    }
+
+
+def test_pydantic_deep_debug_agent_forwards_logfire_metadata_keys(monkeypatch):
+    """run() must call logfire_trace_metadata with the exact ctx-derived kwargs.
+
+    Validates the trace-baggage contract: every key in _build_logfire_metadata
+    is forwarded with the value sourced from the ChatContext (or the documented
+    default for agent_id)."""
+    from contextlib import contextmanager
+
+    from app.modules.intelligence.agents.chat_agents import pydantic_deep_debug_agent
+
+    captured: dict[str, Any] = {}
+
+    @contextmanager
+    def _fake_trace_metadata(**kwargs: Any):
+        captured["kwargs"] = dict(kwargs)
+        captured["call_count"] = captured.get("call_count", 0) + 1
+        yield
+
+    monkeypatch.setattr(
+        pydantic_deep_debug_agent, "logfire_trace_metadata", _fake_trace_metadata
+    )
+
+    ctx = _make_chat_context(
+        user_id="user-meta",
+        conversation_id="conv-meta",
+        curr_agent_id="debug_agent",
+        project_id="proj-meta",
+        project_name="potpie-meta",
+        local_mode=True,
+        repository="acme/widgets",
+        branch="feature/x",
+    )
+
+    fake_agent = MagicMock(name="FakeAgent")
+
+    async def _agent_run(*args: Any, **kwargs: Any):
+        result = MagicMock()
+        result.output = "metadata-run-ok"
+        return result
+
+    fake_agent.run = _agent_run
+
+    debug_agent = _build_debug_agent()
+
+    with patch("pydantic_deep.create_deep_agent", return_value=fake_agent):
+        resp = asyncio.run(debug_agent.run(ctx))
+
+    assert resp.response == "metadata-run-ok"
+    assert captured.get("call_count") == 1, (
+        f"Expected logfire_trace_metadata to be called once, "
+        f"got {captured.get('call_count')!r}"
+    )
+
+    expected = _expected_metadata_from_ctx(ctx)
+    forwarded = captured["kwargs"]
+    assert set(forwarded.keys()) == set(expected.keys()), (
+        f"Metadata key set mismatch.\nExpected: {sorted(expected.keys())!r}\n"
+        f"Got:      {sorted(forwarded.keys())!r}"
+    )
+    for key, expected_value in expected.items():
+        assert forwarded[key] == expected_value, (
+            f"Metadata key {key!r} mismatch: "
+            f"expected {expected_value!r}, got {forwarded[key]!r}"
+        )
+
+
+def test_pydantic_deep_debug_agent_stream_forwards_logfire_metadata_keys(monkeypatch):
+    """run_stream must also call logfire_trace_metadata exactly once with the
+    same ctx-derived kwargs as the non-streaming run()."""
+    from contextlib import contextmanager
+
+    from app.modules.intelligence.agents.chat_agents import pydantic_deep_debug_agent
+
+    captured: dict[str, Any] = {}
+
+    @contextmanager
+    def _fake_trace_metadata(**kwargs: Any):
+        captured["kwargs"] = dict(kwargs)
+        captured["call_count"] = captured.get("call_count", 0) + 1
+        yield
+
+    monkeypatch.setattr(
+        pydantic_deep_debug_agent, "logfire_trace_metadata", _fake_trace_metadata
+    )
+
+    ctx = _make_chat_context(
+        user_id="user-stream",
+        conversation_id="conv-stream",
+        curr_agent_id="debug_agent",
+        project_id="proj-stream",
+        project_name="potpie-stream",
+        local_mode=True,
+        repository="acme/streamer",
+        branch="release/y",
+    )
+
+    agent = _build_debug_agent()
+    fake_pd = _make_fake_agent(
+        nodes=[
+            _ModelRequestNodeStub(events=[_make_part_start_event("trace-ok")]),
+            _EndNodeStub(),
+        ]
+    )
+
+    with patch(
+        "pydantic_deep.create_deep_agent", return_value=fake_pd
+    ), _patch_node_type_checks():
+        chunks = asyncio.run(_collect_stream(agent, ctx))
+
+    # Confirm the stream actually produced output (so the metadata cm was
+    # entered and exited around real work).
+    assert any(c.response == "trace-ok" for c in chunks)
+    assert captured.get("call_count") == 1, (
+        f"Expected logfire_trace_metadata to be called exactly once per stream, "
+        f"got {captured.get('call_count')!r}"
+    )
+
+    expected = _expected_metadata_from_ctx(ctx)
+    forwarded = captured["kwargs"]
+    assert set(forwarded.keys()) == set(expected.keys()), (
+        f"Metadata key set mismatch (stream).\n"
+        f"Expected: {sorted(expected.keys())!r}\n"
+        f"Got:      {sorted(forwarded.keys())!r}"
+    )
+    for key, expected_value in expected.items():
+        assert forwarded[key] == expected_value, (
+            f"Metadata key {key!r} mismatch (stream): "
+            f"expected {expected_value!r}, got {forwarded[key]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# C7. Cancellation exits cooperatively
+# ---------------------------------------------------------------------------
+
+
+class _BlockingModelRequestNode(_ModelRequestNodeStub):
+    """Model-request node whose .stream() yields one event then blocks forever.
+
+    Subclasses _ModelRequestNodeStub so the patched is_model_request_node sees
+    it as a model-request node. Overrides .stream() with our blocking variant
+    so _FakeAgentRun-style node.stream rebinding is not needed."""
+
+    def __init__(self, first_event: Any, block_event: asyncio.Event):
+        super().__init__(events=[first_event])
+        self._first_event = first_event
+        self._block_event = block_event
+
+    def stream(self, _ctx):  # mirrors pydantic-ai node API
+        @asynccontextmanager
+        async def _cm():
+            async def _gen():
+                yield self._first_event
+                # Block indefinitely until cancelled; never reached after that.
+                await self._block_event.wait()
+                # pragma: no cover — unreachable under cancellation
+
+            yield _gen()
+
+        return _cm()
+
+
+class _BlockingFakeAgentRun:
+    """Variant of _FakeAgentRun that yields nodes without overwriting stream()."""
+
+    def __init__(self, nodes: Iterable[Any]):
+        self._nodes = list(nodes)
+        self.ctx = MagicMock(name="run_ctx")
+
+    def __aiter__(self):
+        return self._iter()
+
+    async def _iter(self):
+        for node in self._nodes:
+            yield node
+
+
+def test_pydantic_deep_debug_agent_stream_cancels_cooperatively():
+    """When the stream consumer cancels mid-iteration (via wait_for timeout),
+    the underlying ``agent.iter(...)`` context manager must exit cleanly and
+    no unexpected exception should escape.
+
+    The fake's model-request node emits one event then blocks forever; the test
+    consumes the first chunk under a generous wait_for timeout, then provokes
+    cancellation on the next pull with a short timeout, then closes the
+    generator. We assert the iter context manager's __aexit__ fired."""
+    never_event = asyncio.Event()
+    blocking_node = _BlockingModelRequestNode(
+        first_event=_make_part_start_event("first-chunk"),
+        block_event=never_event,
+    )
+
+    # Tracking iter cm: yields a custom run that does NOT overwrite stream().
+    class _TrackingBlockingIterCM:
+        def __init__(self):
+            self.entered = False
+            self.exited = False
+            self.exit_exc_type: Any = None
+
+        async def __aenter__(self):
+            self.entered = True
+            return _BlockingFakeAgentRun([blocking_node, _EndNodeStub()])
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            self.exited = True
+            self.exit_exc_type = exc_type
+            return False  # don't suppress
+
+    iter_cm = _TrackingBlockingIterCM()
+
+    fake_pd = MagicMock(name="FakeDeepAgent")
+    fake_pd.iter = lambda *args, **kwargs: iter_cm
+
+    agent = _build_debug_agent()
+    ctx = _make_chat_context()
+
+    async def _drive():
+        gen = agent.run_stream(ctx)
+        try:
+            # Pull the first chunk (the PartStartEvent → ChatAgentResponse).
+            first = await asyncio.wait_for(gen.__anext__(), timeout=2.0)
+            assert first.response == "first-chunk", (
+                f"Expected first chunk to be 'first-chunk', got {first.response!r}"
+            )
+
+            # Now try to pull the second chunk; the underlying generator is
+            # blocked on never_event.wait(), so wait_for will TimeoutError.
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(gen.__anext__(), timeout=0.1)
+        finally:
+            # Closing the generator must complete cleanly (no leaked
+            # CancelledError, no unhandled exception escaping aclose()).
+            await gen.aclose()
+
+    with patch(
+        "pydantic_deep.create_deep_agent", return_value=fake_pd
+    ), _patch_node_type_checks():
+        asyncio.run(_drive())
+
+    # The async-with around agent.iter(...) must have been entered and exited.
+    assert iter_cm.entered, "iter() context manager was never entered"
+    assert iter_cm.exited, (
+        "iter() context manager was not exited — cancellation cleanup leaked. "
+        "PydanticDeepDebugAgent.run_stream must close `async with agent.iter(...)` "
+        "when the consumer cancels."
+    )

--- a/tests/unit/intelligence/test_debug_agent_end_to_end.py
+++ b/tests/unit/intelligence/test_debug_agent_end_to_end.py
@@ -441,6 +441,8 @@ from pydantic_ai.messages import (  # noqa: E402
     PartDeltaEvent,
     PartStartEvent,
     TextPartDelta,
+    ThinkingPart,
+    ThinkingPartDelta,
     ToolReturnPart,
 )
 
@@ -594,6 +596,16 @@ def _make_part_delta_event(content_delta: str) -> PartDeltaEvent:
     return PartDeltaEvent(index=0, delta=TextPartDelta(content_delta=content_delta))
 
 
+def _make_thinking_start_event(content: str) -> PartStartEvent:
+    return PartStartEvent(index=0, part=ThinkingPart(content=content))
+
+
+def _make_thinking_delta_event(content_delta: str) -> PartDeltaEvent:
+    return PartDeltaEvent(
+        index=0, delta=ThinkingPartDelta(content_delta=content_delta)
+    )
+
+
 def _make_tool_call_event(name: str, call_id: str, args: dict) -> FunctionToolCallEvent:
     return FunctionToolCallEvent(
         part=ToolCallPart(tool_name=name, tool_call_id=call_id, args=args)
@@ -661,6 +673,75 @@ def test_pydantic_deep_debug_agent_streams_text_deltas():
     )
     # No tool call responses in this scenario
     assert all(c.tool_calls == [] for c in chunks)
+
+
+# ---------------------------------------------------------------------------
+# C1b. Reasoning (ThinkingPart) is wrapped in <think> tags so the webview
+#      renders it in a collapsible think block (same path as the code agent).
+# ---------------------------------------------------------------------------
+
+
+def test_pydantic_deep_debug_agent_wraps_reasoning_in_think_tags():
+    """ThinkingPart/ThinkingPartDelta events must be emitted as <think>...</think>
+    content, with the actual answer text after the closing tag."""
+    agent = _build_debug_agent()
+
+    fake_pd = _make_fake_agent(
+        nodes=[
+            _ModelRequestNodeStub(
+                events=[
+                    _make_thinking_start_event("Let me reason"),
+                    _make_thinking_delta_event(" about the bug"),
+                    _make_part_start_event("The fix is X"),
+                ]
+            ),
+            _EndNodeStub(),
+        ]
+    )
+
+    ctx = _make_chat_context()
+
+    with patch(
+        "pydantic_deep.create_deep_agent", return_value=fake_pd
+    ), _patch_node_type_checks():
+        chunks = asyncio.run(_collect_stream(agent, ctx))
+
+    joined = "".join(c.response for c in chunks if c.response)
+    assert "<think>" in joined and "</think>" in joined, (
+        f"Reasoning must be wrapped in think tags, got {joined!r}"
+    )
+    # Reasoning content sits inside the think block; answer after the close tag.
+    think_body = joined[joined.index("<think>") + len("<think>") : joined.index("</think>")]
+    assert "Let me reason about the bug" in think_body
+    after = joined[joined.index("</think>") + len("</think>") :]
+    assert "The fix is X" in after
+
+
+def test_pydantic_deep_debug_agent_closes_think_tag_when_no_text_follows():
+    """If the model reasons then goes straight to a tool call (no text), the
+    <think> block must still be closed so the webview doesn't swallow the rest."""
+    agent = _build_debug_agent()
+
+    fake_pd = _make_fake_agent(
+        nodes=[
+            _ModelRequestNodeStub(
+                events=[_make_thinking_start_event("reasoning with no answer text")]
+            ),
+            _EndNodeStub(),
+        ]
+    )
+
+    ctx = _make_chat_context()
+
+    with patch(
+        "pydantic_deep.create_deep_agent", return_value=fake_pd
+    ), _patch_node_type_checks():
+        chunks = asyncio.run(_collect_stream(agent, ctx))
+
+    joined = "".join(c.response for c in chunks if c.response)
+    assert joined.count("<think>") == 1
+    assert joined.count("</think>") == 1
+    assert joined.strip().endswith("</think>")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/intelligence/test_debug_agent_end_to_end.py
+++ b/tests/unit/intelligence/test_debug_agent_end_to_end.py
@@ -44,6 +44,26 @@ import pytest
 pytestmark = pytest.mark.unit
 
 # ---------------------------------------------------------------------------
+# Capture original sys.modules / env state *before* this file stubs them. This
+# module imports app modules at collection time, so the stubs must be registered
+# here (not in a fixture); the autouse fixture below restores the original state
+# after this module's tests so the fake torch/sentence_transformers and test DB
+# env don't leak into the rest of the suite.
+# ---------------------------------------------------------------------------
+_STUBBED_MODULE_NAMES = (
+    "torch",
+    "torch.nn",
+    "torch.nn.functional",
+    "torch.nn.modules",
+    "torch._jit_internal",
+    "torch._sources",
+    "torch._VF",
+    "sentence_transformers",
+)
+_ORIGINAL_MODULES = {name: sys.modules.get(name) for name in _STUBBED_MODULE_NAMES}
+_ORIGINAL_ENV = {key: os.environ.get(key) for key in ("POSTGRES_SERVER", "REDIS_URL")}
+
+# ---------------------------------------------------------------------------
 # Env vars required before any app import (same pattern as test_debug_agent_routing.py)
 # ---------------------------------------------------------------------------
 os.environ.setdefault("POSTGRES_SERVER", "postgresql://test:test@localhost:5432/testdb")
@@ -76,6 +96,23 @@ _torch_stub.functional = MagicMock()  # type: ignore[attr-defined]
 _torch_stub.nn = sys.modules["torch.nn"]  # type: ignore[attr-defined]
 _st_stub = _register_stub("sentence_transformers")
 _st_stub.SentenceTransformer = MagicMock(name="SentenceTransformer")  # type: ignore[attr-defined]
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _restore_global_import_state():
+    """Restore sys.modules / env after this module's tests so the fake torch and
+    sentence_transformers stubs (and test DB env) don't poison later tests."""
+    yield
+    for name, original in _ORIGINAL_MODULES.items():
+        if original is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = original
+    for key, original in _ORIGINAL_ENV.items():
+        if original is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = original
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/intelligence/test_debug_agent_hatchet_path.py
+++ b/tests/unit/intelligence/test_debug_agent_hatchet_path.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextvars import copy_context
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -83,11 +84,17 @@ def test_pydantic_deep_debug_initializes_tunnel_context_in_local_mode():
         branch="unstable",
     )
     agent = PydanticDeepDebugAgent(MagicMock(), AgentConfig(role="r", goal="g", backstory="b", tasks=[]), [])
-    agent._set_sandbox_context(ctx)
 
-    assert _get_local_mode() is True
-    assert _get_user_id() == "user-1"
-    assert _get_repository() == "valkey-io/valkey"
+    # _set_sandbox_context mutates process-local ContextVars. Run it (and the
+    # assertions that read those vars) inside a copied context so the mutations
+    # don't leak into other tests on the same worker.
+    def _check():
+        agent._set_sandbox_context(ctx)
+        assert _get_local_mode() is True
+        assert _get_user_id() == "user-1"
+        assert _get_repository() == "valkey-io/valkey"
+
+    copy_context().run(_check)
 
 
 def test_socket_sync_rpc_reuses_event_loop_on_same_thread():

--- a/tests/unit/intelligence/test_debug_agent_hatchet_path.py
+++ b/tests/unit/intelligence/test_debug_agent_hatchet_path.py
@@ -1,0 +1,114 @@
+"""Verify debugging_agent + local_mode works through the Hatchet execution path."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.modules.conversations.utils import conversation_routing as cr
+from app.modules.intelligence.agents.runtime.backend_selection import select_backend
+from app.modules.intelligence.agents.runtime.hatchet_backend import AgentRunInput
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeAsyncRedis:
+    def __init__(self):
+        self.task_ids = []
+
+    async def set_task_id(self, conversation_id, run_id, task_id):
+        self.task_ids.append(task_id)
+
+
+async def test_debugging_agent_routes_to_hatchet_with_local_mode(monkeypatch):
+    """VS Code local_mode must survive enqueue → Hatchet worker → agent context."""
+    monkeypatch.setenv("AGENT_TASK_BACKEND", "hatchet")
+    monkeypatch.setenv("HATCHET_AGENT_ALLOWLIST", "debugging_agent")
+    assert select_backend("debugging_agent") == "hatchet"
+
+    captured = {}
+
+    def _capture(inp, **kw):
+        captured["inp"] = inp
+
+    with patch.object(cr, "select_backend", return_value="hatchet"), patch.object(
+        cr, "enqueue_agent_run", side_effect=_capture
+    ):
+        result = await cr._dispatch_agent_run(
+            conversation_id="conv-1",
+            run_id="run-1",
+            user_id="user-1",
+            query="debug this",
+            agent_id="debugging_agent",
+            node_ids=None,
+            attachment_ids=[],
+            async_redis_manager=_FakeAsyncRedis(),
+            local_mode=True,
+            tunnel_url="socket://abc123",
+        )
+
+    assert result is None
+    inp = captured["inp"]
+    assert isinstance(inp, AgentRunInput)
+    assert inp.local_mode is True
+    assert inp.tunnel_url == "socket://abc123"
+    assert inp.agent_id == "debugging_agent"
+
+
+def test_pydantic_deep_debug_initializes_tunnel_context_in_local_mode():
+    """Hatchet runs PydanticDeepDebugAgent which must set ContextVars before tools."""
+    from app.modules.intelligence.agents.chat_agent import ChatContext
+    from app.modules.intelligence.agents.chat_agents.pydantic_deep_debug_agent import (
+        PydanticDeepDebugAgent,
+    )
+    from app.modules.intelligence.agents.chat_agents.agent_config import AgentConfig
+    from app.modules.intelligence.tools.code_changes_manager import (
+        _get_local_mode,
+        _get_repository,
+        _get_user_id,
+    )
+
+    ctx = ChatContext(
+        project_id="proj-1",
+        project_name="valkey-io/valkey",
+        curr_agent_id="debugging_agent",
+        history=[],
+        query="test",
+        conversation_id="conv-1",
+        user_id="user-1",
+        local_mode=True,
+        repository="valkey-io/valkey",
+        branch="unstable",
+    )
+    agent = PydanticDeepDebugAgent(MagicMock(), AgentConfig(role="r", goal="g", backstory="b", tasks=[]), [])
+    agent._set_sandbox_context(ctx)
+
+    assert _get_local_mode() is True
+    assert _get_user_id() == "user-1"
+    assert _get_repository() == "valkey-io/valkey"
+
+
+def test_socket_sync_rpc_reuses_event_loop_on_same_thread():
+    """Hatchet worker must not close the RPC loop between terminal/DAP tool calls."""
+    from app.modules.tunnel.socket_service import WorkspaceSocketService
+
+    svc = WorkspaceSocketService()
+    loops = []
+
+    async def _fake_execute(self, workspace_id, endpoint, payload, timeout):
+        loops.append(asyncio.get_running_loop())
+        return {"success": True, "result": {"ok": True}}
+
+    with patch.object(
+        WorkspaceSocketService,
+        "_execute_tool_call_with_timeout",
+        _fake_execute,
+    ):
+        svc.execute_tool_call_sync("wid1", "/api/terminal/execute", {"command": "echo 1"})
+        svc.execute_tool_call_sync("wid1", "/api/terminal/execute", {"command": "echo 2"})
+
+    assert len(loops) == 2
+    assert loops[0] is loops[1]
+    assert not loops[0].is_closed()

--- a/tests/unit/intelligence/test_debug_agent_prompt.py
+++ b/tests/unit/intelligence/test_debug_agent_prompt.py
@@ -190,3 +190,99 @@ def test_prompt_requires_card_terminator() -> None:
     assert "terminator" in phase4_section.lower(), (
         "Phase 4 must explicitly call the '---' line a card terminator."
     )
+
+
+# ---------------------------------------------------------------------------
+# 6. Multi-turn flow — pauses + missing-command UX
+# ---------------------------------------------------------------------------
+
+def test_prompt_has_multi_turn_flow_section() -> None:
+    """The OUTPUT CONTRACT must explain that the loop is multi-turn with explicit pauses."""
+    assert "MULTI-TURN FLOW" in debug_task_prompt, (
+        "Expected a MULTI-TURN FLOW section in the OUTPUT CONTRACT."
+    )
+
+
+def test_phase_4_pauses_before_dap_tools() -> None:
+    """Phase 4 must end with a pause for user input before any DAP tool runs."""
+    phase4_idx = debug_task_prompt.find("### Phase 4")
+    phase5_idx = debug_task_prompt.find("### Phase 5")
+    phase4_section = debug_task_prompt[phase4_idx:phase5_idx]
+    # Must instruct the model to NOT call DAP tools in the Phase 4 turn.
+    assert "STOP" in phase4_section, (
+        "Phase 4 must contain a STOP instruction at the end."
+    )
+    assert "set_breakpoints" in phase4_section and "Do NOT call" in phase4_section, (
+        "Phase 4 must explicitly forbid DAP tool calls in the same turn."
+    )
+
+
+def test_phase_4_allows_one_to_four_hypotheses() -> None:
+    """The mandatory count is now 1-4 (not 2-4); a single confident hypothesis is fine."""
+    phase4_idx = debug_task_prompt.find("### Phase 4")
+    phase5_idx = debug_task_prompt.find("### Phase 5")
+    phase4_section = debug_task_prompt[phase4_idx:phase5_idx]
+    assert "1 to 4" in phase4_section, (
+        "Phase 4 count should be '1 to 4 hypotheses' — single hypothesis allowed."
+    )
+
+
+def test_phase_5_entry_requires_list_hypotheses() -> None:
+    """Phase 5 runs in a new turn after the user picks; first action must be
+    list_hypotheses() to recover persisted state."""
+    phase5_idx = debug_task_prompt.find("### Phase 5")
+    phase6_idx = debug_task_prompt.find("### Phase 6")
+    assert phase5_idx != -1 and phase6_idx > phase5_idx
+    phase5_section = debug_task_prompt[phase5_idx:phase6_idx]
+    assert "list_hypotheses()" in phase5_section, (
+        "Phase 5 must require a list_hypotheses() call at entry to recover state."
+    )
+
+
+def test_phase_5c_has_three_cases() -> None:
+    """Phase 5c must enumerate three sub-cases: config available, missing command, no tunnel.
+
+    The 'missing command' case is the new one requested: when the workspace has no
+    launch.json and no inferred commands, agent asks user with two clearly framed options.
+    """
+    phase5_idx = debug_task_prompt.find("### Phase 5")
+    phase6_idx = debug_task_prompt.find("### Phase 6")
+    phase5_section = debug_task_prompt[phase5_idx:phase6_idx]
+    # Three case markers
+    assert "Case A" in phase5_section
+    assert "Case B" in phase5_section
+    assert "Case C" in phase5_section
+    # Missing-command path mentions the two options the user described
+    assert "Tell me a command to run" in phase5_section, (
+        "Case B must offer the 'user supplies command' option."
+    )
+    assert "propose a debug command" in phase5_section, (
+        "Case B must offer the 'agent proposes a command' option."
+    )
+
+
+def test_rejected_verdict_pauses_for_user() -> None:
+    """After a 'rejected' verdict, agent must pause and ask user, not auto-move."""
+    phase5_idx = debug_task_prompt.find("### Phase 5")
+    phase6_idx = debug_task_prompt.find("### Phase 6")
+    phase5_section = debug_task_prompt[phase5_idx:phase6_idx]
+    # Find the 'rejected' sub-section
+    rejected_idx = phase5_section.find('status="rejected"')
+    assert rejected_idx != -1
+    after_rejected = phase5_section[rejected_idx:]
+    # Must contain a pause + question
+    assert "STOP" in after_rejected, (
+        "Rejected verdict must STOP the response, not auto-move to next hypothesis."
+    )
+    assert ("revise hypotheses" in after_rejected.lower()
+            or "try h" in after_rejected.lower()), (
+        "Rejected verdict must offer the user options to revise or move on."
+    )
+
+
+def test_prompt_has_all_of_them_escape_hatch() -> None:
+    """User can override pauses by saying 'all of them' at Phase 4 exit."""
+    assert "all of them" in debug_task_prompt, (
+        "Prompt must support an 'all of them' escape hatch so users can run "
+        "through hypotheses without pausing if they prefer."
+    )

--- a/tests/unit/intelligence/test_debug_agent_prompt.py
+++ b/tests/unit/intelligence/test_debug_agent_prompt.py
@@ -65,9 +65,10 @@ def test_prompt_mentions_tool(tool_name: str) -> None:
 # 2. Markdown contract example is embedded
 # ---------------------------------------------------------------------------
 
-# Use a unique substring from HYPOTHESIS_MARKDOWN_EXAMPLE as the sentinel.
-# "Payment timeout is thrown but not converted" appears only in the example.
-_EXAMPLE_SENTINEL = "Payment timeout is thrown but not converted"
+# Sentinel string from HYPOTHESIS_MARKDOWN_EXAMPLE that is unique to the skeleton.
+# The placeholder text is intentionally generic; the angle-bracket phrase below is
+# specific to the canonical skeleton.
+_EXAMPLE_SENTINEL = "<one-line statement of the suspected root cause>"
 
 
 def test_prompt_embeds_hypothesis_markdown_example() -> None:
@@ -99,4 +100,93 @@ def test_prompt_mentions_no_tunnel_handling() -> None:
     assert found, (
         "Expected the prompt to mention tunnel-unavailable handling "
         f"(one of: {phrases}). None were found."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. OUTPUT CONTRACT section — top-of-prompt guardrails
+# ---------------------------------------------------------------------------
+
+def test_prompt_has_output_contract_section() -> None:
+    """The OUTPUT CONTRACT must appear near the top of the prompt so the model reads
+    it before the per-phase instructions."""
+    assert "OUTPUT CONTRACT" in debug_task_prompt
+    # And it must appear before the first phase header so the model encounters it first.
+    contract_idx = debug_task_prompt.find("OUTPUT CONTRACT")
+    phase1_idx = debug_task_prompt.find("Phase 1")
+    assert contract_idx < phase1_idx, (
+        "OUTPUT CONTRACT must appear before Phase 1 in the prompt."
+    )
+
+
+def test_prompt_has_forbidden_output_list() -> None:
+    """The prompt must explicitly forbid the conclusion-section shapes that previous
+    runs degraded into (CVE writeup / Analysis Summary / etc.)."""
+    assert "FORBIDDEN OUTPUT" in debug_task_prompt
+    forbidden_section_titles = [
+        "Analysis Summary",
+        "Final Summary",
+        "Root Cause Analysis",
+        "Vulnerability Overview",
+        "Recommended Fix",
+    ]
+    for title in forbidden_section_titles:
+        assert title in debug_task_prompt, (
+            f"Expected the FORBIDDEN OUTPUT list to mention {title!r}."
+        )
+
+
+def test_prompt_requires_debugger_state_emission() -> None:
+    """Phase 2 must require the model to emit explicit debugger-state acknowledgement
+    so the user can see when Phase 5 will be skipped."""
+    available_marker = "**Debugger:** available"
+    unavailable_marker = "**Debugger:** unavailable"
+    assert available_marker in debug_task_prompt, (
+        f"Expected required available marker {available_marker!r} in the prompt."
+    )
+    assert unavailable_marker in debug_task_prompt, (
+        f"Expected required unavailable marker {unavailable_marker!r} in the prompt."
+    )
+
+
+def test_prompt_has_refinement_rule() -> None:
+    """If the agent refines its theory after Phase 4, it must call record_hypothesis
+    again rather than write a conclusion based on an un-recorded theory."""
+    assert "REFINEMENT RULE" in debug_task_prompt, (
+        "Expected the prompt to include a REFINEMENT RULE clause."
+    )
+
+
+def test_prompt_makes_phase_1_required() -> None:
+    """Phase 1 (parse_failure_signal) must be flagged as required, since past runs
+    silently skipped it.
+
+    Anchors on '### Phase 1' (the actual heading) rather than 'Phase 1', since the
+    OUTPUT CONTRACT section earlier in the prompt back-references later phases by
+    name.
+    """
+    phase1_idx = debug_task_prompt.find("### Phase 1")
+    phase2_idx = debug_task_prompt.find("### Phase 2")
+    assert phase1_idx != -1, "Expected a '### Phase 1' heading in the prompt."
+    assert phase2_idx > phase1_idx, "Expected '### Phase 2' to follow '### Phase 1'."
+    phase1_section = debug_task_prompt[phase1_idx:phase2_idx]
+    assert "REQUIRED" in phase1_section, (
+        "Phase 1 section must be flagged REQUIRED so the model cannot skip it."
+    )
+
+
+def test_prompt_requires_card_terminator() -> None:
+    """The Phase 4 description must instruct the model to terminate each hypothesis
+    card with a literal '---' line so the webview parser can identify boundaries.
+
+    Anchors on the heading prefix to avoid OUTPUT CONTRACT back-references.
+    """
+    phase4_idx = debug_task_prompt.find("### Phase 4")
+    phase5_idx = debug_task_prompt.find("### Phase 5")
+    assert phase4_idx != -1, "Expected a '### Phase 4' heading in the prompt."
+    assert phase5_idx > phase4_idx, "Expected '### Phase 5' to follow '### Phase 4'."
+    phase4_section = debug_task_prompt[phase4_idx:phase5_idx]
+    assert "---" in phase4_section
+    assert "terminator" in phase4_section.lower(), (
+        "Phase 4 must explicitly call the '---' line a card terminator."
     )

--- a/tests/unit/intelligence/test_debug_agent_prompt.py
+++ b/tests/unit/intelligence/test_debug_agent_prompt.py
@@ -1,0 +1,102 @@
+"""Smoke tests for the rewritten debug_task_prompt (A1.4).
+
+These tests verify that the prompt string wires in all the tools and contract
+constants from the A2/A3/A4/A5/A6/A8 work. They are NOT "did the agent reason
+well" tests — they are "did the prompt actually mention the tools" checks.
+"""
+import pytest
+
+from app.modules.intelligence.agents.chat_agents.system_agents.debug_agent_prompt import (
+    debug_task_prompt,
+)
+from app.modules.intelligence.agents.chat_agents.system_agents.debug_hypothesis_contract import (
+    HYPOTHESIS_MARKDOWN_EXAMPLE,
+    HypothesisStatus,
+)
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# 1. All tool names are mentioned
+# ---------------------------------------------------------------------------
+
+REQUIRED_TOOLS = [
+    # A2 — failure signal parser
+    "parse_failure_signal",
+    # A4 — workspace debug context
+    "get_workspace_debug_context",
+    # A8 — context graph (discovery priority 1)
+    "query_context_graph",
+    # knowledge graph (discovery priority 2)
+    "ask_knowledge_graph_queries",
+    # text search (discovery priority 3)
+    "search_text",
+    # structural navigation (discovery priority 4)
+    "get_code_file_structure",
+    # raw file fetch (discovery priority 5)
+    "fetch_file",
+    # A5 — hypothesis state tools
+    "record_hypothesis",
+    "update_hypothesis_status",
+    "append_hypothesis_evidence",
+    "list_hypotheses",
+    # A3 — DAP debugger tools
+    "set_breakpoints",
+    "start_debug_session",
+    "take_debug_snapshot",
+    "step_over",
+    "step_into",
+    "step_out",
+    "continue_execution",
+    "evaluate_expression",
+    # A6 — validation
+    "run_validation",
+]
+
+
+@pytest.mark.parametrize("tool_name", REQUIRED_TOOLS)
+def test_prompt_mentions_tool(tool_name: str) -> None:
+    assert tool_name in debug_task_prompt, (
+        f"Expected tool '{tool_name}' to appear in debug_task_prompt but it was not found."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Markdown contract example is embedded
+# ---------------------------------------------------------------------------
+
+# Use a unique substring from HYPOTHESIS_MARKDOWN_EXAMPLE as the sentinel.
+# "Payment timeout is thrown but not converted" appears only in the example.
+_EXAMPLE_SENTINEL = "Payment timeout is thrown but not converted"
+
+
+def test_prompt_embeds_hypothesis_markdown_example() -> None:
+    assert _EXAMPLE_SENTINEL in debug_task_prompt, (
+        "Expected a substring of HYPOTHESIS_MARKDOWN_EXAMPLE "
+        f"({_EXAMPLE_SENTINEL!r}) to appear in debug_task_prompt."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Every status enum value is mentioned
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("status", list(HypothesisStatus))
+def test_prompt_mentions_status_value(status: HypothesisStatus) -> None:
+    assert status.value in debug_task_prompt, (
+        f"Expected hypothesis status '{status.value}' to appear in debug_task_prompt."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Tunnel-unavailable handling is present
+# ---------------------------------------------------------------------------
+
+def test_prompt_mentions_no_tunnel_handling() -> None:
+    # At least one of these phrases must be present.
+    phrases = ["no_tunnel", "extension is not connected", "VS Code extension is not connected"]
+    found = any(phrase in debug_task_prompt for phrase in phrases)
+    assert found, (
+        "Expected the prompt to mention tunnel-unavailable handling "
+        f"(one of: {phrases}). None were found."
+    )

--- a/tests/unit/intelligence/test_debug_agent_prompt.py
+++ b/tests/unit/intelligence/test_debug_agent_prompt.py
@@ -10,7 +10,6 @@ from app.modules.intelligence.agents.chat_agents.system_agents.debug_agent_promp
     debug_task_prompt,
 )
 from app.modules.intelligence.agents.chat_agents.system_agents.debug_hypothesis_contract import (
-    HYPOTHESIS_MARKDOWN_EXAMPLE,
     HypothesisStatus,
 )
 
@@ -25,16 +24,16 @@ REQUIRED_TOOLS = [
     "parse_failure_signal",
     # A4 — workspace debug context
     "get_workspace_debug_context",
-    # A8 — context graph (discovery priority 1)
-    "query_context_graph",
-    # knowledge graph (discovery priority 2)
-    "ask_knowledge_graph_queries",
-    # text search (discovery priority 3)
+    # bash/ripgrep search (discovery priority 1)
+    "search_bash",
+    # text search (discovery priority 2)
     "search_text",
-    # structural navigation (discovery priority 4)
+    # structural navigation (discovery priority 3)
     "get_code_file_structure",
-    # raw file fetch (discovery priority 5)
+    # raw file fetch (discovery priority 4)
     "fetch_file",
+    # batch file fetch (discovery priority 5)
+    "fetch_files_batch",
     # A5 — hypothesis state tools
     "record_hypothesis",
     "update_hypothesis_status",
@@ -51,6 +50,10 @@ REQUIRED_TOOLS = [
     "evaluate_expression",
     # A6 — validation
     "run_validation",
+    # Local-mode terminal (Potpie VS Code tunnel)
+    "execute_terminal_command",
+    "terminal_session_output",
+    "terminal_session_signal",
 ]
 
 
@@ -175,6 +178,19 @@ def test_prompt_makes_phase_1_required() -> None:
     )
 
 
+def test_prompt_has_root_cause_discipline_section() -> None:
+    """The prompt should preserve systematic debugging: trace symptoms to source before fixes."""
+    loop_idx = debug_task_prompt.find("## DEBUGGING LOOP")
+    phase1_idx = debug_task_prompt.find("### Phase 1")
+    assert loop_idx != -1 and phase1_idx > loop_idx
+    pre_phase1 = debug_task_prompt[loop_idx:phase1_idx]
+
+    assert "Root-Cause Discipline" in pre_phase1
+    assert "No fix proposal before" in pre_phase1
+    assert "trace backward" in pre_phase1
+    assert "boundary evidence" in pre_phase1
+
+
 def test_prompt_requires_card_terminator() -> None:
     """The Phase 4 description must instruct the model to terminate each hypothesis
     card with a literal '---' line so the webview parser can identify boundaries.
@@ -217,14 +233,38 @@ def test_phase_4_pauses_before_dap_tools() -> None:
     )
 
 
-def test_phase_4_allows_one_to_four_hypotheses() -> None:
-    """The mandatory count is now 1-4 (not 2-4); a single confident hypothesis is fine."""
+def test_phase_4_allows_one_to_five_hypotheses() -> None:
+    """The mandatory count is now 1-5; a single confident hypothesis is still fine."""
     phase4_idx = debug_task_prompt.find("### Phase 4")
     phase5_idx = debug_task_prompt.find("### Phase 5")
     phase4_section = debug_task_prompt[phase4_idx:phase5_idx]
-    assert "1 to 4" in phase4_section, (
-        "Phase 4 count should be '1 to 4 hypotheses' — single hypothesis allowed."
+    assert "1 to 5" in phase4_section, (
+        "Phase 4 count should be '1 to 5 hypotheses' — single hypothesis allowed."
     )
+
+
+def test_phase_3_has_discovery_budget_and_stop_rules() -> None:
+    """Weaker models must stop discovery loops and synthesize hypotheses."""
+    phase3_idx = debug_task_prompt.find("### Phase 3")
+    phase4_idx = debug_task_prompt.find("### Phase 4")
+    assert phase3_idx != -1 and phase4_idx > phase3_idx
+    phase3_section = debug_task_prompt[phase3_idx:phase4_idx]
+
+    assert "Discovery budget and stop rules" in phase3_section
+    assert "at most **three** additional targeted" in phase3_section
+    assert "Never repeat the same search query" in phase3_section
+    assert "synthesize hypotheses from the evidence already gathered" in phase3_section
+
+
+def test_phase_4_requires_traceback_and_pattern_comparison() -> None:
+    """Phase 4 should turn engineer-style tracing into falsifiable hypotheses."""
+    phase4_idx = debug_task_prompt.find("### Phase 4")
+    phase5_idx = debug_task_prompt.find("### Phase 5")
+    assert phase4_idx != -1 and phase5_idx > phase4_idx
+    phase4_section = debug_task_prompt[phase4_idx:phase5_idx]
+
+    assert "Trace backward from the immediate failing line" in phase4_section
+    assert "Compare similar working and broken paths" in phase4_section
 
 
 def test_phase_5_entry_requires_list_hypotheses() -> None:
@@ -261,6 +301,17 @@ def test_phase_5c_has_three_cases() -> None:
     )
 
 
+def test_phase_5c_does_not_treat_initialized_as_runtime_state() -> None:
+    """start_debug_session status='initialized' must be followed by a snapshot."""
+    phase5_idx = debug_task_prompt.find("### Phase 5")
+    phase6_idx = debug_task_prompt.find("### Phase 6")
+    phase5_section = debug_task_prompt[phase5_idx:phase6_idx]
+
+    assert '"initialized"' in phase5_section
+    assert "Do not infer" in phase5_section
+    assert "take_debug_snapshot" in phase5_section
+
+
 def test_rejected_verdict_pauses_for_user() -> None:
     """After a 'rejected' verdict, agent must pause and ask user, not auto-move."""
     phase5_idx = debug_task_prompt.find("### Phase 5")
@@ -285,4 +336,68 @@ def test_prompt_has_all_of_them_escape_hatch() -> None:
     assert "all of them" in debug_task_prompt, (
         "Prompt must support an 'all of them' escape hatch so users can run "
         "through hypotheses without pausing if they prefer."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7. launch.json creation + cleanup narrative
+# ---------------------------------------------------------------------------
+
+def test_phase_5c_offers_launch_json_creation() -> None:
+    """Case B must offer a third option: agent creates launch.json for the session."""
+    phase5_idx = debug_task_prompt.find("### Phase 5")
+    phase6_idx = debug_task_prompt.find("### Phase 6")
+    phase5_section = debug_task_prompt[phase5_idx:phase6_idx]
+
+    assert "launch.json" in phase5_section, (
+        "Case B must mention launch.json as part of the missing-config path."
+    )
+    assert "create" in phase5_section.lower(), (
+        "Case B must offer to create a launch.json for the session."
+    )
+
+
+def test_phase_5c_launch_json_has_cleanup_step() -> None:
+    """After creating launch.json the agent must offer to remove it when done."""
+    phase5_idx = debug_task_prompt.find("### Phase 5")
+    phase6_idx = debug_task_prompt.find("### Phase 6")
+    phase5_section = debug_task_prompt[phase5_idx:phase6_idx]
+
+    assert "cleanup" in phase5_section.lower() or "remove it" in phase5_section.lower(), (
+        "Phase 5c must include a cleanup step for agent-created launch.json."
+    )
+    assert "keep it" in phase5_section.lower(), (
+        "Cleanup prompt must give user the option to keep the generated launch.json."
+    )
+
+
+def test_phase_2_explains_missing_prerequisites() -> None:
+    """Phase 2 must identify which specific prerequisite is missing when unavailable."""
+    phase2_idx = debug_task_prompt.find("### Phase 2")
+    phase3_idx = debug_task_prompt.find("### Phase 3")
+    assert phase2_idx != -1 and phase3_idx > phase2_idx
+    phase2_section = debug_task_prompt[phase2_idx:phase3_idx]
+
+    assert "launch.json" in phase2_section, (
+        "Phase 2 must explicitly check for launch.json presence."
+    )
+    assert "launch_configs" in phase2_section, (
+        "Phase 2 must reference the launch_configs field from get_workspace_debug_context."
+    )
+    assert "inferred_commands" in phase2_section, (
+        "Phase 2 must reference the inferred_commands field from get_workspace_debug_context."
+    )
+
+
+def test_phase_5c_handles_compiled_binary_prerequisite() -> None:
+    """For C/C++ the agent must block on compilation before starting the debug session."""
+    phase5_idx = debug_task_prompt.find("### Phase 5")
+    phase6_idx = debug_task_prompt.find("### Phase 6")
+    phase5_section = debug_task_prompt[phase5_idx:phase6_idx]
+
+    assert "gcc" in phase5_section or "debug symbols" in phase5_section, (
+        "Phase 5c must mention compiling with debug symbols for C/C++ projects."
+    )
+    assert "ready" in phase5_section.lower(), (
+        "Phase 5c must ask user to reply 'ready' after compilation before starting DAP."
     )

--- a/tests/unit/intelligence/test_debug_agent_routing.py
+++ b/tests/unit/intelligence/test_debug_agent_routing.py
@@ -1,14 +1,14 @@
 """
-Smoke tests for DebugAgent._build_agent routing (A7.1 / A7.2).
+Smoke tests for DebugAgent._build_agent routing (Task 5).
 
-These tests verify that the dispatch logic chooses PydanticRagAgent vs
-PydanticMultiAgent correctly based on MultiAgentConfig and supports_pydantic,
-WITHOUT spawning any real LLMs.
+These tests verify that the dispatch logic always returns a PydanticDeepDebugAgent
+regardless of `supports_pydantic` or `MultiAgentConfig.should_use_multi_agent`,
+and never instantiates PydanticRagAgent or PydanticMultiAgent.
 
 The test file pre-populates sys.modules with lightweight stubs for the heavy ML /
 DB packages that are dragged in transitively by the DebugAgent import chain:
 
-  debug_agent → pydantic_multi_agent → tool_service → change_detection_tool
+  debug_agent → pydantic_deep_debug_agent → tool_service → change_detection_tool
               → inference_service → sentence_transformers → torch
 
 This pattern is consistent with how other tests in this project handle import-time
@@ -73,6 +73,7 @@ _st_stub.SentenceTransformer = MagicMock(name="SentenceTransformer")  # type: ig
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_debug_agent():
     """Return a DebugAgent with all constructor deps mocked out."""
     from app.modules.intelligence.agents.chat_agents.system_agents.debug_agent import (
@@ -107,86 +108,179 @@ def _make_minimal_ctx():
 
 
 # ---------------------------------------------------------------------------
-# Test 1 — multi-agent disabled + pydantic supported → PydanticRagAgent
+# Test 1 — DebugAgent._build_agent always returns PydanticDeepDebugAgent
 # ---------------------------------------------------------------------------
 
-def test_debug_agent_uses_pydantic_rag_when_multi_disabled():
-    """
-    When MultiAgentConfig returns False for debugging_agent AND the LLM supports
-    pydantic, _build_agent must return a PydanticRagAgent (not PydanticMultiAgent).
 
-    Sentinel mocks replace the real classes so we don't need to instantiate them
-    (which would require real LLM credentials / DB connections).
+@pytest.mark.parametrize("supports_pydantic", [True, False])
+@pytest.mark.parametrize("should_use_multi", [True, False])
+def test_debug_agent_always_returns_pydantic_deep(supports_pydantic, should_use_multi):
+    """
+    _build_agent must return PydanticDeepDebugAgent regardless of whether the LLM
+    advertises pydantic support or whether MultiAgentConfig says multi-agent is on.
+
+    All other code paths (PydanticRagAgent, PydanticMultiAgent) have been removed.
+    """
+    from app.modules.intelligence.agents.multi_agent_config import MultiAgentConfig
+
+    agent = _make_debug_agent()
+    agent.llm_provider.supports_pydantic.return_value = supports_pydantic
+
+    deep_sentinel = MagicMock(name="PydanticDeepDebugAgent_instance")
+    DeepCls = MagicMock(return_value=deep_sentinel)
+
+    ctx = _make_minimal_ctx()
+
+    with patch(
+        "app.modules.intelligence.agents.chat_agents.system_agents.debug_agent.PydanticDeepDebugAgent",
+        DeepCls,
+    ), patch.object(
+        MultiAgentConfig, "should_use_multi_agent", return_value=should_use_multi
+    ):
+        result = agent._build_agent(ctx)
+
+    assert result is deep_sentinel, (
+        "Expected PydanticDeepDebugAgent to be used for "
+        f"supports_pydantic={supports_pydantic}, should_use_multi={should_use_multi}, "
+        f"but got {result!r}"
+    )
+    DeepCls.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — neither PydanticRagAgent nor PydanticMultiAgent is constructed
+# ---------------------------------------------------------------------------
+
+
+def test_debug_agent_does_not_construct_pydantic_rag_or_multi():
+    """
+    Even when supports_pydantic=True and multi-agent is enabled — historically the
+    routing paths that selected PydanticRagAgent / PydanticMultiAgent — _build_agent
+    must NOT construct either class. They are no longer imported by debug_agent.py;
+    we patch them at their source modules and assert they were never called.
     """
     from app.modules.intelligence.agents.multi_agent_config import MultiAgentConfig
 
     agent = _make_debug_agent()
     agent.llm_provider.supports_pydantic.return_value = True
 
-    rag_sentinel = MagicMock(name="PydanticRagAgent_instance")
-    RagCls = MagicMock(return_value=rag_sentinel)
+    deep_sentinel = MagicMock(name="PydanticDeepDebugAgent_instance")
+    DeepCls = MagicMock(return_value=deep_sentinel)
+    RagCls = MagicMock(name="PydanticRagAgent_class")
     MultiCls = MagicMock(name="PydanticMultiAgent_class")
 
     ctx = _make_minimal_ctx()
 
+    # Patch the canonical source modules so any rogue import path would land here.
     with patch(
-        "app.modules.intelligence.agents.chat_agents.system_agents.debug_agent.PydanticRagAgent",
+        "app.modules.intelligence.agents.chat_agents.system_agents.debug_agent.PydanticDeepDebugAgent",
+        DeepCls,
+    ), patch(
+        "app.modules.intelligence.agents.chat_agents.pydantic_agent.PydanticRagAgent",
         RagCls,
     ), patch(
-        "app.modules.intelligence.agents.chat_agents.system_agents.debug_agent.PydanticMultiAgent",
-        MultiCls,
-    ), patch.object(
-        MultiAgentConfig, "should_use_multi_agent", return_value=False
-    ):
-        result = agent._build_agent(ctx)
-
-    assert result is rag_sentinel, (
-        "Expected PydanticRagAgent to be used when multi-agent is disabled"
-    )
-    MultiCls.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# Test 2 — pydantic unsupported → fallback PydanticRagAgent
-# ---------------------------------------------------------------------------
-
-def test_debug_agent_uses_pydantic_rag_when_pydantic_unsupported():
-    """
-    When the LLM does NOT support pydantic, _build_agent must fall back to
-    PydanticRagAgent regardless of the multi-agent config.
-    """
-    from app.modules.intelligence.agents.multi_agent_config import MultiAgentConfig
-
-    agent = _make_debug_agent()
-    agent.llm_provider.supports_pydantic.return_value = False
-
-    rag_sentinel = MagicMock(name="PydanticRagAgent_instance")
-    RagCls = MagicMock(return_value=rag_sentinel)
-    MultiCls = MagicMock(name="PydanticMultiAgent_class")
-
-    ctx = _make_minimal_ctx()
-
-    # Even if multi-agent config says True, pydantic=False forces the fallback.
-    with patch(
-        "app.modules.intelligence.agents.chat_agents.system_agents.debug_agent.PydanticRagAgent",
-        RagCls,
-    ), patch(
-        "app.modules.intelligence.agents.chat_agents.system_agents.debug_agent.PydanticMultiAgent",
+        "app.modules.intelligence.agents.chat_agents.pydantic_multi_agent.PydanticMultiAgent",
         MultiCls,
     ), patch.object(
         MultiAgentConfig, "should_use_multi_agent", return_value=True
     ):
         result = agent._build_agent(ctx)
 
-    assert result is rag_sentinel, (
-        "Expected PydanticRagAgent fallback when pydantic is unsupported"
-    )
+    assert result is deep_sentinel
+    RagCls.assert_not_called()
     MultiCls.assert_not_called()
 
+    # Sanity-check: debug_agent should not even reference these names anymore.
+    debug_agent_mod = sys.modules[
+        "app.modules.intelligence.agents.chat_agents.system_agents.debug_agent"
+    ]
+    assert not hasattr(debug_agent_mod, "PydanticRagAgent"), (
+        "debug_agent.py should no longer import PydanticRagAgent"
+    )
+    assert not hasattr(debug_agent_mod, "PydanticMultiAgent"), (
+        "debug_agent.py should no longer import PydanticMultiAgent"
+    )
+
 
 # ---------------------------------------------------------------------------
-# Test 3 — MultiAgentConfig default for debugging_agent is False (A7.1 gate)
+# Test 3 — DAP tool filtering still happens, observable via PydanticDeepDebugAgent
 # ---------------------------------------------------------------------------
+
+
+def test_debug_agent_excludes_dap_tools_when_not_local_mode():
+    """DAP and terminal tools should not be exposed outside VS Code/local-mode runs."""
+    from app.modules.intelligence.agents.multi_agent_config import MultiAgentConfig
+
+    agent = _make_debug_agent()
+    agent.llm_provider.supports_pydantic.return_value = True
+    agent.tools_provider.get_tools.return_value = [
+        types.SimpleNamespace(name="fetch_file"),
+        types.SimpleNamespace(name="start_debug_session"),
+        types.SimpleNamespace(name="take_debug_snapshot"),
+        types.SimpleNamespace(name="execute_terminal_command"),
+        types.SimpleNamespace(name="terminal_session_output"),
+    ]
+
+    deep_sentinel = MagicMock(name="PydanticDeepDebugAgent_instance")
+    DeepCls = MagicMock(return_value=deep_sentinel)
+
+    ctx = _make_minimal_ctx()
+    ctx.local_mode = False
+
+    with patch(
+        "app.modules.intelligence.agents.chat_agents.system_agents.debug_agent.PydanticDeepDebugAgent",
+        DeepCls,
+    ), patch.object(
+        MultiAgentConfig, "should_use_multi_agent", return_value=False
+    ):
+        agent._build_agent(ctx)
+
+    passed_tools = DeepCls.call_args.args[2]
+    assert [tool.name for tool in passed_tools] == ["fetch_file"]
+
+
+def test_debug_agent_keeps_dap_and_terminal_tools_when_local_mode():
+    """VS Code/local-mode runs keep DAP and Potpie terminal tools."""
+    from app.modules.intelligence.agents.multi_agent_config import MultiAgentConfig
+
+    agent = _make_debug_agent()
+    agent.llm_provider.supports_pydantic.return_value = True
+    agent.tools_provider.get_tools.return_value = [
+        types.SimpleNamespace(name="fetch_file"),
+        types.SimpleNamespace(name="start_debug_session"),
+        types.SimpleNamespace(name="take_debug_snapshot"),
+        types.SimpleNamespace(name="execute_terminal_command"),
+        types.SimpleNamespace(name="terminal_session_output"),
+    ]
+
+    deep_sentinel = MagicMock(name="PydanticDeepDebugAgent_instance")
+    DeepCls = MagicMock(return_value=deep_sentinel)
+
+    ctx = _make_minimal_ctx()
+    ctx.local_mode = True
+
+    with patch(
+        "app.modules.intelligence.agents.chat_agents.system_agents.debug_agent.PydanticDeepDebugAgent",
+        DeepCls,
+    ), patch.object(
+        MultiAgentConfig, "should_use_multi_agent", return_value=False
+    ):
+        agent._build_agent(ctx)
+
+    passed_tools = DeepCls.call_args.args[2]
+    assert [tool.name for tool in passed_tools] == [
+        "fetch_file",
+        "start_debug_session",
+        "take_debug_snapshot",
+        "execute_terminal_command",
+        "terminal_session_output",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — MultiAgentConfig default for debugging_agent is False (A7.1 gate)
+# ---------------------------------------------------------------------------
+
 
 def test_multi_agent_config_default_for_debugging_agent_is_false(monkeypatch):
     """
@@ -211,8 +305,9 @@ def test_multi_agent_config_default_for_debugging_agent_is_false(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Test 4 — env-var override DEBUG_MULTI_AGENT=true flips the flag
+# Test 5 — env-var override DEBUG_MULTI_AGENT=true flips the flag
 # ---------------------------------------------------------------------------
+
 
 def test_multi_agent_config_env_var_override_works_for_debugging_agent(monkeypatch):
     """

--- a/tests/unit/intelligence/test_debug_agent_routing.py
+++ b/tests/unit/intelligence/test_debug_agent_routing.py
@@ -1,0 +1,235 @@
+"""
+Smoke tests for DebugAgent._build_agent routing (A7.1 / A7.2).
+
+These tests verify that the dispatch logic chooses PydanticRagAgent vs
+PydanticMultiAgent correctly based on MultiAgentConfig and supports_pydantic,
+WITHOUT spawning any real LLMs.
+
+The test file pre-populates sys.modules with lightweight stubs for the heavy ML /
+DB packages that are dragged in transitively by the DebugAgent import chain:
+
+  debug_agent → pydantic_multi_agent → tool_service → change_detection_tool
+              → inference_service → sentence_transformers → torch
+
+This pattern is consistent with how other tests in this project handle import-time
+side-effects (env vars for the DB URL, Neo4j stubs in conftest, etc.).
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Step 1 — set env vars that module-level code reads at import time
+# ---------------------------------------------------------------------------
+# database.py reads POSTGRES_SERVER at module level; give it a parseable URL
+# so create_engine() doesn't explode.  Value never connects to anything.
+os.environ.setdefault("POSTGRES_SERVER", "postgresql://test:test@localhost:5432/testdb")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+
+# ---------------------------------------------------------------------------
+# Step 2 — stub out the heavy ML / transformers packages that are dragged in
+#          through the import chain before they are ever actually needed.
+# ---------------------------------------------------------------------------
+# We only do this if the real packages aren't already importable in this env;
+# this keeps the stubs out of the way in prod where the real packages exist.
+# Stub the ML packages that drag in torch / transformers.  torch has a Python 3.13
+# incompatibility (IndentationError in rnn.py) so we must prevent it from loading.
+# We only stub if the real package hasn't already been successfully imported.
+def _register_stub(name: str, **attrs: object) -> types.ModuleType:
+    mod = sys.modules.get(name)
+    if mod is None:
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    return mod
+
+
+_torch_stub = _register_stub("torch")
+_register_stub("torch.nn", functional=MagicMock())
+_register_stub("torch.nn.functional")
+_register_stub("torch.nn.modules")
+_register_stub("torch._jit_internal")
+_register_stub("torch._sources")
+_register_stub("torch._VF")
+# Make "from torch import _VF as _VF, functional as functional" work.
+_torch_stub._VF = MagicMock()  # type: ignore[attr-defined]
+_torch_stub.functional = MagicMock()  # type: ignore[attr-defined]
+_torch_stub.nn = sys.modules["torch.nn"]  # type: ignore[attr-defined]
+
+_st_stub = _register_stub("sentence_transformers")
+_st_stub.SentenceTransformer = MagicMock(name="SentenceTransformer")  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_debug_agent():
+    """Return a DebugAgent with all constructor deps mocked out."""
+    from app.modules.intelligence.agents.chat_agents.system_agents.debug_agent import (
+        DebugAgent,
+    )
+
+    llm_provider = MagicMock()
+    tools_provider = MagicMock()
+    prompt_provider = MagicMock()
+
+    # tools_provider.get_tools() is called inside _build_agent; return an empty list.
+    tools_provider.get_tools.return_value = []
+
+    return DebugAgent(
+        llm_provider=llm_provider,
+        tools_provider=tools_provider,
+        prompt_provider=prompt_provider,
+    )
+
+
+def _make_minimal_ctx():
+    """Return a minimal ChatContext that satisfies _build_agent requirements."""
+    from app.modules.intelligence.agents.chat_agent import ChatContext
+
+    return ChatContext(
+        project_id="proj-test",
+        project_name="test-project",
+        curr_agent_id="agent-1",
+        history=[],
+        query="why is my code broken?",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — multi-agent disabled + pydantic supported → PydanticRagAgent
+# ---------------------------------------------------------------------------
+
+def test_debug_agent_uses_pydantic_rag_when_multi_disabled():
+    """
+    When MultiAgentConfig returns False for debugging_agent AND the LLM supports
+    pydantic, _build_agent must return a PydanticRagAgent (not PydanticMultiAgent).
+
+    Sentinel mocks replace the real classes so we don't need to instantiate them
+    (which would require real LLM credentials / DB connections).
+    """
+    from app.modules.intelligence.agents.multi_agent_config import MultiAgentConfig
+
+    agent = _make_debug_agent()
+    agent.llm_provider.supports_pydantic.return_value = True
+
+    rag_sentinel = MagicMock(name="PydanticRagAgent_instance")
+    RagCls = MagicMock(return_value=rag_sentinel)
+    MultiCls = MagicMock(name="PydanticMultiAgent_class")
+
+    ctx = _make_minimal_ctx()
+
+    with patch(
+        "app.modules.intelligence.agents.chat_agents.system_agents.debug_agent.PydanticRagAgent",
+        RagCls,
+    ), patch(
+        "app.modules.intelligence.agents.chat_agents.system_agents.debug_agent.PydanticMultiAgent",
+        MultiCls,
+    ), patch.object(
+        MultiAgentConfig, "should_use_multi_agent", return_value=False
+    ):
+        result = agent._build_agent(ctx)
+
+    assert result is rag_sentinel, (
+        "Expected PydanticRagAgent to be used when multi-agent is disabled"
+    )
+    MultiCls.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — pydantic unsupported → fallback PydanticRagAgent
+# ---------------------------------------------------------------------------
+
+def test_debug_agent_uses_pydantic_rag_when_pydantic_unsupported():
+    """
+    When the LLM does NOT support pydantic, _build_agent must fall back to
+    PydanticRagAgent regardless of the multi-agent config.
+    """
+    from app.modules.intelligence.agents.multi_agent_config import MultiAgentConfig
+
+    agent = _make_debug_agent()
+    agent.llm_provider.supports_pydantic.return_value = False
+
+    rag_sentinel = MagicMock(name="PydanticRagAgent_instance")
+    RagCls = MagicMock(return_value=rag_sentinel)
+    MultiCls = MagicMock(name="PydanticMultiAgent_class")
+
+    ctx = _make_minimal_ctx()
+
+    # Even if multi-agent config says True, pydantic=False forces the fallback.
+    with patch(
+        "app.modules.intelligence.agents.chat_agents.system_agents.debug_agent.PydanticRagAgent",
+        RagCls,
+    ), patch(
+        "app.modules.intelligence.agents.chat_agents.system_agents.debug_agent.PydanticMultiAgent",
+        MultiCls,
+    ), patch.object(
+        MultiAgentConfig, "should_use_multi_agent", return_value=True
+    ):
+        result = agent._build_agent(ctx)
+
+    assert result is rag_sentinel, (
+        "Expected PydanticRagAgent fallback when pydantic is unsupported"
+    )
+    MultiCls.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — MultiAgentConfig default for debugging_agent is False (A7.1 gate)
+# ---------------------------------------------------------------------------
+
+def test_multi_agent_config_default_for_debugging_agent_is_false(monkeypatch):
+    """
+    With no env-var override, should_use_multi_agent("debugging_agent") must
+    return False (A7.1 change).
+    """
+    # Remove any env-var override that might be set in the test environment.
+    monkeypatch.delenv("DEBUG_MULTI_AGENT", raising=False)
+    # Ensure the global kill-switch is not accidentally masking via ENABLE_MULTI_AGENT=false.
+    monkeypatch.delenv("ENABLE_MULTI_AGENT", raising=False)
+
+    # Reload so class attributes pick up the (now-absent) env-var state.
+    import app.modules.intelligence.agents.multi_agent_config as cfg_mod
+    importlib.reload(cfg_mod)
+    MultiAgentConfig = cfg_mod.MultiAgentConfig
+
+    result = MultiAgentConfig.should_use_multi_agent("debugging_agent")
+    assert result is False, (
+        "Expected MultiAgentConfig.should_use_multi_agent('debugging_agent') "
+        f"to return False by default (A7.1), but got {result!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — env-var override DEBUG_MULTI_AGENT=true flips the flag
+# ---------------------------------------------------------------------------
+
+def test_multi_agent_config_env_var_override_works_for_debugging_agent(monkeypatch):
+    """
+    Setting DEBUG_MULTI_AGENT=true must override the A7.1 default and return True.
+
+    How to flip back to multi-agent later: set DEBUG_MULTI_AGENT=true in the
+    deployment environment (no code change required).
+    """
+    monkeypatch.setenv("DEBUG_MULTI_AGENT", "true")
+    monkeypatch.delenv("ENABLE_MULTI_AGENT", raising=False)
+
+    import app.modules.intelligence.agents.multi_agent_config as cfg_mod
+    importlib.reload(cfg_mod)
+    MultiAgentConfig = cfg_mod.MultiAgentConfig
+
+    result = MultiAgentConfig.should_use_multi_agent("debugging_agent")
+    assert result is True, (
+        "Expected DEBUG_MULTI_AGENT=true to enable multi-agent for debugging_agent, "
+        f"but got {result!r}"
+    )

--- a/tests/unit/intelligence/test_debug_agent_routing.py
+++ b/tests/unit/intelligence/test_debug_agent_routing.py
@@ -27,6 +27,25 @@ import pytest
 pytestmark = pytest.mark.unit
 
 # ---------------------------------------------------------------------------
+# Capture original sys.modules / env state *before* this file stubs them, so the
+# autouse fixture below can restore it after this module's tests. Otherwise the
+# fake torch/sentence_transformers, test DB env, and the importlib.reload()'d
+# MultiAgentConfig leak into the rest of the suite and can mask real regressions.
+# ---------------------------------------------------------------------------
+_STUBBED_MODULE_NAMES = (
+    "torch",
+    "torch.nn",
+    "torch.nn.functional",
+    "torch.nn.modules",
+    "torch._jit_internal",
+    "torch._sources",
+    "torch._VF",
+    "sentence_transformers",
+)
+_ORIGINAL_MODULES = {name: sys.modules.get(name) for name in _STUBBED_MODULE_NAMES}
+_ORIGINAL_ENV = {key: os.environ.get(key) for key in ("POSTGRES_SERVER", "REDIS_URL")}
+
+# ---------------------------------------------------------------------------
 # Step 1 — set env vars that module-level code reads at import time
 # ---------------------------------------------------------------------------
 # database.py reads POSTGRES_SERVER at module level; give it a parseable URL
@@ -67,6 +86,32 @@ _torch_stub.nn = sys.modules["torch.nn"]  # type: ignore[attr-defined]
 
 _st_stub = _register_stub("sentence_transformers")
 _st_stub.SentenceTransformer = MagicMock(name="SentenceTransformer")  # type: ignore[attr-defined]
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _restore_global_import_state():
+    """Restore sys.modules / env after this module's tests so the fake torch and
+    sentence_transformers stubs (and test DB env) don't poison later tests, and
+    reload MultiAgentConfig so its importlib.reload()'d state doesn't leak."""
+    yield
+    for key, original in _ORIGINAL_ENV.items():
+        if original is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = original
+    # Reload config under the restored env *before* the stubs are torn down, so
+    # the reloaded module no longer reflects a per-test env override.
+    try:
+        import app.modules.intelligence.agents.multi_agent_config as _cfg_mod
+
+        importlib.reload(_cfg_mod)
+    except Exception:
+        pass
+    for name, original in _ORIGINAL_MODULES.items():
+        if original is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = original
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/intelligence/test_debug_agent_tool_allowlist.py
+++ b/tests/unit/intelligence/test_debug_agent_tool_allowlist.py
@@ -21,6 +21,25 @@ import pytest
 pytestmark = pytest.mark.unit
 
 # ---------------------------------------------------------------------------
+# Capture original sys.modules / env state *before* this file stubs them, so the
+# autouse fixture below can restore it after this module's tests. Otherwise the
+# fake torch/sentence_transformers and test DB env leak into the rest of the
+# suite and can hide real import/config regressions.
+# ---------------------------------------------------------------------------
+_STUBBED_MODULE_NAMES = (
+    "torch",
+    "torch.nn",
+    "torch.nn.functional",
+    "torch.nn.modules",
+    "torch._jit_internal",
+    "torch._sources",
+    "torch._VF",
+    "sentence_transformers",
+)
+_ORIGINAL_MODULES = {name: sys.modules.get(name) for name in _STUBBED_MODULE_NAMES}
+_ORIGINAL_ENV = {key: os.environ.get(key) for key in ("POSTGRES_SERVER", "REDIS_URL")}
+
+# ---------------------------------------------------------------------------
 # Step 1 — set env vars that module-level code reads at import time
 # ---------------------------------------------------------------------------
 os.environ.setdefault("POSTGRES_SERVER", "postgresql://test:test@localhost:5432/testdb")
@@ -54,6 +73,23 @@ _torch_stub.nn = sys.modules["torch.nn"]  # type: ignore[attr-defined]
 
 _st_stub = _register_stub("sentence_transformers")
 _st_stub.SentenceTransformer = MagicMock(name="SentenceTransformer")  # type: ignore[attr-defined]
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _restore_global_import_state():
+    """Restore sys.modules / env after this module's tests so the fake torch and
+    sentence_transformers stubs (and test DB env) don't poison later tests."""
+    yield
+    for name, original in _ORIGINAL_MODULES.items():
+        if original is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = original
+    for key, original in _ORIGINAL_ENV.items():
+        if original is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = original
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/intelligence/test_debug_agent_tool_allowlist.py
+++ b/tests/unit/intelligence/test_debug_agent_tool_allowlist.py
@@ -1,0 +1,435 @@
+"""
+Tool allow-list tests for DebugAgent._build_agent (Task 3).
+
+These tests assert that the DebugAgent requests EXACTLY the spec-defined tool
+list from `tools_provider.get_tools(...)` — no more, no fewer — and explicitly
+verify that excluded categories (KG/code-graph, web, broad sandbox shell/edit/
+git, broad todo, requirements) never appear in the request.
+
+The setup mirrors `test_debug_agent_routing.py` so the import chain works
+without spawning real LLMs / DB connections.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Step 1 — set env vars that module-level code reads at import time
+# ---------------------------------------------------------------------------
+os.environ.setdefault("POSTGRES_SERVER", "postgresql://test:test@localhost:5432/testdb")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+
+
+# ---------------------------------------------------------------------------
+# Step 2 — stub out the heavy ML / transformers packages that are dragged in
+#          through the import chain before they are ever actually needed.
+# ---------------------------------------------------------------------------
+def _register_stub(name: str, **attrs: object) -> types.ModuleType:
+    mod = sys.modules.get(name)
+    if mod is None:
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    return mod
+
+
+_torch_stub = _register_stub("torch")
+_register_stub("torch.nn", functional=MagicMock())
+_register_stub("torch.nn.functional")
+_register_stub("torch.nn.modules")
+_register_stub("torch._jit_internal")
+_register_stub("torch._sources")
+_register_stub("torch._VF")
+_torch_stub._VF = MagicMock()  # type: ignore[attr-defined]
+_torch_stub.functional = MagicMock()  # type: ignore[attr-defined]
+_torch_stub.nn = sys.modules["torch.nn"]  # type: ignore[attr-defined]
+
+_st_stub = _register_stub("sentence_transformers")
+_st_stub.SentenceTransformer = MagicMock(name="SentenceTransformer")  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Spec expectations (Task 3)
+# ---------------------------------------------------------------------------
+
+EXPECTED_BASE_TOOLS: tuple[str, ...] = (
+    "parse_failure_signal",
+    "get_workspace_debug_context",
+    "get_code_file_structure",
+    "search_text",
+    "search_bash",
+    "fetch_file",
+    "fetch_files_batch",
+    "run_validation",
+    "record_hypothesis",
+    "update_hypothesis_status",
+    "append_hypothesis_evidence",
+    "list_hypotheses",
+    "read_todos",
+    "add_todo",
+    "update_todo_status",
+    "get_available_tasks",
+)
+
+EXPECTED_DAP_TOOLS: tuple[str, ...] = (
+    "start_debug_session",
+    "set_breakpoints",
+    "take_debug_snapshot",
+    "step_over",
+    "step_into",
+    "step_out",
+    "continue_execution",
+    "evaluate_expression",
+    "list_debug_sessions",
+    "stop_debug_session",
+)
+
+EXPECTED_TERMINAL_TOOLS: tuple[str, ...] = (
+    "execute_terminal_command",
+    "terminal_session_output",
+    "terminal_session_signal",
+)
+
+# Tools the spec explicitly forbids the DebugAgent from requesting.
+EXCLUDED_WEB_TOOLS: tuple[str, ...] = (
+    "webpage_extractor",
+    "web_search_tool",
+)
+EXCLUDED_KG_TOOLS: tuple[str, ...] = (
+    "ask_knowledge_graph_queries",
+    "query_context_graph",
+    "analyze_code_structure",
+    "get_code_from_node_id",
+    "get_code_from_probable_node_name",
+    "get_code_graph_from_node_id",
+    "get_code_graph_from_node_name",
+)
+EXCLUDED_SANDBOX_TOOLS: tuple[str, ...] = (
+    "sandbox_text_editor",
+    "sandbox_shell",
+    "sandbox_search",
+    "sandbox_git",
+)
+EXCLUDED_BROAD_TODO_TOOLS: tuple[str, ...] = (
+    "write_todos",
+    "remove_todo",
+    "add_subtask",
+    "set_dependency",
+)
+EXCLUDED_REQUIREMENTS_TOOLS: tuple[str, ...] = (
+    "add_requirements",
+    "get_requirements",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_debug_agent():
+    """Return a DebugAgent with all constructor deps mocked out."""
+    from app.modules.intelligence.agents.chat_agents.system_agents.debug_agent import (
+        DebugAgent,
+    )
+
+    llm_provider = MagicMock()
+    tools_provider = MagicMock()
+    prompt_provider = MagicMock()
+
+    # _build_agent fetches the tools and then routes on supports_pydantic. We
+    # don't care about the tools' identity — only the names passed in.
+    tools_provider.get_tools.return_value = []
+    llm_provider.supports_pydantic.return_value = True
+
+    return DebugAgent(
+        llm_provider=llm_provider,
+        tools_provider=tools_provider,
+        prompt_provider=prompt_provider,
+    )
+
+
+def _make_minimal_ctx():
+    """Return a minimal ChatContext that satisfies _build_agent requirements."""
+    from app.modules.intelligence.agents.chat_agent import ChatContext
+
+    return ChatContext(
+        project_id="proj-test",
+        project_name="test-project",
+        curr_agent_id="agent-1",
+        history=[],
+        query="why is my code broken?",
+    )
+
+
+def _requested_tool_names(agent, ctx) -> list[str]:
+    """Invoke _build_agent and return the names passed to get_tools(...) as a list."""
+    from app.modules.intelligence.agents.multi_agent_config import MultiAgentConfig
+
+    deep_sentinel = MagicMock(name="PydanticDeepDebugAgent_instance")
+    DeepCls = MagicMock(return_value=deep_sentinel)
+
+    with patch(
+        "app.modules.intelligence.agents.chat_agents.system_agents.debug_agent.PydanticDeepDebugAgent",
+        DeepCls,
+    ), patch.object(MultiAgentConfig, "should_use_multi_agent", return_value=False):
+        agent._build_agent(ctx)
+
+    # get_tools(...) is called exactly once with a list of names.
+    assert agent.tools_provider.get_tools.call_count == 1, (
+        "Expected tools_provider.get_tools to be called exactly once during _build_agent, "
+        f"but it was called {agent.tools_provider.get_tools.call_count} times."
+    )
+    call = agent.tools_provider.get_tools.call_args
+    # Support both positional and keyword invocations.
+    if call.args:
+        names = call.args[0]
+    else:
+        names = call.kwargs.get("tool_names") or call.kwargs.get("names")
+    assert names is not None, "Could not locate the tool names argument in the call."
+    return list(names)
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — exact allow-list shape
+# ---------------------------------------------------------------------------
+
+
+def test_debug_agent_requests_only_spec_tools_from_tools_provider():
+    """
+    _build_agent must call tools_provider.get_tools(...) exactly once with a list
+    that contains every spec-included tool, no excluded tool, and the full union of
+    base + DAP + terminal tool tuples.
+    """
+    agent = _make_debug_agent()
+    ctx = _make_minimal_ctx()
+    # local_mode controls post-fetch DAP filtering — not what's requested from
+    # the provider. The request must always be the union; the filter happens
+    # AFTER fetching. To make this explicit, set local_mode=True so no filter
+    # runs and the returned names = what was passed in.
+    ctx.local_mode = True
+
+    names = _requested_tool_names(agent, ctx)
+
+    # 1. Exact length.
+    expected_count = (
+        len(EXPECTED_BASE_TOOLS)
+        + len(EXPECTED_DAP_TOOLS)
+        + len(EXPECTED_TERMINAL_TOOLS)
+    )
+    assert len(names) == expected_count, (
+        f"Expected {expected_count} tool names "
+        f"({len(EXPECTED_BASE_TOOLS)} base + {len(EXPECTED_DAP_TOOLS)} DAP + "
+        f"{len(EXPECTED_TERMINAL_TOOLS)} terminal), got {len(names)}: {names}"
+    )
+
+    # 2. Every spec tool present.
+    for tool in EXPECTED_BASE_TOOLS:
+        assert tool in names, f"Missing required base tool: {tool!r}"
+    for tool in EXPECTED_DAP_TOOLS:
+        assert tool in names, f"Missing required DAP tool: {tool!r}"
+    for tool in EXPECTED_TERMINAL_TOOLS:
+        assert tool in names, f"Missing required terminal tool: {tool!r}"
+
+    # 3. No excluded tool present.
+    forbidden = (
+        EXCLUDED_WEB_TOOLS
+        + EXCLUDED_KG_TOOLS
+        + EXCLUDED_SANDBOX_TOOLS
+        + EXCLUDED_BROAD_TODO_TOOLS
+        + EXCLUDED_REQUIREMENTS_TOOLS
+    )
+    leaked = [t for t in forbidden if t in names]
+    assert not leaked, f"DebugAgent must not request excluded tools, but found: {leaked}"
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — KG / code-graph tools
+# ---------------------------------------------------------------------------
+
+
+def test_debug_agent_excludes_kg_tools():
+    """No knowledge-graph / code-graph tools may be requested."""
+    agent = _make_debug_agent()
+    ctx = _make_minimal_ctx()
+    ctx.local_mode = True
+
+    names = _requested_tool_names(agent, ctx)
+
+    for tool in EXCLUDED_KG_TOOLS:
+        assert tool not in names, (
+            f"KG/code-graph tool {tool!r} must NOT be requested by DebugAgent, "
+            f"but it appears in: {names}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — Web tools
+# ---------------------------------------------------------------------------
+
+
+def test_debug_agent_excludes_web_tools():
+    """Neither webpage_extractor nor web_search_tool may be requested."""
+    agent = _make_debug_agent()
+    ctx = _make_minimal_ctx()
+    ctx.local_mode = True
+
+    names = _requested_tool_names(agent, ctx)
+
+    for tool in EXCLUDED_WEB_TOOLS:
+        assert tool not in names, (
+            f"Web tool {tool!r} must NOT be requested by DebugAgent, "
+            f"but it appears in: {names}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — Sandbox shell/edit/git tools
+# ---------------------------------------------------------------------------
+
+
+def test_debug_agent_excludes_sandbox_shell_edit_git_tools():
+    """Broad sandbox tools (shell/edit/search/git) must NOT be requested."""
+    agent = _make_debug_agent()
+    ctx = _make_minimal_ctx()
+    ctx.local_mode = True
+
+    names = _requested_tool_names(agent, ctx)
+
+    for tool in EXCLUDED_SANDBOX_TOOLS:
+        assert tool not in names, (
+            f"Sandbox tool {tool!r} must NOT be requested by DebugAgent, "
+            f"but it appears in: {names}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — Broad todo tools
+# ---------------------------------------------------------------------------
+
+
+def test_debug_agent_excludes_broad_todo_tools():
+    """Broad todo tools (write_todos, remove_todo, add_subtask, set_dependency) excluded."""
+    agent = _make_debug_agent()
+    ctx = _make_minimal_ctx()
+    ctx.local_mode = True
+
+    names = _requested_tool_names(agent, ctx)
+
+    for tool in EXCLUDED_BROAD_TODO_TOOLS:
+        assert tool not in names, (
+            f"Broad todo tool {tool!r} must NOT be requested by DebugAgent, "
+            f"but it appears in: {names}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — Requirements tools
+# ---------------------------------------------------------------------------
+
+
+def test_debug_agent_excludes_requirements_tools():
+    """Requirements tools (add_requirements, get_requirements) excluded."""
+    agent = _make_debug_agent()
+    ctx = _make_minimal_ctx()
+    ctx.local_mode = True
+
+    names = _requested_tool_names(agent, ctx)
+
+    for tool in EXCLUDED_REQUIREMENTS_TOOLS:
+        assert tool not in names, (
+            f"Requirements tool {tool!r} must NOT be requested by DebugAgent, "
+            f"but it appears in: {names}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 7 — Focused todo tools must be included
+# ---------------------------------------------------------------------------
+
+
+def test_debug_agent_includes_focused_todo_tools():
+    """Focused todo tools (read/add/update_status/get_available) must be requested."""
+    agent = _make_debug_agent()
+    ctx = _make_minimal_ctx()
+    ctx.local_mode = True
+
+    names = _requested_tool_names(agent, ctx)
+
+    for tool in ("read_todos", "add_todo", "update_todo_status", "get_available_tasks"):
+        assert tool in names, (
+            f"Focused todo tool {tool!r} must be requested by DebugAgent, "
+            f"but it is missing from: {names}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 8 — Hypothesis tools must be included (extra sanity check)
+# ---------------------------------------------------------------------------
+
+
+def test_debug_agent_includes_hypothesis_tools():
+    """All four hypothesis-tracking tools must be requested."""
+    agent = _make_debug_agent()
+    ctx = _make_minimal_ctx()
+    ctx.local_mode = True
+
+    names = _requested_tool_names(agent, ctx)
+
+    for tool in (
+        "record_hypothesis",
+        "update_hypothesis_status",
+        "append_hypothesis_evidence",
+        "list_hypotheses",
+    ):
+        assert tool in names, (
+            f"Hypothesis tool {tool!r} must be requested by DebugAgent, "
+            f"but it is missing from: {names}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 9 — Module-level constants are wired into the requested list
+# ---------------------------------------------------------------------------
+
+
+def test_debug_agent_module_constants_match_spec():
+    """
+    The module-level DEBUG_AGENT_BASE_TOOLS and DEBUG_AGENT_DAP_TOOLS tuples must
+    exactly match the spec — this guards against drift between the spec and the
+    code without requiring a full _build_agent invocation.
+    """
+    from app.modules.intelligence.agents.chat_agents.system_agents import debug_agent
+
+    assert set(debug_agent.DEBUG_AGENT_BASE_TOOLS) == set(EXPECTED_BASE_TOOLS)
+    assert set(debug_agent.DEBUG_AGENT_DAP_TOOLS) == set(EXPECTED_DAP_TOOLS)
+    assert set(debug_agent.DEBUG_AGENT_TERMINAL_TOOLS) == set(EXPECTED_TERMINAL_TOOLS)
+    # LOCAL_MODE_ONLY_TOOL_NAMES must cover DAP + terminal for the non-local filter.
+    assert debug_agent.DAP_TOOL_NAMES == set(debug_agent.DEBUG_AGENT_DAP_TOOLS)
+    assert debug_agent.TERMINAL_TOOL_NAMES == set(debug_agent.DEBUG_AGENT_TERMINAL_TOOLS)
+    assert debug_agent.LOCAL_MODE_ONLY_TOOL_NAMES == (
+        debug_agent.DAP_TOOL_NAMES | debug_agent.TERMINAL_TOOL_NAMES
+    )
+
+
+def test_debug_agent_includes_terminal_tools_in_local_mode_request():
+    """Terminal tools must be requested (filtered out only when local_mode=False)."""
+    agent = _make_debug_agent()
+    ctx = _make_minimal_ctx()
+    ctx.local_mode = True
+
+    names = _requested_tool_names(agent, ctx)
+
+    for tool in EXPECTED_TERMINAL_TOOLS:
+        assert tool in names, (
+            f"Terminal tool {tool!r} must be requested by DebugAgent in local_mode, "
+            f"but it is missing from: {names}"
+        )

--- a/tests/unit/intelligence/test_debug_hypothesis_contract.py
+++ b/tests/unit/intelligence/test_debug_hypothesis_contract.py
@@ -111,8 +111,6 @@ def test_discovery_priority_order_contains_all_expected_tools():
 
 def test_example_contains_hypothesis_title_pattern():
     assert "## Hypothesis" in HYPOTHESIS_MARKDOWN_EXAMPLE
-    # The worked example title
-    assert "Payment timeout" in HYPOTHESIS_MARKDOWN_EXAMPLE
 
 
 def test_example_status_line_value_is_a_valid_enum_member():
@@ -134,3 +132,32 @@ def test_example_contains_evidence_section():
 
 def test_example_contains_validation_plan_section():
     assert "### Validation Plan" in HYPOTHESIS_MARKDOWN_EXAMPLE
+
+
+def test_example_ends_with_card_terminator():
+    """Every hypothesis card must end with a literal '---' on its own line so the
+    VS Code webview parser can identify card boundaries reliably."""
+    assert HYPOTHESIS_MARKDOWN_EXAMPLE.rstrip().endswith("---"), (
+        "Example must end with '---' as the card terminator the webview parser keys on."
+    )
+
+
+def test_example_is_structural_skeleton_not_domain_specific():
+    """The canonical example must be a generic skeleton with placeholders, not a
+    concrete domain scenario the model could pattern-match against.
+
+    A previous version of this example embedded an e-commerce payment timeout
+    narrative; models on real codebases (e.g. C, systems code) borrowed its
+    vocabulary inappropriately. The skeleton uses angle-bracket placeholders to
+    make borrowing impossible.
+    """
+    # Must contain placeholder syntax — at least one <placeholder> in evidence/plan
+    assert "<" in HYPOTHESIS_MARKDOWN_EXAMPLE and ">" in HYPOTHESIS_MARKDOWN_EXAMPLE, (
+        "Example should use <placeholder> syntax to signal structural-only intent."
+    )
+    # Must NOT contain the old e-commerce vocabulary
+    forbidden_terms = ["Payment timeout", "chargeCard", "createOrder", "Sentry", "PaymentTimeoutError"]
+    for term in forbidden_terms:
+        assert term not in HYPOTHESIS_MARKDOWN_EXAMPLE, (
+            f"Example contains domain-specific term {term!r}; should be generic skeleton."
+        )

--- a/tests/unit/intelligence/test_debug_hypothesis_contract.py
+++ b/tests/unit/intelligence/test_debug_hypothesis_contract.py
@@ -1,0 +1,136 @@
+"""Unit tests for the debug hypothesis markdown contract module.
+
+Verifies the contract's enum order, section headers, discovery priority,
+and the worked example — so any accidental change to the single source of
+truth breaks loudly before it propagates to the VS Code webview parser.
+"""
+import pytest
+
+from app.modules.intelligence.agents.chat_agents.system_agents.debug_hypothesis_contract import (
+    HypothesisStatus,
+    HYPOTHESIS_STATUS_ENUM,
+    HYPOTHESIS_SECTION_HEADERS,
+    DISCOVERY_PRIORITY_ORDER,
+    HYPOTHESIS_MARKDOWN_EXAMPLE,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# 1. HypothesisStatus enum
+# ---------------------------------------------------------------------------
+
+EXPECTED_STATUS_ORDER = [
+    "proposed",
+    "debugging",
+    "needs_evidence",
+    "supported",
+    "rejected",
+    "fix_proposed",
+    "needs_revision",
+    "validated",
+]
+
+
+def test_hypothesis_status_has_exactly_eight_members():
+    assert len(HypothesisStatus) == 8
+
+
+def test_hypothesis_status_members_are_in_documented_order():
+    actual = [member.value for member in HypothesisStatus]
+    assert actual == EXPECTED_STATUS_ORDER
+
+
+def test_hypothesis_status_values_are_accessible_by_name():
+    for name in EXPECTED_STATUS_ORDER:
+        member = HypothesisStatus(name)
+        assert member.value == name
+
+
+def test_hypothesis_status_enum_alias_is_same_class():
+    assert HYPOTHESIS_STATUS_ENUM is HypothesisStatus
+
+
+# ---------------------------------------------------------------------------
+# 2. HYPOTHESIS_SECTION_HEADERS
+# ---------------------------------------------------------------------------
+
+def test_section_headers_contains_title_format_string():
+    title_fmt = HYPOTHESIS_SECTION_HEADERS["title"]
+    # Must contain placeholders for n and title
+    assert "{n}" in title_fmt
+    assert "{title}" in title_fmt
+    assert title_fmt.startswith("## Hypothesis")
+
+
+def test_section_headers_contains_status_format_string():
+    status_fmt = HYPOTHESIS_SECTION_HEADERS["status"]
+    assert "{status}" in status_fmt
+    assert status_fmt.startswith("### Status:")
+
+
+def test_section_headers_contains_evidence_literal():
+    assert HYPOTHESIS_SECTION_HEADERS["evidence"] == "### Evidence"
+
+
+def test_section_headers_contains_validation_plan_literal():
+    assert HYPOTHESIS_SECTION_HEADERS["validation_plan"] == "### Validation Plan"
+
+
+def test_section_headers_contains_debugger_evidence_literal():
+    assert HYPOTHESIS_SECTION_HEADERS["debugger_evidence"] == "### Debugger Evidence"
+
+
+def test_section_headers_contains_fix_proposal_literal():
+    assert HYPOTHESIS_SECTION_HEADERS["fix_proposal"] == "### Fix Proposal"
+
+
+# ---------------------------------------------------------------------------
+# 3. DISCOVERY_PRIORITY_ORDER
+# ---------------------------------------------------------------------------
+
+def test_discovery_priority_order_starts_with_context_graph():
+    assert DISCOVERY_PRIORITY_ORDER[0] == "query_context_graph"
+
+
+def test_discovery_priority_order_contains_all_expected_tools():
+    expected = [
+        "query_context_graph",
+        "ask_knowledge_graph_queries",
+        "search_text",
+        "get_code_file_structure",
+        "fetch_file",
+    ]
+    assert DISCOVERY_PRIORITY_ORDER == expected
+
+
+# ---------------------------------------------------------------------------
+# 4. HYPOTHESIS_MARKDOWN_EXAMPLE
+# ---------------------------------------------------------------------------
+
+def test_example_contains_hypothesis_title_pattern():
+    assert "## Hypothesis" in HYPOTHESIS_MARKDOWN_EXAMPLE
+    # The worked example title
+    assert "Payment timeout" in HYPOTHESIS_MARKDOWN_EXAMPLE
+
+
+def test_example_status_line_value_is_a_valid_enum_member():
+    lines = HYPOTHESIS_MARKDOWN_EXAMPLE.splitlines()
+    status_line = next(
+        (line for line in lines if line.startswith("### Status:")),
+        None,
+    )
+    assert status_line is not None, "No '### Status:' line found in example"
+    status_value = status_line.split(":", 1)[1].strip()
+    # Must be parseable as a HypothesisStatus member
+    member = HypothesisStatus(status_value)
+    assert member.value == status_value
+
+
+def test_example_contains_evidence_section():
+    assert "### Evidence" in HYPOTHESIS_MARKDOWN_EXAMPLE
+
+
+def test_example_contains_validation_plan_section():
+    assert "### Validation Plan" in HYPOTHESIS_MARKDOWN_EXAMPLE

--- a/tests/unit/intelligence/test_debug_hypothesis_contract.py
+++ b/tests/unit/intelligence/test_debug_hypothesis_contract.py
@@ -90,19 +90,25 @@ def test_section_headers_contains_fix_proposal_literal():
 # 3. DISCOVERY_PRIORITY_ORDER
 # ---------------------------------------------------------------------------
 
-def test_discovery_priority_order_starts_with_context_graph():
-    assert DISCOVERY_PRIORITY_ORDER[0] == "query_context_graph"
+def test_discovery_priority_order_starts_with_search_bash():
+    assert DISCOVERY_PRIORITY_ORDER[0] == "search_bash"
 
 
 def test_discovery_priority_order_contains_all_expected_tools():
     expected = [
-        "query_context_graph",
-        "ask_knowledge_graph_queries",
+        "search_bash",
         "search_text",
         "get_code_file_structure",
         "fetch_file",
+        "fetch_files_batch",
     ]
     assert DISCOVERY_PRIORITY_ORDER == expected
+
+
+def test_discovery_priority_order_excludes_knowledge_graph_tools():
+    """DebugAgent is a pure pydantic-deep agent and must not depend on KG discovery."""
+    assert "query_context_graph" not in DISCOVERY_PRIORITY_ORDER
+    assert "ask_knowledge_graph_queries" not in DISCOVERY_PRIORITY_ORDER
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/intelligence/test_get_workspace_debug_context_tool.py
+++ b/tests/unit/intelligence/test_get_workspace_debug_context_tool.py
@@ -1,0 +1,742 @@
+"""Unit tests for get_workspace_debug_context tool (A4).
+
+Covers all required scenarios from the task spec:
+  1. Success: dispatch returns a populated payload → populated fields, available=True, message=None.
+  2. Partial success: only launch_configs populated → other lists empty, available=True.
+  3. Tunnel unavailable (no_tunnel) → available=False, message mentions no tunnel.
+  4. Unknown route (E4 not yet implemented) → available=False, message states handler missing.
+  5. Timeout → available=False, message mentions timeout.
+  6. Exception during dispatch → caught, returns available=False with error message.
+  7. focus_path forwarded into RPC payload (mock call inspection).
+  8. Schema round-trip: build WorkspaceDebugContext with all fields, dump → validate.
+  9. Pydantic-level schema: LaunchConfig requires name, type, request; program optional.
+  10. Pydantic-level schema: InferredCommand requires label, command, source.
+  11. Tool registered in tool_service.py (source check).
+  12. "get_workspace_debug_context" appears in DebugAgent's get_tools([...]) list.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Set mandatory env vars before any app module is imported.
+os.environ.setdefault("POSTGRES_SERVER", "postgresql://test:test@localhost:5432/testdb")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+
+import pytest
+from unittest.mock import patch, call
+
+from app.modules.intelligence.tools.get_workspace_debug_context_tool import (
+    LaunchConfig,
+    InferredCommand,
+    RecentChange,
+    WorkspaceDebugContext,
+    get_workspace_debug_context,
+    get_workspace_debug_context_tool,
+    _MSG_NO_TUNNEL,
+    _MSG_TIMEOUT,
+    _MSG_UNKNOWN_ROUTE,
+    _MSG_TUNNEL_UNREACHABLE,
+)
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Patch targets — mirror the _PATCH_TARGET style from test_run_validation_tool.py
+# ---------------------------------------------------------------------------
+
+_PATCH_TARGET = (
+    "app.modules.intelligence.tools.get_workspace_debug_context_tool.route_workspace_debug_context"
+)
+_CONTEXT_PATCH = (
+    "app.modules.intelligence.tools.get_workspace_debug_context_tool.get_context_vars"
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / payload builders
+# ---------------------------------------------------------------------------
+
+
+def _full_payload() -> dict:
+    """Return a fully-populated extension response payload."""
+    return {
+        "launch_configs": [
+            {"name": "Python: Flask", "type": "python", "request": "launch", "program": "app.py"},
+            {"name": "Node: Attach", "type": "node", "request": "attach", "program": None},
+        ],
+        "debug_adapters": ["python", "node"],
+        "recent_changes": [
+            {
+                "file": "src/server.py",
+                "commit_sha": "abc1234",
+                "commit_message": "fix: handle timeout properly",
+                "relative_time": "3 hours ago",
+            }
+        ],
+        "related_tests": ["tests/test_server.py", "tests/test_utils.py"],
+        "inferred_commands": [
+            {
+                "label": "pytest",
+                "command": "pytest tests/",
+                "source": "pyproject.toml",
+            }
+        ],
+    }
+
+
+def _launch_only_payload() -> dict:
+    """Return a partial response — only launch_configs populated."""
+    return {
+        "launch_configs": [
+            {"name": "Run App", "type": "go", "request": "launch", "program": "main.go"},
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Success: fully populated payload → available=True, all fields populated
+# ---------------------------------------------------------------------------
+
+
+def test_success_available_true():
+    with patch(_PATCH_TARGET, return_value=(_full_payload(), None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = get_workspace_debug_context()
+
+    assert result["available"] is True
+
+
+def test_success_message_is_none():
+    with patch(_PATCH_TARGET, return_value=(_full_payload(), None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = get_workspace_debug_context()
+
+    assert result["message"] is None
+
+
+def test_success_launch_configs_populated():
+    with patch(_PATCH_TARGET, return_value=(_full_payload(), None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = get_workspace_debug_context()
+
+    assert len(result["launch_configs"]) == 2
+    names = [lc["name"] for lc in result["launch_configs"]]
+    assert "Python: Flask" in names
+    assert "Node: Attach" in names
+
+
+def test_success_debug_adapters_populated():
+    with patch(_PATCH_TARGET, return_value=(_full_payload(), None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = get_workspace_debug_context()
+
+    assert result["debug_adapters"] == ["python", "node"]
+
+
+def test_success_recent_changes_populated():
+    with patch(_PATCH_TARGET, return_value=(_full_payload(), None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = get_workspace_debug_context()
+
+    assert len(result["recent_changes"]) == 1
+    assert result["recent_changes"][0]["file"] == "src/server.py"
+    assert result["recent_changes"][0]["commit_sha"] == "abc1234"
+    assert result["recent_changes"][0]["relative_time"] == "3 hours ago"
+
+
+def test_success_related_tests_populated():
+    with patch(_PATCH_TARGET, return_value=(_full_payload(), None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = get_workspace_debug_context()
+
+    assert "tests/test_server.py" in result["related_tests"]
+
+
+def test_success_inferred_commands_populated():
+    with patch(_PATCH_TARGET, return_value=(_full_payload(), None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = get_workspace_debug_context()
+
+    assert len(result["inferred_commands"]) == 1
+    cmd = result["inferred_commands"][0]
+    assert cmd["label"] == "pytest"
+    assert cmd["command"] == "pytest tests/"
+    assert cmd["source"] == "pyproject.toml"
+
+
+# ---------------------------------------------------------------------------
+# 2. Partial success: only launch_configs in payload → other lists empty
+# ---------------------------------------------------------------------------
+
+
+def test_partial_success_available_true():
+    with patch(_PATCH_TARGET, return_value=(_launch_only_payload(), None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = get_workspace_debug_context()
+
+    assert result["available"] is True
+
+
+def test_partial_success_launch_configs_has_data():
+    with patch(_PATCH_TARGET, return_value=(_launch_only_payload(), None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = get_workspace_debug_context()
+
+    assert len(result["launch_configs"]) == 1
+    assert result["launch_configs"][0]["name"] == "Run App"
+
+
+def test_partial_success_other_lists_empty():
+    with patch(_PATCH_TARGET, return_value=(_launch_only_payload(), None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = get_workspace_debug_context()
+
+    assert result["debug_adapters"] == []
+    assert result["recent_changes"] == []
+    assert result["related_tests"] == []
+    assert result["inferred_commands"] == []
+
+
+def test_partial_success_message_is_none():
+    with patch(_PATCH_TARGET, return_value=(_launch_only_payload(), None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = get_workspace_debug_context()
+
+    assert result["message"] is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Tunnel unavailable: dispatch returns (None, "no_tunnel")
+# ---------------------------------------------------------------------------
+
+
+def test_no_tunnel_available_false():
+    with patch(_PATCH_TARGET, return_value=(None, "no_tunnel")), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = get_workspace_debug_context()
+
+    assert result["available"] is False
+
+
+def test_no_tunnel_message_mentions_no_tunnel():
+    with patch(_PATCH_TARGET, return_value=(None, "no_tunnel")), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = get_workspace_debug_context()
+
+    msg = result["message"] or ""
+    # Should say something about the extension not being connected
+    assert "not connected" in msg.lower() or "no tunnel" in msg.lower() or "extension" in msg.lower()
+
+
+def test_no_tunnel_all_lists_empty():
+    with patch(_PATCH_TARGET, return_value=(None, "no_tunnel")), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = get_workspace_debug_context()
+
+    assert result["launch_configs"] == []
+    assert result["debug_adapters"] == []
+    assert result["recent_changes"] == []
+    assert result["related_tests"] == []
+    assert result["inferred_commands"] == []
+
+
+# ---------------------------------------------------------------------------
+# 4. Unknown route — extension has not implemented E4 yet
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_route_available_false():
+    with patch(_PATCH_TARGET, return_value=(None, "unknown_route")), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = get_workspace_debug_context()
+
+    assert result["available"] is False
+
+
+def test_unknown_route_message_states_handler_missing():
+    with patch(_PATCH_TARGET, return_value=(None, "unknown_route")), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = get_workspace_debug_context()
+
+    msg = result["message"] or ""
+    # Must clearly indicate the handler is not yet implemented on the extension
+    assert (
+        "not yet implemented" in msg.lower()
+        or "e4" in msg.lower()
+        or "handler" in msg.lower()
+        or "pending" in msg.lower()
+    )
+
+
+def test_unknown_route_all_lists_empty():
+    with patch(_PATCH_TARGET, return_value=(None, "unknown_route")), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = get_workspace_debug_context()
+
+    assert result["launch_configs"] == []
+    assert result["recent_changes"] == []
+    assert result["related_tests"] == []
+
+
+# ---------------------------------------------------------------------------
+# 5. Timeout: dispatch returns (None, "timeout")
+# ---------------------------------------------------------------------------
+
+
+def test_timeout_available_false():
+    with patch(_PATCH_TARGET, return_value=(None, "timeout")), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = get_workspace_debug_context()
+
+    assert result["available"] is False
+
+
+def test_timeout_message_mentions_timeout():
+    with patch(_PATCH_TARGET, return_value=(None, "timeout")), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = get_workspace_debug_context()
+
+    msg = result["message"] or ""
+    assert "timeout" in msg.lower() or "timed out" in msg.lower()
+
+
+def test_timeout_all_lists_empty():
+    with patch(_PATCH_TARGET, return_value=(None, "timeout")), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = get_workspace_debug_context()
+
+    assert result["launch_configs"] == []
+    assert result["inferred_commands"] == []
+
+
+# ---------------------------------------------------------------------------
+# 6. Exception during dispatch → caught, available=False with error message
+# ---------------------------------------------------------------------------
+
+
+def test_exception_available_false():
+    with patch(_PATCH_TARGET, side_effect=RuntimeError("socket exploded")), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = get_workspace_debug_context()
+
+    assert result["available"] is False
+
+
+def test_exception_message_contains_error_text():
+    with patch(_PATCH_TARGET, side_effect=RuntimeError("socket exploded")), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = get_workspace_debug_context()
+
+    msg = result["message"] or ""
+    assert "socket exploded" in msg
+
+
+def test_exception_does_not_raise():
+    """The tool must never propagate exceptions to the agent."""
+    with patch(_PATCH_TARGET, side_effect=Exception("catastrophic failure")), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        # Should not raise
+        result = get_workspace_debug_context()
+
+    assert result["available"] is False
+
+
+# ---------------------------------------------------------------------------
+# 7. focus_path forwarded into the RPC payload
+# ---------------------------------------------------------------------------
+
+
+def test_focus_path_forwarded_to_dispatch():
+    with patch(_PATCH_TARGET, return_value=(None, "no_tunnel")) as mock_rpc, \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        get_workspace_debug_context(focus_path="src/payments/service.py")
+
+    mock_rpc.assert_called_once()
+    kwargs = mock_rpc.call_args
+    # focus_path must appear in the call (either positional or keyword)
+    all_args = list(kwargs.args) + list(kwargs.kwargs.values())
+    assert "src/payments/service.py" in all_args or kwargs.kwargs.get("focus_path") == "src/payments/service.py"
+
+
+def test_focus_path_none_when_not_provided():
+    with patch(_PATCH_TARGET, return_value=(None, "no_tunnel")) as mock_rpc, \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        get_workspace_debug_context()
+
+    mock_rpc.assert_called_once()
+    # focus_path should be None (default)
+    kwargs = mock_rpc.call_args.kwargs
+    assert kwargs.get("focus_path") is None or "focus_path" not in kwargs
+
+
+def test_focus_path_forwarded_on_success():
+    """focus_path must be forwarded regardless of dispatch outcome."""
+    with patch(_PATCH_TARGET, return_value=(_full_payload(), None)) as mock_rpc, \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        get_workspace_debug_context(focus_path="app/models.py")
+
+    mock_rpc.assert_called_once()
+    kwargs = mock_rpc.call_args.kwargs
+    assert kwargs.get("focus_path") == "app/models.py"
+
+
+# ---------------------------------------------------------------------------
+# 8. Schema round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_schema_round_trip_full():
+    ctx = WorkspaceDebugContext(
+        launch_configs=[
+            LaunchConfig(name="Flask Debug", type="python", request="launch", program="run.py"),
+        ],
+        debug_adapters=["python", "node", "go"],
+        recent_changes=[
+            RecentChange(
+                file="app/views.py",
+                commit_sha="deadbee",
+                commit_message="refactor: split view logic",
+                relative_time="5 hours ago",
+            )
+        ],
+        related_tests=["tests/test_views.py"],
+        inferred_commands=[
+            InferredCommand(label="pytest", command="pytest -x tests/", source="pyproject.toml")
+        ],
+        available=True,
+        message=None,
+    )
+    json_str = ctx.model_dump_json()
+    restored = WorkspaceDebugContext.model_validate_json(json_str)
+
+    assert restored.available is True
+    assert restored.message is None
+    assert len(restored.launch_configs) == 1
+    assert restored.launch_configs[0].name == "Flask Debug"
+    assert restored.launch_configs[0].program == "run.py"
+    assert restored.debug_adapters == ["python", "node", "go"]
+    assert len(restored.recent_changes) == 1
+    assert restored.recent_changes[0].file == "app/views.py"
+    assert restored.recent_changes[0].relative_time == "5 hours ago"
+    assert "tests/test_views.py" in restored.related_tests
+    assert len(restored.inferred_commands) == 1
+    assert restored.inferred_commands[0].source == "pyproject.toml"
+
+
+def test_schema_round_trip_unavailable():
+    ctx = WorkspaceDebugContext(
+        available=False,
+        message="VS Code extension not connected.",
+    )
+    json_str = ctx.model_dump_json()
+    restored = WorkspaceDebugContext.model_validate_json(json_str)
+
+    assert restored.available is False
+    assert restored.message == "VS Code extension not connected."
+    assert restored.launch_configs == []
+    assert restored.debug_adapters == []
+    assert restored.recent_changes == []
+    assert restored.related_tests == []
+    assert restored.inferred_commands == []
+
+
+# ---------------------------------------------------------------------------
+# 9. Pydantic-level schema: LaunchConfig field requirements
+# ---------------------------------------------------------------------------
+
+
+def test_launch_config_requires_name():
+    with pytest.raises(Exception):
+        LaunchConfig(type="python", request="launch")  # type: ignore[call-arg]
+
+
+def test_launch_config_requires_type():
+    with pytest.raises(Exception):
+        LaunchConfig(name="Debug", request="launch")  # type: ignore[call-arg]
+
+
+def test_launch_config_requires_request():
+    with pytest.raises(Exception):
+        LaunchConfig(name="Debug", type="python")  # type: ignore[call-arg]
+
+
+def test_launch_config_program_is_optional():
+    lc = LaunchConfig(name="Debug", type="python", request="launch")
+    assert lc.program is None
+
+
+def test_launch_config_program_can_be_set():
+    lc = LaunchConfig(name="Debug", type="python", request="launch", program="main.py")
+    assert lc.program == "main.py"
+
+
+def test_launch_config_valid_minimal():
+    lc = LaunchConfig(name="My Launch", type="node", request="attach")
+    assert lc.name == "My Launch"
+    assert lc.type == "node"
+    assert lc.request == "attach"
+
+
+# ---------------------------------------------------------------------------
+# 10. Pydantic-level schema: InferredCommand field requirements
+# ---------------------------------------------------------------------------
+
+
+def test_inferred_command_requires_label():
+    with pytest.raises(Exception):
+        InferredCommand(command="pytest", source="pyproject.toml")  # type: ignore[call-arg]
+
+
+def test_inferred_command_requires_command():
+    with pytest.raises(Exception):
+        InferredCommand(label="pytest", source="pyproject.toml")  # type: ignore[call-arg]
+
+
+def test_inferred_command_requires_source():
+    with pytest.raises(Exception):
+        InferredCommand(label="pytest", command="pytest tests/")  # type: ignore[call-arg]
+
+
+def test_inferred_command_valid():
+    ic = InferredCommand(label="npm test", command="npm test", source="package.json scripts.test")
+    assert ic.label == "npm test"
+    assert ic.command == "npm test"
+    assert ic.source == "package.json scripts.test"
+
+
+# ---------------------------------------------------------------------------
+# 11. Tool registered in tool_service.py (source check)
+# ---------------------------------------------------------------------------
+
+
+def test_tool_registered_in_tool_service():
+    import pathlib
+
+    tools_dir = (
+        pathlib.Path(__file__).parents[3]
+        / "app"
+        / "modules"
+        / "intelligence"
+        / "tools"
+    )
+    source = (tools_dir / "tool_service.py").read_text(encoding="utf-8")
+
+    assert "get_workspace_debug_context_tool" in source, (
+        "tool_service.py must import get_workspace_debug_context_tool"
+    )
+    assert (
+        '"get_workspace_debug_context"' in source
+        or "'get_workspace_debug_context'" in source
+    ), "tool_service.py must register the tool under the key 'get_workspace_debug_context'"
+
+
+# ---------------------------------------------------------------------------
+# 12. DebugAgent tool list contains get_workspace_debug_context
+# ---------------------------------------------------------------------------
+
+
+def test_get_workspace_debug_context_in_debug_agent_tool_list():
+    import ast
+    import pathlib
+
+    src_path = (
+        pathlib.Path(__file__).parents[3]
+        / "app"
+        / "modules"
+        / "intelligence"
+        / "agents"
+        / "chat_agents"
+        / "system_agents"
+        / "debug_agent.py"
+    )
+    source = src_path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    tool_list: list[str] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get_tools"
+            and node.args
+            and isinstance(node.args[0], ast.List)
+        ):
+            for elt in node.args[0].elts:
+                if isinstance(elt, ast.Constant):
+                    tool_list.append(elt.value)
+
+    assert tool_list, "Could not find get_tools([...]) call in debug_agent.py"
+    assert "get_workspace_debug_context" in tool_list, (
+        f"'get_workspace_debug_context' not found in DebugAgent's get_tools([...]) call. "
+        f"Found: {tool_list}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bonus: tunnel_unreachable error type
+# ---------------------------------------------------------------------------
+
+
+def test_tunnel_unreachable_available_false():
+    with patch(_PATCH_TARGET, return_value=(None, "tunnel_unreachable")), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = get_workspace_debug_context()
+
+    assert result["available"] is False
+
+
+def test_tunnel_unreachable_message_mentions_tunnel():
+    with patch(_PATCH_TARGET, return_value=(None, "tunnel_unreachable")), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = get_workspace_debug_context()
+
+    msg = result["message"] or ""
+    assert "tunnel" in msg.lower() or "extension" in msg.lower()
+
+
+# ---------------------------------------------------------------------------
+# Bonus: StructuredTool factory sanity check
+# ---------------------------------------------------------------------------
+
+
+def test_tool_factory_returns_structured_tool():
+    from langchain_core.tools import StructuredTool
+
+    tool = get_workspace_debug_context_tool()
+    assert isinstance(tool, StructuredTool)
+    assert tool.name == "get_workspace_debug_context"
+
+
+def test_tool_factory_has_args_schema():
+    from app.modules.intelligence.tools.get_workspace_debug_context_tool import (
+        GetWorkspaceDebugContextInput,
+    )
+
+    tool = get_workspace_debug_context_tool()
+    assert tool.args_schema is GetWorkspaceDebugContextInput
+
+
+# ---------------------------------------------------------------------------
+# Bonus: message constants are non-empty strings (regression guard)
+# ---------------------------------------------------------------------------
+
+
+def test_message_constants_are_non_empty():
+    assert _MSG_NO_TUNNEL
+    assert _MSG_TIMEOUT
+    assert _MSG_UNKNOWN_ROUTE
+    assert _MSG_TUNNEL_UNREACHABLE
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher-level: HTTP timeout path returns (None, "timeout")
+# ---------------------------------------------------------------------------
+
+
+def test_route_workspace_debug_context_http_timeout_returns_timeout_code():
+    """An httpx.TimeoutException raised during HTTP dispatch must surface as
+    (None, "timeout") from route_workspace_debug_context — NOT "unknown_error".
+
+    Strategy:
+    - Make get_tunnel_service().get_tunnel_url() return an http:// URL so the
+      HTTP branch (not the socket branch) is taken.
+    - Make get_tunnel_service().get_workspace_id() return None (unused in this
+      path, but avoids AttributeError if accessed).
+    - Stub _get_tunnel_url / _get_repository / _get_branch so no real context
+      lookups fire.
+    - Patch httpx.Client.post to raise httpx.TimeoutException.
+    """
+    import httpx
+    from unittest.mock import MagicMock, patch as _patch
+
+    from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
+        route_workspace_debug_context,
+    )
+
+    http_tunnel_url = "http://localhost:49152"
+
+    mock_tunnel_service = MagicMock()
+    mock_tunnel_service.get_tunnel_url.return_value = http_tunnel_url
+    mock_tunnel_service.get_workspace_id.return_value = None
+
+    with _patch(
+        "app.modules.tunnel.tunnel_service.get_tunnel_service",
+        return_value=mock_tunnel_service,
+    ), _patch(
+        "app.modules.intelligence.tools.code_changes_manager._get_tunnel_url",
+        return_value=None,
+    ), _patch(
+        "app.modules.intelligence.tools.code_changes_manager._get_repository",
+        return_value=None,
+    ), _patch(
+        "app.modules.intelligence.tools.code_changes_manager._get_branch",
+        return_value=None,
+    ), _patch.object(
+        httpx.Client,
+        "post",
+        side_effect=httpx.TimeoutException("timed out"),
+    ):
+        result, err = route_workspace_debug_context(
+            focus_path=None,
+            user_id="u1",
+            conversation_id="c1",
+            timeout=1.0,
+        )
+
+    assert result is None
+    assert err == "timeout"
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher-level: HTTP ConnectError path returns (None, "tunnel_unreachable")
+# ---------------------------------------------------------------------------
+
+
+def test_route_workspace_debug_context_http_connect_error_returns_tunnel_unreachable():
+    """An httpx.ConnectError raised during HTTP dispatch must surface as
+    (None, "tunnel_unreachable") from route_workspace_debug_context — NOT "unknown_error".
+
+    Strategy mirrors the HTTP-timeout test directly above:
+    - Make get_tunnel_service().get_tunnel_url() return an http:// URL so the
+      HTTP branch (not the socket branch) is taken.
+    - Patch httpx.Client.post to raise httpx.ConnectError (DNS / refused).
+    """
+    import httpx
+    from unittest.mock import MagicMock, patch as _patch
+
+    from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
+        route_workspace_debug_context,
+    )
+
+    http_tunnel_url = "http://localhost:49152"
+
+    mock_tunnel_service = MagicMock()
+    mock_tunnel_service.get_tunnel_url.return_value = http_tunnel_url
+    mock_tunnel_service.get_workspace_id.return_value = None
+
+    with _patch(
+        "app.modules.tunnel.tunnel_service.get_tunnel_service",
+        return_value=mock_tunnel_service,
+    ), _patch(
+        "app.modules.intelligence.tools.code_changes_manager._get_tunnel_url",
+        return_value=None,
+    ), _patch(
+        "app.modules.intelligence.tools.code_changes_manager._get_repository",
+        return_value=None,
+    ), _patch(
+        "app.modules.intelligence.tools.code_changes_manager._get_branch",
+        return_value=None,
+    ), _patch.object(
+        httpx.Client,
+        "post",
+        side_effect=httpx.ConnectError("dns failure"),
+    ):
+        result, err = route_workspace_debug_context(
+            focus_path=None,
+            user_id="u1",
+            conversation_id="c1",
+            timeout=1.0,
+        )
+
+    assert result is None
+    assert err == "tunnel_unreachable"

--- a/tests/unit/intelligence/test_get_workspace_debug_context_tool.py
+++ b/tests/unit/intelligence/test_get_workspace_debug_context_tool.py
@@ -26,6 +26,8 @@ os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
 import pytest
 from unittest.mock import patch
 
+from pydantic import ValidationError
+
 from app.modules.intelligence.tools.get_workspace_debug_context_tool import (
     LaunchConfig,
     InferredCommand,
@@ -446,17 +448,17 @@ def test_schema_round_trip_unavailable():
 
 
 def test_launch_config_requires_name():
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         LaunchConfig(type="python", request="launch")  # type: ignore[call-arg]
 
 
 def test_launch_config_requires_type():
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         LaunchConfig(name="Debug", request="launch")  # type: ignore[call-arg]
 
 
 def test_launch_config_requires_request():
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         LaunchConfig(name="Debug", type="python")  # type: ignore[call-arg]
 
 
@@ -483,17 +485,17 @@ def test_launch_config_valid_minimal():
 
 
 def test_inferred_command_requires_label():
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         InferredCommand(command="pytest", source="pyproject.toml")  # type: ignore[call-arg]
 
 
 def test_inferred_command_requires_command():
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         InferredCommand(label="pytest", source="pyproject.toml")  # type: ignore[call-arg]
 
 
 def test_inferred_command_requires_source():
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         InferredCommand(label="pytest", command="pytest tests/")  # type: ignore[call-arg]
 
 

--- a/tests/unit/intelligence/test_get_workspace_debug_context_tool.py
+++ b/tests/unit/intelligence/test_get_workspace_debug_context_tool.py
@@ -24,7 +24,7 @@ os.environ.setdefault("POSTGRES_SERVER", "postgresql://test:test@localhost:5432/
 os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
 
 import pytest
-from unittest.mock import patch, call
+from unittest.mock import patch
 
 from app.modules.intelligence.tools.get_workspace_debug_context_tool import (
     LaunchConfig,
@@ -536,38 +536,19 @@ def test_tool_registered_in_tool_service():
 
 
 def test_get_workspace_debug_context_in_debug_agent_tool_list():
-    import ast
-    import pathlib
-
-    src_path = (
-        pathlib.Path(__file__).parents[3]
-        / "app"
-        / "modules"
-        / "intelligence"
-        / "agents"
-        / "chat_agents"
-        / "system_agents"
-        / "debug_agent.py"
+    from app.modules.intelligence.agents.chat_agents.system_agents.debug_agent import (
+        DEBUG_AGENT_BASE_TOOLS,
+        DEBUG_AGENT_DAP_TOOLS,
+        DEBUG_AGENT_TERMINAL_TOOLS,
     )
-    source = src_path.read_text(encoding="utf-8")
-    tree = ast.parse(source)
 
-    tool_list: list[str] = []
-    for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute)
-            and node.func.attr == "get_tools"
-            and node.args
-            and isinstance(node.args[0], ast.List)
-        ):
-            for elt in node.args[0].elts:
-                if isinstance(elt, ast.Constant):
-                    tool_list.append(elt.value)
-
-    assert tool_list, "Could not find get_tools([...]) call in debug_agent.py"
+    tool_list = (
+        list(DEBUG_AGENT_BASE_TOOLS)
+        + list(DEBUG_AGENT_DAP_TOOLS)
+        + list(DEBUG_AGENT_TERMINAL_TOOLS)
+    )
     assert "get_workspace_debug_context" in tool_list, (
-        f"'get_workspace_debug_context' not found in DebugAgent's get_tools([...]) call. "
+        f"'get_workspace_debug_context' not found in DebugAgent's tool allow-list. "
         f"Found: {tool_list}"
     )
 

--- a/tests/unit/intelligence/test_hypothesis_state_tools.py
+++ b/tests/unit/intelligence/test_hypothesis_state_tools.py
@@ -1,0 +1,583 @@
+"""Unit tests for hypothesis state tools (A5).
+
+Covers:
+  1. record_hypothesis returns a record with a non-empty id, status=PROPOSED by default,
+     and both created_at / updated_at set.
+  2. Two record_hypothesis calls produce DIFFERENT ids.
+  3. update_hypothesis_status updates the status and bumps updated_at (strictly greater).
+  4. update_hypothesis_status for an unknown id returns an error ({"error": ...}) not a
+     silent no-op — consistent with how todos returns a plain string for unknown ids.
+  5. append_hypothesis_evidence appends without losing prior entries.
+  6. list_hypotheses returns ALL created records in id order.
+  7. Cross-execution-context isolation: two separate ContextVar contexts do NOT see each
+     other's hypotheses (mirrors the parallel-agent-run isolation of TodoStorage).
+  8. Two sequential update_hypothesis_status calls both apply (last-write-wins, no corruption).
+  9. Status round-trips through Pydantic serialisation (enum value persists and reads
+     back as the same enum member).
+ 10. Tool registration: all four tool names appear as keys in tool_service.py's
+     _initialize_tools dict (AST inspection — avoids importing the heavy ML chain).
+ 11. All four tool names appear in DebugAgent's get_tools([...]) call (AST inspection).
+"""
+
+from __future__ import annotations
+
+import os
+
+# Set mandatory env vars before any app module is imported (same pattern as A8 tests).
+os.environ.setdefault("POSTGRES_SERVER", "postgresql://test:test@localhost:5432/testdb")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+
+import contextvars
+from datetime import datetime, timezone
+
+import pytest
+
+from app.modules.intelligence.agents.chat_agents.system_agents.debug_hypothesis_contract import (
+    HypothesisStatus,
+)
+from app.modules.intelligence.tools.hypothesis_state_tool import (
+    HypothesisRecord,
+    HypothesisStore,
+    RecordHypothesisInput,
+    UpdateHypothesisStatusInput,
+    AppendHypothesisEvidenceInput,
+    _hypothesis_store_ctx,
+    get_hypothesis_store,
+    record_hypothesis,
+    update_hypothesis_status,
+    append_hypothesis_evidence,
+    list_hypotheses,
+    create_hypothesis_state_tools,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fresh_store() -> HypothesisStore:
+    """Create a brand-new HypothesisStore, install it in the current ContextVar,
+    and return it.  Used to guarantee a clean state before each test."""
+    store = HypothesisStore()
+    _hypothesis_store_ctx.set(store)
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def isolated_store():
+    """Each test gets its own fresh HypothesisStore in the current context."""
+    _fresh_store()
+    yield
+    # Clean up — reset to None so the next test's autouse fixture can re-create
+    _hypothesis_store_ctx.set(None)
+
+
+# ---------------------------------------------------------------------------
+# 1. record_hypothesis — basic properties
+# ---------------------------------------------------------------------------
+
+
+def test_record_hypothesis_returns_nonempty_id():
+    result = record_hypothesis(title="Payment timeout not mapped to 402")
+    assert result["id"] != ""
+    assert result["id"].startswith("hyp_")
+
+
+def test_record_hypothesis_default_status_is_proposed():
+    result = record_hypothesis(title="Some hypothesis")
+    assert result["status"] == HypothesisStatus.PROPOSED.value
+
+
+def test_record_hypothesis_timestamps_are_set():
+    result = record_hypothesis(title="Another hypothesis")
+    assert result["created_at"] is not None
+    assert result["updated_at"] is not None
+
+
+def test_record_hypothesis_created_and_updated_at_equal_on_creation():
+    result = record_hypothesis(title="Timestamps equal at creation")
+    assert result["created_at"] == result["updated_at"]
+
+
+def test_record_hypothesis_with_explicit_status():
+    result = record_hypothesis(
+        title="Debugging in progress",
+        status=HypothesisStatus.DEBUGGING,
+    )
+    assert result["status"] == HypothesisStatus.DEBUGGING.value
+
+
+def test_record_hypothesis_with_evidence_and_plan():
+    result = record_hypothesis(
+        title="With evidence",
+        evidence=["Stack trace shows timeout at chargeCard"],
+        validation_plan=["Set breakpoint at chargeCard"],
+    )
+    assert result["evidence"] == ["Stack trace shows timeout at chargeCard"]
+    assert result["validation_plan"] == ["Set breakpoint at chargeCard"]
+
+
+# ---------------------------------------------------------------------------
+# 2. Two consecutive calls produce different ids
+# ---------------------------------------------------------------------------
+
+
+def test_two_record_calls_produce_different_ids():
+    r1 = record_hypothesis(title="Hypothesis A")
+    r2 = record_hypothesis(title="Hypothesis B")
+    assert r1["id"] != r2["id"]
+
+
+def test_ids_are_sequential():
+    r1 = record_hypothesis(title="First")
+    r2 = record_hypothesis(title="Second")
+    r3 = record_hypothesis(title="Third")
+    assert r1["id"] == "hyp_1"
+    assert r2["id"] == "hyp_2"
+    assert r3["id"] == "hyp_3"
+
+
+# ---------------------------------------------------------------------------
+# 3. update_hypothesis_status — updates status and bumps updated_at
+# ---------------------------------------------------------------------------
+
+
+def test_update_status_changes_status():
+    r = record_hypothesis(title="Will be updated")
+    result = update_hypothesis_status(
+        hypothesis_id=r["id"],
+        status=HypothesisStatus.DEBUGGING,
+    )
+    assert result["status"] == HypothesisStatus.DEBUGGING.value
+
+
+def test_update_status_bumps_updated_at():
+    import time
+
+    r = record_hypothesis(title="Timestamp bump test")
+    created_updated = r["updated_at"]
+
+    # Small sleep to ensure monotonically later timestamp
+    time.sleep(0.01)
+
+    result = update_hypothesis_status(
+        hypothesis_id=r["id"],
+        status=HypothesisStatus.SUPPORTED,
+    )
+    # updated_at after the update must be strictly later
+    assert result["updated_at"] > created_updated
+
+
+def test_update_status_does_not_change_created_at():
+    r = record_hypothesis(title="Created at must stay")
+    result = update_hypothesis_status(
+        hypothesis_id=r["id"],
+        status=HypothesisStatus.REJECTED,
+    )
+    assert result["created_at"] == r["created_at"]
+
+
+# ---------------------------------------------------------------------------
+# 4. update_hypothesis_status — unknown id returns error
+# ---------------------------------------------------------------------------
+
+
+def test_update_status_unknown_id_returns_error():
+    result = update_hypothesis_status(
+        hypothesis_id="hyp_999",
+        status=HypothesisStatus.REJECTED,
+    )
+    assert "error" in result
+    assert "hyp_999" in result["error"]
+
+
+def test_update_status_unknown_id_is_not_silent():
+    """Calling update_hypothesis_status with an unknown id MUST NOT silently succeed."""
+    result = update_hypothesis_status(
+        hypothesis_id="nonexistent",
+        status=HypothesisStatus.VALIDATED,
+    )
+    # Error is surfaced, not swallowed
+    assert "error" in result
+    assert result.get("status") is None  # no status field on an error response
+
+
+# ---------------------------------------------------------------------------
+# 5. append_hypothesis_evidence — appends without losing prior entries
+# ---------------------------------------------------------------------------
+
+
+def test_append_evidence_grows_list():
+    r = record_hypothesis(
+        title="Evidence accumulator",
+        evidence=["Initial observation"],
+    )
+    update_result = append_hypothesis_evidence(
+        hypothesis_id=r["id"],
+        evidence="Second observation",
+    )
+    assert len(update_result["evidence"]) == 2
+    assert update_result["evidence"][0] == "Initial observation"
+    assert update_result["evidence"][1] == "Second observation"
+
+
+def test_append_evidence_to_empty_list():
+    r = record_hypothesis(title="No initial evidence")
+    result = append_hypothesis_evidence(
+        hypothesis_id=r["id"],
+        evidence="First observation",
+    )
+    assert result["evidence"] == ["First observation"]
+
+
+def test_append_evidence_multiple_times():
+    r = record_hypothesis(title="Multiple appends")
+    for i in range(5):
+        result = append_hypothesis_evidence(
+            hypothesis_id=r["id"],
+            evidence=f"Observation {i}",
+        )
+    assert len(result["evidence"]) == 5
+
+
+def test_append_evidence_unknown_id_returns_error():
+    result = append_hypothesis_evidence(
+        hypothesis_id="hyp_404",
+        evidence="This should fail",
+    )
+    assert "error" in result
+    assert "hyp_404" in result["error"]
+
+
+def test_append_evidence_bumps_updated_at():
+    import time
+
+    r = record_hypothesis(title="Updated at check")
+    original_updated = r["updated_at"]
+    time.sleep(0.01)
+    result = append_hypothesis_evidence(
+        hypothesis_id=r["id"],
+        evidence="New observation",
+    )
+    assert result["updated_at"] > original_updated
+
+
+# ---------------------------------------------------------------------------
+# 6. list_hypotheses — returns all created records in id order
+# ---------------------------------------------------------------------------
+
+
+def test_list_hypotheses_returns_all_records():
+    record_hypothesis(title="Alpha")
+    record_hypothesis(title="Beta")
+    record_hypothesis(title="Gamma")
+    result = list_hypotheses()
+    assert len(result["hypotheses"]) == 3
+
+
+def test_list_hypotheses_empty_when_none_recorded():
+    result = list_hypotheses()
+    assert result["hypotheses"] == []
+
+
+def test_list_hypotheses_in_creation_order():
+    r1 = record_hypothesis(title="First")
+    r2 = record_hypothesis(title="Second")
+    result = list_hypotheses()
+    ids = [h["id"] for h in result["hypotheses"]]
+    assert ids == [r1["id"], r2["id"]]
+
+
+# ---------------------------------------------------------------------------
+# 7. Cross-execution-context isolation
+# ---------------------------------------------------------------------------
+
+
+def test_cross_context_isolation():
+    """Two separate ContextVar execution contexts must NOT see each other's hypotheses.
+
+    This mirrors how separate async agent runs (different ContextVar contexts)
+    maintain isolated TodoStorage instances in the todos family.
+    """
+    # Current context already has a fresh store (via autouse fixture).
+    record_hypothesis(title="Hypothesis in context A")
+    record_hypothesis(title="Another one in context A")
+    assert len(list_hypotheses()["hypotheses"]) == 2
+
+    # Run a callable in a brand-new ContextVar context (simulates a parallel agent run)
+    captured: list = []
+
+    def run_in_context_b() -> None:
+        # Install a fresh store for this context
+        _hypothesis_store_ctx.set(HypothesisStore())
+        # Record a different hypothesis
+        record_hypothesis(title="Hypothesis in context B")
+        # This context should see only 1 hypothesis
+        captured.append(list_hypotheses()["hypotheses"])
+
+    # contextvars.copy_context().run() creates an isolated copy of the context,
+    # which starts with the current ContextVar values but writes back to the copy —
+    # the original context is unaffected.
+    ctx_b = contextvars.copy_context()
+    ctx_b.run(run_in_context_b)
+
+    # Context B saw exactly 1 hypothesis (its own)
+    assert len(captured[0]) == 1
+    assert captured[0][0]["title"] == "Hypothesis in context B"
+
+    # Context A still sees 2 hypotheses (unaffected by context B)
+    assert len(list_hypotheses()["hypotheses"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# 8. Sequential updates — last-write-wins, no corruption
+# ---------------------------------------------------------------------------
+
+
+def test_two_sequential_status_updates_both_apply():
+    r = record_hypothesis(title="Sequential updates")
+    update_hypothesis_status(
+        hypothesis_id=r["id"],
+        status=HypothesisStatus.DEBUGGING,
+    )
+    second = update_hypothesis_status(
+        hypothesis_id=r["id"],
+        status=HypothesisStatus.SUPPORTED,
+    )
+    assert second["status"] == HypothesisStatus.SUPPORTED.value
+
+
+def test_sequential_updates_do_not_corrupt_other_hypotheses():
+    r1 = record_hypothesis(title="Target of updates")
+    r2 = record_hypothesis(title="Untouched sibling")
+
+    update_hypothesis_status(hypothesis_id=r1["id"], status=HypothesisStatus.DEBUGGING)
+    update_hypothesis_status(hypothesis_id=r1["id"], status=HypothesisStatus.REJECTED)
+
+    all_hyps = {h["id"]: h for h in list_hypotheses()["hypotheses"]}
+    assert all_hyps[r1["id"]]["status"] == HypothesisStatus.REJECTED.value
+    # r2 should still be PROPOSED — untouched
+    assert all_hyps[r2["id"]]["status"] == HypothesisStatus.PROPOSED.value
+
+
+# ---------------------------------------------------------------------------
+# 9. Status round-trips through Pydantic serialisation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status", list(HypothesisStatus))
+def test_status_roundtrip_through_serialization(status: HypothesisStatus):
+    """Every HypothesisStatus value must survive a model_dump / model_validate cycle."""
+    r = record_hypothesis(title=f"Status round-trip {status.value}", status=status)
+    # Deserialise back into a HypothesisRecord
+    restored = HypothesisRecord.model_validate(r)
+    assert restored.status == status
+
+
+@pytest.mark.parametrize("status", list(HypothesisStatus))
+def test_update_status_roundtrip(status: HypothesisStatus):
+    """update_hypothesis_status must persist and return the exact same enum member."""
+    r = record_hypothesis(title="Roundtrip after update")
+    result = update_hypothesis_status(hypothesis_id=r["id"], status=status)
+    restored = HypothesisRecord.model_validate(result)
+    assert restored.status == status
+
+
+# ---------------------------------------------------------------------------
+# 10. Tool registration in tool_service.py (AST inspection — no heavy import)
+# ---------------------------------------------------------------------------
+
+
+def test_all_four_tools_registered_in_tool_service_source():
+    """Verify tool_service.py wires up hypothesis state tools via create_hypothesis_state_tools().
+
+    The four tool names are registered via a loop (same as the todos pattern), so they
+    don't appear as literal strings in tool_service.py.  Instead we verify:
+      (a) create_hypothesis_state_tools is imported and called in tool_service.py, AND
+      (b) each tool name is declared as a literal in hypothesis_state_tool.py itself
+          (inside create_hypothesis_state_tools), proving the factory produces them.
+
+    This mirrors the A8 test pattern: AST inspection avoids the heavy ML import chain.
+    """
+    import ast
+    import pathlib
+
+    tools_dir = (
+        pathlib.Path(__file__).parents[3]
+        / "app"
+        / "modules"
+        / "intelligence"
+        / "tools"
+    )
+
+    # (a) tool_service.py must import and call create_hypothesis_state_tools
+    ts_source = (tools_dir / "tool_service.py").read_text(encoding="utf-8")
+    assert "create_hypothesis_state_tools" in ts_source, (
+        "tool_service.py must import create_hypothesis_state_tools from hypothesis_state_tool"
+    )
+
+    # (b) hypothesis_state_tool.py must declare all four tool names as string literals
+    hs_source = (tools_dir / "hypothesis_state_tool.py").read_text(encoding="utf-8")
+    hs_tree = ast.parse(hs_source)
+
+    declared_names: list[str] = []
+    for node in ast.walk(hs_tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            declared_names.append(node.value)
+
+    expected = [
+        "record_hypothesis",
+        "update_hypothesis_status",
+        "append_hypothesis_evidence",
+        "list_hypotheses",
+    ]
+    for name in expected:
+        assert name in declared_names, (
+            f"'{name}' not found as a string literal in hypothesis_state_tool.py. "
+            f"create_hypothesis_state_tools() must define a SimpleTool with this name."
+        )
+
+
+def test_hypothesis_state_tool_import_in_tool_service_source():
+    """tool_service.py must import from hypothesis_state_tool."""
+    import pathlib
+
+    src_path = (
+        pathlib.Path(__file__).parents[3]
+        / "app"
+        / "modules"
+        / "intelligence"
+        / "tools"
+        / "tool_service.py"
+    )
+    source = src_path.read_text(encoding="utf-8")
+    assert "hypothesis_state_tool" in source, (
+        "tool_service.py must import from hypothesis_state_tool"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 11. DebugAgent tool list (AST inspection)
+# ---------------------------------------------------------------------------
+
+
+def test_all_four_tools_in_debug_agent_tool_list():
+    """All four hypothesis tool names must appear in DebugAgent's get_tools([...]) call."""
+    import ast
+    import pathlib
+
+    src_path = (
+        pathlib.Path(__file__).parents[3]
+        / "app"
+        / "modules"
+        / "intelligence"
+        / "agents"
+        / "chat_agents"
+        / "system_agents"
+        / "debug_agent.py"
+    )
+    source = src_path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    tool_list: list[str] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get_tools"
+            and node.args
+            and isinstance(node.args[0], ast.List)
+        ):
+            for elt in node.args[0].elts:
+                if isinstance(elt, ast.Constant):
+                    tool_list.append(elt.value)
+
+    assert tool_list, "Could not find get_tools([...]) call in debug_agent.py"
+
+    expected = [
+        "record_hypothesis",
+        "update_hypothesis_status",
+        "append_hypothesis_evidence",
+        "list_hypotheses",
+    ]
+    for name in expected:
+        assert name in tool_list, (
+            f"'{name}' not found in DebugAgent's get_tools([...]) list. "
+            f"Found: {tool_list}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 12. Pydantic input schema sanity checks
+# ---------------------------------------------------------------------------
+
+
+def test_record_hypothesis_input_defaults():
+    inp = RecordHypothesisInput(title="Test")
+    assert inp.status == HypothesisStatus.PROPOSED
+    assert inp.evidence == []
+    assert inp.validation_plan == []
+
+
+def test_update_hypothesis_status_input_requires_both_fields():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        UpdateHypothesisStatusInput(hypothesis_id="hyp_1")  # missing status
+
+    with pytest.raises(ValidationError):
+        UpdateHypothesisStatusInput(status=HypothesisStatus.DEBUGGING)  # missing id
+
+
+def test_append_hypothesis_evidence_input_requires_both_fields():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        AppendHypothesisEvidenceInput(hypothesis_id="hyp_1")  # missing evidence
+
+    with pytest.raises(ValidationError):
+        AppendHypothesisEvidenceInput(evidence="Observation")  # missing id
+
+
+# ---------------------------------------------------------------------------
+# 13. create_hypothesis_state_tools returns the expected tool names
+# ---------------------------------------------------------------------------
+
+
+def test_create_hypothesis_state_tools_returns_four_tools():
+    tools = create_hypothesis_state_tools()
+    names = {t.name for t in tools}
+    assert names == {
+        "record_hypothesis",
+        "update_hypothesis_status",
+        "append_hypothesis_evidence",
+        "list_hypotheses",
+    }
+
+
+# ---------------------------------------------------------------------------
+# 14. conversation_id on HypothesisRecord (A5.1)
+# ---------------------------------------------------------------------------
+
+
+def test_record_carries_store_conversation_id():
+    """HypothesisRecord should carry the conversation_id from the bound store."""
+    store = HypothesisStore(conversation_id="conv_xyz_123")
+    _hypothesis_store_ctx.set(store)
+    result = record_hypothesis(title="Conv-id test hypothesis")
+    assert result["conversation_id"] == "conv_xyz_123"
+
+
+def test_record_default_conversation_id_is_empty_string():
+    """When HypothesisStore is created with no conversation_id, it defaults to empty string."""
+    # The autouse fixture installs a fresh default store (no conversation_id)
+    result = record_hypothesis(title="Default conversation_id hypothesis")
+    assert result["conversation_id"] == ""

--- a/tests/unit/intelligence/test_hypothesis_state_tools.py
+++ b/tests/unit/intelligence/test_hypothesis_state_tools.py
@@ -28,7 +28,6 @@ os.environ.setdefault("POSTGRES_SERVER", "postgresql://test:test@localhost:5432/
 os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
 
 import contextvars
-from datetime import datetime, timezone
 
 import pytest
 
@@ -42,7 +41,6 @@ from app.modules.intelligence.tools.hypothesis_state_tool import (
     UpdateHypothesisStatusInput,
     AppendHypothesisEvidenceInput,
     _hypothesis_store_ctx,
-    get_hypothesis_store,
     record_hypothesis,
     update_hypothesis_status,
     append_hypothesis_evidence,
@@ -470,37 +468,18 @@ def test_hypothesis_state_tool_import_in_tool_service_source():
 
 
 def test_all_four_tools_in_debug_agent_tool_list():
-    """All four hypothesis tool names must appear in DebugAgent's get_tools([...]) call."""
-    import ast
-    import pathlib
-
-    src_path = (
-        pathlib.Path(__file__).parents[3]
-        / "app"
-        / "modules"
-        / "intelligence"
-        / "agents"
-        / "chat_agents"
-        / "system_agents"
-        / "debug_agent.py"
+    """All four hypothesis tool names must appear in DebugAgent's tool allow-list."""
+    from app.modules.intelligence.agents.chat_agents.system_agents.debug_agent import (
+        DEBUG_AGENT_BASE_TOOLS,
+        DEBUG_AGENT_DAP_TOOLS,
+        DEBUG_AGENT_TERMINAL_TOOLS,
     )
-    source = src_path.read_text(encoding="utf-8")
-    tree = ast.parse(source)
 
-    tool_list: list[str] = []
-    for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute)
-            and node.func.attr == "get_tools"
-            and node.args
-            and isinstance(node.args[0], ast.List)
-        ):
-            for elt in node.args[0].elts:
-                if isinstance(elt, ast.Constant):
-                    tool_list.append(elt.value)
-
-    assert tool_list, "Could not find get_tools([...]) call in debug_agent.py"
+    tool_list = (
+        list(DEBUG_AGENT_BASE_TOOLS)
+        + list(DEBUG_AGENT_DAP_TOOLS)
+        + list(DEBUG_AGENT_TERMINAL_TOOLS)
+    )
 
     expected = [
         "record_hypothesis",
@@ -510,7 +489,7 @@ def test_all_four_tools_in_debug_agent_tool_list():
     ]
     for name in expected:
         assert name in tool_list, (
-            f"'{name}' not found in DebugAgent's get_tools([...]) list. "
+            f"'{name}' not found in DebugAgent's tool allow-list. "
             f"Found: {tool_list}"
         )
 
@@ -581,3 +560,118 @@ def test_record_default_conversation_id_is_empty_string():
     # The autouse fixture installs a fresh default store (no conversation_id)
     result = record_hypothesis(title="Default conversation_id hypothesis")
     assert result["conversation_id"] == ""
+
+
+# ---------------------------------------------------------------------------
+# 15. Schema coercion: string evidence/validation_plan → List[str]
+#
+# Root-cause guard: Traces 019e44e1... and 019e44dc... both showed the LLM
+# passing evidence/validation_plan as multi-line strings (following the prompt
+# example `evidence="<bullet points>"`) rather than as lists. This caused
+# RecordHypothesisInput pydantic validation to raise ValidationError, which
+# handle_exception caught and returned "An internal error occurred." — causing
+# record_hypothesis to silently fail and the hypothesis store to stay empty.
+#
+# The fix adds a field_validator that coerces str → List[str] by splitting on
+# newlines and stripping list markers. These tests lock that in.
+# ---------------------------------------------------------------------------
+
+
+def test_record_hypothesis_input_accepts_string_evidence():
+    """RecordHypothesisInput must coerce a newline-joined string to List[str].
+
+    The prompt example shows evidence as a string; the LLM follows the example.
+    Without coercion, pydantic raises ValidationError → tool returns
+    'An internal error occurred.' and the hypothesis store stays empty.
+    """
+    inp = RecordHypothesisInput(
+        title="Zero-length check missing",
+        evidence="- ASan shows heap-buffer-overflow in zipmapNext\n- Error: length=0",
+    )
+    assert isinstance(inp.evidence, list), "evidence must be coerced to a list"
+    assert len(inp.evidence) >= 1
+
+
+def test_record_hypothesis_input_accepts_string_validation_plan():
+    """RecordHypothesisInput must coerce a string validation_plan to List[str]."""
+    inp = RecordHypothesisInput(
+        title="Zero-length check missing",
+        validation_plan="- Set breakpoint at zipmapValidateIntegrity\n- Check length == 0",
+    )
+    assert isinstance(inp.validation_plan, list), "validation_plan must be coerced to a list"
+    assert len(inp.validation_plan) >= 1
+
+
+def test_record_hypothesis_input_string_evidence_splits_correctly():
+    """Each non-empty line (minus leading list markers) becomes a separate entry."""
+    inp = RecordHypothesisInput(
+        title="Test",
+        evidence="- First observation\n- Second observation\n- Third observation",
+    )
+    assert len(inp.evidence) == 3
+    assert inp.evidence[0] == "First observation"
+    assert inp.evidence[1] == "Second observation"
+    assert inp.evidence[2] == "Third observation"
+
+
+def test_record_hypothesis_input_empty_string_evidence_becomes_empty_list():
+    """An empty string for evidence must result in an empty list, not ['']."""
+    inp = RecordHypothesisInput(title="Test", evidence="")
+    assert inp.evidence == []
+
+
+def test_record_hypothesis_input_list_evidence_passes_through_unchanged():
+    """List evidence must not be modified by the coercion validator."""
+    obs = ["Stack trace shows auth.py:42", "NPE when user is None"]
+    inp = RecordHypothesisInput(title="Test", evidence=obs)
+    assert inp.evidence == obs
+
+
+# ---------------------------------------------------------------------------
+# 16. Full tool pipeline: string evidence must NOT trigger 'An internal error'
+#
+# These tests exercise the same code path the production agent uses:
+#   LLM args → RecordHypothesisInput validation → record_hypothesis() → store
+# ---------------------------------------------------------------------------
+
+
+def test_wrapped_record_hypothesis_succeeds_with_string_evidence():
+    """Simulates what the LLM does in practice: pass evidence as a string.
+
+    The tool must not return 'An internal error occurred.' after the schema fix.
+    Without the fix, pydantic raises ValidationError which handle_exception
+    swallows, leaving the hypothesis store empty.
+    """
+    import asyncio
+    from app.modules.intelligence.agents.chat_agents.multi_agent.utils.tool_utils import (
+        _adapt_func_for_from_schema,
+        handle_exception,
+    )
+
+    tools = create_hypothesis_state_tools()
+    rh_tool = next(t for t in tools if t.name == "record_hypothesis")
+    adapted = _adapt_func_for_from_schema(rh_tool)
+    wrapped = handle_exception(adapted)
+
+    result = asyncio.run(
+        wrapped(
+            title="Zero-length validation missing in zipmapValidateIntegrity",
+            status="proposed",
+            evidence="- ASan shows heap-buffer-overflow in zipmapNext at rdb.c:2408\n"
+                     "- Error message: Hash zipmap with big length (0)",
+            validation_plan="- Set breakpoint at zipmapValidateIntegrity\n"
+                            "- Verify length == 0 is not rejected",
+        )
+    )
+
+    assert result != "An internal error occurred. Please try again later.", (
+        "record_hypothesis must not return an internal-error string when evidence "
+        "is passed as a string. This indicates RecordHypothesisInput is rejecting "
+        "string evidence instead of coercing it to a list."
+    )
+    assert isinstance(result, dict), f"Expected dict result, got {type(result)}: {result!r}"
+    assert result.get("id", "").startswith("hyp_"), f"Expected hypothesis id, got: {result}"
+    # Verify the hypothesis actually landed in the store
+    stored = list_hypotheses()["hypotheses"]
+    assert len(stored) == 1
+    assert stored[0]["id"] == result["id"]

--- a/tests/unit/intelligence/test_local_search_tool_registration.py
+++ b/tests/unit/intelligence/test_local_search_tool_registration.py
@@ -1,0 +1,93 @@
+"""Regression tests for local search tool exposure to agents."""
+
+from pathlib import Path
+
+import pytest
+
+from app.modules.intelligence.tools.local_search_tools import tools as local_tools
+from app.modules.intelligence.tools.local_search_tools.search_bash_tool import (
+    SearchBashInput,
+)
+from app.modules.intelligence.tools.local_search_tools.search_text_tool import (
+    SearchTextInput,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_create_local_search_tools_exposes_text_and_bash():
+    tool_map = {tool.name: tool for tool in local_tools.create_local_search_tools()}
+
+    assert "search_text" in tool_map
+    assert "search_bash" in tool_map
+    assert tool_map["search_text"].args_schema is SearchTextInput
+    assert tool_map["search_bash"].args_schema is SearchBashInput
+
+
+def test_search_text_structured_tool_invokes_model_wrapper(monkeypatch):
+    captured: dict[str, SearchTextInput] = {}
+
+    def fake_search_text(input_data: SearchTextInput) -> str:
+        captured["input"] = input_data
+        return "ok"
+
+    monkeypatch.setattr(local_tools, "search_text_tool", fake_search_text)
+    tool = next(t for t in local_tools.create_local_search_tools() if t.name == "search_text")
+
+    assert tool.invoke({"query": "zipmapRawKeyLength", "use_bash": True}) == "ok"
+    assert captured["input"].query == "zipmapRawKeyLength"
+    assert captured["input"].use_bash is True
+
+
+def test_search_bash_structured_tool_invokes_model_wrapper(monkeypatch):
+    captured: dict[str, SearchBashInput] = {}
+
+    def fake_search_bash(input_data: SearchBashInput) -> str:
+        captured["input"] = input_data
+        return "ok"
+
+    monkeypatch.setattr(local_tools, "search_bash_tool", fake_search_bash)
+    tool = next(t for t in local_tools.create_local_search_tools() if t.name == "search_bash")
+
+    assert tool.invoke({"command": 'rg -n "zipmapEncodeLength" src tests'}) == "ok"
+    assert captured["input"].command == 'rg -n "zipmapEncodeLength" src tests'
+
+
+def test_tool_service_registers_local_search_tool_factory():
+    source = (
+        Path(__file__).parents[3]
+        / "app"
+        / "modules"
+        / "intelligence"
+        / "tools"
+        / "tool_service.py"
+    ).read_text(encoding="utf-8")
+
+    assert "create_local_search_tools" in source
+
+
+def test_debug_agent_requests_search_bash_after_search_text():
+    from app.modules.intelligence.agents.chat_agents.system_agents.debug_agent import (
+        DEBUG_AGENT_BASE_TOOLS,
+        DEBUG_AGENT_DAP_TOOLS,
+        DEBUG_AGENT_TERMINAL_TOOLS,
+    )
+
+    tool_list = (
+        list(DEBUG_AGENT_BASE_TOOLS)
+        + list(DEBUG_AGENT_DAP_TOOLS)
+        + list(DEBUG_AGENT_TERMINAL_TOOLS)
+    )
+    assert "search_text" in tool_list
+    assert "search_bash" in tool_list
+    assert tool_list.index("search_text") < tool_list.index("search_bash")
+
+
+def test_debug_agent_requests_terminal_tools_for_local_mode():
+    from app.modules.intelligence.agents.chat_agents.system_agents.debug_agent import (
+        DEBUG_AGENT_TERMINAL_TOOLS,
+    )
+
+    assert "execute_terminal_command" in DEBUG_AGENT_TERMINAL_TOOLS
+    assert "terminal_session_output" in DEBUG_AGENT_TERMINAL_TOOLS
+    assert "terminal_session_signal" in DEBUG_AGENT_TERMINAL_TOOLS

--- a/tests/unit/intelligence/test_parse_failure_signal_tool.py
+++ b/tests/unit/intelligence/test_parse_failure_signal_tool.py
@@ -1,0 +1,523 @@
+"""Unit tests for parse_failure_signal tool.
+
+Tests cover all supported failure signal formats:
+  - Python traceback → pasted_log
+  - pytest failure → failed_test
+  - Node/TypeScript stack → pasted_log
+  - Jest failure → failed_test
+  - Go goroutine dump → pasted_log
+  - Natural language symptom → nl_symptom
+  - Malformed/empty input → nl_symptom, no crash
+  - input_type_hint honored even when content is ambiguous
+"""
+import pytest
+
+from app.modules.intelligence.tools.parse_failure_signal_tool import (
+    ParseFailureSignalInput,
+    parse_failure_signal,
+)
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Fixture strings — realistic shapes, not stubs
+# ---------------------------------------------------------------------------
+
+PYTHON_TRACEBACK = """\
+Traceback (most recent call last):
+  File "src/payments/payment_service.py", line 120, in process_payment
+    result = adapter.charge(order)
+  File "src/payments/adapters/stripe_adapter.py", line 42, in charge
+    response = self._client.charges.create(**params)
+  File "/usr/local/lib/python3.11/site-packages/stripe/api_resources/charge.py", line 33, in create
+    return cls._static_request("post", cls.class_url(), **params)
+requests.exceptions.Timeout: HTTPSConnectionPool(host='api.stripe.com', port=443): Read timed out. (read timeout=30)
+"""
+
+PYTEST_FAILURE = """\
+FAILED tests/payments/test_payment_service.py::test_charge_returns_402_on_timeout - AssertionError: assert 500 == 402
+  where 500 = <Response [500]>.status_code
+
+________________________________ test_charge_returns_402_on_timeout ________________________________
+
+    def test_charge_returns_402_on_timeout():
+        response = client.post("/checkout", json={"amount": 100})
+>       assert response.status_code == 402
+E       AssertionError: assert 500 == 402
+E        +  where 500 = <Response [500]>.status_code
+
+tests/payments/test_payment_service.py:34: AssertionError
+"""
+
+NODE_TS_STACK = """\
+ERROR checkout.create_order payment_adapter.timeout request_id=req_456
+Stack: createOrder at src/checkout/createOrder.ts:88
+       chargeCard at src/payments/paymentAdapter.ts:42
+
+PaymentTimeoutError: Payment provider timed out after 30000ms
+    at PaymentAdapter.chargeCard (src/payments/paymentAdapter.ts:42:15)
+    at CheckoutService.createOrder (src/checkout/createOrder.ts:88:22)
+    at processTicksAndRejections (internal/process/task_queues.js:95:5)
+"""
+
+# Mixed symbolled and bare frames — exercises _NODE_AT_BARE_RE (symbol=None) path
+NODE_TS_MIXED_STACK = """\
+Error: ENOENT: no such file or directory, open '/etc/config.json'
+    at Object.openSync (node:fs:603:3)
+    at /app/src/loaders/config.js:42:18
+    at loadAll (/app/src/loaders/index.js:88:12)
+    at /app/src/bootstrap.js:14:5
+    at processTicksAndRejections (node:internal/process/task_queues:96:5)
+"""
+
+JEST_FAILURE = """\
+ FAIL tests/checkout/checkout.integration.test.ts
+  ● Checkout > test_charge_returns_402_on_timeout
+
+    expect(received).toBe(expected)
+
+    Expected: 402
+    Received: 500
+
+      32 |     const response = await request(app).post('/checkout').send({ amount: 100 });
+    > 33 |     expect(response.status).toBe(402);
+         |                             ^
+      34 |   });
+
+      at Object.<anonymous> (tests/checkout/checkout.integration.test.ts:33:29)
+"""
+
+GO_STACK = """\
+goroutine 1 [running]:
+main.chargeCard(0xc000104000, 0xc000078180)
+\t/home/user/project/payments/adapter.go:42 +0x1a4
+main.createOrder(0xc000104000)
+\t/home/user/project/checkout/order.go:88 +0x6c
+main.main()
+\t/home/user/project/main.go:22 +0x58
+exit status 2
+"""
+
+NL_SYMPTOM = "Checkout returns 500 when payment times out instead of a controlled payment failure response."
+
+EMPTY_INPUT = ""
+
+RANDOM_GARBAGE = "!!@#$%^&*()\n\x00\x01\x02garbage bytes here\nno frames at all"
+
+AMBIGUOUS_MIXED = """\
+Some log output that has no clear format.
+Just a few lines of text.
+Maybe it mentions an error somewhere.
+"""
+
+
+# ---------------------------------------------------------------------------
+# 1. Python traceback → pasted_log
+# ---------------------------------------------------------------------------
+
+def test_python_traceback_classification():
+    result = parse_failure_signal(PYTHON_TRACEBACK)
+    assert result["classification"] == "pasted_log"
+
+
+def test_python_traceback_frames_extracted():
+    result = parse_failure_signal(PYTHON_TRACEBACK)
+    frames = result["stack_frames"]
+    assert len(frames) >= 2
+
+
+def test_python_traceback_frame_file_paths():
+    result = parse_failure_signal(PYTHON_TRACEBACK)
+    files = [f["file"] for f in result["stack_frames"]]
+    assert any("payment_service.py" in f for f in files)
+    assert any("stripe_adapter.py" in f for f in files)
+
+
+def test_python_traceback_frame_line_numbers():
+    result = parse_failure_signal(PYTHON_TRACEBACK)
+    frames = result["stack_frames"]
+    # frames for our source files should have line numbers
+    src_frames = [f for f in frames if "site-packages" not in f["file"]]
+    for frame in src_frames:
+        assert frame["line"] is not None
+
+
+def test_python_traceback_frame_symbols():
+    result = parse_failure_signal(PYTHON_TRACEBACK)
+    frames = result["stack_frames"]
+    symbols = [f["symbol"] for f in frames]
+    assert "process_payment" in symbols or "charge" in symbols
+
+
+def test_python_traceback_error_type():
+    result = parse_failure_signal(PYTHON_TRACEBACK)
+    # The final error line is "requests.exceptions.Timeout: ..."
+    # error_type should capture the class name
+    assert result["error_type"] is not None
+    assert "Timeout" in result["error_type"] or "requests" in result["error_type"]
+
+
+def test_python_traceback_frame_language():
+    result = parse_failure_signal(PYTHON_TRACEBACK)
+    for frame in result["stack_frames"]:
+        if frame["file"].endswith(".py"):
+            assert frame["language"] == "python"
+
+
+def test_python_traceback_signature_non_empty():
+    result = parse_failure_signal(PYTHON_TRACEBACK)
+    assert result["signature"]
+    assert len(result["signature"]) > 0
+
+
+def test_python_traceback_raw_excerpt_present():
+    result = parse_failure_signal(PYTHON_TRACEBACK)
+    assert len(result["raw_excerpt"]) <= 300
+    assert result["raw_excerpt"] in PYTHON_TRACEBACK
+
+
+# ---------------------------------------------------------------------------
+# 2. pytest failure → failed_test
+# ---------------------------------------------------------------------------
+
+def test_pytest_classification():
+    result = parse_failure_signal(PYTEST_FAILURE)
+    assert result["classification"] == "failed_test"
+
+
+def test_pytest_error_type_extracted():
+    result = parse_failure_signal(PYTEST_FAILURE)
+    assert result["error_type"] is not None
+    assert "AssertionError" in result["error_type"]
+
+
+def test_pytest_frames_extracted():
+    result = parse_failure_signal(PYTEST_FAILURE)
+    frames = result["stack_frames"]
+    assert len(frames) >= 1
+    files = [f["file"] for f in frames]
+    assert any("test_payment_service.py" in f for f in files)
+
+
+def test_pytest_signature_contains_test_name():
+    result = parse_failure_signal(PYTEST_FAILURE)
+    # signature should reference something meaningful from the failure
+    assert result["signature"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Node/TypeScript stack → pasted_log, frames in correct order
+# ---------------------------------------------------------------------------
+
+def test_node_ts_classification():
+    result = parse_failure_signal(NODE_TS_STACK)
+    assert result["classification"] == "pasted_log"
+
+
+def test_node_ts_frames_order():
+    result = parse_failure_signal(NODE_TS_STACK)
+    frames = result["stack_frames"]
+    files = [f["file"] for f in frames]
+    # chargeCard comes before createOrder in the 'at' stack lines
+    adapter_idx = next((i for i, f in enumerate(files) if "paymentAdapter" in f), None)
+    checkout_idx = next((i for i, f in enumerate(files) if "createOrder" in f), None)
+    assert adapter_idx is not None
+    assert checkout_idx is not None
+    assert adapter_idx < checkout_idx
+
+
+def test_node_ts_frames_with_symbol():
+    result = parse_failure_signal(NODE_TS_STACK)
+    frames = result["stack_frames"]
+    symbols = [f["symbol"] for f in frames if f["symbol"]]
+    assert "PaymentAdapter.chargeCard" in symbols or "chargeCard" in symbols
+
+
+def test_node_ts_frames_line_numbers():
+    result = parse_failure_signal(NODE_TS_STACK)
+    frames = result["stack_frames"]
+    src_frames = [f for f in frames if "internal/" not in f["file"]]
+    for frame in src_frames:
+        assert frame["line"] is not None
+
+
+def test_node_ts_frame_language():
+    result = parse_failure_signal(NODE_TS_STACK)
+    for frame in result["stack_frames"]:
+        if frame["file"].endswith(".ts"):
+            assert frame["language"] == "typescript"
+        elif frame["file"].endswith(".js"):
+            assert frame["language"] == "javascript"
+
+
+def test_node_ts_error_type():
+    result = parse_failure_signal(NODE_TS_STACK)
+    assert result["error_type"] is not None
+    assert "PaymentTimeoutError" in result["error_type"]
+
+
+def test_node_stack_with_mixed_symbol_and_bare_frames():
+    """Node stack with symbolled frames AND bare 'at file:line:col' frames.
+
+    Exercises the _NODE_AT_BARE_RE path that sets symbol=None while still
+    populating the file field.
+    """
+    result = parse_failure_signal(NODE_TS_MIXED_STACK)
+
+    # classification
+    assert result["classification"] == "pasted_log"
+
+    frames = result["stack_frames"]
+
+    # at least 4 frames from the 5-line stack
+    assert len(frames) >= 4
+
+    # at least one bare frame (symbol is None, file is set)
+    bare_frames = [f for f in frames if f["symbol"] is None and f.get("file")]
+    assert len(bare_frames) >= 1, "Expected at least one bare frame with symbol=None"
+
+    # at least one symbolled frame (symbol is not None, file is set)
+    sym_frames = [f for f in frames if f["symbol"] is not None and f.get("file")]
+    assert len(sym_frames) >= 1, "Expected at least one frame with a symbol"
+
+    # frame order matches input order:
+    # 'config.js' (bare, line 2 of the at-block) must appear before 'index.js' (symbolled, line 3)
+    files = [f["file"] for f in frames]
+    config_idx = next((i for i, f in enumerate(files) if "config.js" in f), None)
+    index_idx = next((i for i, f in enumerate(files) if "index.js" in f), None)
+    assert config_idx is not None, "config.js frame not found"
+    assert index_idx is not None, "index.js frame not found"
+    assert config_idx < index_idx, "config.js should appear before index.js"
+
+
+# ---------------------------------------------------------------------------
+# 4. Jest failure → failed_test
+# ---------------------------------------------------------------------------
+
+def test_jest_classification():
+    result = parse_failure_signal(JEST_FAILURE)
+    assert result["classification"] == "failed_test"
+
+
+def test_jest_frames_extracted():
+    result = parse_failure_signal(JEST_FAILURE)
+    frames = result["stack_frames"]
+    assert len(frames) >= 1
+    files = [f["file"] for f in frames]
+    assert any("checkout.integration.test.ts" in f for f in files)
+
+
+def test_jest_error_type_or_none():
+    result = parse_failure_signal(JEST_FAILURE)
+    # Jest failures often don't have an explicit error class name in the FAIL line
+    # but may have expect(...).toBe(...) shape — error_type may be None or set
+    # We just verify it doesn't crash and returns a string or None
+    assert result["error_type"] is None or isinstance(result["error_type"], str)
+
+
+# ---------------------------------------------------------------------------
+# 5. Go goroutine dump → pasted_log, frames extracted
+# ---------------------------------------------------------------------------
+
+def test_go_classification():
+    result = parse_failure_signal(GO_STACK)
+    assert result["classification"] == "pasted_log"
+
+
+def test_go_frames_extracted():
+    result = parse_failure_signal(GO_STACK)
+    frames = result["stack_frames"]
+    assert len(frames) >= 2
+
+
+def test_go_frame_files_and_lines():
+    result = parse_failure_signal(GO_STACK)
+    frames = result["stack_frames"]
+    files = [f["file"] for f in frames]
+    assert any("adapter.go" in f for f in files)
+    assert any("order.go" in f for f in files)
+    for frame in frames:
+        if frame["file"].endswith(".go"):
+            assert frame["line"] is not None
+
+
+def test_go_frame_language():
+    result = parse_failure_signal(GO_STACK)
+    for frame in result["stack_frames"]:
+        if frame["file"].endswith(".go"):
+            assert frame["language"] == "go"
+
+
+def test_go_frame_symbols():
+    result = parse_failure_signal(GO_STACK)
+    frames = result["stack_frames"]
+    symbols = [f["symbol"] for f in frames if f["symbol"]]
+    assert len(symbols) >= 1
+
+
+# ---------------------------------------------------------------------------
+# 6. Natural language symptom → nl_symptom
+# ---------------------------------------------------------------------------
+
+def test_nl_symptom_classification():
+    result = parse_failure_signal(NL_SYMPTOM)
+    assert result["classification"] == "nl_symptom"
+
+
+def test_nl_symptom_empty_frames():
+    result = parse_failure_signal(NL_SYMPTOM)
+    assert result["stack_frames"] == []
+
+
+def test_nl_symptom_error_type_none():
+    result = parse_failure_signal(NL_SYMPTOM)
+    assert result["error_type"] is None
+
+
+def test_nl_symptom_signature_from_text():
+    result = parse_failure_signal(NL_SYMPTOM)
+    # signature should be first ~60 chars of the input
+    assert result["signature"]
+    assert len(result["signature"]) <= 64  # some tolerance
+
+
+# ---------------------------------------------------------------------------
+# 7. Malformed / empty input → no crash, nl_symptom
+# ---------------------------------------------------------------------------
+
+def test_empty_string_no_crash():
+    result = parse_failure_signal(EMPTY_INPUT)
+    assert result is not None
+
+
+def test_empty_string_classification():
+    result = parse_failure_signal(EMPTY_INPUT)
+    assert result["classification"] == "nl_symptom"
+
+
+def test_empty_string_empty_frames():
+    result = parse_failure_signal(EMPTY_INPUT)
+    assert result["stack_frames"] == []
+
+
+def test_random_garbage_no_crash():
+    result = parse_failure_signal(RANDOM_GARBAGE)
+    assert result is not None
+
+
+def test_random_garbage_classification():
+    result = parse_failure_signal(RANDOM_GARBAGE)
+    assert result["classification"] == "nl_symptom"
+
+
+def test_random_garbage_empty_frames():
+    result = parse_failure_signal(RANDOM_GARBAGE)
+    assert result["stack_frames"] == []
+
+
+# ---------------------------------------------------------------------------
+# 8. input_type_hint honored
+# ---------------------------------------------------------------------------
+
+def test_hint_pasted_log_overrides_ambiguous():
+    result = parse_failure_signal(AMBIGUOUS_MIXED, input_type_hint="pasted_log")
+    assert result["classification"] == "pasted_log"
+
+
+def test_hint_failed_test_overrides_ambiguous():
+    result = parse_failure_signal(AMBIGUOUS_MIXED, input_type_hint="failed_test")
+    assert result["classification"] == "failed_test"
+
+
+def test_hint_nl_symptom_overrides_ambiguous():
+    result = parse_failure_signal(AMBIGUOUS_MIXED, input_type_hint="nl_symptom")
+    assert result["classification"] == "nl_symptom"
+
+
+def test_hint_failed_test_on_python_traceback():
+    """When a hint is supplied for an ambiguous case, it should be honored."""
+    result = parse_failure_signal(PYTHON_TRACEBACK, input_type_hint="failed_test")
+    # Python traceback + pytest hint → failed_test wins
+    assert result["classification"] == "failed_test"
+
+
+# ---------------------------------------------------------------------------
+# 9. Return shape — always valid keys present
+# ---------------------------------------------------------------------------
+
+REQUIRED_KEYS = {"signature", "classification", "stack_frames", "error_type", "raw_excerpt"}
+
+
+@pytest.mark.parametrize("raw_text", [
+    PYTHON_TRACEBACK,
+    PYTEST_FAILURE,
+    NODE_TS_STACK,
+    JEST_FAILURE,
+    GO_STACK,
+    NL_SYMPTOM,
+    EMPTY_INPUT,
+    RANDOM_GARBAGE,
+])
+def test_result_always_has_required_keys(raw_text):
+    result = parse_failure_signal(raw_text)
+    for key in REQUIRED_KEYS:
+        assert key in result, f"Missing key: {key}"
+
+
+@pytest.mark.parametrize("raw_text", [
+    PYTHON_TRACEBACK,
+    PYTEST_FAILURE,
+    NODE_TS_STACK,
+    JEST_FAILURE,
+    GO_STACK,
+    NL_SYMPTOM,
+    EMPTY_INPUT,
+])
+def test_stack_frames_always_list(raw_text):
+    result = parse_failure_signal(raw_text)
+    assert isinstance(result["stack_frames"], list)
+
+
+@pytest.mark.parametrize("raw_text", [
+    PYTHON_TRACEBACK,
+    NODE_TS_STACK,
+    GO_STACK,
+])
+def test_stack_frames_have_required_keys(raw_text):
+    result = parse_failure_signal(raw_text)
+    for frame in result["stack_frames"]:
+        assert "file" in frame
+        assert "line" in frame
+        assert "symbol" in frame
+        assert "language" in frame
+
+
+# ---------------------------------------------------------------------------
+# 10. Regression: .tsx signature must not end with a trailing dot (Bug 1)
+# ---------------------------------------------------------------------------
+
+def test_jest_signature_no_trailing_dot_on_tsx():
+    result = parse_failure_signal(JEST_FAILURE)
+    assert not result["signature"].endswith(".")
+
+
+def test_tsx_inline_no_trailing_dot():
+    """Inline spot-check: a minimal Node stack ending in a .tsx frame."""
+    tsx_stack = (
+        "FAIL tests/Button.test.tsx\n"
+        "  at render (src/Button.tsx:42:5)\n"
+        "Expected: 1\n"
+        "Received: 0\n"
+    )
+    result = parse_failure_signal(tsx_stack)
+    assert not result["signature"].endswith(".")
+
+
+# ---------------------------------------------------------------------------
+# 11. Regression: markdown ● bullets must NOT classify as jest (Bug 2)
+# ---------------------------------------------------------------------------
+
+def test_markdown_bullets_not_classified_as_jest():
+    text = "● First finding\n● Second finding\n● Third finding\n"
+    result = parse_failure_signal(text)
+    assert result["classification"] == "nl_symptom"

--- a/tests/unit/intelligence/test_parse_failure_signal_tool.py
+++ b/tests/unit/intelligence/test_parse_failure_signal_tool.py
@@ -13,7 +13,6 @@ Tests cover all supported failure signal formats:
 import pytest
 
 from app.modules.intelligence.tools.parse_failure_signal_tool import (
-    ParseFailureSignalInput,
     parse_failure_signal,
 )
 

--- a/tests/unit/intelligence/test_query_context_graph_tool.py
+++ b/tests/unit/intelligence/test_query_context_graph_tool.py
@@ -1,0 +1,340 @@
+"""Unit tests for query_context_graph tool (stub).
+
+Covers:
+  1. Stub returns available=False, results==[], message mentions fallback tools.
+  2. Stub accepts and ignores arbitrary query/project_id/limit values.
+  3. ContextGraphResult and QueryContextGraphOutput round-trip through Pydantic.
+  4. Tool is registered in ToolService._initialize_tools and retrievable by name.
+  5. "query_context_graph" is in DebugAgent's tool list at the FIRST position of
+     the discovery section (immediately before ask_knowledge_graph_queries).
+"""
+from __future__ import annotations
+
+import os
+
+# Set a dummy POSTGRES_SERVER before any app module is imported.
+# app/core/database.py calls create_engine(os.getenv("POSTGRES_SERVER")) at
+# module level; without a value the import explodes.  The value only needs to
+# be a syntactically valid URL — the engine is never actually connected to in
+# these unit tests.
+os.environ.setdefault("POSTGRES_SERVER", "postgresql://test:test@localhost:5432/testdb")
+# Also set REDIS_URL to avoid similar issues with other eagerly-initialised modules.
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pydantic import ValidationError
+
+from app.modules.intelligence.tools.query_context_graph_tool import (
+    ContextGraphResult,
+    QueryContextGraphInput,
+    QueryContextGraphOutput,
+    query_context_graph,
+    query_context_graph_tool,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# 1. Stub always returns available=False with empty results and a message
+# ---------------------------------------------------------------------------
+
+
+def test_stub_available_is_false():
+    result = query_context_graph(
+        query="where is payment timeout handled",
+        project_id="proj-123",
+    )
+    assert result["available"] is False
+
+
+def test_stub_results_is_empty_list():
+    result = query_context_graph(
+        query="find all error handlers",
+        project_id="proj-abc",
+    )
+    assert result["results"] == []
+
+
+def test_stub_message_mentions_ask_knowledge_graph_queries():
+    result = query_context_graph(
+        query="any query",
+        project_id="any-project",
+    )
+    assert result["message"] is not None
+    assert "ask_knowledge_graph_queries" in result["message"]
+
+
+def test_stub_message_mentions_fallback_theme():
+    """Message must reference the fallback concept so the agent can act on it."""
+    result = query_context_graph(
+        query="any query",
+        project_id="any-project",
+    )
+    assert result["message"] is not None
+    # The message should tell the agent to fall back to alternative tools
+    msg = result["message"].lower()
+    assert "fall back" in msg or "fallback" in msg
+
+
+# ---------------------------------------------------------------------------
+# 2. Stub accepts and ignores arbitrary inputs — must not raise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "query,project_id,limit",
+    [
+        ("where is payment timeout handled", "proj_123", 10),
+        ("", "proj_123", 10),
+        ("x", "proj_123", 100_000),
+    ],
+)
+def test_stub_accepts_varied_inputs(query, project_id, limit):
+    result = query_context_graph(query=query, project_id=project_id, limit=limit)
+    # Stub ignores inputs and always returns the unavailable shape
+    assert result["available"] is False
+    assert result["results"] == []
+
+
+def test_input_schema_default_limit_is_ten():
+    assert QueryContextGraphInput.model_fields["limit"].default == 10
+
+
+def test_context_graph_result_score_out_of_bounds_rejected():
+    with pytest.raises(ValidationError):
+        ContextGraphResult(file="a.py", score=1.5)
+    with pytest.raises(ValidationError):
+        ContextGraphResult(file="a.py", score=-0.1)
+
+
+def test_context_graph_result_score_bounds_accepted():
+    ContextGraphResult(file="a.py", score=0.0)
+    ContextGraphResult(file="a.py", score=1.0)
+
+
+# ---------------------------------------------------------------------------
+# 3. Pydantic round-trip for ContextGraphResult and QueryContextGraphOutput
+# ---------------------------------------------------------------------------
+
+
+def test_context_graph_result_roundtrip_all_fields():
+    original = ContextGraphResult(
+        file="src/payments/adapter.py",
+        symbol="PaymentAdapter.charge",
+        snippet="    raise PaymentTimeoutError('timed out')",
+        score=0.92,
+    )
+    dumped = original.model_dump()
+    restored = ContextGraphResult.model_validate(dumped)
+
+    assert restored.file == original.file
+    assert restored.symbol == original.symbol
+    assert restored.snippet == original.snippet
+    assert restored.score == original.score
+
+
+def test_context_graph_result_roundtrip_optional_fields_none():
+    original = ContextGraphResult(file="src/app.py", score=0.5)
+    dumped = original.model_dump()
+    restored = ContextGraphResult.model_validate(dumped)
+
+    assert restored.file == "src/app.py"
+    assert restored.symbol is None
+    assert restored.snippet is None
+    assert restored.score == 0.5
+
+
+def test_query_context_graph_output_roundtrip_stub_shape():
+    original = QueryContextGraphOutput(
+        available=False,
+        results=[],
+        message="context graph service not yet wired; agent should fall back to "
+        "ask_knowledge_graph_queries / search_text / file structure tools",
+    )
+    dumped = original.model_dump()
+    restored = QueryContextGraphOutput.model_validate(dumped)
+
+    assert restored.available is False
+    assert restored.results == []
+    assert "ask_knowledge_graph_queries" in (restored.message or "")
+
+
+def test_query_context_graph_output_roundtrip_real_service_shape():
+    """Simulate what the real service would return when it has hits."""
+    hit = ContextGraphResult(
+        file="src/checkout/createOrder.ts",
+        symbol="CheckoutService.createOrder",
+        snippet="  throw new PaymentTimeoutError(err.message);",
+        score=0.95,
+    )
+    original = QueryContextGraphOutput(
+        available=True,
+        results=[hit],
+        message=None,
+    )
+    dumped = original.model_dump()
+    restored = QueryContextGraphOutput.model_validate(dumped)
+
+    assert restored.available is True
+    assert len(restored.results) == 1
+    assert restored.results[0].file == "src/checkout/createOrder.ts"
+    assert restored.message is None
+
+
+# ---------------------------------------------------------------------------
+# 4. Tool is registered in ToolService and is NOT embedding-dependent
+#    (tested via AST inspection of tool_service.py source to avoid the
+#    heavyweight module-level import chain that pulls in torch/transformers)
+# ---------------------------------------------------------------------------
+
+
+def test_tool_registered_in_tool_service_source():
+    """_initialize_tools() in tool_service.py must contain the key 'query_context_graph'.
+
+    We inspect the source via AST rather than importing ToolService, which would
+    pull in sentence_transformers → torch, an ML dependency incompatible with the
+    Python 3.13 venv used in unit-test runs.
+    """
+    import ast
+    import pathlib
+
+    src_path = (
+        pathlib.Path(__file__).parents[3]
+        / "app" / "modules" / "intelligence" / "tools" / "tool_service.py"
+    )
+    source = src_path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    registered_keys: list[str] = []
+    for node in ast.walk(tree):
+        # Find dict literals that look like {"tool_name": <call>, ...}
+        if isinstance(node, ast.Dict):
+            for key in node.keys:
+                if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                    registered_keys.append(key.value)
+
+    assert "query_context_graph" in registered_keys, (
+        f"'query_context_graph' not found as a key in any dict in tool_service.py. "
+        f"Keys found: {registered_keys}"
+    )
+
+
+def test_tool_not_in_embedding_dependent_tools_source():
+    """EMBEDDING_DEPENDENT_TOOLS in tool_service.py must NOT contain 'query_context_graph'."""
+    import ast
+    import pathlib
+
+    src_path = (
+        pathlib.Path(__file__).parents[3]
+        / "app" / "modules" / "intelligence" / "tools" / "tool_service.py"
+    )
+    source = src_path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    # Find the set literal assigned to EMBEDDING_DEPENDENT_TOOLS
+    embedding_tool_names: list[str] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and any(
+                isinstance(t, ast.Name) and t.id == "EMBEDDING_DEPENDENT_TOOLS"
+                for t in node.targets
+            )
+        ):
+            if isinstance(node.value, ast.Set):
+                for elt in node.value.elts:
+                    if isinstance(elt, ast.Constant):
+                        embedding_tool_names.append(elt.value)
+
+    assert "query_context_graph" not in embedding_tool_names, (
+        "'query_context_graph' must NOT be in EMBEDDING_DEPENDENT_TOOLS"
+    )
+
+
+def test_query_context_graph_tool_import_exists_in_tool_service_source():
+    """tool_service.py must import from query_context_graph_tool."""
+    import pathlib
+
+    src_path = (
+        pathlib.Path(__file__).parents[3]
+        / "app" / "modules" / "intelligence" / "tools" / "tool_service.py"
+    )
+    source = src_path.read_text(encoding="utf-8")
+    assert "query_context_graph_tool" in source, (
+        "tool_service.py must import from query_context_graph_tool"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. "query_context_graph" is FIRST in DebugAgent's discovery section
+# ---------------------------------------------------------------------------
+
+
+def test_query_context_graph_is_first_discovery_tool_in_debug_agent():
+    """query_context_graph must appear in the DebugAgent tool list AND must be
+    immediately before ask_knowledge_graph_queries (first in discovery section).
+
+    Tested via AST inspection to avoid importing the heavy debug_agent module chain.
+    """
+    import ast
+    import pathlib
+
+    src_path = (
+        pathlib.Path(__file__).parents[3]
+        / "app" / "modules" / "intelligence" / "agents"
+        / "chat_agents" / "system_agents" / "debug_agent.py"
+    )
+    source = src_path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    tool_list: list[str] = []
+    for node in ast.walk(tree):
+        # Look for a call: *.get_tools([...], ...)
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get_tools"
+            and node.args
+            and isinstance(node.args[0], ast.List)
+        ):
+            for elt in node.args[0].elts:
+                if isinstance(elt, ast.Constant):
+                    tool_list.append(elt.value)
+
+    assert tool_list, "Could not find get_tools([...]) call in debug_agent.py"
+    assert "query_context_graph" in tool_list, (
+        "'query_context_graph' not found in DebugAgent tool list"
+    )
+
+    qcg_idx = tool_list.index("query_context_graph")
+    assert "ask_knowledge_graph_queries" in tool_list, (
+        "'ask_knowledge_graph_queries' not found in DebugAgent tool list"
+    )
+    akg_idx = tool_list.index("ask_knowledge_graph_queries")
+
+    assert qcg_idx < akg_idx, (
+        f"'query_context_graph' (index {qcg_idx}) must come before "
+        f"'ask_knowledge_graph_queries' (index {akg_idx}) — it is first in the discovery section"
+    )
+    # Verify it immediately precedes ask_knowledge_graph_queries (no other discovery
+    # tool inserted between them by mistake)
+    assert qcg_idx + 1 == akg_idx, (
+        f"'query_context_graph' (index {qcg_idx}) must be IMMEDIATELY before "
+        f"'ask_knowledge_graph_queries' (index {akg_idx})"
+    )
+
+
+def test_discovery_priority_order_first_entry_matches_tool_name():
+    """DISCOVERY_PRIORITY_ORDER[0] must be exactly 'query_context_graph'."""
+    from app.modules.intelligence.agents.chat_agents.system_agents.debug_hypothesis_contract import (
+        DISCOVERY_PRIORITY_ORDER,
+    )
+
+    assert DISCOVERY_PRIORITY_ORDER[0] == "query_context_graph", (
+        f"Expected DISCOVERY_PRIORITY_ORDER[0] == 'query_context_graph', "
+        f"got {DISCOVERY_PRIORITY_ORDER[0]!r}"
+    )

--- a/tests/unit/intelligence/test_query_context_graph_tool.py
+++ b/tests/unit/intelligence/test_query_context_graph_tool.py
@@ -5,8 +5,11 @@ Covers:
   2. Stub accepts and ignores arbitrary query/project_id/limit values.
   3. ContextGraphResult and QueryContextGraphOutput round-trip through Pydantic.
   4. Tool is registered in ToolService._initialize_tools and retrievable by name.
-  5. "query_context_graph" is in DebugAgent's tool list at the FIRST position of
-     the discovery section (immediately before ask_knowledge_graph_queries).
+
+Note: the DebugAgent no longer uses query_context_graph (it was removed from the
+DebugAgent's discovery flow when DebugAgent was repositioned as a pure pydantic-deep
+agent). The tool itself remains registered for other agents, so these tests cover
+the tool's own contract — not its presence in DebugAgent.
 """
 from __future__ import annotations
 
@@ -21,8 +24,6 @@ os.environ.setdefault("POSTGRES_SERVER", "postgresql://test:test@localhost:5432/
 # Also set REDIS_URL to avoid similar issues with other eagerly-initialised modules.
 os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
 
-from unittest.mock import MagicMock, patch
-
 import pytest
 
 from pydantic import ValidationError
@@ -32,7 +33,6 @@ from app.modules.intelligence.tools.query_context_graph_tool import (
     QueryContextGraphInput,
     QueryContextGraphOutput,
     query_context_graph,
-    query_context_graph_tool,
 )
 
 pytestmark = pytest.mark.unit
@@ -153,7 +153,7 @@ def test_query_context_graph_output_roundtrip_stub_shape():
         available=False,
         results=[],
         message="context graph service not yet wired; agent should fall back to "
-        "ask_knowledge_graph_queries / search_text / file structure tools",
+        "ask_knowledge_graph_queries / search_text / search_bash / file structure tools",
     )
     dumped = original.model_dump()
     restored = QueryContextGraphOutput.model_validate(dumped)
@@ -266,75 +266,4 @@ def test_query_context_graph_tool_import_exists_in_tool_service_source():
     source = src_path.read_text(encoding="utf-8")
     assert "query_context_graph_tool" in source, (
         "tool_service.py must import from query_context_graph_tool"
-    )
-
-
-# ---------------------------------------------------------------------------
-# 5. "query_context_graph" is FIRST in DebugAgent's discovery section
-# ---------------------------------------------------------------------------
-
-
-def test_query_context_graph_is_first_discovery_tool_in_debug_agent():
-    """query_context_graph must appear in the DebugAgent tool list AND must be
-    immediately before ask_knowledge_graph_queries (first in discovery section).
-
-    Tested via AST inspection to avoid importing the heavy debug_agent module chain.
-    """
-    import ast
-    import pathlib
-
-    src_path = (
-        pathlib.Path(__file__).parents[3]
-        / "app" / "modules" / "intelligence" / "agents"
-        / "chat_agents" / "system_agents" / "debug_agent.py"
-    )
-    source = src_path.read_text(encoding="utf-8")
-    tree = ast.parse(source)
-
-    tool_list: list[str] = []
-    for node in ast.walk(tree):
-        # Look for a call: *.get_tools([...], ...)
-        if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute)
-            and node.func.attr == "get_tools"
-            and node.args
-            and isinstance(node.args[0], ast.List)
-        ):
-            for elt in node.args[0].elts:
-                if isinstance(elt, ast.Constant):
-                    tool_list.append(elt.value)
-
-    assert tool_list, "Could not find get_tools([...]) call in debug_agent.py"
-    assert "query_context_graph" in tool_list, (
-        "'query_context_graph' not found in DebugAgent tool list"
-    )
-
-    qcg_idx = tool_list.index("query_context_graph")
-    assert "ask_knowledge_graph_queries" in tool_list, (
-        "'ask_knowledge_graph_queries' not found in DebugAgent tool list"
-    )
-    akg_idx = tool_list.index("ask_knowledge_graph_queries")
-
-    assert qcg_idx < akg_idx, (
-        f"'query_context_graph' (index {qcg_idx}) must come before "
-        f"'ask_knowledge_graph_queries' (index {akg_idx}) — it is first in the discovery section"
-    )
-    # Verify it immediately precedes ask_knowledge_graph_queries (no other discovery
-    # tool inserted between them by mistake)
-    assert qcg_idx + 1 == akg_idx, (
-        f"'query_context_graph' (index {qcg_idx}) must be IMMEDIATELY before "
-        f"'ask_knowledge_graph_queries' (index {akg_idx})"
-    )
-
-
-def test_discovery_priority_order_first_entry_matches_tool_name():
-    """DISCOVERY_PRIORITY_ORDER[0] must be exactly 'query_context_graph'."""
-    from app.modules.intelligence.agents.chat_agents.system_agents.debug_hypothesis_contract import (
-        DISCOVERY_PRIORITY_ORDER,
-    )
-
-    assert DISCOVERY_PRIORITY_ORDER[0] == "query_context_graph", (
-        f"Expected DISCOVERY_PRIORITY_ORDER[0] == 'query_context_graph', "
-        f"got {DISCOVERY_PRIORITY_ORDER[0]!r}"
     )

--- a/tests/unit/intelligence/test_reasoning_manager.py
+++ b/tests/unit/intelligence/test_reasoning_manager.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 
 import pytest
 

--- a/tests/unit/intelligence/test_run_validation_tool.py
+++ b/tests/unit/intelligence/test_run_validation_tool.py
@@ -1,0 +1,535 @@
+"""Unit tests for run_validation tool (A6).
+
+Tests cover all four status branches and auxiliary behaviours:
+  1.  Success path: exit_code=0 → status=passed, evidence mentions wall time.
+  2.  Failure path: exit_code=1, pytest-shaped output → status=failed, evidence
+      carries "failed —" prefix and the first error-shaped line.
+  3.  Failure path: exit_code=2, generic stderr "Error: something broke" →
+      status=failed, evidence picks up that line.
+  4.  Failure path, no error-shaped line → falls back to last non-empty line.
+  5.  Timeout path: executor returns "timeout" error_type → status=timed_out,
+      exit_code=None, evidence mentions the timeout limit.
+  6.  Error path: no-tunnel error_type → status=error, evidence includes message.
+  7.  output_excerpt is capped at ~800 chars.
+  8.  evidence_summary is capped at 240 chars.
+  9.  command field echoes the input.
+  10. Tool registered in tool_service.py (AST source check).
+  11. "run_validation" appears in DebugAgent's get_tools([...]) list (AST check).
+"""
+
+from __future__ import annotations
+
+import os
+
+# Set mandatory env vars before any app module is imported.
+os.environ.setdefault("POSTGRES_SERVER", "postgresql://test:test@localhost:5432/testdb")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from app.modules.intelligence.tools.run_validation_tool import (
+    RunValidationInput,
+    RunValidationResult,
+    run_validation,
+    run_validation_tool,
+    _find_last_error_line,
+    _last_nonempty_line,
+    _build_evidence_summary,
+    _MAX_EXCERPT_CHARS,
+    _MAX_EVIDENCE_CHARS,
+)
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Helpers — patch target for route_terminal_command
+# ---------------------------------------------------------------------------
+
+_PATCH_TARGET = (
+    "app.modules.intelligence.tools.run_validation_tool.route_terminal_command"
+)
+_CONTEXT_PATCH = (
+    "app.modules.intelligence.tools.run_validation_tool.get_context_vars"
+)
+
+
+def _make_result(
+    *,
+    success: bool = True,
+    exit_code: int = 0,
+    output: str = "",
+    error: str = "",
+    duration_ms: int = 4300,
+) -> dict:
+    return {
+        "success": success,
+        "exit_code": exit_code,
+        "output": output,
+        "error": error,
+        "duration_ms": duration_ms,
+        "command": "pytest",
+        "truncated": False,
+        "warnings": [],
+        "timed_out": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Success path: exit_code=0 → status=passed
+# ---------------------------------------------------------------------------
+
+
+def test_success_path_status_passed():
+    result_dict = _make_result(success=True, exit_code=0, output="1 passed in 4.3s", duration_ms=4300)
+    with patch(_PATCH_TARGET, return_value=(result_dict, None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = run_validation(command="pytest tests/test_foo.py")
+
+    assert result["status"] == "passed"
+    assert result["exit_code"] == 0
+    assert "passed" in result["evidence_summary"].lower()
+    assert result["command"] == "pytest tests/test_foo.py"
+
+
+def test_success_path_evidence_mentions_wall_time():
+    result_dict = _make_result(success=True, exit_code=0, duration_ms=4300)
+    with patch(_PATCH_TARGET, return_value=(result_dict, None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = run_validation(command="pytest tests/test_foo.py")
+
+    # duration_ms=4300 → 4.3s in evidence
+    assert "4.3s" in result["evidence_summary"]
+
+
+def test_success_path_exit_code_populated():
+    result_dict = _make_result(success=True, exit_code=0)
+    with patch(_PATCH_TARGET, return_value=(result_dict, None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = run_validation(command="npm test")
+
+    assert result["exit_code"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 2. Failure path: exit_code=1, pytest-shaped output
+# ---------------------------------------------------------------------------
+
+_PYTEST_OUTPUT = """\
+FAILED tests/payments/test_payment_service.py::test_charge_returns_402_on_timeout - AssertionError: assert 500 == 402
+  where 500 = <Response [500]>.status_code
+
+tests/payments/test_payment_service.py:34: AssertionError
+1 failed in 2.1s
+"""
+
+
+def test_failure_path_exit1_pytest_status_failed():
+    result_dict = _make_result(success=False, exit_code=1, output=_PYTEST_OUTPUT)
+    with patch(_PATCH_TARGET, return_value=(result_dict, None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = run_validation(command="pytest tests/payments/test_payment_service.py")
+
+    assert result["status"] == "failed"
+    assert result["exit_code"] == 1
+
+
+def test_failure_path_exit1_evidence_has_failed_prefix():
+    result_dict = _make_result(success=False, exit_code=1, output=_PYTEST_OUTPUT)
+    with patch(_PATCH_TARGET, return_value=(result_dict, None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = run_validation(command="pytest tests/payments/test_payment_service.py")
+
+    assert result["evidence_summary"].startswith("failed —")
+
+
+def test_failure_path_exit1_evidence_contains_error_line():
+    result_dict = _make_result(success=False, exit_code=1, output=_PYTEST_OUTPUT)
+    with patch(_PATCH_TARGET, return_value=(result_dict, None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = run_validation(command="pytest tests/payments/test_payment_service.py")
+
+    # Should surface something from the FAILED line or AssertionError
+    summary = result["evidence_summary"]
+    assert "AssertionError" in summary or "FAILED" in summary or "assert" in summary.lower()
+
+
+# ---------------------------------------------------------------------------
+# 3. Failure path: exit_code=2, generic stderr "Error: something broke"
+# ---------------------------------------------------------------------------
+
+_GENERIC_STDERR = "Error: something broke\nsome other info"
+
+
+def test_failure_path_exit2_generic_stderr_status_failed():
+    result_dict = _make_result(success=False, exit_code=2, error=_GENERIC_STDERR)
+    with patch(_PATCH_TARGET, return_value=(result_dict, None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = run_validation(command="npm test")
+
+    assert result["status"] == "failed"
+    assert result["exit_code"] == 2
+
+
+def test_failure_path_exit2_evidence_picks_error_line():
+    result_dict = _make_result(success=False, exit_code=2, error=_GENERIC_STDERR)
+    with patch(_PATCH_TARGET, return_value=(result_dict, None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = run_validation(command="npm test")
+
+    # "Error:" is in the pattern — should appear in evidence
+    assert "Error" in result["evidence_summary"] or "broke" in result["evidence_summary"]
+
+
+# ---------------------------------------------------------------------------
+# 4. Failure path with no error-shaped line → last non-empty line fallback
+# ---------------------------------------------------------------------------
+
+_PLAIN_FAIL_OUTPUT = "Starting tests...\nAll tests completed.\nSome tests did not pass."
+
+
+def test_failure_no_error_line_falls_back_to_last_nonempty():
+    result_dict = _make_result(success=False, exit_code=1, output=_PLAIN_FAIL_OUTPUT)
+    with patch(_PATCH_TARGET, return_value=(result_dict, None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = run_validation(command="./run_tests.sh")
+
+    # No pattern match → falls back to "Some tests did not pass."
+    assert result["status"] == "failed"
+    assert result["evidence_summary"].startswith("failed —")
+    assert "Some tests did not pass" in result["evidence_summary"]
+
+
+# ---------------------------------------------------------------------------
+# 5. Timeout path
+# ---------------------------------------------------------------------------
+
+
+def test_timeout_status_is_timed_out():
+    with patch(_PATCH_TARGET, return_value=(None, "timeout")), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = run_validation(command="pytest", timeout_seconds=30)
+
+    assert result["status"] == "timed_out"
+
+
+def test_timeout_exit_code_is_none():
+    with patch(_PATCH_TARGET, return_value=(None, "timeout")), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = run_validation(command="pytest", timeout_seconds=30)
+
+    assert result["exit_code"] is None
+
+
+def test_timeout_evidence_mentions_limit():
+    with patch(_PATCH_TARGET, return_value=(None, "timeout")), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = run_validation(command="pytest", timeout_seconds=120)
+
+    assert "120" in result["evidence_summary"]
+    assert "limit" in result["evidence_summary"].lower() or "timed out" in result["evidence_summary"].lower()
+
+
+# ---------------------------------------------------------------------------
+# 6. Error path: no-tunnel → status=error
+# ---------------------------------------------------------------------------
+
+
+def test_error_path_no_tunnel_status_error():
+    with patch(_PATCH_TARGET, return_value=(None, "no_tunnel")), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = run_validation(command="pytest")
+
+    assert result["status"] == "error"
+    assert result["exit_code"] is None
+
+
+def test_error_path_evidence_includes_message():
+    with patch(_PATCH_TARGET, return_value=(None, "no_tunnel")), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = run_validation(command="pytest")
+
+    assert "no_tunnel" in result["evidence_summary"] or "Could not run" in result["evidence_summary"]
+
+
+def test_error_path_command_not_found():
+    """Command-not-found scenario: executor raises exception."""
+    with patch(_PATCH_TARGET, side_effect=Exception("command not found: pytest")), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = run_validation(command="pytest nonexistent_module")
+
+    assert result["status"] == "error"
+    assert result["exit_code"] is None
+    assert "command not found" in result["evidence_summary"]
+
+
+def test_blocked_command_treated_as_error():
+    result_dict = _make_result(success=False, exit_code=-1, error="command blocked by security policy")
+    with patch(_PATCH_TARGET, return_value=(result_dict, None)), \
+         patch(_CONTEXT_PATCH, return_value=("u1", "c1")):
+        result = run_validation(command="rm -rf /")
+    assert result["status"] == "error"
+    assert result["exit_code"] is None
+    assert "blocked" in result["evidence_summary"].lower() or "could not run" in result["evidence_summary"].lower()
+
+
+# ---------------------------------------------------------------------------
+# 7. output_excerpt is capped at ~800 chars
+# ---------------------------------------------------------------------------
+
+
+def test_output_excerpt_capped():
+    long_output = "x" * 2000
+    result_dict = _make_result(success=True, exit_code=0, output=long_output)
+    with patch(_PATCH_TARGET, return_value=(result_dict, None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = run_validation(command="pytest")
+
+    assert len(result["output_excerpt"]) <= _MAX_EXCERPT_CHARS
+
+
+def test_output_excerpt_short_output_not_truncated():
+    short_output = "1 passed in 0.1s"
+    result_dict = _make_result(success=True, exit_code=0, output=short_output)
+    with patch(_PATCH_TARGET, return_value=(result_dict, None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = run_validation(command="pytest")
+
+    assert result["output_excerpt"] == short_output
+
+
+# ---------------------------------------------------------------------------
+# 8. evidence_summary is capped at 240 chars
+# ---------------------------------------------------------------------------
+
+
+def test_evidence_summary_capped_at_240_chars():
+    # A very long error line that would overflow 240 chars
+    long_error_line = "AssertionError: " + "a" * 500
+    long_output = long_error_line + "\n"
+    result_dict = _make_result(success=False, exit_code=1, output=long_output)
+    with patch(_PATCH_TARGET, return_value=(result_dict, None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = run_validation(command="pytest")
+
+    assert len(result["evidence_summary"]) <= _MAX_EVIDENCE_CHARS
+
+
+def test_evidence_summary_max_constant_is_240():
+    assert _MAX_EVIDENCE_CHARS == 240
+
+
+# ---------------------------------------------------------------------------
+# 9. command field echoes the input
+# ---------------------------------------------------------------------------
+
+
+def test_command_field_echoes_input():
+    cmd = "npm test -- src/checkout/createOrder.test.ts"
+    result_dict = _make_result(success=True, exit_code=0)
+    with patch(_PATCH_TARGET, return_value=(result_dict, None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = run_validation(command=cmd)
+
+    assert result["command"] == cmd
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for internal helpers (fast, no mocking needed)
+# ---------------------------------------------------------------------------
+
+
+def test_find_last_error_line_finds_assertion_error():
+    output = "running tests\nAssertionError: expected 402, got 500\nsome trailing text"
+    line = _find_last_error_line(output)
+    assert line is not None
+    assert "AssertionError" in line
+
+
+def test_find_last_error_line_finds_error_colon():
+    output = "starting\nError: connection refused\nend"
+    line = _find_last_error_line(output)
+    assert line is not None
+    assert "Error" in line
+
+
+def test_find_last_error_line_finds_failed_line():
+    output = "FAILED tests/foo.py::test_bar - AssertionError: x != y\n1 failed"
+    line = _find_last_error_line(output)
+    assert line is not None
+    # Either the FAILED line or the assertion line
+    assert "FAILED" in line or "AssertionError" in line
+
+
+def test_find_last_error_line_returns_none_when_no_match():
+    output = "all tests passed\n1 passed in 0.5s"
+    line = _find_last_error_line(output)
+    assert line is None
+
+
+def test_last_nonempty_line_returns_last_non_blank():
+    output = "line one\nline two\n\n  \nline three\n\n"
+    result = _last_nonempty_line(output)
+    assert result == "line three"
+
+
+def test_last_nonempty_line_empty_string():
+    result = _last_nonempty_line("")
+    assert result == ""
+
+
+def test_build_evidence_summary_passed():
+    summary = _build_evidence_summary("passed", 4.3, "", 120)
+    assert "passed" in summary.lower()
+    assert "4.3s" in summary
+
+
+def test_build_evidence_summary_timed_out():
+    summary = _build_evidence_summary("timed_out", 120.0, "", 120)
+    assert "120" in summary
+
+
+def test_build_evidence_summary_error():
+    summary = _build_evidence_summary("error", 0.1, "", 120, "command not found")
+    assert "command not found" in summary
+
+
+def test_build_evidence_summary_cap():
+    long_line = "AssertionError: " + "x" * 400
+    summary = _build_evidence_summary("failed", 1.0, long_line + "\n", 120)
+    assert len(summary) <= _MAX_EVIDENCE_CHARS
+
+
+# ---------------------------------------------------------------------------
+# 10. Tool registration in tool_service.py (AST source check)
+# ---------------------------------------------------------------------------
+
+
+def test_run_validation_registered_in_tool_service():
+    """run_validation_tool must be imported and registered in tool_service.py."""
+    import pathlib
+
+    tools_dir = (
+        pathlib.Path(__file__).parents[3]
+        / "app"
+        / "modules"
+        / "intelligence"
+        / "tools"
+    )
+    source = (tools_dir / "tool_service.py").read_text(encoding="utf-8")
+
+    assert "run_validation_tool" in source, (
+        "tool_service.py must import run_validation_tool from run_validation_tool module"
+    )
+    assert '"run_validation"' in source or "'run_validation'" in source, (
+        "tool_service.py must register the tool under the key 'run_validation'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 11. DebugAgent tool list (AST inspection)
+# ---------------------------------------------------------------------------
+
+
+def test_run_validation_in_debug_agent_tool_list():
+    """'run_validation' must appear in DebugAgent's get_tools([...]) call."""
+    import ast
+    import pathlib
+
+    src_path = (
+        pathlib.Path(__file__).parents[3]
+        / "app"
+        / "modules"
+        / "intelligence"
+        / "agents"
+        / "chat_agents"
+        / "system_agents"
+        / "debug_agent.py"
+    )
+    source = src_path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    tool_list: list[str] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get_tools"
+            and node.args
+            and isinstance(node.args[0], ast.List)
+        ):
+            for elt in node.args[0].elts:
+                if isinstance(elt, ast.Constant):
+                    tool_list.append(elt.value)
+
+    assert tool_list, "Could not find get_tools([...]) call in debug_agent.py"
+    assert "run_validation" in tool_list, (
+        f"'run_validation' not found in DebugAgent's get_tools([...]) call. "
+        f"Found: {tool_list}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 12. Regression tests for bare FAILED/FAIL line anchor bug
+# ---------------------------------------------------------------------------
+
+
+def test_failed_alone_on_line_returns_failed_as_evidence():
+    """FAILED followed by a newline must anchor to the FAILED line, not the next."""
+    output = "some prelude\nFAILED\nnext line text\n"
+    result_dict = _make_result(success=False, exit_code=1, output=output)
+    with patch(_PATCH_TARGET, return_value=(result_dict, None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = run_validation(command="jest")
+
+    summary = result["evidence_summary"]
+    assert "FAILED" in summary
+    assert "next line text" not in summary
+
+
+def test_fail_alone_on_line_returns_fail_as_evidence():
+    """FAIL followed by a newline must anchor to the FAIL line, not the next."""
+    output = "running tests...\nFAIL\nbottom"
+    result_dict = _make_result(success=False, exit_code=1, output=output)
+    with patch(_PATCH_TARGET, return_value=(result_dict, None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = run_validation(command="jest")
+
+    summary = result["evidence_summary"]
+    assert "FAIL" in summary
+    assert "bottom" not in summary
+
+
+def test_failed_followed_by_space_still_works():
+    """FAILED followed by a space (common pytest case) must still work correctly."""
+    output = "FAILED tests/foo.py::test_bar - AssertionError: expected 1 got 2"
+    result_dict = _make_result(success=False, exit_code=1, output=output)
+    with patch(_PATCH_TARGET, return_value=(result_dict, None)), \
+         patch(_CONTEXT_PATCH, return_value=("user1", "conv1")):
+        result = run_validation(command="pytest tests/foo.py")
+
+    summary = result["evidence_summary"]
+    # The line contains AssertionError — it should appear in evidence
+    assert "AssertionError" in summary or "FAILED" in summary
+
+
+# ---------------------------------------------------------------------------
+# 13. RunValidationResult Pydantic round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_result_pydantic_round_trip():
+    r = RunValidationResult(
+        status="passed",
+        exit_code=0,
+        evidence_summary="Command passed in 1.2s",
+        output_excerpt="1 passed in 1.2s",
+        wall_time_seconds=1.2,
+        command="pytest",
+    )
+    d = r.model_dump()
+    r2 = RunValidationResult.model_validate(d)
+    assert r2.status == "passed"
+    assert r2.exit_code == 0
+    assert r2.command == "pytest"

--- a/tests/unit/intelligence/test_run_validation_tool.py
+++ b/tests/unit/intelligence/test_run_validation_tool.py
@@ -25,15 +25,13 @@ import os
 os.environ.setdefault("POSTGRES_SERVER", "postgresql://test:test@localhost:5432/testdb")
 os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 
 from app.modules.intelligence.tools.run_validation_tool import (
-    RunValidationInput,
     RunValidationResult,
     run_validation,
-    run_validation_tool,
     _find_last_error_line,
     _last_nonempty_line,
     _build_evidence_summary,
@@ -433,39 +431,20 @@ def test_run_validation_registered_in_tool_service():
 
 
 def test_run_validation_in_debug_agent_tool_list():
-    """'run_validation' must appear in DebugAgent's get_tools([...]) call."""
-    import ast
-    import pathlib
-
-    src_path = (
-        pathlib.Path(__file__).parents[3]
-        / "app"
-        / "modules"
-        / "intelligence"
-        / "agents"
-        / "chat_agents"
-        / "system_agents"
-        / "debug_agent.py"
+    """'run_validation' must appear in DebugAgent's tool allow-list."""
+    from app.modules.intelligence.agents.chat_agents.system_agents.debug_agent import (
+        DEBUG_AGENT_BASE_TOOLS,
+        DEBUG_AGENT_DAP_TOOLS,
+        DEBUG_AGENT_TERMINAL_TOOLS,
     )
-    source = src_path.read_text(encoding="utf-8")
-    tree = ast.parse(source)
 
-    tool_list: list[str] = []
-    for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute)
-            and node.func.attr == "get_tools"
-            and node.args
-            and isinstance(node.args[0], ast.List)
-        ):
-            for elt in node.args[0].elts:
-                if isinstance(elt, ast.Constant):
-                    tool_list.append(elt.value)
-
-    assert tool_list, "Could not find get_tools([...]) call in debug_agent.py"
+    tool_list = (
+        list(DEBUG_AGENT_BASE_TOOLS)
+        + list(DEBUG_AGENT_DAP_TOOLS)
+        + list(DEBUG_AGENT_TERMINAL_TOOLS)
+    )
     assert "run_validation" in tool_list, (
-        f"'run_validation' not found in DebugAgent's get_tools([...]) call. "
+        f"'run_validation' not found in DebugAgent's tool allow-list. "
         f"Found: {tool_list}"
     )
 

--- a/tests/unit/intelligence/test_tunnel_socket_error_normalization.py
+++ b/tests/unit/intelligence/test_tunnel_socket_error_normalization.py
@@ -124,3 +124,52 @@ def test_route_dap_command_maps_handler_timeout_to_timeout():
 
     assert result is None
     assert error_type == "timeout"
+
+
+def test_route_dap_command_http_422_maps_to_domain_error_not_tunnel_unreachable():
+    import httpx
+    from unittest.mock import MagicMock, patch
+
+    from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
+        route_dap_command,
+    )
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 422
+    mock_resp.json.return_value = {
+        "error": "debug_adapter_unavailable: No registered debug adapter for type 'cppdbg'.",
+        "adapter_type": "cppdbg",
+    }
+    mock_resp.text = mock_resp.json.return_value["error"]
+
+    svc = MagicMock()
+    svc.get_tunnel_url.return_value = "http://localhost:49152"
+    svc.get_workspace_id.return_value = None
+
+    with patch(
+        "app.modules.tunnel.tunnel_service.get_tunnel_service",
+        return_value=svc,
+    ), patch(
+        "app.modules.intelligence.tools.code_changes_manager._get_tunnel_url",
+        return_value=None,
+    ), patch(
+        "app.modules.intelligence.tools.code_changes_manager._get_repository",
+        return_value=None,
+    ), patch(
+        "app.modules.intelligence.tools.code_changes_manager._get_branch",
+        return_value=None,
+    ), patch.object(
+        httpx.Client,
+        "post",
+        return_value=mock_resp,
+    ):
+        result, error_type = route_dap_command(
+            method="start_session",
+            payload={"program": "a.py"},
+            user_id="u1",
+            conversation_id="c1",
+        )
+
+    assert result is None
+    assert error_type == "debug_adapter_unavailable: No registered debug adapter for type 'cppdbg'."
+    assert error_type != "tunnel_unreachable"

--- a/tests/unit/intelligence/test_tunnel_socket_error_normalization.py
+++ b/tests/unit/intelligence/test_tunnel_socket_error_normalization.py
@@ -1,0 +1,126 @@
+"""Regression tests for Socket.IO timeout error classification."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("POSTGRES_SERVER", "postgresql://test:test@localhost:5432/testdb")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+
+pytestmark = pytest.mark.unit
+
+
+def _socket_tunnel_service() -> MagicMock:
+    svc = MagicMock()
+    svc.get_tunnel_url.return_value = "socket://workspace-1"
+    svc.get_workspace_id.return_value = "workspace-1"
+    return svc
+
+
+def _route_patches(socket_return):
+    return (
+        patch(
+            "app.modules.tunnel.tunnel_service.get_tunnel_service",
+            return_value=_socket_tunnel_service(),
+        ),
+        patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_tunnel_url",
+            return_value=None,
+        ),
+        patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_repository",
+            return_value=None,
+        ),
+        patch(
+            "app.modules.intelligence.tools.code_changes_manager._get_branch",
+            return_value=None,
+        ),
+        patch(
+            "app.modules.intelligence.tools.local_search_tools.tunnel_utils._execute_via_socket",
+            return_value=socket_return,
+        ),
+    )
+
+
+def test_execute_via_socket_normalizes_extension_handler_timeout():
+    from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
+        _execute_via_socket,
+    )
+
+    svc = MagicMock()
+    svc.execute_tool_call_with_fallback.return_value = {
+        "success": False,
+        "error": "Handler timed out after 29500ms",
+    }
+
+    with patch(
+        "app.modules.tunnel.tunnel_service.get_tunnel_service",
+        return_value=svc,
+    ):
+        result, error_type = _execute_via_socket(
+            user_id="u1",
+            conversation_id="c1",
+            endpoint="/api/debug/start-session",
+            payload={},
+            tunnel_url="socket://workspace-1",
+            timeout=30.0,
+            return_error=True,
+        )
+
+    assert result is None
+    assert error_type == "timeout"
+
+
+def test_route_terminal_command_maps_handler_timeout_to_timeout():
+    from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
+        route_terminal_command,
+    )
+
+    patches = _route_patches((None, "Handler timed out after 24500ms"))
+    with patches[0], patches[1], patches[2], patches[3], patches[4]:
+        result, error_type = route_terminal_command(
+            command="sleep 60",
+            timeout=20_000,
+            user_id="u1",
+            conversation_id="c1",
+        )
+
+    assert result is None
+    assert error_type == "timeout"
+
+
+def test_route_workspace_debug_context_maps_handler_timeout_to_timeout():
+    from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
+        route_workspace_debug_context,
+    )
+
+    patches = _route_patches((None, "Handler timed out after 29500ms"))
+    with patches[0], patches[1], patches[2], patches[3], patches[4]:
+        result, error_type = route_workspace_debug_context(
+            user_id="u1",
+            conversation_id="c1",
+        )
+
+    assert result is None
+    assert error_type == "timeout"
+
+
+def test_route_dap_command_maps_handler_timeout_to_timeout():
+    from app.modules.intelligence.tools.local_search_tools.tunnel_utils import (
+        route_dap_command,
+    )
+
+    patches = _route_patches((None, "Handler timed out after 29500ms"))
+    with patches[0], patches[1], patches[2], patches[3], patches[4]:
+        result, error_type = route_dap_command(
+            method="start_session",
+            payload={"program": "a.py"},
+            user_id="u1",
+            conversation_id="c1",
+        )
+
+    assert result is None
+    assert error_type == "timeout"

--- a/tests/unit/tunnel/test_workspace_socket_invalidation.py
+++ b/tests/unit/tunnel/test_workspace_socket_invalidation.py
@@ -32,27 +32,60 @@ def test_invalidate_workspace_socket_deletes_forward_and_reverse_keys():
     assert svc.redis_client.delete.call_count == 2
 
 
-def test_get_tunnel_url_false_after_invalidation():
-    from app.modules.tunnel.tunnel_service import TunnelService
+def test_get_tunnel_url_false_after_invalidation(monkeypatch):
+    """Drive the online → offline transition through invalidate_workspace_socket()
+    and confirm get_tunnel_url() reflects it, instead of pre-forcing the result."""
+    from app.modules.tunnel.tunnel_service import (
+        TunnelService,
+        SOCKET_TUNNEL_PREFIX,
+    )
+    from app.modules.tunnel.socket_server import (
+        WORKSPACE_SOCKET_KEY_PREFIX,
+        SOCKET_WORKSPACE_KEY_PREFIX,
+    )
+    from app.modules.tunnel import socket_service as socket_service_mod
+
+    workspace_id = "wid123"
+
+    # In-memory redis backing: the workspace forward key marks the socket online.
+    store = {
+        f"{WORKSPACE_SOCKET_KEY_PREFIX}{workspace_id}": "sid-abc",
+        f"{SOCKET_WORKSPACE_KEY_PREFIX}sid-abc": workspace_id,
+    }
+
+    redis_client = MagicMock()
+    redis_client.get.side_effect = lambda key: store.get(key)
+
+    def _delete(key):
+        return 1 if store.pop(key, None) is not None else 0
+
+    redis_client.delete.side_effect = _delete
 
     svc = TunnelService.__new__(TunnelService)
-    svc.redis_client = MagicMock()
+    svc.redis_client = redis_client
     svc._in_memory_workspace_tunnel_records = {}
-    svc.get_workspace_id = MagicMock(return_value="wid123")
-    svc.redis_client.get.return_value = None
-    svc.redis_client.delete.return_value = 1
+    svc.get_workspace_id = MagicMock(return_value=workspace_id)
+    svc.get_workspace_tunnel_record = MagicMock(return_value=None)
 
-    from app.modules.tunnel.socket_service import get_socket_service
+    # Socket service reports online iff the forward key is still present in redis,
+    # so deleting it via invalidation flips the status. Scoped via monkeypatch.
+    socket_svc = MagicMock()
+    socket_svc.is_workspace_online.side_effect = lambda wid: bool(
+        store.get(f"{WORKSPACE_SOCKET_KEY_PREFIX}{wid}")
+    )
+    monkeypatch.setattr(socket_service_mod, "get_socket_service", lambda: socket_svc)
 
-    socket_svc = get_socket_service()
-    socket_svc.is_workspace_online = MagicMock(return_value=False)
-
-    svc.get_workspace_socket_status = lambda workspace_id: socket_svc.is_workspace_online(
-        workspace_id
+    # Online before invalidation.
+    assert (
+        svc.get_tunnel_url("user-1", "conv-1", repository="owner/repo")
+        == SOCKET_TUNNEL_PREFIX + workspace_id
     )
 
-    url = svc.get_tunnel_url("user-1", "conv-1", repository="owner/repo")
-    assert url is None
+    # Invalidation drives the state transition (deletes the forward key).
+    assert svc.invalidate_workspace_socket(workspace_id) is True
+
+    # Now offline → no tunnel URL.
+    assert svc.get_tunnel_url("user-1", "conv-1", repository="owner/repo") is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tunnel/test_workspace_socket_invalidation.py
+++ b/tests/unit/tunnel/test_workspace_socket_invalidation.py
@@ -1,0 +1,219 @@
+"""Tests for stale workspace socket cleanup."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_invalidate_workspace_socket_deletes_forward_and_reverse_keys():
+    from app.modules.tunnel.tunnel_service import TunnelService
+
+    svc = TunnelService.__new__(TunnelService)
+    svc.redis_client = MagicMock()
+    svc._in_memory_workspace_tunnel_records = {}
+
+    svc.redis_client.get.return_value = "sid-abc"
+    svc.redis_client.delete.return_value = 1
+    svc.redis_client.get.side_effect = [
+        "sid-abc",  # forward key lookup
+        json.dumps(
+            {"user_id": "user-1", "repo_url": "owner/repo", "status": "active"}
+        ),
+    ]
+
+    removed = svc.invalidate_workspace_socket("b2c2c1ae2cfffd87")
+
+    assert removed is True
+    assert svc.redis_client.delete.call_count == 2
+
+
+def test_get_tunnel_url_false_after_invalidation():
+    from app.modules.tunnel.tunnel_service import TunnelService
+
+    svc = TunnelService.__new__(TunnelService)
+    svc.redis_client = MagicMock()
+    svc._in_memory_workspace_tunnel_records = {}
+    svc.get_workspace_id = MagicMock(return_value="wid123")
+    svc.redis_client.get.return_value = None
+    svc.redis_client.delete.return_value = 1
+
+    from app.modules.tunnel.socket_service import get_socket_service
+
+    socket_svc = get_socket_service()
+    socket_svc.is_workspace_online = MagicMock(return_value=False)
+
+    svc.get_workspace_socket_status = lambda workspace_id: socket_svc.is_workspace_online(
+        workspace_id
+    )
+
+    url = svc.get_tunnel_url("user-1", "conv-1", repository="owner/repo")
+    assert url is None
+
+
+@pytest.mark.asyncio
+async def test_rpc_timeout_does_not_invalidate_workspace_socket(monkeypatch):
+    from app.modules.tunnel import socket_service
+    from app.modules.tunnel.tunnel_service import TunnelConnectionError
+
+    svc = socket_service.WorkspaceSocketService.__new__(
+        socket_service.WorkspaceSocketService
+    )
+    svc._get_socket_id = AsyncMock(return_value="sid-abc")
+
+    pubsub = MagicMock()
+    pubsub.subscribe = AsyncMock()
+    pubsub.unsubscribe = AsyncMock()
+    pubsub.close = AsyncMock()
+    redis_client = MagicMock()
+    redis_client.pubsub.return_value = pubsub
+    svc._get_redis = AsyncMock(return_value=redis_client)
+
+    svc._publish_tool_call = AsyncMock()
+    invalidate = MagicMock()
+    monkeypatch.setattr(
+        socket_service, "_invalidate_workspace_after_rpc_failure", invalidate
+    )
+
+    async def fake_wait_for(awaitable, timeout):
+        close = getattr(awaitable, "close", None)
+        if close:
+            close()
+        raise socket_service.asyncio.TimeoutError()
+
+    monkeypatch.setattr(socket_service.asyncio, "wait_for", fake_wait_for)
+
+    with pytest.raises(TunnelConnectionError) as exc:
+        await svc._execute_tool_call_impl(
+            "b2c2c1ae2cfffd87",
+            "/api/terminal/execute",
+            {"command": "gcc -g add_numbers.c"},
+            timeout=0.1,
+        )
+
+    assert exc.value.last_error == "timeout"
+    invalidate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_backend_loop_mismatch_does_not_invalidate_workspace_socket(monkeypatch):
+    from app.modules.tunnel import socket_service
+    from app.modules.tunnel.tunnel_service import TunnelConnectionError
+
+    svc = socket_service.WorkspaceSocketService.__new__(
+        socket_service.WorkspaceSocketService
+    )
+    svc._get_socket_id = AsyncMock(return_value="sid-abc")
+
+    pubsub = MagicMock()
+    pubsub.subscribe = AsyncMock()
+    pubsub.unsubscribe = AsyncMock()
+    pubsub.close = AsyncMock()
+    redis_client = MagicMock()
+    redis_client.pubsub.return_value = pubsub
+    svc._get_redis = AsyncMock(return_value=redis_client)
+    svc._publish_tool_call = AsyncMock(
+        side_effect=RuntimeError("got Future <Future pending> attached to a different loop")
+    )
+
+    invalidate = MagicMock()
+    monkeypatch.setattr(
+        socket_service, "_invalidate_workspace_after_rpc_failure", invalidate
+    )
+
+    with pytest.raises(TunnelConnectionError) as exc:
+        await svc._execute_tool_call_impl(
+            "b2c2c1ae2cfffd87",
+            "/api/debug/start-session",
+            {"program": "/tmp/zipmap_repro"},
+            timeout=0.1,
+        )
+
+    assert exc.value.last_error == "backend_loop_mismatch"
+    invalidate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_emit_failure_still_invalidates_workspace_socket(monkeypatch):
+    from app.modules.tunnel import socket_service
+    from app.modules.tunnel.tunnel_service import TunnelConnectionError
+
+    svc = socket_service.WorkspaceSocketService.__new__(
+        socket_service.WorkspaceSocketService
+    )
+    svc._get_socket_id = AsyncMock(return_value="sid-abc")
+
+    pubsub = MagicMock()
+    pubsub.subscribe = AsyncMock()
+    pubsub.unsubscribe = AsyncMock()
+    pubsub.close = AsyncMock()
+    redis_client = MagicMock()
+    redis_client.pubsub.return_value = pubsub
+    svc._get_redis = AsyncMock(return_value=redis_client)
+    svc._publish_tool_call = AsyncMock(side_effect=RuntimeError("redis unavailable"))
+
+    invalidate = MagicMock()
+    monkeypatch.setattr(
+        socket_service, "_invalidate_workspace_after_rpc_failure", invalidate
+    )
+
+    with pytest.raises(TunnelConnectionError) as exc:
+        await svc._execute_tool_call_impl(
+            "b2c2c1ae2cfffd87",
+            "/api/debug/start-session",
+            {"program": "/tmp/zipmap_repro"},
+            timeout=0.1,
+        )
+
+    assert exc.value.last_error == "emit_failed"
+    invalidate.assert_called_once_with(
+        "b2c2c1ae2cfffd87", reason="emit_failed", socket_id="sid-abc"
+    )
+
+
+@pytest.mark.asyncio
+async def test_publish_tool_call_uses_fresh_redis_publisher(monkeypatch):
+    from app.modules.tunnel import socket_service
+
+    svc = socket_service.WorkspaceSocketService.__new__(
+        socket_service.WorkspaceSocketService
+    )
+    published = []
+
+    class Publisher:
+        async def publish(self, channel, payload):
+            published.append((channel, json.loads(payload)))
+
+        async def aclose(self):
+            pass
+
+    manager = MagicMock()
+    manager.redis_url = "redis://redis:6379/0"
+    manager.channel = "socketio"
+    manager.redis_options = {}
+    manager.host_id = "socket-server-host"
+    manager.json = json
+    monkeypatch.setattr(socket_service.sio, "manager", manager)
+    monkeypatch.setattr(socket_service.sio, "emit", AsyncMock())
+    monkeypatch.setattr(
+        socket_service.aioredis,
+        "from_url",
+        MagicMock(return_value=Publisher()),
+    )
+
+    await svc._publish_tool_call("sid-abc", {"correlation_id": "corr-1"})
+
+    assert len(published) == 1
+    channel, message = published[0]
+    assert channel == "socketio"
+    assert message["method"] == "emit"
+    assert message["event"] == "tool_call"
+    assert message["namespace"] == socket_service.WORKSPACE_NAMESPACE
+    assert message["room"] == "sid-abc"
+    assert message["data"] == [{"correlation_id": "corr-1"}]
+    assert message["host_id"] != manager.host_id
+    socket_service.sio.emit.assert_not_awaited()


### PR DESCRIPTION
## Summary

Adds the VS Code–integrated debugging agent: hypothesis-driven workflow, DAP tools (breakpoints, stepping, evaluate), tunnel/socket integration, and Hatchet routing for `debugging_agent`.

Also includes the pydantic-ai request-limit fix so long DAP sessions are not capped at 50 model calls.

## Test plan

- [ ] `pytest tests/unit/intelligence/test_debug* tests/unit/intelligence/test_dap* tests/smoke/test_debug_agent_smoke.py`
- [ ] Manual: start Hatchet worker, run `debugging_agent` in local mode with VS Code tunnel
- [ ] Verify long debug sessions no longer hit `UsageLimitExceeded` at 50 requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hypothesis-driven debugging workflow, in-memory hypothesis tools, rich debug-agent prompt, Pydantic deep-debug agent, full DAP debugger toolset, workspace debug-context, failure-parsing and run-validation tools, and local search/terminal tooling.

* **Bug Fixes**
  * Cursor-aware reconnects for agent streams, improved socket/tunnel error handling and workspace socket invalidation, and configurable CLI process log level.

* **Improvements**
  * Reduced console tracing noise by default and updated model vision detection.

* **Tests**
  * Extensive new unit and smoke tests across agents, tools, tunneling, and prompts.

* **Documentation**
  * VS Code extension debug-handoff guidance added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->