### PR TITLE
feat: automated PR review via GitHub webhook and Action

### DIFF
--- a/examples/potpie-pr-review.yml
+++ b/examples/potpie-pr-review.yml
@@ -46,4 +46,5 @@ jobs:
 
           curl -sf -X POST "$POTPIE_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
+            -H "X-GitHub-Event: pull_request" \
             -d "$payload"

--- a/examples/potpie-pr-review.yml
+++ b/examples/potpie-pr-review.yml
@@ -1,0 +1,49 @@
+# Potpie Automated PR Review
+#
+# Copy this file to .github/workflows/potpie-pr-review.yml in your repository.
+#
+# One-time setup in your repo's GitHub settings:
+#   Settings -> Secrets and variables -> Actions -> New repository secret
+#   Name:  POTPIE_WEBHOOK_URL
+#   Value: https://<your-potpie-host>/api/v1/github/webhook
+#
+# That's it. Every new PR will get an automated Potpie review comment.
+
+name: Potpie PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  potpie-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Potpie PR Review
+        env:
+          POTPIE_WEBHOOK_URL: ${{ secrets.POTPIE_WEBHOOK_URL }}
+          GH_EVENT_ACTION: ${{ github.event.action }}
+          GH_PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_PR_TITLE: ${{ github.event.pull_request.title }}
+          GH_BRANCH: ${{ github.event.pull_request.head.ref }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          payload=$(jq -n \
+            --arg action "$GH_EVENT_ACTION" \
+            --arg pr_number "$GH_PR_NUMBER" \
+            --arg pr_title "$GH_PR_TITLE" \
+            --arg branch "$GH_BRANCH" \
+            --arg repo "$GH_REPO" \
+            '{
+              action: $action,
+              pull_request: {
+                number: ($pr_number | tonumber),
+                title: $pr_title,
+                head: { ref: $branch }
+              },
+              repository: { full_name: $repo }
+            }')
+
+          curl -sf -X POST "$POTPIE_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "$payload"

--- a/legacy/app/main.py
+++ b/legacy/app/main.py
@@ -29,6 +29,7 @@ from app.core.models import *  # noqa #necessary for models to not give import e
 from app.modules.analytics.analytics_router import router as analytics_router
 from app.modules.auth.auth_router import auth_router
 from app.modules.code_provider.github.github_router import router as github_router
+from app.modules.code_provider.github.github_webhook_router import router as github_webhook_router
 from app.modules.conversations.conversations_router import (
     router as conversations_router,
 )
@@ -160,6 +161,7 @@ class MainApp:
         self.app.include_router(projects_router, prefix="/api/v1", tags=["Projects"])
         self.app.include_router(search_router, prefix="/api/v1", tags=["Search"])
         self.app.include_router(github_router, prefix="/api/v1", tags=["Github"])
+        self.app.include_router(github_webhook_router, prefix="/api/v1", tags=["Github"])
         self.app.include_router(agent_router, prefix="/api/v1", tags=["Agents"])
         self.app.include_router(provider_router, prefix="/api/v1", tags=["Providers"])
         self.app.include_router(tool_router, prefix="/api/v1", tags=["Tools"])

--- a/legacy/app/modules/code_provider/github/github_webhook_router.py
+++ b/legacy/app/modules/code_provider/github/github_webhook_router.py
@@ -44,7 +44,7 @@ def _verify_signature(payload: bytes, signature: str, secret: str) -> bool:
 
 
 def _post_pr_comment(repo_name: str, pr_number: int, body: str) -> None:
-    from github import Github
+    from github import Github, GithubException
 
     token = (os.getenv("GH_TOKEN_LIST", "").split(",")[0].strip()
              or os.getenv("GITHUB_APP_TOKEN", ""))
@@ -52,10 +52,19 @@ def _post_pr_comment(repo_name: str, pr_number: int, body: str) -> None:
         logger.warning("No GitHub token available to post PR review comment")
         return
 
-    gh = Github(token)
-    repo = gh.get_repo(repo_name)
-    pr = repo.get_pull(pr_number)
-    pr.create_issue_comment(f"## Potpie PR Review\n\n{body}")
+    try:
+        gh = Github(token)
+        repo = gh.get_repo(repo_name)
+        pr = repo.get_pull(pr_number)
+        pr.create_issue_comment(f"## Potpie PR Review\n\n{body}")
+    except GithubException as e:
+        logger.error(
+            "Failed to post PR comment",
+            repo_name=repo_name,
+            pr_number=pr_number,
+            error=str(e),
+            status_code=getattr(e, "status", None),
+        )
 
 
 async def _run_pr_review(
@@ -101,7 +110,8 @@ async def _run_pr_review(
         )
 
         result = await agents_service.execute(ctx)
-        review_body = result.response if result else "Potpie could not generate a review."
+        review_body = (result.response if result and result.response
+                       else "Potpie could not generate a review.")
         _post_pr_comment(repo_name, pr_number, review_body)
 
     except Exception:
@@ -138,11 +148,14 @@ async def github_webhook(
     if action not in ("opened", "synchronize", "reopened"):
         return {"status": "ignored", "action": action}
 
-    pr = data["pull_request"]
-    repo_name = data["repository"]["full_name"]
-    pr_number = pr["number"]
-    branch = pr["head"]["ref"]
-    pr_title = pr["title"]
+    try:
+        pr = data["pull_request"]
+        repo_name = data["repository"]["full_name"]
+        pr_number = pr["number"]
+        branch = pr["head"]["ref"]
+        pr_title = pr["title"]
+    except KeyError as e:
+        raise HTTPException(status_code=400, detail=f"Malformed payload: missing {e}")
 
     background_tasks.add_task(
         _run_pr_review,

--- a/legacy/app/modules/code_provider/github/github_webhook_router.py
+++ b/legacy/app/modules/code_provider/github/github_webhook_router.py
@@ -37,6 +37,7 @@ logger = get_logger(__name__)
 
 
 def _verify_signature(payload: bytes, signature: str, secret: str) -> bool:
+    """Verify a GitHub webhook HMAC-SHA256 signature against the raw payload."""
     expected = "sha256=" + hmac.new(
         secret.encode(), payload, hashlib.sha256
     ).hexdigest()
@@ -44,6 +45,7 @@ def _verify_signature(payload: bytes, signature: str, secret: str) -> bool:
 
 
 def _post_pr_comment(repo_name: str, pr_number: int, body: str) -> None:
+    """Post a review comment on a GitHub PR using a token from GH_TOKEN_LIST."""
     from github import Github, GithubException
 
     token = (os.getenv("GH_TOKEN_LIST", "").split(",")[0].strip()
@@ -131,6 +133,7 @@ async def github_webhook(
     x_hub_signature_256: Optional[str] = Header(None),
     x_github_event: Optional[str] = Header(None),
 ):
+    """Receive a GitHub webhook event and enqueue an automated PR review."""
     payload = await request.body()
 
     secret = os.getenv("GITHUB_WEBHOOK_SECRET")

--- a/legacy/app/modules/code_provider/github/github_webhook_router.py
+++ b/legacy/app/modules/code_provider/github/github_webhook_router.py
@@ -1,0 +1,155 @@
+"""GitHub webhook handler for automated PR reviews.
+
+When a PR is opened/updated, GitHub calls POST /api/v1/github/webhook.
+This handler looks up the Potpie project for that repo, runs the
+BlastRadiusAgent (code_changes_agent) on the PR, and posts the findings
+as a comment directly on the pull request.
+
+Setup required:
+  - GITHUB_WEBHOOK_SECRET env var: the secret you configure in GitHub
+    (Settings -> Webhooks -> Secret). Leave unset to skip signature check
+    (only for local testing).
+  - GH_TOKEN_LIST env var: GitHub token used to post the review comment.
+    Already used by other parts of the codebase.
+"""
+
+import hashlib
+import hmac
+import json
+import os
+from typing import Optional
+
+from fastapi import BackgroundTasks, Header, HTTPException, Request
+from sqlalchemy.orm import Session
+
+from app.core.database import SessionLocal
+from app.modules.intelligence.agents.agents_service import AgentsService
+from app.modules.intelligence.agents.chat_agent import ChatContext
+from app.modules.intelligence.prompts.prompt_service import PromptService
+from app.modules.intelligence.provider.provider_service import ProviderService
+from app.modules.intelligence.tools.tool_service import ToolService
+from app.modules.projects.projects_service import ProjectService
+from app.modules.utils.APIRouter import APIRouter
+from observability import get_logger
+
+router = APIRouter()
+logger = get_logger(__name__)
+
+
+def _verify_signature(payload: bytes, signature: str, secret: str) -> bool:
+    expected = "sha256=" + hmac.new(
+        secret.encode(), payload, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(expected, signature)
+
+
+def _post_pr_comment(repo_name: str, pr_number: int, body: str) -> None:
+    from github import Github
+
+    token = (os.getenv("GH_TOKEN_LIST", "").split(",")[0].strip()
+             or os.getenv("GITHUB_APP_TOKEN", ""))
+    if not token:
+        logger.warning("No GitHub token available to post PR review comment")
+        return
+
+    gh = Github(token)
+    repo = gh.get_repo(repo_name)
+    pr = repo.get_pull(pr_number)
+    pr.create_issue_comment(f"## Potpie PR Review\n\n{body}")
+
+
+async def _run_pr_review(
+    repo_name: str,
+    pr_number: int,
+    branch: str,
+    pr_title: str,
+) -> None:
+    """Run in background: analyse the PR with BlastRadiusAgent and post findings."""
+    db: Session = SessionLocal()
+    try:
+        project_service = ProjectService(db)
+        project = await project_service.get_global_project_from_db(
+            repo_name=repo_name,
+            branch_name=branch,
+        )
+        if not project:
+            logger.info(
+                "No Potpie project found for repo — skipping PR review",
+                repo_name=repo_name,
+                branch=branch,
+            )
+            return
+
+        user_id = project.user_id
+        llm_provider = ProviderService(db, user_id)
+        tools_provider = ToolService(db, user_id)
+        prompt_provider = PromptService(db)
+        agents_service = AgentsService(db, llm_provider, prompt_provider, tools_provider)
+
+        ctx = ChatContext(
+            project_id=str(project.id),
+            project_name=project.repo_name,
+            curr_agent_id="code_changes_agent",
+            history=[],
+            query=(
+                f"Review pull request '{pr_title}' (#{pr_number}) on branch '{branch}'. "
+                "Identify what could break, flag risky changes, and summarise your findings."
+            ),
+            user_id=user_id,
+            repository=repo_name,
+            branch=branch,
+        )
+
+        result = await agents_service.execute(ctx)
+        review_body = result.response if result else "Potpie could not generate a review."
+        _post_pr_comment(repo_name, pr_number, review_body)
+
+    except Exception:
+        logger.exception(
+            "PR review background task failed",
+            repo_name=repo_name,
+            pr_number=pr_number,
+        )
+    finally:
+        db.close()
+
+
+@router.post("/github/webhook")
+async def github_webhook(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    x_hub_signature_256: Optional[str] = Header(None),
+    x_github_event: Optional[str] = Header(None),
+):
+    payload = await request.body()
+
+    secret = os.getenv("GITHUB_WEBHOOK_SECRET")
+    if secret:
+        if not x_hub_signature_256:
+            raise HTTPException(status_code=400, detail="Missing X-Hub-Signature-256 header")
+        if not _verify_signature(payload, x_hub_signature_256, secret):
+            raise HTTPException(status_code=401, detail="Invalid webhook signature")
+
+    if x_github_event != "pull_request":
+        return {"status": "ignored", "event": x_github_event}
+
+    data = json.loads(payload)
+    action = data.get("action")
+    if action not in ("opened", "synchronize", "reopened"):
+        return {"status": "ignored", "action": action}
+
+    pr = data["pull_request"]
+    repo_name = data["repository"]["full_name"]
+    pr_number = pr["number"]
+    branch = pr["head"]["ref"]
+    pr_title = pr["title"]
+
+    background_tasks.add_task(
+        _run_pr_review,
+        repo_name=repo_name,
+        pr_number=pr_number,
+        branch=branch,
+        pr_title=pr_title,
+    )
+
+    return {"status": "accepted", "pr": pr_number, "repo": repo_name}

--- a/legacy/tests/unit/code_provider/test_github_webhook_router.py
+++ b/legacy/tests/unit/code_provider/test_github_webhook_router.py
@@ -26,16 +26,21 @@ client = TestClient(app)
 # ── signature verification ────────────────────────────────────────────────────
 
 class TestVerifySignature:
+    """Tests for HMAC-SHA256 webhook signature verification."""
+
     def test_valid_signature(self):
+        """Returns True when signature matches the payload and secret."""
         secret = "mysecret"
         payload = b'{"action": "opened"}'
         sig = "sha256=" + hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
         assert _verify_signature(payload, sig, secret) is True
 
     def test_invalid_signature(self):
+        """Returns False when the signature digest does not match."""
         assert _verify_signature(b"payload", "sha256=wrong", "secret") is False
 
     def test_missing_sha256_prefix(self):
+        """Returns False when the signature is missing the sha256= prefix."""
         assert _verify_signature(b"payload", "badsig", "secret") is False
 
 
@@ -53,7 +58,10 @@ PR_PAYLOAD = {
 
 
 class TestGithubWebhookEndpoint:
+    """Tests for the POST /github/webhook endpoint."""
+
     def _post(self, payload=None, event="pull_request", secret=None):
+        """Helper to POST a webhook payload with optional signature."""
         body = json.dumps(payload or PR_PAYLOAD).encode()
         headers = {"X-GitHub-Event": event}
         if secret:
@@ -62,17 +70,20 @@ class TestGithubWebhookEndpoint:
         return client.post("/github/webhook", content=body, headers=headers)
 
     def test_non_pr_event_is_ignored(self):
+        """Non-pull_request events return status ignored."""
         resp = self._post(event="push")
         assert resp.status_code == 200
         assert resp.json()["status"] == "ignored"
 
     def test_pr_action_not_in_allowlist_is_ignored(self):
+        """PR actions outside the allowlist (e.g. closed) return status ignored."""
         payload = {**PR_PAYLOAD, "action": "closed"}
         resp = self._post(payload=payload)
         assert resp.status_code == 200
         assert resp.json()["status"] == "ignored"
 
     def test_missing_signature_rejected_when_secret_set(self):
+        """Returns 400 when GITHUB_WEBHOOK_SECRET is set but no signature header is sent."""
         with patch.dict("os.environ", {"GITHUB_WEBHOOK_SECRET": "mysecret"}):
             body = json.dumps(PR_PAYLOAD).encode()
             resp = client.post(
@@ -83,6 +94,7 @@ class TestGithubWebhookEndpoint:
         assert resp.status_code == 400
 
     def test_wrong_signature_rejected(self):
+        """Returns 401 when the provided signature does not match the payload."""
         with patch.dict("os.environ", {"GITHUB_WEBHOOK_SECRET": "mysecret"}):
             body = json.dumps(PR_PAYLOAD).encode()
             resp = client.post(
@@ -96,6 +108,7 @@ class TestGithubWebhookEndpoint:
         assert resp.status_code == 401
 
     def test_valid_pr_accepted_and_background_task_queued(self):
+        """Valid PR payload returns 200 accepted and queues the review background task."""
         with patch(
             "app.modules.code_provider.github.github_webhook_router._run_pr_review"
         ) as mock_task:
@@ -110,12 +123,14 @@ class TestGithubWebhookEndpoint:
 
     @pytest.mark.parametrize("action", ["opened", "synchronize", "reopened"])
     def test_all_trigger_actions_accepted(self, action):
+        """All three trigger actions (opened, synchronize, reopened) are accepted."""
         payload = {**PR_PAYLOAD, "action": action}
         resp = self._post(payload=payload)
         assert resp.status_code == 200
         assert resp.json()["status"] == "accepted"
 
     def test_valid_signature_accepted(self):
+        """Request with correct HMAC signature is accepted when secret is configured."""
         secret = "topsecret"
         with patch.dict("os.environ", {"GITHUB_WEBHOOK_SECRET": secret}):
             resp = self._post(secret=secret)
@@ -126,8 +141,11 @@ class TestGithubWebhookEndpoint:
 # ── background task ───────────────────────────────────────────────────────────
 
 class TestRunPrReview:
+    """Tests for the _run_pr_review background task."""
+
     @pytest.mark.asyncio
     async def test_skips_when_no_project_found(self):
+        """Silently skips posting a review when no matching Potpie project exists."""
         from app.modules.code_provider.github.github_webhook_router import _run_pr_review
 
         mock_project_service = MagicMock()
@@ -139,7 +157,6 @@ class TestRunPrReview:
             mock_db.return_value.__enter__ = MagicMock(return_value=MagicMock())
             mock_db.return_value.__exit__ = MagicMock(return_value=False)
 
-            # Should complete without error when no project is found
             await _run_pr_review("acme/unknown-repo", 1, "main", "Test PR")
 
         mock_project_service.get_global_project_from_db.assert_called_once_with(
@@ -149,6 +166,7 @@ class TestRunPrReview:
 
     @pytest.mark.asyncio
     async def test_runs_agent_and_posts_comment_when_project_exists(self):
+        """Runs BlastRadiusAgent and posts review comment when a matching project is found."""
         from app.modules.code_provider.github.github_webhook_router import _run_pr_review
 
         mock_project = MagicMock()

--- a/legacy/tests/unit/code_provider/test_github_webhook_router.py
+++ b/legacy/tests/unit/code_provider/test_github_webhook_router.py
@@ -1,0 +1,182 @@
+"""Unit tests for the GitHub webhook PR review endpoint."""
+
+import hashlib
+import hmac
+import json
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Must be set before any app import that touches app.core.database (it creates
+# the SQLAlchemy engine at module level and needs a non-None URL).
+os.environ.setdefault("POSTGRES_SERVER", "postgresql://test:test@localhost:5432/test_db")
+
+from app.modules.code_provider.github.github_webhook_router import router, _verify_signature
+
+pytestmark = pytest.mark.unit
+
+app = FastAPI()
+app.include_router(router)
+client = TestClient(app)
+
+
+# ── signature verification ────────────────────────────────────────────────────
+
+class TestVerifySignature:
+    def test_valid_signature(self):
+        secret = "mysecret"
+        payload = b'{"action": "opened"}'
+        sig = "sha256=" + hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+        assert _verify_signature(payload, sig, secret) is True
+
+    def test_invalid_signature(self):
+        assert _verify_signature(b"payload", "sha256=wrong", "secret") is False
+
+    def test_missing_sha256_prefix(self):
+        assert _verify_signature(b"payload", "badsig", "secret") is False
+
+
+# ── webhook endpoint ──────────────────────────────────────────────────────────
+
+PR_PAYLOAD = {
+    "action": "opened",
+    "pull_request": {
+        "number": 42,
+        "title": "Add new feature",
+        "head": {"ref": "feat/new-feature"},
+    },
+    "repository": {"full_name": "acme/my-repo"},
+}
+
+
+class TestGithubWebhookEndpoint:
+    def _post(self, payload=None, event="pull_request", secret=None):
+        body = json.dumps(payload or PR_PAYLOAD).encode()
+        headers = {"X-GitHub-Event": event}
+        if secret:
+            sig = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+            headers["X-Hub-Signature-256"] = sig
+        return client.post("/github/webhook", content=body, headers=headers)
+
+    def test_non_pr_event_is_ignored(self):
+        resp = self._post(event="push")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ignored"
+
+    def test_pr_action_not_in_allowlist_is_ignored(self):
+        payload = {**PR_PAYLOAD, "action": "closed"}
+        resp = self._post(payload=payload)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ignored"
+
+    def test_missing_signature_rejected_when_secret_set(self):
+        with patch.dict("os.environ", {"GITHUB_WEBHOOK_SECRET": "mysecret"}):
+            body = json.dumps(PR_PAYLOAD).encode()
+            resp = client.post(
+                "/github/webhook",
+                content=body,
+                headers={"X-GitHub-Event": "pull_request"},
+            )
+        assert resp.status_code == 400
+
+    def test_wrong_signature_rejected(self):
+        with patch.dict("os.environ", {"GITHUB_WEBHOOK_SECRET": "mysecret"}):
+            body = json.dumps(PR_PAYLOAD).encode()
+            resp = client.post(
+                "/github/webhook",
+                content=body,
+                headers={
+                    "X-GitHub-Event": "pull_request",
+                    "X-Hub-Signature-256": "sha256=badsignature",
+                },
+            )
+        assert resp.status_code == 401
+
+    def test_valid_pr_accepted_and_background_task_queued(self):
+        with patch(
+            "app.modules.code_provider.github.github_webhook_router._run_pr_review"
+        ) as mock_task:
+            resp = self._post()
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "accepted"
+        assert data["pr"] == 42
+        assert data["repo"] == "acme/my-repo"
+
+    @pytest.mark.parametrize("action", ["opened", "synchronize", "reopened"])
+    def test_all_trigger_actions_accepted(self, action):
+        payload = {**PR_PAYLOAD, "action": action}
+        resp = self._post(payload=payload)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "accepted"
+
+    def test_valid_signature_accepted(self):
+        secret = "topsecret"
+        with patch.dict("os.environ", {"GITHUB_WEBHOOK_SECRET": secret}):
+            resp = self._post(secret=secret)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "accepted"
+
+
+# ── background task ───────────────────────────────────────────────────────────
+
+class TestRunPrReview:
+    @pytest.mark.asyncio
+    async def test_skips_when_no_project_found(self):
+        from app.modules.code_provider.github.github_webhook_router import _run_pr_review
+
+        mock_project_service = MagicMock()
+        mock_project_service.get_global_project_from_db = AsyncMock(return_value=None)
+
+        with patch("app.modules.code_provider.github.github_webhook_router.SessionLocal") as mock_db, \
+             patch("app.modules.code_provider.github.github_webhook_router.ProjectService",
+                   return_value=mock_project_service):
+            mock_db.return_value.__enter__ = MagicMock(return_value=MagicMock())
+            mock_db.return_value.__exit__ = MagicMock(return_value=False)
+
+            # Should complete without error when no project is found
+            await _run_pr_review("acme/unknown-repo", 1, "main", "Test PR")
+
+        mock_project_service.get_global_project_from_db.assert_called_once_with(
+            repo_name="acme/unknown-repo",
+            branch_name="main",
+        )
+
+    @pytest.mark.asyncio
+    async def test_runs_agent_and_posts_comment_when_project_exists(self):
+        from app.modules.code_provider.github.github_webhook_router import _run_pr_review
+
+        mock_project = MagicMock()
+        mock_project.id = "proj-123"
+        mock_project.repo_name = "acme/my-repo"
+        mock_project.user_id = "user-abc"
+
+        mock_project_service = MagicMock()
+        mock_project_service.get_global_project_from_db = AsyncMock(return_value=mock_project)
+
+        mock_result = MagicMock()
+        mock_result.response = "This PR looks risky — auth middleware is affected."
+
+        mock_agents_service = MagicMock()
+        mock_agents_service.execute = AsyncMock(return_value=mock_result)
+
+        with patch("app.modules.code_provider.github.github_webhook_router.SessionLocal"), \
+             patch("app.modules.code_provider.github.github_webhook_router.ProjectService",
+                   return_value=mock_project_service), \
+             patch("app.modules.code_provider.github.github_webhook_router.ProviderService"), \
+             patch("app.modules.code_provider.github.github_webhook_router.ToolService"), \
+             patch("app.modules.code_provider.github.github_webhook_router.PromptService"), \
+             patch("app.modules.code_provider.github.github_webhook_router.AgentsService",
+                   return_value=mock_agents_service), \
+             patch("app.modules.code_provider.github.github_webhook_router._post_pr_comment") as mock_post:
+
+            await _run_pr_review("acme/my-repo", 42, "feat/new-feature", "Add new feature")
+
+        mock_agents_service.execute.assert_called_once()
+        mock_post.assert_called_once_with(
+            "acme/my-repo", 42, "This PR looks risky — auth middleware is affected."
+        )

--- a/legacy/tests/unit/code_provider/test_github_webhook_router.py
+++ b/legacy/tests/unit/code_provider/test_github_webhook_router.py
@@ -106,6 +106,7 @@ class TestGithubWebhookEndpoint:
         assert data["status"] == "accepted"
         assert data["pr"] == 42
         assert data["repo"] == "acme/my-repo"
+        mock_task.assert_called_once()
 
     @pytest.mark.parametrize("action", ["opened", "synchronize", "reopened"])
     def test_all_trigger_actions_accepted(self, action):


### PR DESCRIPTION
## What this does

Wires Potpie's existing `BlastRadiusAgent` into a GitHub webhook so PRs
get reviewed automatically — no editor plugin required.

When a developer opens or updates a pull request:
1. A GitHub Action sends a POST to `/api/v1/github/webhook`
2. Potpie looks up the project for that repo + branch
3. Runs `code_changes_agent` (BlastRadiusAgent) on the PR
4. Posts the findings as a comment on the pull request

## Why this matters

Cursor and Windsurf live inside the editor. This puts Potpie inside the
CI pipeline — a surface they cannot reach. Engineering teams get AI
analysis on every PR before a human reviewer even opens it.

## Files changed

- `legacy/app/modules/code_provider/github/github_webhook_router.py` —
  webhook endpoint, signature verification, background agent execution
- `legacy/app/main.py` — registers the new router
- `examples/potpie-pr-review.yml` — drop-in GitHub Action template

## Testing

14 unit tests, all passing. Covers signature verification, ignored events,
auth rejection, all trigger actions, and the full agent→comment flow.

End-to-end testing requires a running Potpie instance with a parsed
project and a GitHub token — covered in the setup instructions in the
Action template.
