### PR TITLE
Add bug_auth_token_expiry_race benchmark scenario fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ venv/
 !potpie/context-engine/benchmarks/data/**/*.json
 !potpie/context-engine/tests/data/**/*.json
 !potpie/context-engine/tests/fixtures/**/*.json
+!potpie/context-engine/benchmarks/fixtures/raw_events/**/*.json
 # Vendored Daytona local-dev stack (config bound into the compose containers)
 !potpie/sandbox/daytona/**/*.json
 # Potpie CLI setup-wizard logo (generated asset, must ship in the package)

--- a/potpie/context-engine/benchmarks/fixtures/raw_events/linear/ops_355_jwt_expiry_symptom.json
+++ b/potpie/context-engine/benchmarks/fixtures/raw_events/linear/ops_355_jwt_expiry_symptom.json
@@ -1,0 +1,69 @@
+{
+  "connector": "linear",
+  "event_type": "issue",
+  "action": "create",
+  "source_id": "linear:issue:OPS-355:create",
+  "occurred_at": "2026-01-15T00:00:00Z",
+  "repo_name": "acme/platform",
+  "payload": {
+    "action": "create",
+    "type": "Issue",
+    "createdAt": "2026-05-26T09:14:22.000Z",
+    "webhookId": "wh-linear-ops355-create",
+    "data": {
+      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "identifier": "OPS-355",
+      "title": "Intermittent 401 errors from auth-service under concurrent load",
+      "description": "## Symptom\n\nDuring peak traffic (~2k RPS) customers and internal services report sporadic **401 Unauthorized** responses from **auth-service**. Failures are non-deterministic — the same bearer token succeeds on retry.\n\n## Observed behavior\n\n- api-gateway access logs show bursts of `401` on `/v1/introspect` and `/v1/refresh`\n- checkout-api and user-profile-api see downstream 401s when forwarding tokens\n- Error rate spikes to ~3% for 5–10 minute windows, then clears without deploys\n- No obvious correlation with deploys, key rotation, or client version\n\n## Initial triage\n\n- Redis and Postgres look healthy\n- JWT signing keys unchanged\n- No recent auth-service config changes\n\n## Status\n\nRoot cause **not yet identified**. Tracking as active incident.\n\n## Links\n\n- Grafana: auth-service 401 rate panel\n- PagerDuty: PD-AUTH-401-SPIKE",
+      "priority": 1,
+      "priorityLabel": "Urgent",
+      "url": "https://linear.app/acme/issue/OPS-355",
+      "createdAt": "2026-05-26T09:14:22.000Z",
+      "updatedAt": "2026-05-26T09:14:22.000Z",
+      "state": {
+        "id": "state-in-progress-001",
+        "name": "In Progress",
+        "type": "started",
+        "color": "#f2c94c"
+      },
+      "team": {
+        "id": "team-ops-001",
+        "key": "OPS",
+        "name": "Operations"
+      },
+      "teamId": "team-ops-001",
+      "assignee": {
+        "id": "user-maya-chen",
+        "name": "Maya Chen",
+        "displayName": "Maya Chen",
+        "email": "maya.chen@example.test"
+      },
+      "creator": {
+        "id": "user-jordan-park",
+        "name": "Jordan Park",
+        "displayName": "Jordan Park",
+        "email": "jordan.park@example.test"
+      },
+      "labels": [
+        {
+          "id": "label-incident",
+          "name": "incident",
+          "color": "#eb5757"
+        },
+        {
+          "id": "label-auth",
+          "name": "auth-service",
+          "color": "#2f80ed"
+        }
+      ],
+      "project": {
+        "id": "proj-platform-reliability",
+        "name": "Platform Reliability"
+      }
+    }
+  },
+  "_meta": {
+    "captured_from": "synthetic",
+    "redactions": []
+  }
+}

--- a/potpie/context-engine/benchmarks/fixtures/raw_events/linear/ops_431_jwt_race_root_cause.json
+++ b/potpie/context-engine/benchmarks/fixtures/raw_events/linear/ops_431_jwt_race_root_cause.json
@@ -1,0 +1,84 @@
+{
+  "connector": "linear",
+  "event_type": "issue",
+  "action": "create",
+  "source_id": "linear:issue:OPS-431:create",
+  "occurred_at": "2026-01-15T00:00:00Z",
+  "repo_name": "acme/platform",
+  "payload": {
+    "action": "create",
+    "type": "Issue",
+    "createdAt": "2026-05-30T11:42:08.000Z",
+    "webhookId": "wh-linear-ops431-create",
+    "data": {
+      "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+      "identifier": "OPS-431",
+      "title": "Root cause: JWT token expiry race between refresh worker and request handler",
+      "description": "## Summary\n\nIdentified the root cause of the intermittent 401s tracked in **OPS-355**: a **JWT token expiry race condition** inside **auth-service**.\n\n## Root cause\n\nauth-service runs two independent code paths that both evaluate token expiry without coordination:\n\n1. **Request handler** — validates the bearer token on `/v1/introspect` and API calls\n2. **Background refresh worker** — proactively rotates refresh tokens nearing expiry\n\nUnder concurrent load both paths can observe the same session within a narrow window (~50–120ms). The worker rotates the refresh token and invalidates the prior access token while an in-flight request still presents the old token. The handler rejects it with **401 Unauthorized** even though the client believed the token was valid milliseconds earlier.\n\nThere is no shared lock or single source of truth for \"token generation epoch\" across the worker and handler.\n\n## Related\n\n- Parent / symptom ticket: **OPS-355**\n\n## Fix direction\n\n- Serialize refresh via Redis distributed lock keyed on `session_id`\n- Introduce monotonic `token_version` checked atomically in both paths\n- Add integration test reproducing concurrent refresh + introspect\n\n## Owners\n\n- @maya-chen (auth-service lead)\n- @jordan-park (SRE on-call)",
+      "priority": 1,
+      "priorityLabel": "Urgent",
+      "url": "https://linear.app/acme/issue/OPS-431",
+      "createdAt": "2026-05-30T11:42:08.000Z",
+      "updatedAt": "2026-05-30T11:42:08.000Z",
+      "state": {
+        "id": "state-in-progress-002",
+        "name": "In Progress",
+        "type": "started",
+        "color": "#f2c94c"
+      },
+      "team": {
+        "id": "team-ops-001",
+        "key": "OPS",
+        "name": "Operations"
+      },
+      "teamId": "team-ops-001",
+      "assignee": {
+        "id": "user-maya-chen",
+        "name": "Maya Chen",
+        "displayName": "Maya Chen",
+        "email": "maya.chen@example.test"
+      },
+      "creator": {
+        "id": "user-maya-chen",
+        "name": "Maya Chen",
+        "displayName": "Maya Chen",
+        "email": "maya.chen@example.test"
+      },
+      "labels": [
+        {
+          "id": "label-incident",
+          "name": "incident",
+          "color": "#eb5757"
+        },
+        {
+          "id": "label-auth",
+          "name": "auth-service",
+          "color": "#2f80ed"
+        },
+        {
+          "id": "label-root-cause",
+          "name": "root-cause",
+          "color": "#9b51e0"
+        }
+      ],
+      "project": {
+        "id": "proj-platform-reliability",
+        "name": "Platform Reliability"
+      },
+      "relations": [
+        {
+          "type": "related",
+          "issue": {
+            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "identifier": "OPS-355",
+            "title": "Intermittent 401 errors from auth-service under concurrent load"
+          }
+        }
+      ]
+    }
+  },
+  "_meta": {
+    "captured_from": "synthetic",
+    "redactions": []
+  }
+}

--- a/potpie/context-engine/benchmarks/fixtures/raw_events/notion/postmortem_jwt_race.json
+++ b/potpie/context-engine/benchmarks/fixtures/raw_events/notion/postmortem_jwt_race.json
@@ -1,0 +1,59 @@
+{
+  "connector": "notion",
+  "event_type": "page",
+  "action": "created",
+  "source_id": "notion:page:jwt-race-postmortem:created",
+  "occurred_at": "2026-01-15T00:00:00Z",
+  "repo_name": "acme/platform",
+  "payload": {
+    "object": "page",
+    "id": "notion-page-jwt-race-pm-001",
+    "created_time": "2026-06-02T16:30:00.000Z",
+    "last_edited_time": "2026-06-02T16:30:00.000Z",
+    "url": "https://www.notion.so/acme/JWT-Token-Expiry-Race-Postmortem-jwt-race-postmortem",
+    "icon": {
+      "type": "emoji",
+      "emoji": "🔐"
+    },
+    "properties": {
+      "Name": {
+        "id": "title",
+        "type": "title",
+        "title": [
+          {
+            "type": "text",
+            "plain_text": "Postmortem: JWT Token Expiry Race (OPS-355 / OPS-431)",
+            "text": {
+              "content": "Postmortem: JWT Token Expiry Race (OPS-355 / OPS-431)"
+            }
+          }
+        ]
+      },
+      "Status": {
+        "type": "select",
+        "select": {
+          "name": "Published"
+        }
+      },
+      "Service": {
+        "type": "multi_select",
+        "multi_select": [
+          {
+            "name": "auth-service"
+          }
+        ]
+      },
+      "Severity": {
+        "type": "select",
+        "select": {
+          "name": "SEV-2"
+        }
+      }
+    },
+    "content": "# Postmortem: JWT Token Expiry Race\n\n**Incident:** OPS-355 (symptom) → OPS-431 (root cause)\n**Service:** auth-service\n**Authors:** Maya Chen (@maya-chen), Jordan Park (@jordan-park)\n**Date:** 2026-06-02\n\n## Timeline\n\n| Time (UTC) | Event |\n|---|---|\n| 2026-05-26 09:14 | OPS-355 opened — intermittent 401s under concurrent load, root cause unknown |\n| 2026-05-27 14:20 | #incidents-auth Slack thread opened; on-call begins correlating refresh worker metrics with 401 spikes |\n| 2026-05-30 11:42 | OPS-431 opened — JWT token expiry race condition identified; links to OPS-355 |\n| 2026-05-31 18:00 | Fix deployed: Redis lock + token_version guard around refresh path |\n| 2026-06-01 09:00 | 401 error rate returned to baseline; incident closed |\n\n## Root cause\n\nauth-service had **two independent expiry checks** with no coordination:\n\n- the **background token refresh worker** rotates refresh tokens when `exp - now < refresh_leeway`\n- the **request handler** validates bearer tokens on introspection and downstream calls\n\nUnder concurrent load, both paths could act on the same session within a ~50–120ms window. The worker invalidated an access token the handler was still accepting, producing **intermittent 401 Unauthorized** responses that cleared on client retry (after refresh).\n\nThis is a classic **JWT token expiry race condition** driven by **concurrent token refresh** without a shared lock or monotonic token version.\n\n## Resolution\n\n1. Added a Redis distributed lock keyed on `session_id` around the refresh worker critical section\n2. Introduced `token_version` incremented atomically on every refresh; handler rejects stale versions with a structured error\n3. Added load test `tests/integration/test_concurrent_refresh_race.py` reproducing the race\n\n## Follow-ups\n\n- [ ] Audit other services for duplicate expiry checks outside auth-service\n- [ ] Add `auth_refresh_race_window_ms` metric and alert\n- [ ] Document refresh locking contract in `services/auth-service/README.md`\n- [ ] Review on-call runbook for auth 401 spikes (link OPS-355 / OPS-431)\n\n## Related tickets\n\n- OPS-355 — symptom report\n- OPS-431 — root cause ticket"
+  },
+  "_meta": {
+    "captured_from": "synthetic",
+    "redactions": []
+  }
+}

--- a/potpie/context-engine/benchmarks/fixtures/raw_events/slack/thread_jwt_race_diagnosis.json
+++ b/potpie/context-engine/benchmarks/fixtures/raw_events/slack/thread_jwt_race_diagnosis.json
@@ -1,0 +1,76 @@
+{
+  "connector": "slack",
+  "event_type": "message",
+  "action": "thread",
+  "source_id": "slack:thread:C04AUTH401:1737028800.001234",
+  "occurred_at": "2026-01-15T00:00:00Z",
+  "repo_name": "acme/platform",
+  "payload": {
+    "type": "message",
+    "subtype": "thread_broadcast",
+    "channel": "C04AUTH401",
+    "channel_name": "incidents-auth",
+    "thread_ts": "1737028800.001234",
+    "team_id": "T0ACME001",
+    "messages": [
+      {
+        "type": "message",
+        "user": "U004JORDAN",
+        "username": "jordan-park",
+        "real_name": "Jordan Park",
+        "text": "<!here> seeing another 401 spike on auth-service — PD-AUTH-401-SPIKE is firing again. Same pattern as OPS-355: bursts under load, clears on retry. Logs attached. @maya-chen can you take point? You're auth owner per CODEOWNERS.",
+        "ts": "1737028800.001234",
+        "thread_ts": "1737028800.001234"
+      },
+      {
+        "type": "message",
+        "user": "U014MAYA",
+        "username": "maya-chen",
+        "real_name": "Maya Chen",
+        "text": "On it. Pulling auth-service metrics now. 401 rate correlates with `token_refresh_worker` cycle — spikes exactly when the background refresh job runs every 30s.",
+        "ts": "1737028801.445678",
+        "thread_ts": "1737028800.001234"
+      },
+      {
+        "type": "message",
+        "user": "U014MAYA",
+        "username": "maya-chen",
+        "real_name": "Maya Chen",
+        "text": "Hypothesis: the refresh worker and the request handler both check expiry independently. Under concurrent load there's a narrow window where the worker rotates the refresh token while an in-flight request still presents the old access token → 401.",
+        "ts": "1737028805.112233",
+        "thread_ts": "1737028800.001234"
+      },
+      {
+        "type": "message",
+        "user": "U004JORDAN",
+        "username": "jordan-park",
+        "real_name": "Jordan Park",
+        "text": "That matches the trace I grabbed — introspect 401 happens ~80ms after a refresh_worker log line for the same session_id. No deploy, keys look fine.",
+        "ts": "1737028809.778899",
+        "thread_ts": "1737028800.001234"
+      },
+      {
+        "type": "message",
+        "user": "U001SAM",
+        "username": "sam-kim",
+        "real_name": "Sam Kim",
+        "text": "checkout-api is just forwarding tokens from clients — we're not re-validating expiry locally. If auth rejects a token mid-flow we surface the 401 downstream. Happy to help repro if you need a concurrent client.",
+        "ts": "1737028814.334455",
+        "thread_ts": "1737028800.001234"
+      },
+      {
+        "type": "message",
+        "user": "U014MAYA",
+        "username": "maya-chen",
+        "real_name": "Maya Chen",
+        "text": "Confirmed in staging with Sam's repro script — concurrent refresh + introspect hits the race ~2% of the time. Opening OPS-431 for root cause and linking to OPS-355. Fix will need a lock or single expiry authority across worker + handler.",
+        "ts": "1737028820.667788",
+        "thread_ts": "1737028800.001234"
+      }
+    ]
+  },
+  "_meta": {
+    "captured_from": "synthetic",
+    "redactions": []
+  }
+}

--- a/potpie/context-engine/benchmarks/fixtures/raw_events/universe/acme/00-auth-service.json
+++ b/potpie/context-engine/benchmarks/fixtures/raw_events/universe/acme/00-auth-service.json
@@ -1,0 +1,37 @@
+{
+  "connector": "repo_docs",
+  "event_type": "service_manifest",
+  "action": "create",
+  "source_id": "repo_docs:service_manifest:auth-service:create",
+  "occurred_at": "2026-01-15T00:00:00Z",
+  "repo_name": "acme/platform",
+  "payload": {
+    "path": "services/auth-service/service.yaml",
+    "service": {
+      "name": "auth-service",
+      "display_name": "Auth Service",
+      "description": "Issues and refreshes JWT access tokens for Acme platform clients. Owns token signing keys, refresh-token rotation, and the background token refresh worker.",
+      "repo": "acme/platform",
+      "path": "services/auth-service",
+      "language": "python",
+      "team": "@platform-platform",
+      "capabilities": [
+        "jwt-issuance",
+        "jwt-refresh",
+        "session-validation"
+      ],
+      "dependencies": {
+        "datastores": ["auth-redis", "auth-postgres"],
+        "services": []
+      },
+      "runtime": {
+        "port": 8080,
+        "health_check": "/healthz"
+      }
+    }
+  },
+  "_meta": {
+    "captured_from": "synthetic",
+    "redactions": []
+  }
+}

--- a/potpie/context-engine/benchmarks/fixtures/raw_events/universe/acme/01-api-gateway.json
+++ b/potpie/context-engine/benchmarks/fixtures/raw_events/universe/acme/01-api-gateway.json
@@ -1,0 +1,37 @@
+{
+  "connector": "repo_docs",
+  "event_type": "service_manifest",
+  "action": "create",
+  "source_id": "repo_docs:service_manifest:api-gateway:create",
+  "occurred_at": "2026-01-15T00:00:00Z",
+  "repo_name": "acme/platform",
+  "payload": {
+    "path": "services/api-gateway/service.yaml",
+    "service": {
+      "name": "api-gateway",
+      "display_name": "API Gateway",
+      "description": "Edge gateway that terminates TLS, validates JWTs via auth-service introspection, and routes traffic to downstream services.",
+      "repo": "acme/platform",
+      "path": "services/api-gateway",
+      "language": "go",
+      "team": "@platform-edge",
+      "capabilities": [
+        "jwt-validation",
+        "rate-limiting",
+        "request-routing"
+      ],
+      "dependencies": {
+        "datastores": ["gateway-redis"],
+        "services": ["auth-service"]
+      },
+      "runtime": {
+        "port": 443,
+        "health_check": "/healthz"
+      }
+    }
+  },
+  "_meta": {
+    "captured_from": "synthetic",
+    "redactions": []
+  }
+}

--- a/potpie/context-engine/benchmarks/fixtures/raw_events/universe/acme/02-checkout-api.json
+++ b/potpie/context-engine/benchmarks/fixtures/raw_events/universe/acme/02-checkout-api.json
@@ -1,0 +1,36 @@
+{
+  "connector": "repo_docs",
+  "event_type": "service_manifest",
+  "action": "create",
+  "source_id": "repo_docs:service_manifest:checkout-api:create",
+  "occurred_at": "2026-01-15T00:00:00Z",
+  "repo_name": "acme/platform",
+  "payload": {
+    "path": "services/checkout-api/service.yaml",
+    "service": {
+      "name": "checkout-api",
+      "display_name": "Checkout API",
+      "description": "Orchestrates multi-step checkout flows. Forwards bearer tokens from clients to downstream services without re-validating expiry locally.",
+      "repo": "acme/platform",
+      "path": "services/checkout-api",
+      "language": "python",
+      "team": "@platform-checkout",
+      "capabilities": [
+        "checkout-orchestration",
+        "cart-management"
+      ],
+      "dependencies": {
+        "datastores": ["checkout-postgres"],
+        "services": ["auth-service", "api-gateway", "payments-svc"]
+      },
+      "runtime": {
+        "port": 8081,
+        "health_check": "/healthz"
+      }
+    }
+  },
+  "_meta": {
+    "captured_from": "synthetic",
+    "redactions": []
+  }
+}

--- a/potpie/context-engine/benchmarks/fixtures/raw_events/universe/acme/03-user-profile-api.json
+++ b/potpie/context-engine/benchmarks/fixtures/raw_events/universe/acme/03-user-profile-api.json
@@ -1,0 +1,36 @@
+{
+  "connector": "repo_docs",
+  "event_type": "service_manifest",
+  "action": "create",
+  "source_id": "repo_docs:service_manifest:user-profile-api:create",
+  "occurred_at": "2026-01-15T00:00:00Z",
+  "repo_name": "acme/platform",
+  "payload": {
+    "path": "services/user-profile-api/service.yaml",
+    "service": {
+      "name": "user-profile-api",
+      "display_name": "User Profile API",
+      "description": "Serves account and profile endpoints. Relies on auth-service JWT validation at the gateway and passes through access tokens on internal calls.",
+      "repo": "acme/platform",
+      "path": "services/user-profile-api",
+      "language": "python",
+      "team": "@platform-identity",
+      "capabilities": [
+        "profile-read",
+        "profile-update"
+      ],
+      "dependencies": {
+        "datastores": ["profile-postgres"],
+        "services": ["auth-service", "api-gateway"]
+      },
+      "runtime": {
+        "port": 8082,
+        "health_check": "/healthz"
+      }
+    }
+  },
+  "_meta": {
+    "captured_from": "synthetic",
+    "redactions": []
+  }
+}

--- a/potpie/context-engine/benchmarks/fixtures/raw_events/universe/acme/10-team.json
+++ b/potpie/context-engine/benchmarks/fixtures/raw_events/universe/acme/10-team.json
@@ -1,0 +1,82 @@
+{
+  "connector": "repo_docs",
+  "event_type": "codeowners",
+  "action": "create",
+  "source_id": "repo_docs:codeowners:acme-platform:create",
+  "occurred_at": "2026-01-15T00:00:00Z",
+  "repo_name": "acme/platform",
+  "payload": {
+    "path": "CODEOWNERS",
+    "content": "# Acme platform ownership\n/services/auth-service/     @platform-platform @maya-chen\n/services/api-gateway/       @platform-edge @jordan-park\n/services/checkout-api/      @platform-checkout @sam-kim\n/services/user-profile-api/  @platform-identity @priya-shah\n",
+    "rules": [
+      {
+        "pattern": "/services/auth-service/",
+        "owners": ["@platform-platform", "@maya-chen"],
+        "line_no": 2
+      },
+      {
+        "pattern": "/services/api-gateway/",
+        "owners": ["@platform-edge", "@jordan-park"],
+        "line_no": 3
+      },
+      {
+        "pattern": "/services/checkout-api/",
+        "owners": ["@platform-checkout", "@sam-kim"],
+        "line_no": 4
+      },
+      {
+        "pattern": "/services/user-profile-api/",
+        "owners": ["@platform-identity", "@priya-shah"],
+        "line_no": 5
+      }
+    ],
+    "assignments": [
+      {
+        "service": "auth-service",
+        "team": "@platform-platform",
+        "lead": {
+          "handle": "@maya-chen",
+          "name": "Maya Chen",
+          "bench_alias": "bench-user-14"
+        },
+        "on_call": {
+          "handle": "@jordan-park",
+          "name": "Jordan Park",
+          "bench_alias": "bench-user-4",
+          "rotation": "SRE primary on-call"
+        }
+      },
+      {
+        "service": "api-gateway",
+        "team": "@platform-edge",
+        "lead": {
+          "handle": "@jordan-park",
+          "name": "Jordan Park",
+          "bench_alias": "bench-user-4"
+        }
+      },
+      {
+        "service": "checkout-api",
+        "team": "@platform-checkout",
+        "lead": {
+          "handle": "@sam-kim",
+          "name": "Sam Kim",
+          "bench_alias": "bench-user-1"
+        }
+      },
+      {
+        "service": "user-profile-api",
+        "team": "@platform-identity",
+        "lead": {
+          "handle": "@priya-shah",
+          "name": "Priya Shah",
+          "bench_alias": "bench-user-7"
+        }
+      }
+    ]
+  },
+  "_meta": {
+    "captured_from": "synthetic",
+    "redactions": []
+  }
+}

--- a/potpie/context-engine/benchmarks/scenarios/bug_auth_token_expiry_race.yaml
+++ b/potpie/context-engine/benchmarks/scenarios/bug_auth_token_expiry_race.yaml
@@ -1,0 +1,36 @@
+id: bug_auth_token_expiry_race
+use_case: BUG
+universe: acme
+
+seed:
+  # Universe files under fixtures/raw_events/universe/acme/ are ingested at -365d
+  # via the `universe: acme` declaration (00-auth-service, 01-api-gateway,
+  # 02-checkout-api, 03-user-profile-api, 10-team).
+
+ingest:
+  # OPS-355 symptom: around -14d
+  - { event: linear/ops_355_jwt_expiry_symptom.json, at: "-14d" }
+  # Slack thread: around -13d
+  - { event: slack/thread_jwt_race_diagnosis.json, at: "-13d" }
+  # OPS-431 root cause: around -10d
+  - { event: linear/ops_431_jwt_race_root_cause.json, at: "-10d" }
+  # Notion postmortem: around -7d
+  - { event: notion/postmortem_jwt_race.json, at: "-7d" }
+
+query:
+  intent: "What caused the intermittent 401 errors in the auth service and how was it resolved?"
+  include: [issues, pages, messages]
+  scope: { services: [auth-service] }
+
+ground_truth:
+  must_cite:
+    - linear:issue:OPS-355:create
+    - linear:issue:OPS-431:create
+    - notion:page:jwt-race-postmortem:created
+    - slack:thread:C04AUTH401:1737028800.001234
+  must_not_cite: []
+  expected_answer_contains:
+    - JWT token expiry race condition
+    - concurrent token refresh
+    - OPS-355
+    - OPS-431


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the complete fixture set for the `bug_auth_token_expiry_race` benchmark scenario: a JWT token expiry race condition in auth-service that causes intermittent 401s under concurrent load.

## Files added

### Acme universe (`fixtures/raw_events/universe/acme/`)
- **4 service manifests** (`repo_docs` / `service_manifest`): `auth-service`, `api-gateway`, `checkout-api`, `user-profile-api`
- **1 CODEOWNERS file** (`repo_docs` / `codeowners`): maps services to owners including Maya Chen (auth lead) and Jordan Park (SRE on-call)

### Signal fixtures (`fixtures/raw_events/`)
| File | Connector | Story beat |
|---|---|---|
| `linear/ops_355_jwt_expiry_symptom.json` | linear / issue / create | Symptom report — intermittent 401s, no root cause |
| `slack/thread_jwt_race_diagnosis.json` | slack / message / thread | Real-time diagnosis narrowing to refresh worker race |
| `linear/ops_431_jwt_race_root_cause.json` | linear / issue / create | Root cause identified, links OPS-355 |
| `notion/postmortem_jwt_race.json` | notion / page / created | Postmortem with timeline, fix, follow-ups |

### Scenario YAML (`scenarios/bug_auth_token_expiry_race.yaml`)
- Ingest timeline: OPS-355 (-14d) → Slack (-13d) → OPS-431 (-10d) → postmortem (-7d)
- Query scoped to `auth-service`
- Ground truth `must_cite` source_ids aligned with fixture envelopes

## Validation

All 9 fixture envelopes pass `validate_all_fixtures()`. Acme universe discovery yields 5 seed files at `-365d`.

## Other

- Added `.gitignore` exception for `benchmarks/fixtures/raw_events/**/*.json` so synthetic fixtures can be committed (previously blocked by global `*.json` rule).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77153dc5-a224-4895-b592-5dfc4f50e698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77153dc5-a224-4895-b592-5dfc4f50e698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

