### PR TITLE
Fix: _process_result always returns truncated result regardless of size

### DIFF
--- a/legacy/app/modules/intelligence/tools/kg_based_tools/get_code_from_node_id_tool.py
+++ b/legacy/app/modules/intelligence/tools/kg_based_tools/get_code_from_node_id_tool.py
@@ -219,7 +219,8 @@ class GetCodeFromNodeIdTool:
                 node_id=node_id,
                 project_id=project.id,
             )
-        return truncated_result
+            return truncated_result
+        return result
 
     @staticmethod
     def _get_relative_file_path(file_path: str) -> str:


### PR DESCRIPTION
Fixes #724

## Problem
`_process_result` in `GetCodeFromNodeIdTool` was always returning 
`truncated_result` even for results under 80,000 characters. This meant 
AI agents were receiving unnecessarily truncated responses instead of 
the full result.

## Fix
Return the original `result` when it's under the 80,000 character limit, 
and only return `truncated_result` when truncation is actually needed.

## Changes
- `legacy/app/modules/intelligence/tools/kg_based_tools/get_code_from_node_id_tool.py`
  - Added `return result` for the normal (under size limit) case
  - Moved `return truncated_result` inside the `if` block where it belongs