### PR TITLE
Fix interactive setup source deferral

### DIFF
--- a/potpie/context-engine/application/services/setup_orchestrator.py
+++ b/potpie/context-engine/application/services/setup_orchestrator.py
@@ -90,6 +90,8 @@ def _skip_reason(step: str, plan: SetupPlan) -> str | None:
         return "in-process host — no detached daemon / service unit to manage"
     if step == "source" and not plan.repo:
         return "no --repo provided"
+    if step == "source" and plan.defer_default_pot:
+        return "deferred until post-setup first pot"
     if step == "pot.default" and plan.defer_default_pot:
         return "named in post-setup wizard"
     if step == "skills" and plan.defer_skills:
@@ -194,11 +196,7 @@ class DefaultSetupOrchestrator:
             self._step("auth", hard("auth"), self.auth.init_local),
             self._step("source", hard("source"), lambda: self._source(plan)),
             *(
-                [
-                    self._step(
-                        "skills", hard("skills"), lambda: self._skills(plan)
-                    )
-                ]
+                [self._step("skills", hard("skills"), lambda: self._skills(plan))]
                 if not plan.defer_skills
                 else []
             ),
@@ -240,6 +238,8 @@ class DefaultSetupOrchestrator:
         return f"active pot '{pot.name}' ({pot.pot_id})"
 
     def _source(self, plan: SetupPlan) -> StepResult:
+        if plan.defer_default_pot:
+            return StepResult("source", SKIPPED, "deferred until post-setup first pot")
         if not plan.repo:
             return StepResult("source", SKIPPED, "no --repo")
         active = self.pots.active_pot()
@@ -255,7 +255,9 @@ class DefaultSetupOrchestrator:
 
     def _skills(self, plan: SetupPlan) -> str | StepResult:
         if plan.agent.strip().lower() == "default":
-            return StepResult("skills", SKIPPED, "no global skill target for default agent")
+            return StepResult(
+                "skills", SKIPPED, "no global skill target for default agent"
+            )
         result = self.skills.install(agent=plan.agent)
         return f"installed {list(result.changed)} for {plan.agent}"
 

--- a/potpie/context-engine/application/services/setup_orchestrator.py
+++ b/potpie/context-engine/application/services/setup_orchestrator.py
@@ -238,10 +238,10 @@ class DefaultSetupOrchestrator:
         return f"active pot '{pot.name}' ({pot.pot_id})"
 
     def _source(self, plan: SetupPlan) -> StepResult:
+        if not plan.repo:
+            return StepResult("source", SKIPPED, "no --repo provided")
         if plan.defer_default_pot:
             return StepResult("source", SKIPPED, "deferred until post-setup first pot")
-        if not plan.repo:
-            return StepResult("source", SKIPPED, "no --repo")
         active = self.pots.active_pot()
         if active is None:
             return StepResult("source", SKIPPED, "no active pot")

--- a/potpie/context-engine/tests/unit/test_setup_defer_pot.py
+++ b/potpie/context-engine/tests/unit/test_setup_defer_pot.py
@@ -6,7 +6,7 @@ import pytest
 
 from adapters.outbound.graph.backends.in_memory_backend import InMemoryGraphBackend
 from bootstrap.host_wiring import build_host_shell
-from domain.lifecycle import SetupPlan
+from domain.lifecycle import SKIPPED, SetupPlan
 
 
 @pytest.fixture()
@@ -25,6 +25,25 @@ def test_setup_run_skips_pot_default_when_deferred(host) -> None:
     assert host.pots.active_pot() is None
 
 
+def test_setup_run_defers_source_when_default_pot_deferred(host) -> None:
+    existing = host.pots.create_pot(name="existing", use=True)
+
+    report = host.setup.run(
+        SetupPlan(repo="potpie", agent="claude", defer_default_pot=True),
+    )
+
+    steps = {s.step: s for s in report.steps}
+    assert steps["source"].state == SKIPPED
+    assert steps["source"].detail == "deferred until post-setup first pot"
+    assert host.pots.list_sources(pot_id=existing.pot_id) == []
+
+
 def test_setup_preview_omits_pot_default_when_deferred(host) -> None:
     preview = host.setup.preview(SetupPlan(defer_default_pot=True))
     assert all(step.step != "pot.default" for step in preview.steps)
+
+
+def test_setup_preview_marks_source_deferred_when_default_pot_deferred(host) -> None:
+    preview = host.setup.preview(SetupPlan(defer_default_pot=True))
+    source = next(step for step in preview.steps if step.step == "source")
+    assert source.skip_reason == "deferred until post-setup first pot"

--- a/potpie/context-engine/tests/unit/test_setup_defer_pot.py
+++ b/potpie/context-engine/tests/unit/test_setup_defer_pot.py
@@ -47,3 +47,17 @@ def test_setup_preview_marks_source_deferred_when_default_pot_deferred(host) -> 
     preview = host.setup.preview(SetupPlan(defer_default_pot=True))
     source = next(step for step in preview.steps if step.step == "source")
     assert source.skip_reason == "deferred until post-setup first pot"
+
+
+def test_setup_source_reason_matches_preview_when_repo_missing_and_pot_deferred(
+    host,
+) -> None:
+    plan = SetupPlan(repo=None, defer_default_pot=True)
+
+    preview = host.setup.preview(plan)
+    report = host.setup.run(plan)
+
+    preview_source = next(step for step in preview.steps if step.step == "source")
+    run_source = next(step for step in report.steps if step.step == "source")
+    assert preview_source.skip_reason == "no --repo provided"
+    assert run_source.detail == "no --repo provided"


### PR DESCRIPTION
## Summary

- defer repo/source registration when interactive setup defers first-pot creation
- keep the setup preview reason aligned with the runtime behavior
- add regression coverage for an existing active pot receiving no repo source during deferred setup

## Why

Interactive setup creates the first pot later in the post-setup wizard. If source registration runs before that wizard step, a user with an existing active pot can have the repo attached to the old pot instead of the newly named first pot.

Fixes #881.

## Verification

- uv run --package potpie-context-engine pytest potpie/context-engine/tests/unit/test_setup_defer_pot.py -q
- uv run --package potpie-context-engine pytest potpie/context-engine/tests/unit/test_setup_*.py -q
- uv run --package potpie-context-engine pytest potpie/context-engine/tests/conformance/test_host_shell_end_to_end.py::test_setup_orchestrator_provisions_and_creates_default_pot potpie/context-engine/tests/conformance/test_host_shell_end_to_end.py::test_setup_is_idempotent potpie/context-engine/tests/conformance/test_host_shell_end_to_end.py::test_setup_dry_run_executes_nothing potpie/context-engine/tests/conformance/test_host_shell_end_to_end.py::test_setup_preview_classifies_owners_and_host_gated_hardness -q
- uv run --package potpie-context-engine ruff check potpie/context-engine/application/services/setup_orchestrator.py potpie/context-engine/tests/unit/test_setup_defer_pot.py
- uv run --package potpie-context-engine basedpyright --level error potpie/context-engine/application/services/setup_orchestrator.py potpie/context-engine/tests/unit/test_setup_defer_pot.py
- git diff --check
- isolated CLI smoke: potpie --json setup --repo . --agent claude --yes