### PR TITLE
Removed unecessary data shown in UI

### DIFF
--- a/potpie/context-engine/adapters/inbound/cli/commands/bootstrap.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/bootstrap.py
@@ -90,7 +90,6 @@ def register(root: typer.Typer) -> None:
                     agent=agent,
                     scan=scan,
                     use_rich=True,
-                    config_home=getattr(host.config, "home", None),
                 )
                 if report.ok:
                     setup_ux.maybe_prompt_github_login(

--- a/potpie/context-engine/adapters/inbound/cli/ui/potpie_logo_anim.py
+++ b/potpie/context-engine/adapters/inbound/cli/ui/potpie_logo_anim.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from typing import Any
 
 from rich.align import Align
 from rich.console import Console, Group
@@ -10,7 +11,7 @@ from rich.live import Live
 from rich.padding import Padding
 from rich.text import Text
 
-from adapters.inbound.cli.ui.brand import LOGO_COLOR, LOGO_DIM_STYLE, LOGO_STYLE
+from adapters.inbound.cli.ui.brand import LOGO_COLOR, LOGO_DIM_STYLE, LOGO_STYLE, UI_MUTED_STYLE
 from adapters.inbound.cli.ui.logo_rotation import render_intro_logo, render_static_intro_logo
 from adapters.inbound.cli.ui.static_logo_loader import VIEWPORT_WIDTH, load_static_logo
 
@@ -193,6 +194,7 @@ def _finish_screen(
     logo: Text,
     sparkle_frame: int | None,
     content_w: int,
+    agent_hint: str | None = None,
 ) -> Group:
     """Celebration layout; ``sparkle_frame`` animates sparkles, ``None`` keeps them fixed."""
     if sparkle_frame is None:
@@ -201,7 +203,7 @@ def _finish_screen(
     else:
         top_sparkle = _celebration_sparkle(sparkle_frame)
         bottom_sparkle = _celebration_sparkle(sparkle_frame + 2)
-    return Group(
+    body: list[Any] = [
         Text(""),
         _center_on_logo(top_sparkle, logo=logo, content_w=content_w),
         _center_on_logo(Text("potpie", style=_ACCENT), logo=logo, content_w=content_w),
@@ -211,14 +213,18 @@ def _finish_screen(
         _left_splash(Text.from_markup(headline), content_w),
         _center_on_logo(Text(subline, style=_ACCENT), logo=logo, content_w=content_w),
         _center_on_logo(bottom_sparkle, logo=logo, content_w=content_w),
-        Text(""),
-    )
+    ]
+    if agent_hint:
+        body.append(Text(agent_hint, style=UI_MUTED_STYLE))
+    body.append(Text(""))
+    return Group(*body)
 
 
 def play_setup_finish(
     console: Console,
     *,
     pot_name: str,
+    agent_hint: str | None = None,
     seconds: float = _FINISH_SECONDS,
     panel_width: int | None = None,
 ) -> None:
@@ -253,6 +259,7 @@ def play_setup_finish(
             logo=logo,
             sparkle_frame=None,
             content_w=content_w,
+            agent_hint=agent_hint,
         )
 
     interval = 1.0 / _FINISH_FPS

--- a/potpie/context-engine/adapters/inbound/cli/ui/setup_ux.py
+++ b/potpie/context-engine/adapters/inbound/cli/ui/setup_ux.py
@@ -126,7 +126,7 @@ def render_setup_report(
 POST_SETUP_INTEGRATION_OPTIONS: tuple[tuple[str, str], ...] = (
     ("linear", "Linear"),
     ("jira", "Jira"),
-    ("confluence", "Atlassian"),
+    ("confluence", "Confluence"),
 )
 POST_SETUP_INTEGRATION_ORDER: tuple[str, ...] = tuple(
     option_id for option_id, _ in POST_SETUP_INTEGRATION_OPTIONS
@@ -175,7 +175,10 @@ def install_agents_globally(agents: list[str]) -> list[tuple[str, Any]]:
 
 def _agent_label(agent: str) -> str:
     labels = dict(POST_SETUP_AGENT_OPTIONS)
-    return labels.get(agent, agent)
+    key = agent.strip().lower()
+    if key in labels:
+        return labels[key]
+    return key.replace("_", " ").title()
 
 
 def _install_agents_globally_with_progress(agents: list[str]) -> list[tuple[str, Any]]:
@@ -248,6 +251,33 @@ def _format_agent_list(labels: list[str]) -> str:
     if len(labels) == 2:
         return f"{labels[0]} and {labels[1]}"
     return f"{', '.join(labels[:-1])}, and {labels[-1]}"
+
+
+def _agent_usage_hint(agent_ids: list[str]) -> str | None:
+    if not agent_ids:
+        return None
+    labels = [_agent_label(agent_id) for agent_id in agent_ids]
+    return (
+        f"Open {_format_agent_list(labels)} — Potpie skills are ready to use."
+    )
+
+
+def _globally_installed_harnesses() -> list[str]:
+    """Harnesses that already have Potpie skills on disk (any prior setup run)."""
+    from adapters.inbound.cli.commands._common import get_host
+
+    host = get_host()
+    installed: list[str] = []
+    for agent in POST_SETUP_AGENT_ORDER:
+        if agent == "default":
+            continue
+        try:
+            status = host.skills.status(agent=agent, scope="global")
+        except ValueError:
+            continue
+        if status.installed:
+            installed.append(agent)
+    return installed
 
 
 def _try_login(handler) -> None:
@@ -356,7 +386,11 @@ def _register_repo_source(*, repo: str) -> None:
     host.pots.add_source(pot_id=active.pot_id, kind="repo", location=repo)
 
 
-def _maybe_prompt_first_pot(*, repo: Path | None, default_pot_name: str) -> None:
+def _maybe_prompt_first_pot(
+    *,
+    repo: Path | None,
+    default_pot_name: str,
+) -> None:
     from adapters.inbound.cli.commands._common import get_host
     from adapters.inbound.cli.ui.interactive_prompts import prompt_first_pot_name
     from adapters.inbound.cli.ui.potpie_logo_anim import play_setup_finish
@@ -374,7 +408,11 @@ def _maybe_prompt_first_pot(*, repo: Path | None, default_pot_name: str) -> None
     if repo_str:
         _register_repo_source(repo=repo_str)
 
-    play_setup_finish(stderr_console(), pot_name=pot.name)
+    play_setup_finish(
+        stderr_console(),
+        pot_name=pot.name,
+        agent_hint=_agent_usage_hint(_globally_installed_harnesses()),
+    )
 
 
 __all__ = [

--- a/potpie/context-engine/adapters/inbound/cli/ui/setup_ux.py
+++ b/potpie/context-engine/adapters/inbound/cli/ui/setup_ux.py
@@ -60,6 +60,7 @@ _MIN_DWELL_S = 0.18
 _UI_HIDE_WHEN: dict[str, frozenset[str]] = {
     "auth": frozenset({"not_implemented", "skipped"}),
     "source": frozenset({"skipped"}),
+    "state_store.provision": frozenset({"skipped"}),
 }
 
 
@@ -177,20 +178,6 @@ def _agent_label(agent: str) -> str:
     return labels.get(agent, agent)
 
 
-def _print_agent_install_summary(repo: Path, results: list[tuple[str, Any]]) -> None:
-    from adapters.inbound.cli.ui.output import print_plain_line
-
-    for agent, result in results:
-        created = len(result.created)
-        updated = len(result.updated)
-        unchanged = len(result.unchanged)
-        print_plain_line(
-            f"{_agent_label(agent)} repo skills installed successfully "
-            f"({created} new, {updated} updated, {unchanged} unchanged).",
-            as_json=False,
-        )
-
-
 def _install_agents_globally_with_progress(agents: list[str]) -> list[tuple[str, Any]]:
     from adapters.inbound.cli.ui.output import print_plain_line
 
@@ -275,11 +262,8 @@ def _try_login(handler) -> None:
         raise
 
 
-def _maybe_prompt_agent_skills(*, repo: Path, setup_agent: str) -> None:
-    from adapters.inbound.cli.ui.interactive_prompts import (
-        prompt_multi_checkbox,
-        prompt_yes_no,
-    )
+def _maybe_prompt_agent_skills(*, setup_agent: str) -> None:
+    from adapters.inbound.cli.ui.interactive_prompts import prompt_multi_checkbox
 
     valid = frozenset(agent for agent in POST_SETUP_AGENT_ORDER if agent != "default")
     default_checked = (
@@ -310,18 +294,6 @@ def _maybe_prompt_agent_skills(*, repo: Path, setup_agent: str) -> None:
         if agent in selected_set and agent != "default"
     ]
     _install_agents_globally_with_progress(agents)
-
-    try:
-        install_repo = prompt_yes_no(
-            "Also install Potpie skills into this repo?",
-            default=False,
-        )
-    except (KeyboardInterrupt, EOFError):
-        install_repo = False
-    if install_repo:
-        results = install_agents_to_repo(repo, agents)
-        if results:
-            _print_agent_install_summary(repo, results)
 
 
 def maybe_prompt_github_login(
@@ -366,7 +338,7 @@ def maybe_prompt_github_login(
             _try_login(lambda p=provider: run_integration_login(p))
 
     if repo is not None:
-        _maybe_prompt_agent_skills(repo=repo, setup_agent=setup_agent)
+        _maybe_prompt_agent_skills(setup_agent=setup_agent)
 
     _maybe_prompt_first_pot(repo=repo, default_pot_name=default_pot_name)
 

--- a/potpie/context-engine/adapters/inbound/cli/ui/setup_ux.py
+++ b/potpie/context-engine/adapters/inbound/cli/ui/setup_ux.py
@@ -56,6 +56,19 @@ STATE_MAP: dict[str, StepStatus] = {
 # Synthetic per-row dwell so the (already-complete) run reads as live.
 _MIN_DWELL_S = 0.18
 
+# Soft steps that are hidden when they only report no-op / stub outcomes.
+_UI_HIDE_WHEN: dict[str, frozenset[str]] = {
+    "auth": frozenset({"not_implemented", "skipped"}),
+    "source": frozenset({"skipped"}),
+}
+
+
+def _visible_in_checklist(step: Any) -> bool:
+    hidden = _UI_HIDE_WHEN.get(step.step)
+    if hidden is None:
+        return True
+    return step.state not in hidden
+
 
 def rich_enabled(*, as_json: bool) -> bool:
     """True when the animated wizard should drive output (TTY, not --json)."""
@@ -69,12 +82,12 @@ def render_setup_report(
     agent: str,
     scan: bool,
     use_rich: bool,
-    config_home: Path | None = None,
     pot_name: str | None = None,
 ) -> None:
     """Replay a completed ``SetupReport`` through the animated checklist."""
     wizard = SetupWizardUI(use_rich=use_rich)
-    for step in report.steps:
+    visible_steps = [step for step in report.steps if _visible_in_checklist(step)]
+    for step in visible_steps:
         running, done = STEP_LABELS.get(step.step, (step.step, step.step))
         if step.step == "skills":
             running = f"Installing agent skills ({agent})…"
@@ -86,7 +99,7 @@ def render_setup_report(
 
     failed_step_id: str | None = None
     with wizard.live():
-        for step in report.steps:
+        for step in visible_steps:
             with wizard.run_step(step.step):
                 if use_rich:
                     time.sleep(_MIN_DWELL_S)
@@ -102,11 +115,7 @@ def render_setup_report(
         wizard.print_failed(step_id=failed_step_id)
         return
 
-    setup_path = str(config_home / "config.json") if config_home else ""
-    data_path = str(config_home) if config_home else ""
     wizard.print_complete_summary(
-        setup_path=setup_path,
-        data_path=data_path,
         pot_name=None if report.plan.defer_default_pot else (pot_name or report.plan.pot),
         already_setup=False,
     )

--- a/potpie/context-engine/adapters/inbound/cli/ui/setup_wizard_ui.py
+++ b/potpie/context-engine/adapters/inbound/cli/ui/setup_wizard_ui.py
@@ -293,8 +293,6 @@ class SetupWizardUI:
     def print_complete_summary(
         self,
         *,
-        setup_path: str,
-        data_path: str,
         pot_name: str | None = None,
         already_setup: bool,
     ) -> None:
@@ -307,7 +305,6 @@ class SetupWizardUI:
 
         console = stderr_console()
         width = panel_width_for_console(console)
-        cw = content_width_for_panel(width)
         console.print()
         title = (
             f"[bold {LOGO_COLOR}]Potpie is ready![/bold {LOGO_COLOR}]"
@@ -315,10 +312,7 @@ class SetupWizardUI:
             else "[dim]Already set up — no changes needed.[/dim]"
         )
         console.print(title)
-        lines = [
-            f"[{LOGO_COLOR}]✓[/{LOGO_COLOR}] Config [cyan]{escape(_truncate_middle(setup_path, cw - 10))}[/cyan]",
-            f"[{LOGO_COLOR}]✓[/{LOGO_COLOR}] Data [cyan]{escape(_truncate_middle(data_path, cw - 8))}[/cyan]",
-        ]
+        lines: list[str] = []
         if pot_name:
             lines.append(
                 f"[{LOGO_COLOR}]✓[/{LOGO_COLOR}] Pot [bold]{escape(pot_name)}[/bold]"

--- a/potpie/context-engine/tests/unit/test_setup_agent_skills.py
+++ b/potpie/context-engine/tests/unit/test_setup_agent_skills.py
@@ -48,6 +48,38 @@ def test_maybe_prompt_agent_skills_installs_selected(
     assert globally_installed == ["claude"]
 
 
+def test_globally_installed_harnesses_reports_all_agents_with_skills(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from types import SimpleNamespace
+
+    class _Skills:
+        def status(self, *, agent: str, scope: str) -> SimpleNamespace:
+            installed = agent in {"cursor", "opencode"}
+            skills = (SimpleNamespace(id="potpie-cli"),) if installed else ()
+            return SimpleNamespace(installed=skills)
+
+    monkeypatch.setattr(
+        "adapters.inbound.cli.commands._common.get_host",
+        lambda: SimpleNamespace(skills=_Skills()),
+    )
+
+    assert setup_ux._globally_installed_harnesses() == ["cursor", "opencode"]
+
+
+def test_agent_usage_hint_formats_installed_harnesses() -> None:
+    assert setup_ux._agent_usage_hint(["claude"]) == (
+        "Open Claude — Potpie skills are ready to use."
+    )
+    assert setup_ux._agent_usage_hint(["claude", "cursor"]) == (
+        "Open Claude and Cursor — Potpie skills are ready to use."
+    )
+    assert setup_ux._agent_usage_hint(["opencode", "codex", "cursor"]) == (
+        "Open OpenCode, Codex, and Cursor — Potpie skills are ready to use."
+    )
+    assert setup_ux._agent_usage_hint([]) is None
+
+
 def test_post_setup_wizard_runs_skills_after_integrations(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
 ) -> None:

--- a/potpie/context-engine/tests/unit/test_setup_agent_skills.py
+++ b/potpie/context-engine/tests/unit/test_setup_agent_skills.py
@@ -30,7 +30,6 @@ def test_maybe_prompt_agent_skills_installs_selected(
     repo.mkdir()
     (repo / ".git").mkdir()
     globally_installed: list[str] = []
-    repo_installed: list[str] = []
 
     monkeypatch.setattr(
         interactive_prompts,
@@ -43,47 +42,10 @@ def test_maybe_prompt_agent_skills_installs_selected(
         lambda agents: globally_installed.extend(agents)
         or [(agent, object()) for agent in agents],
     )
-    monkeypatch.setattr(
-        setup_ux,
-        "install_agents_to_repo",
-        lambda _repo, agents: repo_installed.extend(agents) or [],
-    )
-    monkeypatch.setattr(interactive_prompts, "prompt_yes_no", lambda *_a, **_k: False)
 
-    setup_ux._maybe_prompt_agent_skills(repo=repo, setup_agent="claude")
+    setup_ux._maybe_prompt_agent_skills(setup_agent="claude")
 
     assert globally_installed == ["claude"]
-    assert repo_installed == []
-
-
-def test_maybe_prompt_agent_skills_can_install_repo_local(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
-) -> None:
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    (repo / ".git").mkdir()
-    repo_installed: list[str] = []
-
-    monkeypatch.setattr(
-        interactive_prompts,
-        "prompt_multi_checkbox",
-        lambda *_a, **_k: ["cursor"],
-    )
-    monkeypatch.setattr(
-        setup_ux,
-        "install_agents_globally",
-        lambda agents: [(agent, object()) for agent in agents],
-    )
-    monkeypatch.setattr(
-        setup_ux,
-        "install_agents_to_repo",
-        lambda _repo, agents: repo_installed.extend(agents) or [],
-    )
-    monkeypatch.setattr(interactive_prompts, "prompt_yes_no", lambda *_a, **_k: True)
-
-    setup_ux._maybe_prompt_agent_skills(repo=repo, setup_agent="cursor")
-
-    assert repo_installed == ["cursor"]
 
 
 def test_post_setup_wizard_runs_skills_after_integrations(
@@ -109,7 +71,6 @@ def test_post_setup_wizard_runs_skills_after_integrations(
         return ["claude"]
 
     monkeypatch.setattr(interactive_prompts, "prompt_multi_checkbox", _checkbox)
-    monkeypatch.setattr(interactive_prompts, "prompt_yes_no", lambda *_a, **_k: False)
     monkeypatch.setattr(
         setup_ux,
         "install_agents_globally",


### PR DESCRIPTION
**Changes made**

1. Hide checklist rows:

- Auth related row that was not implemented.
- source is skipped (already registered, no repo, etc.)
- Removed the Config/Data lines 
- Dropped the unused config_home argument to render_setup_report

2. Atlassian -> Confluence 
3. Remove prompt asking to store skills locally in repo.
4. Give hint at the end to use your own agents to test potpie skills. 

<img width="695" height="267" alt="Screenshot 2026-06-11 at 12 25 22 PM" src="https://github.com/user-attachments/assets/3ef08313-2832-4292-96cb-389af3ae92be" />
<img width="367" height="86" alt="Screenshot 2026-06-11 at 12 26 09 PM" src="https://github.com/user-attachments/assets/83bffcdf-83c3-48cf-9a94-babafa23ba3a" />
<img width="530" height="347" alt="Screenshot 2026-06-11 at 12 26 58 PM" src="https://github.com/user-attachments/assets/5da50b86-81e4-404c-9509-83767f66b7e4" />
