### PR TITLE
fix(cli): smooth GitHub login cancel flow, auto-open countdown, and setup skip when authenticated

### DIFF
--- a/potpie/context-engine/adapters/inbound/cli/auth/github_commands.py
+++ b/potpie/context-engine/adapters/inbound/cli/auth/github_commands.py
@@ -39,6 +39,11 @@ from adapters.inbound.cli.telemetry.usage_events import (
 )
 from adapters.inbound.cli.ui.output import emit_error, print_json_blob, print_plain_line
 
+if sys.platform == "win32":
+    import msvcrt
+else:
+    msvcrt = None
+
 EXIT_CANCELLED = 130
 GITHUB_AUTO_OPEN_SECONDS = 10
 _GITHUB_OPEN_PROMPT_PREFIX = (
@@ -103,8 +108,8 @@ def _finish_inline_prompt() -> None:
 
 
 def _stdin_enter_pressed_windows(*, timeout: float) -> bool:
-    import msvcrt
-
+    if msvcrt is None:
+        return False
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if msvcrt.kbhit():

--- a/potpie/context-engine/adapters/inbound/cli/auth/github_commands.py
+++ b/potpie/context-engine/adapters/inbound/cli/auth/github_commands.py
@@ -8,8 +8,8 @@ import time
 import webbrowser
 from typing import NoReturn
 
-from click.exceptions import Abort
 import typer
+from click.exceptions import Abort
 
 from adapters.outbound.cli_auth.env_bootstrap import load_cli_env
 from adapters.outbound.cli_auth.github import (
@@ -102,14 +102,33 @@ def _finish_inline_prompt() -> None:
     sys.stdout.flush()
 
 
+def _stdin_enter_pressed_windows(*, timeout: float) -> bool:
+    import msvcrt
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if msvcrt.kbhit():
+            char = msvcrt.getwch()
+            if char in ("\r", "\n"):
+                return True
+        time.sleep(0.05)
+    return False
+
+
 def _wait_for_enter_or_auto_open(
     *,
     seconds: int = GITHUB_AUTO_OPEN_SECONDS,
     input_stream=None,
 ) -> None:
     input_stream = input_stream or sys.stdin
+    use_windows_stdin = input_stream is sys.stdin and sys.platform == "win32"
     for remaining in range(seconds, 0, -1):
         _write_inline_prompt(f"{_GITHUB_OPEN_PROMPT_PREFIX}{remaining}s")
+        if use_windows_stdin:
+            if _stdin_enter_pressed_windows(timeout=1.0):
+                _finish_inline_prompt()
+                return
+            continue
         try:
             ready, _, _ = select.select([input_stream], [], [], 1)
         except (OSError, TypeError, ValueError):

--- a/potpie/context-engine/adapters/inbound/cli/auth/github_commands.py
+++ b/potpie/context-engine/adapters/inbound/cli/auth/github_commands.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import select
+import sys
+import time
 import webbrowser
 from typing import NoReturn
 
+from click.exceptions import Abort
 import typer
 
 from adapters.outbound.cli_auth.env_bootstrap import load_cli_env
@@ -35,6 +39,12 @@ from adapters.inbound.cli.telemetry.usage_events import (
 )
 from adapters.inbound.cli.ui.output import emit_error, print_json_blob, print_plain_line
 
+EXIT_CANCELLED = 130
+GITHUB_AUTO_OPEN_SECONDS = 10
+_GITHUB_OPEN_PROMPT_PREFIX = (
+    "Copy the code. Press Enter to open now, or GitHub opens in "
+)
+
 github_app = typer.Typer(help="GitHub integration.")
 github_test_app = typer.Typer(
     help="Deprecated: use `potpie github repos`.",
@@ -59,13 +69,12 @@ def _open_github_device_verification(user_code: str, verification_uri: str) -> b
         as_json=False,
     )
     print_plain_line(f"Copy this code: {user_code}", as_json=False)
-    print_plain_line(
-        "Copy the code, then press Enter to open GitHub.",
-        as_json=False,
-    )
-    typer.confirm(
-        "Press Enter after copying the code", default=True, show_default=False
-    )
+    try:
+        _wait_for_enter_or_auto_open()
+    except BaseException as exc:
+        if _is_github_login_cancel(exc):
+            _cancel_github_login()
+        raise
     print_plain_line("Opening GitHub now...", as_json=False)
 
     opened = webbrowser.open(verification_uri)
@@ -83,26 +92,34 @@ def _open_github_device_verification(user_code: str, verification_uri: str) -> b
     return True
 
 
-def _capture_unexpected_auth_error(
-    exc: BaseException,
-    *,
-    title: str,
-    verbose: bool,
-) -> NoReturn:
-    from adapters.inbound.cli.sentry_runtime import capture_unexpected_cli_error
+def _write_inline_prompt(message: str) -> None:
+    sys.stdout.write(f"\r\033[K{message}")
+    sys.stdout.flush()
 
-    capture_unexpected_cli_error(
-        exc,
-        error_code="unexpected_cli_error",
-        error_kind="unexpected",
-    )
-    emit_error(
-        title,
-        "Unexpected internal error.",
-        code="unexpected_cli_error",
-        verbose=verbose,
-    )
-    raise typer.Exit(code=EXIT_AUTH) from exc
+
+def _finish_inline_prompt() -> None:
+    sys.stdout.write("\r\033[K\n")
+    sys.stdout.flush()
+
+
+def _wait_for_enter_or_auto_open(
+    *,
+    seconds: int = GITHUB_AUTO_OPEN_SECONDS,
+    input_stream=None,
+) -> None:
+    input_stream = input_stream or sys.stdin
+    for remaining in range(seconds, 0, -1):
+        _write_inline_prompt(f"{_GITHUB_OPEN_PROMPT_PREFIX}{remaining}s")
+        try:
+            ready, _, _ = select.select([input_stream], [], [], 1)
+        except (OSError, TypeError, ValueError):
+            time.sleep(1)
+            ready = []
+        if ready:
+            input_stream.readline()
+            _finish_inline_prompt()
+            return
+    _finish_inline_prompt()
 
 
 def github_login_impl() -> None:
@@ -194,7 +211,13 @@ def github_login_impl() -> None:
         raise typer.Exit(code=EXIT_AUTH) from exc
     except typer.Exit:
         raise
+    except (Abort, KeyboardInterrupt, EOFError) as exc:
+        if _is_github_login_cancel(exc):
+            _cancel_github_login()
+        raise
     except Exception as exc:  # noqa: BLE001
+        if _is_github_login_cancel(exc):
+            _cancel_github_login()
         capture_github_auth_event(
             "cli_onboarding_github_auth_failed",
             entrypoint=entrypoint,
@@ -228,6 +251,18 @@ def github_login_impl() -> None:
     print_plain_line(
         f"Logged in to GitHub as {login}" + (f" ({email})" if email else ""),
         as_json=False,
+    )
+
+
+def _cancel_github_login() -> NoReturn:
+    typer.echo()
+    print_plain_line("GitHub login cancelled.", as_json=False)
+    raise typer.Exit(code=EXIT_CANCELLED) from None
+
+
+def _is_github_login_cancel(exc: BaseException) -> bool:
+    return isinstance(exc, (Abort, KeyboardInterrupt, EOFError)) or (
+        exc.__class__.__name__ == "Abort"
     )
 
 

--- a/potpie/context-engine/adapters/inbound/cli/ui/setup_ux.py
+++ b/potpie/context-engine/adapters/inbound/cli/ui/setup_ux.py
@@ -317,7 +317,9 @@ def _try_login(handler) -> None:
 
     try:
         handler()
-    except typer.Exit:
+    except typer.Exit as exc:
+        if getattr(exc, "exit_code", None) == 130:
+            raise
         pass
     except (KeyboardInterrupt, EOFError):
         raise

--- a/potpie/context-engine/adapters/inbound/cli/ui/setup_ux.py
+++ b/potpie/context-engine/adapters/inbound/cli/ui/setup_ux.py
@@ -14,6 +14,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from adapters.inbound.cli.commands._common import get_store
 from adapters.inbound.cli.telemetry.onboarding_events import (
     capture_github_prompt_outcome,
     capture_github_prompt_shown,
@@ -326,8 +327,6 @@ def _try_login(handler) -> None:
 
 
 def _github_status() -> dict[str, Any]:
-    from adapters.inbound.cli.commands._common import get_store
-
     return get_store().get_integration_status("github")
 
 

--- a/potpie/context-engine/adapters/inbound/cli/ui/setup_ux.py
+++ b/potpie/context-engine/adapters/inbound/cli/ui/setup_ux.py
@@ -323,6 +323,31 @@ def _try_login(handler) -> None:
         raise
 
 
+def _github_status() -> dict[str, Any]:
+    from adapters.inbound.cli.commands._common import get_store
+
+    return get_store().get_integration_status("github")
+
+
+def _github_already_authenticated() -> bool:
+    try:
+        status = _github_status()
+    except Exception:  # noqa: BLE001
+        return False
+    if not bool(status.get("authenticated")):
+        return False
+    login = str(status.get("login") or "").strip()
+    suffix = f" as {login}" if login else ""
+    from adapters.inbound.cli.ui.output import print_plain_line
+
+    print_plain_line(
+        f"GitHub already connected{suffix}; skipping login.",
+        as_json=False,
+        markup=False,
+    )
+    return True
+
+
 def _maybe_prompt_agent_skills(*, setup_agent: str) -> None:
     from adapters.inbound.cli.ui.interactive_prompts import prompt_multi_checkbox
 
@@ -399,27 +424,30 @@ def maybe_prompt_github_login(
 
     import typer
 
-    prompt_started_ms = now_ms()
-    capture_github_prompt_shown(default_answer=True)
-    try:
-        confirmed = typer.confirm(
-            "Would you like to log in to GitHub now?",
-            default=True,
-        )
-    except (KeyboardInterrupt, EOFError):
-        capture_github_prompt_outcome(
-            "aborted",
-            duration_ms=elapsed_ms(prompt_started_ms),
-        )
-        confirmed = False
+    if not _github_already_authenticated():
+        prompt_started_ms = now_ms()
+        capture_github_prompt_shown(default_answer=True)
+        try:
+            confirmed = typer.confirm(
+                "Would you like to log in to GitHub now?",
+                default=True,
+            )
+        except (KeyboardInterrupt, EOFError):
+            capture_github_prompt_outcome(
+                "aborted",
+                duration_ms=elapsed_ms(prompt_started_ms),
+            )
+            confirmed = False
+        else:
+            capture_github_prompt_outcome(
+                "accepted" if confirmed else "declined",
+                duration_ms=elapsed_ms(prompt_started_ms),
+            )
+        if confirmed:
+            with onboarding_entrypoint("post_setup_github_prompt"):
+                _try_login(github_login_impl)
     else:
-        capture_github_prompt_outcome(
-            "accepted" if confirmed else "declined",
-            duration_ms=elapsed_ms(prompt_started_ms),
-        )
-    if confirmed:
-        with onboarding_entrypoint("post_setup_github_prompt"):
-            _try_login(github_login_impl)
+        capture_github_prompt_outcome("skipped", duration_ms=0)
 
     capture_onboarding_event(
         "cli_onboarding_integration_picker_shown",

--- a/potpie/context-engine/adapters/outbound/cli_auth/credentials_store.py
+++ b/potpie/context-engine/adapters/outbound/cli_auth/credentials_store.py
@@ -1376,7 +1376,11 @@ def write_provider_credentials(provider: str, payload: dict[str, Any]) -> None:
     if not access_token:
         raise ProviderCredentialError("GitHub access token is required.")
     previous_metadata = get_integration_metadata(key)
-    previous_token = _load_keychain_secret("GitHub token", _GITHUB_TOKEN_SECRET)
+    previous_token = (
+        _load_keychain_secret("GitHub token", _GITHUB_TOKEN_SECRET)
+        if previous_metadata
+        else ""
+    )
     stored_payload["token_storage"] = _store_keychain_secret(
         "GitHub token",
         _GITHUB_TOKEN_SECRET,

--- a/potpie/context-engine/adapters/outbound/cli_auth/credentials_store.py
+++ b/potpie/context-engine/adapters/outbound/cli_auth/credentials_store.py
@@ -1375,6 +1375,8 @@ def write_provider_credentials(provider: str, payload: dict[str, Any]) -> None:
     access_token = str(stored_payload.pop("access_token", "") or "").strip()
     if not access_token:
         raise ProviderCredentialError("GitHub access token is required.")
+    previous_metadata = get_integration_metadata(key)
+    previous_token = _load_keychain_secret("GitHub token", _GITHUB_TOKEN_SECRET)
     stored_payload["token_storage"] = _store_keychain_secret(
         "GitHub token",
         _GITHUB_TOKEN_SECRET,
@@ -1384,7 +1386,14 @@ def write_provider_credentials(provider: str, payload: dict[str, Any]) -> None:
         write_integration_metadata(key, stored_payload)
     except Exception:
         try:
-            _delete_keychain_secret("GitHub token", _GITHUB_TOKEN_SECRET)
+            if previous_metadata and previous_token:
+                _store_keychain_secret(
+                    "GitHub token",
+                    _GITHUB_TOKEN_SECRET,
+                    previous_token,
+                )
+            else:
+                _delete_keychain_secret("GitHub token", _GITHUB_TOKEN_SECRET)
         except Exception:
             pass
         raise

--- a/potpie/context-engine/adapters/outbound/cli_auth/credentials_store.py
+++ b/potpie/context-engine/adapters/outbound/cli_auth/credentials_store.py
@@ -1383,7 +1383,10 @@ def write_provider_credentials(provider: str, payload: dict[str, Any]) -> None:
     try:
         write_integration_metadata(key, stored_payload)
     except Exception:
-        _delete_keychain_secret("GitHub token", _GITHUB_TOKEN_SECRET)
+        try:
+            _delete_keychain_secret("GitHub token", _GITHUB_TOKEN_SECRET)
+        except Exception:
+            pass
         raise
 
 

--- a/potpie/context-engine/adapters/outbound/cli_auth/credentials_store.py
+++ b/potpie/context-engine/adapters/outbound/cli_auth/credentials_store.py
@@ -1380,7 +1380,11 @@ def write_provider_credentials(provider: str, payload: dict[str, Any]) -> None:
         _GITHUB_TOKEN_SECRET,
         access_token,
     )
-    write_integration_metadata(key, stored_payload)
+    try:
+        write_integration_metadata(key, stored_payload)
+    except Exception:
+        _delete_keychain_secret("GitHub token", _GITHUB_TOKEN_SECRET)
+        raise
 
 
 def get_provider_credentials(provider: str) -> dict[str, Any]:

--- a/potpie/context-engine/tests/_auth_fakes.py
+++ b/potpie/context-engine/tests/_auth_fakes.py
@@ -156,6 +156,17 @@ class InMemoryCredentialStore:
         self.integrations.pop(provider, None)
 
     def get_integration_status(self, provider: str) -> dict[str, Any]:
+        if provider == "github":
+            credentials = self.providers.get(provider, {})
+            account = credentials.get("account")
+            account_dict = dict(account) if isinstance(account, dict) else {}
+            return {
+                "provider": provider,
+                "authenticated": bool(credentials.get("access_token")),
+                "login": account_dict.get("login"),
+                "email": account_dict.get("email"),
+                "expires_at": credentials.get("expires_at"),
+            }
         tokens = self.integrations.get(provider, {})
         authenticated = bool(tokens.get("access_token") or tokens.get("api_token"))
         return {

--- a/potpie/context-engine/tests/unit/test_credentials_store.py
+++ b/potpie/context-engine/tests/unit/test_credentials_store.py
@@ -549,6 +549,7 @@ def test_write_provider_credentials_rolls_back_keyring_token_on_metadata_failure
     fake_keyring: dict[tuple[str, str], str],
 ) -> None:
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setattr(cs.sys, "platform", "darwin")
 
     def _fail_metadata(_provider: str, _metadata: dict[str, object]) -> None:
         raise OSError("metadata write failed")

--- a/potpie/context-engine/tests/unit/test_credentials_store.py
+++ b/potpie/context-engine/tests/unit/test_credentials_store.py
@@ -578,7 +578,11 @@ def test_write_provider_credentials_preserves_metadata_error_when_cleanup_fails(
     def _fail_metadata(_provider: str, _metadata: dict[str, object]) -> None:
         raise OSError("metadata write failed")
 
+    cleanup_calls = 0
+
     def _fail_cleanup(_label: str, _secret_name: str) -> None:
+        nonlocal cleanup_calls
+        cleanup_calls += 1
         raise cs.ProviderCredentialError("cleanup failed")
 
     monkeypatch.setattr(cs, "write_integration_metadata", _fail_metadata)
@@ -594,6 +598,8 @@ def test_write_provider_credentials_preserves_metadata_error_when_cleanup_fails(
                 "account": {"login": "octocat", "id": 1},
             },
         )
+
+    assert cleanup_calls == 1
 
 
 def test_linux_integration_secrets_stored_in_json_file(

--- a/potpie/context-engine/tests/unit/test_credentials_store.py
+++ b/potpie/context-engine/tests/unit/test_credentials_store.py
@@ -569,6 +569,33 @@ def test_write_provider_credentials_rolls_back_keyring_token_on_metadata_failure
     assert ("potpie", "github_token") not in fake_keyring
 
 
+def test_write_provider_credentials_preserves_metadata_error_when_cleanup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+
+    def _fail_metadata(_provider: str, _metadata: dict[str, object]) -> None:
+        raise OSError("metadata write failed")
+
+    def _fail_cleanup(_label: str, _secret_name: str) -> None:
+        raise cs.ProviderCredentialError("cleanup failed")
+
+    monkeypatch.setattr(cs, "write_integration_metadata", _fail_metadata)
+    monkeypatch.setattr(cs, "_delete_keychain_secret", _fail_cleanup)
+
+    with pytest.raises(OSError, match="metadata write failed"):
+        cs.write_provider_credentials(
+            "github",
+            {
+                "provider": "github",
+                "provider_host": "github.com",
+                "access_token": "plaintext-token",
+                "account": {"login": "octocat", "id": 1},
+            },
+        )
+
+
 def test_linux_integration_secrets_stored_in_json_file(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/potpie/context-engine/tests/unit/test_credentials_store.py
+++ b/potpie/context-engine/tests/unit/test_credentials_store.py
@@ -461,6 +461,32 @@ def test_get_provider_credentials_reads_from_integration_secrets_file(
     assert cs.get_provider_credentials("github")["access_token"] == "from-file"
 
 
+def test_github_status_detects_keyring_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    fake_keyring: dict[tuple[str, str], str],
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setattr(cs.sys, "platform", "darwin")
+    cs.write_provider_credentials(
+        "github",
+        {
+            "provider": "github",
+            "provider_host": "github.com",
+            "access_token": "plaintext-token",
+            "account": {"login": "octocat", "email": "octo@example.com"},
+            "updated_at": "2026-05-29T00:00:00+00:00",
+        },
+    )
+
+    status = cs.get_integration_status("github")
+
+    assert status["authenticated"] is True
+    assert status["login"] == "octocat"
+    assert status["email"] == "octo@example.com"
+    assert status["token_storage"] == "keychain"
+
+
 def test_get_provider_credentials_raises_when_integration_secret_missing(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -517,6 +543,32 @@ def test_write_provider_credentials_raises_on_keychain_failure(
     assert "Failed to store GitHub token in system keychain" in str(exc.value)
 
 
+def test_write_provider_credentials_rolls_back_keyring_token_on_metadata_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    fake_keyring: dict[tuple[str, str], str],
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+
+    def _fail_metadata(_provider: str, _metadata: dict[str, object]) -> None:
+        raise OSError("metadata write failed")
+
+    monkeypatch.setattr(cs, "write_integration_metadata", _fail_metadata)
+
+    with pytest.raises(OSError, match="metadata write failed"):
+        cs.write_provider_credentials(
+            "github",
+            {
+                "provider": "github",
+                "provider_host": "github.com",
+                "access_token": "plaintext-token",
+                "account": {"login": "octocat", "id": 1},
+            },
+        )
+
+    assert ("potpie", "github_token") not in fake_keyring
+
+
 def test_linux_integration_secrets_stored_in_json_file(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -549,6 +601,57 @@ def test_linux_integration_secrets_stored_in_json_file(
     metadata = json.loads(cs.credentials_path().read_text(encoding="utf-8"))
     assert metadata["integrations"]["github"]["token_storage"] == "file"
     assert cs.get_provider_credentials("github")["access_token"] == "linux-file-token"
+
+
+def test_github_status_detects_linux_file_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setattr(cs.sys, "platform", "linux")
+    cs.write_provider_credentials(
+        "github",
+        {
+            "provider": "github",
+            "provider_host": "github.com",
+            "access_token": "linux-file-token",
+            "account": {"login": "octocat", "email": "octo@example.com"},
+            "updated_at": "2026-05-29T00:00:00+00:00",
+        },
+    )
+
+    status = cs.get_integration_status("github")
+
+    assert status["authenticated"] is True
+    assert status["login"] == "octocat"
+    assert status["email"] == "octo@example.com"
+    assert status["token_storage"] == "file"
+
+
+def test_write_provider_credentials_rolls_back_linux_file_token_on_metadata_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setattr(cs.sys, "platform", "linux")
+
+    def _fail_metadata(_provider: str, _metadata: dict[str, object]) -> None:
+        raise OSError("metadata write failed")
+
+    monkeypatch.setattr(cs, "write_integration_metadata", _fail_metadata)
+
+    with pytest.raises(OSError, match="metadata write failed"):
+        cs.write_provider_credentials(
+            "github",
+            {
+                "provider": "github",
+                "provider_host": "github.com",
+                "access_token": "linux-file-token",
+                "account": {"login": "octocat", "id": 1},
+            },
+        )
+
+    assert not cs.integration_secrets_path().is_file()
 
 
 def test_linux_potpie_api_key_still_uses_keyring(
@@ -613,6 +716,32 @@ def test_linux_integration_secret_uses_file_even_when_keyring_is_available(
     metadata = json.loads(cs.credentials_path().read_text(encoding="utf-8"))
     assert metadata["integrations"]["github"]["token_storage"] == "file"
     assert cs.get_provider_credentials("github")["access_token"] == "linux-file-token"
+
+
+def test_github_status_detects_linux_legacy_keyring_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    fake_keyring: dict[tuple[str, str], str],
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setattr(cs.sys, "platform", "linux")
+    fake_keyring[("potpie", "github_token")] = "legacy-keyring-token"
+    cs.write_integration_metadata(
+        "github",
+        {
+            "provider": "github",
+            "provider_host": "github.com",
+            "token_storage": "keychain",
+            "account": {"login": "octocat", "email": "octo@example.com"},
+        },
+    )
+
+    status = cs.get_integration_status("github")
+
+    assert status["authenticated"] is True
+    assert status["login"] == "octocat"
+    assert status["email"] == "octo@example.com"
+    assert status["token_storage"] == "keychain"
 
 
 def test_linux_delete_integration_secret_surfaces_provider_error(

--- a/potpie/context-engine/tests/unit/test_credentials_store.py
+++ b/potpie/context-engine/tests/unit/test_credentials_store.py
@@ -570,6 +570,43 @@ def test_write_provider_credentials_rolls_back_keyring_token_on_metadata_failure
     assert ("potpie", "github_token") not in fake_keyring
 
 
+def test_write_provider_credentials_restores_existing_token_on_metadata_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    fake_keyring: dict[tuple[str, str], str],
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setattr(cs.sys, "platform", "darwin")
+    cs.write_provider_credentials(
+        "github",
+        {
+            "provider": "github",
+            "provider_host": "github.com",
+            "access_token": "old-token",
+            "account": {"login": "octocat", "id": 1},
+        },
+    )
+
+    def _fail_metadata(_provider: str, _metadata: dict[str, object]) -> None:
+        raise OSError("metadata write failed")
+
+    monkeypatch.setattr(cs, "write_integration_metadata", _fail_metadata)
+
+    with pytest.raises(OSError, match="metadata write failed"):
+        cs.write_provider_credentials(
+            "github",
+            {
+                "provider": "github",
+                "provider_host": "github.com",
+                "access_token": "new-token",
+                "account": {"login": "octocat", "id": 1},
+            },
+        )
+
+    assert fake_keyring[("potpie", "github_token")] == "old-token"
+    assert cs.get_provider_credentials("github")["access_token"] == "old-token"
+
+
 def test_write_provider_credentials_preserves_metadata_error_when_cleanup_fails(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/potpie/context-engine/tests/unit/test_github_cli_auth.py
+++ b/potpie/context-engine/tests/unit/test_github_cli_auth.py
@@ -690,7 +690,7 @@ def test_git_login_does_not_store_when_account_verification_fails(
 ) -> None:
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
     monkeypatch.setattr(gh_cmds.webbrowser, "open", lambda _url: True)
-    monkeypatch.setattr(gh_cmds.typer, "confirm", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(gh_cmds, "_wait_for_enter_or_auto_open", lambda: None)
     monkeypatch.setattr(
         gh_cmds,
         "request_device_code",

--- a/potpie/context-engine/tests/unit/test_github_cli_auth.py
+++ b/potpie/context-engine/tests/unit/test_github_cli_auth.py
@@ -478,14 +478,12 @@ def test_wait_for_enter_or_auto_open_uses_msvcrt_on_windows(
         return kbhit_calls["count"] == 1
 
     fake_msvcrt = types.SimpleNamespace(kbhit=_kbhit, getwch=lambda: "\r")
+    fake_select_module = types.SimpleNamespace(
+        select=lambda *_args, **_kwargs: pytest.fail("Windows path must not use select")
+    )
     monkeypatch.setattr(gh_cmds.sys, "platform", "win32")
     monkeypatch.setitem(sys.modules, "msvcrt", fake_msvcrt)
-    monkeypatch.setattr(
-        gh_cmds,
-        "select",
-        "select",
-        lambda *_args, **_kwargs: pytest.fail("Windows path must not use select"),
-    )
+    monkeypatch.setattr(gh_cmds, "select", fake_select_module)
 
     gh_cmds._wait_for_enter_or_auto_open(seconds=10)
 

--- a/potpie/context-engine/tests/unit/test_github_cli_auth.py
+++ b/potpie/context-engine/tests/unit/test_github_cli_auth.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import io
-import sys
 import types
 from typing import Any
 
@@ -482,7 +481,7 @@ def test_wait_for_enter_or_auto_open_uses_msvcrt_on_windows(
         select=lambda *_args, **_kwargs: pytest.fail("Windows path must not use select")
     )
     monkeypatch.setattr(gh_cmds.sys, "platform", "win32")
-    monkeypatch.setitem(sys.modules, "msvcrt", fake_msvcrt)
+    monkeypatch.setattr(gh_cmds, "msvcrt", fake_msvcrt)
     monkeypatch.setattr(gh_cmds, "select", fake_select_module)
 
     gh_cmds._wait_for_enter_or_auto_open(seconds=10)

--- a/potpie/context-engine/tests/unit/test_github_cli_auth.py
+++ b/potpie/context-engine/tests/unit/test_github_cli_auth.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import io
+import sys
+import types
 from typing import Any
 
 import httpx
@@ -463,6 +465,36 @@ def test_wait_for_enter_or_auto_open_times_out_on_same_line(
     assert "\r\033[KCopy the code. Press Enter to open now, or GitHub opens in 1s" in out
     assert "Opening GitHub now..." not in out
     assert sleeps == []
+
+
+def test_wait_for_enter_or_auto_open_uses_msvcrt_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    kbhit_calls = {"count": 0}
+
+    def _kbhit() -> bool:
+        kbhit_calls["count"] += 1
+        return kbhit_calls["count"] == 1
+
+    fake_msvcrt = types.SimpleNamespace(kbhit=_kbhit, getwch=lambda: "\r")
+    monkeypatch.setattr(gh_cmds.sys, "platform", "win32")
+    monkeypatch.setitem(sys.modules, "msvcrt", fake_msvcrt)
+    monkeypatch.setattr(
+        gh_cmds,
+        "select",
+        "select",
+        lambda *_args, **_kwargs: pytest.fail("Windows path must not use select"),
+    )
+
+    gh_cmds._wait_for_enter_or_auto_open(seconds=10)
+
+    out = capsys.readouterr().out
+    assert (
+        "Copy the code. Press Enter to open now, or GitHub opens in 10s"
+        in out
+    )
+    assert "Opening GitHub now" not in out
 
 
 def test_github_login_ctrl_c_at_enter_prompt_exits_cleanly(

--- a/potpie/context-engine/tests/unit/test_github_cli_auth.py
+++ b/potpie/context-engine/tests/unit/test_github_cli_auth.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import types
+import io
 from typing import Any
 
 import httpx
@@ -305,23 +305,16 @@ def test_github_login_stores_token_only_after_verification(
 ) -> None:
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
     opened_urls: list[str] = []
-    slept: list[int] = []
     monkeypatch.setattr(
         gh_cmds.webbrowser,
         "open",
         lambda url: opened_urls.append(url) or True,
     )
+    waited: list[bool] = []
     monkeypatch.setattr(
         gh_cmds,
-        "time",
-        types.SimpleNamespace(sleep=lambda seconds: slept.append(seconds)),
-        raising=False,
-    )
-    entered: list[str] = []
-    monkeypatch.setattr(
-        gh_cmds.typer,
-        "confirm",
-        lambda message, **_kwargs: entered.append(message) or True,
+        "_wait_for_enter_or_auto_open",
+        lambda: waited.append(True),
     )
     monkeypatch.setattr(
         gh_cmds,
@@ -373,12 +366,10 @@ def test_github_login_stores_token_only_after_verification(
     assert opened_urls == [gh_auth.GITHUB_VERIFICATION_URI]
     assert "GitHub login requires a one-time verification code." in result.stdout
     assert "Copy this code: ABCD-EFGH" in result.stdout
-    assert "Copy the code, then press Enter to open GitHub." in result.stdout
     assert "Paste the copied code into GitHub to continue." in result.stdout
     assert "Waiting for authorization" in result.stdout
     assert "Logged in to GitHub as octocat (octocat@example.com)" in result.stdout
-    assert slept == []
-    assert entered == ["Press Enter after copying the code"]
+    assert waited == [True]
 
 
 def test_github_login_prints_verification_url_when_browser_open_fails(
@@ -388,11 +379,9 @@ def test_github_login_prints_verification_url_when_browser_open_fails(
     monkeypatch.setattr(gh_cmds.webbrowser, "open", lambda _url: False)
     monkeypatch.setattr(
         gh_cmds,
-        "time",
-        types.SimpleNamespace(sleep=lambda _seconds: None),
-        raising=False,
+        "_wait_for_enter_or_auto_open",
+        lambda: None,
     )
-    monkeypatch.setattr(gh_cmds.typer, "confirm", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(
         gh_cmds,
         "request_device_code",
@@ -427,6 +416,167 @@ def test_github_login_prints_verification_url_when_browser_open_fails(
     assert "Could not open a browser automatically. Open this URL:" in result.stdout
     assert gh_auth.GITHUB_VERIFICATION_URI in result.stdout
     assert "Paste the copied code into GitHub to continue." not in result.stdout
+
+
+def test_wait_for_enter_or_auto_open_returns_when_enter_is_pressed(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    input_stream = io.StringIO("\n")
+    monkeypatch.setattr(
+        gh_cmds.select,
+        "select",
+        lambda _read, _write, _error, _timeout: ([input_stream], [], []),
+    )
+    monkeypatch.setattr(
+        gh_cmds.time,
+        "sleep",
+        lambda _seconds: pytest.fail("enter should skip the countdown sleep"),
+    )
+
+    gh_cmds._wait_for_enter_or_auto_open(seconds=10, input_stream=input_stream)
+
+    out = capsys.readouterr().out
+    assert (
+        "Copy the code. Press Enter to open now, or GitHub opens in 10s"
+        in out
+    )
+    assert "Opening GitHub now" not in out
+
+
+def test_wait_for_enter_or_auto_open_times_out_on_same_line(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sleeps: list[int] = []
+    monkeypatch.setattr(
+        gh_cmds.select,
+        "select",
+        lambda _read, _write, _error, _timeout: ([], [], []),
+    )
+    monkeypatch.setattr(gh_cmds.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    gh_cmds._wait_for_enter_or_auto_open(seconds=2, input_stream=io.StringIO(""))
+
+    out = capsys.readouterr().out
+    assert "\r\033[KCopy the code. Press Enter to open now, or GitHub opens in 2s" in out
+    assert "\r\033[KCopy the code. Press Enter to open now, or GitHub opens in 1s" in out
+    assert "Opening GitHub now..." not in out
+    assert sleeps == []
+
+
+def test_github_login_ctrl_c_at_enter_prompt_exits_cleanly(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setattr(
+        gh_cmds.webbrowser,
+        "open",
+        lambda _url: pytest.fail("cancelled login must not open the browser"),
+    )
+
+    def _cancel() -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(gh_cmds, "_wait_for_enter_or_auto_open", _cancel)
+    monkeypatch.setattr(
+        gh_cmds,
+        "request_device_code",
+        lambda: gh_auth.DeviceCode(
+            device_code="dev-code",
+            user_code="ABCD-EFGH",
+            verification_uri=gh_auth.GITHUB_VERIFICATION_URI,
+            expires_in=900,
+            interval=5,
+        ),
+    )
+    monkeypatch.setattr(
+        gh_cmds,
+        "poll_for_access_token",
+        lambda _device: pytest.fail("cancelled login must not poll for a token"),
+    )
+
+    result = runner.invoke(cli_main.app, ["auth", "github", "login"])
+
+    assert result.exit_code == gh_cmds.EXIT_CANCELLED
+    assert "Copy this code: ABCD-EFGH" in result.stdout
+    assert "\nGitHub login cancelled." in result.stdout
+    assert "Traceback" not in result.stdout
+    assert "Abort" not in result.stdout
+    assert "NameError" not in result.stdout
+    assert cs.get_integration_metadata("github") == {}
+
+
+def test_github_login_click_abort_from_prompt_exits_cleanly(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setattr(
+        gh_cmds,
+        "_open_github_device_verification",
+        lambda *_args: (_ for _ in ()).throw(gh_cmds.Abort()),
+    )
+    monkeypatch.setattr(
+        gh_cmds,
+        "request_device_code",
+        lambda: gh_auth.DeviceCode(
+            device_code="dev-code",
+            user_code="ABCD-EFGH",
+            verification_uri=gh_auth.GITHUB_VERIFICATION_URI,
+            expires_in=900,
+            interval=5,
+        ),
+    )
+    monkeypatch.setattr(
+        gh_cmds,
+        "poll_for_access_token",
+        lambda _device: pytest.fail("cancelled login must not poll for a token"),
+    )
+
+    result = runner.invoke(cli_main.app, ["auth", "github", "login"])
+
+    assert result.exit_code == gh_cmds.EXIT_CANCELLED
+    assert "\nGitHub login cancelled." in result.stdout
+    assert "GitHub login failed" not in result.stdout
+    assert "Unexpected error" not in result.stdout
+    assert cs.get_integration_metadata("github") == {}
+
+
+def test_github_login_abort_named_exception_exits_cleanly(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    class Abort(Exception):
+        pass
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setattr(
+        gh_cmds,
+        "_open_github_device_verification",
+        lambda *_args: (_ for _ in ()).throw(Abort()),
+    )
+    monkeypatch.setattr(
+        gh_cmds,
+        "request_device_code",
+        lambda: gh_auth.DeviceCode(
+            device_code="dev-code",
+            user_code="ABCD-EFGH",
+            verification_uri=gh_auth.GITHUB_VERIFICATION_URI,
+            expires_in=900,
+            interval=5,
+        ),
+    )
+    monkeypatch.setattr(
+        gh_cmds,
+        "poll_for_access_token",
+        lambda _device: pytest.fail("cancelled login must not poll for a token"),
+    )
+
+    result = runner.invoke(cli_main.app, ["auth", "github", "login"])
+
+    assert result.exit_code == gh_cmds.EXIT_CANCELLED
+    assert "\nGitHub login cancelled." in result.stdout
+    assert "GitHub login failed" not in result.stdout
+    assert "Unexpected error" not in result.stdout
 
 
 def test_github_login_json_mode_does_not_open_browser_or_print_countdown(

--- a/potpie/context-engine/tests/unit/test_setup_post_auth_prompts.py
+++ b/potpie/context-engine/tests/unit/test_setup_post_auth_prompts.py
@@ -4,13 +4,21 @@ from __future__ import annotations
 
 import pytest
 
+from adapters.inbound.cli.commands import _common
 from adapters.inbound.cli.ui import interactive_prompts, setup_ux
+from tests._auth_fakes import InMemoryCredentialStore
+
+
+@pytest.fixture(autouse=True)
+def _reset_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(_common._state, "store", None)
 
 
 def test_maybe_prompt_github_login_runs_selected_integrations(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(setup_ux, "is_interactive_tty", lambda: True)
+    _common.set_store(InMemoryCredentialStore())
     calls: list[str] = []
 
     monkeypatch.setattr(
@@ -41,8 +49,78 @@ def test_maybe_prompt_github_login_runs_github_when_confirmed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(setup_ux, "is_interactive_tty", lambda: True)
+    _common.set_store(InMemoryCredentialStore())
     calls: list[str] = []
 
+    monkeypatch.setattr(
+        "typer.confirm",
+        lambda *_a, **_k: True,
+    )
+    monkeypatch.setattr(
+        interactive_prompts,
+        "prompt_multi_checkbox",
+        lambda *_a, **_k: [],
+    )
+    monkeypatch.setattr(
+        "adapters.inbound.cli.auth.github_commands.github_login_impl",
+        lambda: calls.append("github"),
+    )
+
+    monkeypatch.setattr(setup_ux, "_maybe_prompt_first_pot", lambda **_k: None)
+    setup_ux.maybe_prompt_github_login(repo=None)
+
+    assert calls == ["github"]
+
+
+def test_maybe_prompt_github_login_skips_when_already_authenticated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(setup_ux, "is_interactive_tty", lambda: True)
+    store = InMemoryCredentialStore()
+    store.write_provider_credentials(
+        "github",
+        {
+            "access_token": "stored-token",
+            "account": {"login": "octocat", "email": "octo@example.com"},
+        },
+    )
+    _common.set_store(store)
+    messages: list[str] = []
+
+    monkeypatch.setattr(
+        "adapters.inbound.cli.ui.output.print_plain_line",
+        lambda message, **_kwargs: messages.append(message),
+    )
+    monkeypatch.setattr(
+        "typer.confirm",
+        lambda *_a, **_k: pytest.fail("GitHub prompt should be skipped"),
+    )
+    monkeypatch.setattr(
+        interactive_prompts,
+        "prompt_multi_checkbox",
+        lambda *_a, **_k: [],
+    )
+    monkeypatch.setattr(
+        "adapters.inbound.cli.auth.github_commands.github_login_impl",
+        lambda: pytest.fail("GitHub login should be skipped"),
+    )
+
+    monkeypatch.setattr(setup_ux, "_maybe_prompt_first_pot", lambda **_k: None)
+    setup_ux.maybe_prompt_github_login(repo=None)
+
+    assert messages == ["GitHub already connected as octocat; skipping login."]
+
+
+def test_maybe_prompt_github_login_prompts_when_status_check_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(setup_ux, "is_interactive_tty", lambda: True)
+    calls: list[str] = []
+
+    def _fail_status() -> dict[str, object]:
+        raise RuntimeError("credential store unavailable")
+
+    monkeypatch.setattr(setup_ux, "_github_status", _fail_status)
     monkeypatch.setattr(
         "typer.confirm",
         lambda *_a, **_k: True,

--- a/potpie/context-engine/tests/unit/test_setup_post_auth_prompts.py
+++ b/potpie/context-engine/tests/unit/test_setup_post_auth_prompts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+import typer
 
 from adapters.inbound.cli.commands import _common
 from adapters.inbound.cli.ui import interactive_prompts, setup_ux
@@ -70,6 +71,34 @@ def test_maybe_prompt_github_login_runs_github_when_confirmed(
     setup_ux.maybe_prompt_github_login(repo=None)
 
     assert calls == ["github"]
+
+
+def test_maybe_prompt_github_login_cancel_exits_setup_flow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(setup_ux, "is_interactive_tty", lambda: True)
+    _common.set_store(InMemoryCredentialStore())
+
+    monkeypatch.setattr("typer.confirm", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        interactive_prompts,
+        "prompt_multi_checkbox",
+        lambda *_a, **_k: pytest.fail("setup should exit before integration picker"),
+    )
+    monkeypatch.setattr(
+        "adapters.inbound.cli.auth.github_commands.github_login_impl",
+        lambda: (_ for _ in ()).throw(typer.Exit(code=130)),
+    )
+    monkeypatch.setattr(
+        setup_ux,
+        "_maybe_prompt_first_pot",
+        lambda **_k: pytest.fail("setup should exit before first-pot prompt"),
+    )
+
+    with pytest.raises(typer.Exit) as exc:
+        setup_ux.maybe_prompt_github_login(repo=None)
+
+    assert exc.value.exit_code == 130
 
 
 def test_maybe_prompt_github_login_skips_when_already_authenticated(


### PR DESCRIPTION
## Summary
Fixes https://github.com/potpie-ai/potpie/issues/879
- Improve GitHub device-flow login UX: after showing the verification code, show an inline countdown (`Press Enter to open now, or GitHub opens in Ns`) and auto-open the browser after 10 seconds instead of blocking on a separate confirm prompt.
- Handle user cancellation cleanly on Ctrl+C / Click Abort during login — print `GitHub login cancelled.`, exit with code 130, and avoid tracebacks, token polling, or partial credential writes.
- Skip the post-setup “Would you like to log in to GitHub now?” prompt when GitHub is already authenticated (shows `GitHub already connected as <login>; skipping login.`).
- Roll back the keychain token if integration metadata write fails after a successful token store, preventing orphaned secrets.
- Use `msvcrt` on Windows so Enter-to-open works (Unix uses `select` on stdin).

## Test plan
<img width="735" height="286" alt="Screenshot 2026-06-12 at 5 23 29 PM" src="https://github.com/user-attachments/assets/80dd36e4-fa11-40a8-9f79-ebd8159737d2" />

- [x] `uv run pytest tests/unit/test_github_cli_auth.py tests/unit/test_credentials_store.py tests/unit/test_setup_post_auth_prompts.py`
- [ ] `potpie github login` — verify countdown, Enter opens browser immediately, auto-open after 10s
- [ ] Ctrl+C at the countdown prompt — verify clean cancel message and exit code 130
- [ ] `potpie setup` with GitHub already logged in — verify login prompt is skipped
- [ ] `potpie setup` without GitHub credentials — verify login prompt still appears
- [ ] (Windows) verify Enter-to-open works during the countdown prompt

