### PR TITLE
Add posthog instrumentation

### DIFF
--- a/potpie/context-engine/adapters/inbound/cli/auth/auth_commands.py
+++ b/potpie/context-engine/adapters/inbound/cli/auth/auth_commands.py
@@ -437,7 +437,7 @@ def _run_tracked_integration_login(
     )
     try:
         runner()
-    except typer.Exit as exc:
+    except Exception as exc:  # noqa: BLE001 - auth telemetry must record failures.
         capture_integration_auth_event(
             "cli_onboarding_integration_auth_failed",
             provider=provider,

--- a/potpie/context-engine/adapters/inbound/cli/auth/auth_commands.py
+++ b/potpie/context-engine/adapters/inbound/cli/auth/auth_commands.py
@@ -7,7 +7,8 @@ import threading
 import time
 import urllib.parse
 import webbrowser
-from typing import Any
+from collections.abc import Callable
+from typing import Any, Literal
 
 import typer
 from rich.markup import escape
@@ -42,6 +43,13 @@ from adapters.outbound.cli_auth.integration_session import (
 )
 from adapters.outbound.cli_auth.integration_verify import verify_integration_access
 from adapters.inbound.cli.commands._common import EXIT_AUTH, EXIT_UNAVAILABLE, get_store
+from adapters.inbound.cli.telemetry.onboarding_events import (
+    capture_integration_auth_event,
+    current_entrypoint,
+    elapsed_ms,
+    now_ms,
+    sanitized_failure_kind,
+)
 from adapters.inbound.cli.ui.output import emit_error, print_json_blob, print_plain_line
 from adapters.outbound.cli_auth.pkce import generate_pkce_pair
 from adapters.outbound.cli_auth.provider_config import (
@@ -65,6 +73,7 @@ confluence_app = typer.Typer(help="Confluence integration and read.")
 
 _OAUTH_CALLBACK_TIMEOUT = 300.0
 _ALL_PROVIDERS: tuple[Provider, ...] = ("github", "linear", "jira", "confluence")
+IntegrationAuthProvider = Literal["linear", "jira", "confluence"]
 
 
 def _canonical_provider_for_json(product: str) -> str:
@@ -92,9 +101,7 @@ def _print_standard_logout(
     if was_authenticated:
         message = "Logged out successfully."
     else:
-        message = (
-            "No active session found. Any stale local credentials were removed."
-        )
+        message = "No active session found. Any stale local credentials were removed."
     payload: dict[str, Any] = {"ok": True, "provider": provider}
     if not was_authenticated:
         payload["cleared_stale"] = True
@@ -191,9 +198,7 @@ def _print_linear_login_success(
     who = account[0] or account[1] or "Linear"
     token_storage = str(status.get("token_storage") or "keychain")
     storage_label = (
-        "system keychain"
-        if token_storage == "keychain"
-        else "local credentials file"
+        "system keychain" if token_storage == "keychain" else "local credentials file"
     )
     org_suffix = f" @ {account[2]}" if account[2] else ""
     if refreshed:
@@ -266,8 +271,7 @@ def _run_linear_oauth_flow(*, force: bool = False, add: bool = False) -> None:
                 )
                 return
             print_plain_line(
-                "Linear is already connected"
-                + (f" ({names})." if names else "."),
+                "Linear is already connected" + (f" ({names})." if names else "."),
                 as_json=False,
             )
             print_plain_line(
@@ -412,18 +416,61 @@ def _run_linear_oauth_flow(*, force: bool = False, add: bool = False) -> None:
     _print_linear_login_success(get_integration_status("linear"), tokens=tokens)
 
 
+def _integration_auth_provider(provider: str) -> IntegrationAuthProvider:
+    key = provider.strip().lower()
+    if key == "linear" or key == "jira" or key == "confluence":
+        return key
+    raise ValueError(f"Unknown integration provider {provider!r}.")
+
+
+def _run_tracked_integration_login(
+    provider: IntegrationAuthProvider,
+    *,
+    entrypoint: str,
+    runner: Callable[[], None],
+) -> None:
+    started_ms = now_ms()
+    capture_integration_auth_event(
+        "cli_onboarding_integration_auth_started",
+        provider=provider,
+        entrypoint=entrypoint,
+    )
+    try:
+        runner()
+    except typer.Exit as exc:
+        capture_integration_auth_event(
+            "cli_onboarding_integration_auth_failed",
+            provider=provider,
+            entrypoint=entrypoint,
+            duration_ms=elapsed_ms(started_ms),
+            failure_kind=sanitized_failure_kind(exc),
+        )
+        raise
+    capture_integration_auth_event(
+        "cli_onboarding_integration_auth_completed",
+        provider=provider,
+        entrypoint=entrypoint,
+        duration_ms=elapsed_ms(started_ms),
+    )
+
+
 def run_integration_login(provider: str, *, force: bool = False) -> None:
     """Run the standard login flow for ``linear``, ``jira``, or ``confluence``."""
-    key = provider.strip().lower()
-    if key == "linear":
-        _run_linear_oauth_flow(force=force)
-        return
-    if key in ("jira", "confluence"):
+    key = _integration_auth_provider(provider)
+
+    def _run() -> None:
+        if key == "linear":
+            _run_linear_oauth_flow(force=force)
+            return
         load_cli_env()
         j, v = _flags()
         run_atlassian_api_token_auth(key, force=force, as_json=j, verbose=v)
-        return
-    raise ValueError(f"Unknown integration provider {provider!r}.")
+
+    _run_tracked_integration_login(
+        key,
+        entrypoint=current_entrypoint("direct_integration_auth"),
+        runner=_run,
+    )
 
 
 def integration_status(
@@ -613,7 +660,11 @@ def auth_linear(
     ),
 ) -> None:
     """Authenticate with Linear via OAuth (PKCE)."""
-    _run_linear_oauth_flow(force=force)
+    _run_tracked_integration_login(
+        "linear",
+        entrypoint="direct_integration_auth",
+        runner=lambda: _run_linear_oauth_flow(force=force),
+    )
 
 
 def _esc(value: Any) -> str:
@@ -642,7 +693,11 @@ def linear_login(
     ),
 ) -> None:
     """Authenticate with Linear via OAuth (PKCE)."""
-    _run_linear_oauth_flow(force=force, add=add)
+    _run_tracked_integration_login(
+        "linear",
+        entrypoint="direct_integration_auth",
+        runner=lambda: _run_linear_oauth_flow(force=force, add=add),
+    )
 
 
 @linear_app.command("logout")
@@ -723,7 +778,6 @@ def _print_linear_issue_row(row: dict[str, Any]) -> None:
         _print_remote_line(f"  Updated: {_esc(row.get('updated'))}")
     if row.get("url"):
         _print_remote_line(f"  URL: {_esc(row.get('url'))}")
-
 
 
 def _build_auth_compat_linear() -> typer.Typer:
@@ -893,16 +947,24 @@ def jira_login(
     ),
 ) -> None:
     """Connect Jira with an Atlassian API token (Jira access only)."""
-    load_cli_env()
-    j, v = _flags()
-    run_atlassian_api_token_auth(
+
+    def _run() -> None:
+        load_cli_env()
+        j, v = _flags()
+        run_atlassian_api_token_auth(
+            "jira",
+            force=force,
+            as_json=j,
+            verbose=v,
+            email=email,
+            api_token=api_token,
+            site_subdomain=site_subdomain,
+        )
+
+    _run_tracked_integration_login(
         "jira",
-        force=force,
-        as_json=j,
-        verbose=v,
-        email=email,
-        api_token=api_token,
-        site_subdomain=site_subdomain,
+        entrypoint="direct_integration_auth",
+        runner=_run,
     )
 
 
@@ -981,16 +1043,24 @@ def confluence_login(
     ),
 ) -> None:
     """Connect Confluence with an Atlassian API token (Confluence access only)."""
-    load_cli_env()
-    j, v = _flags()
-    run_atlassian_api_token_auth(
+
+    def _run() -> None:
+        load_cli_env()
+        j, v = _flags()
+        run_atlassian_api_token_auth(
+            "confluence",
+            force=force,
+            as_json=j,
+            verbose=v,
+            email=email,
+            api_token=api_token,
+            site_subdomain=site_subdomain,
+        )
+
+    _run_tracked_integration_login(
         "confluence",
-        force=force,
-        as_json=j,
-        verbose=v,
-        email=email,
-        api_token=api_token,
-        site_subdomain=site_subdomain,
+        entrypoint="direct_integration_auth",
+        runner=_run,
     )
 
 

--- a/potpie/context-engine/adapters/inbound/cli/auth/github_commands.py
+++ b/potpie/context-engine/adapters/inbound/cli/auth/github_commands.py
@@ -23,6 +23,13 @@ from adapters.outbound.cli_auth.credentials_store import (
     _integration_secret_store_label,
     get_integration_status,
 )
+from adapters.inbound.cli.telemetry.onboarding_events import (
+    capture_github_auth_event,
+    current_entrypoint,
+    elapsed_ms,
+    now_ms,
+    sanitized_failure_kind,
+)
 from adapters.inbound.cli.ui.output import emit_error, print_json_blob, print_plain_line
 
 github_app = typer.Typer(help="GitHub integration.")
@@ -43,7 +50,7 @@ def _flags() -> tuple[bool, bool]:
     return is_json(), is_verbose()
 
 
-def _open_github_device_verification(user_code: str, verification_uri: str) -> None:
+def _open_github_device_verification(user_code: str, verification_uri: str) -> bool:
     print_plain_line(
         "GitHub login requires a one-time verification code.",
         as_json=False,
@@ -65,11 +72,12 @@ def _open_github_device_verification(user_code: str, verification_uri: str) -> N
             as_json=False,
         )
         print_plain_line(verification_uri, as_json=False, markup=False)
-        return
+        return False
     print_plain_line(
         "Paste the copied code into GitHub to continue.",
         as_json=False,
     )
+    return True
 
 
 def _capture_unexpected_auth_error(
@@ -98,33 +106,105 @@ def github_login_impl() -> None:
     """Authenticate the CLI with GitHub using device flow."""
     load_cli_env()
     j, v = _flags()
+    entrypoint = current_entrypoint("direct_github_auth")
+    auth_started_ms = now_ms()
+    stage = "started"
+    capture_github_auth_event(
+        "cli_onboarding_github_auth_started",
+        entrypoint=entrypoint,
+    )
     account = None
     payload = None
     try:
         store = get_store()
+        stage = "device_code"
+        stage_started_ms = now_ms()
         device_code = request_device_code()
+        capture_github_auth_event(
+            "cli_onboarding_github_device_code_requested",
+            entrypoint=entrypoint,
+            duration_ms=elapsed_ms(stage_started_ms),
+        )
         if not j:
-            _open_github_device_verification(
+            stage_started_ms = now_ms()
+            opened = _open_github_device_verification(
                 device_code.user_code,
                 device_code.verification_uri,
             )
+            capture_github_auth_event(
+                "cli_onboarding_github_browser_open_attempted",
+                entrypoint=entrypoint,
+                duration_ms=elapsed_ms(stage_started_ms),
+                browser_opened=opened,
+            )
             print_plain_line("Waiting for authorization...", as_json=False)
+        stage = "token_poll"
+        capture_github_auth_event(
+            "cli_onboarding_github_token_poll_started",
+            entrypoint=entrypoint,
+        )
+        stage_started_ms = now_ms()
         token = poll_for_access_token(device_code)
+        capture_github_auth_event(
+            "cli_onboarding_github_token_poll_completed",
+            entrypoint=entrypoint,
+            duration_ms=elapsed_ms(stage_started_ms),
+        )
+        stage = "account_verified"
+        stage_started_ms = now_ms()
         account = verify_account(token.access_token)
+        capture_github_auth_event(
+            "cli_onboarding_github_account_verified",
+            entrypoint=entrypoint,
+            duration_ms=elapsed_ms(stage_started_ms),
+        )
         payload = build_provider_credentials(
             token, account, verification_uri=device_code.verification_uri
         )
+        stage = "credentials_stored"
+        stage_started_ms = now_ms()
         store.write_provider_credentials("github", payload.as_dict())
+        capture_github_auth_event(
+            "cli_onboarding_github_credentials_stored",
+            entrypoint=entrypoint,
+            duration_ms=elapsed_ms(stage_started_ms),
+        )
     except GitHubDeviceFlowError as exc:
+        capture_github_auth_event(
+            "cli_onboarding_github_auth_failed",
+            entrypoint=entrypoint,
+            duration_ms=elapsed_ms(auth_started_ms),
+            failure_stage=stage,
+            failure_kind=sanitized_failure_kind(exc),
+        )
         emit_error("GitHub login failed", str(exc), verbose=v)
         raise typer.Exit(code=EXIT_AUTH) from exc
     except (ProviderCredentialError, CredentialStoreError) as exc:
+        capture_github_auth_event(
+            "cli_onboarding_github_auth_failed",
+            entrypoint=entrypoint,
+            duration_ms=elapsed_ms(auth_started_ms),
+            failure_stage=stage,
+            failure_kind=sanitized_failure_kind(exc),
+        )
         emit_error("GitHub login failed", str(exc), verbose=v)
         raise typer.Exit(code=EXIT_AUTH) from exc
     except typer.Exit:
         raise
     except Exception as exc:  # noqa: BLE001
+        capture_github_auth_event(
+            "cli_onboarding_github_auth_failed",
+            entrypoint=entrypoint,
+            duration_ms=elapsed_ms(auth_started_ms),
+            failure_stage=stage,
+            failure_kind=sanitized_failure_kind(exc),
+        )
         _capture_unexpected_auth_error(exc, title="GitHub login failed", verbose=v)
+    capture_github_auth_event(
+        "cli_onboarding_github_auth_completed",
+        entrypoint=entrypoint,
+        duration_ms=elapsed_ms(auth_started_ms),
+    )
 
     if j:
         print_json_blob(
@@ -171,12 +251,12 @@ def github_logout_impl() -> None:
         print_json_blob(payload, as_json=True)
         return
 
-    from adapters.inbound.cli.auth.auth_commands import _print_standard_logout
-
-    _print_standard_logout(
-        was_authenticated=was_authenticated,
-        provider="github",
-        j=False,
+    if was_authenticated:
+        print_plain_line("Logged out successfully.", as_json=False)
+        return
+    print_plain_line(
+        "No active session found. Any stale local credentials were removed.",
+        as_json=False,
     )
 
 
@@ -314,6 +394,5 @@ git_app.add_typer(git_test_app, name="test")
 
 def register_github_commands(root_app: typer.Typer) -> None:
     """Deprecated: use ``register_integration_commands``."""
-    from adapters.inbound.cli.auth.auth_commands import register_integration_commands
-
-    register_integration_commands(root_app)
+    root_app.add_typer(github_app, name="github")
+    root_app.add_typer(git_app, name="git")

--- a/potpie/context-engine/adapters/inbound/cli/commands/_common.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/_common.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import json
 from contextlib import contextmanager
-from typing import Any, Iterator
+from typing import Any, Iterator, NoReturn
 
 import typer
 
@@ -104,7 +104,7 @@ def fail(
     detail: str | None = None,
     next_action: str | None = None,
     exit_code: int = EXIT_VALIDATION,
-) -> None:
+) -> NoReturn:
     """Emit the structured error contract and exit with the given code."""
     if is_json():
         typer.echo(

--- a/potpie/context-engine/adapters/inbound/cli/commands/bootstrap.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/bootstrap.py
@@ -7,6 +7,8 @@ from all three services via ``context_status``.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import typer
 
 from adapters.inbound.cli.commands._common import (
@@ -17,6 +19,18 @@ from adapters.inbound.cli.commands._common import (
     is_json,
     resolve_pot_id,
 )
+from adapters.inbound.cli.telemetry.onboarding_events import (
+    CliSetupAnalyticsObserver,
+    begin_setup_run,
+    capture_activation_succeeded,
+    capture_project_binding_event,
+    capture_setup_completed,
+    capture_setup_dry_run_completed,
+    capture_setup_started,
+    elapsed_ms,
+    now_ms,
+)
+from adapters.inbound.cli.ui import setup_ux
 from domain.errors import CapabilityNotImplemented
 from domain.lifecycle import SetupPlan
 from domain.ports.agent_context import StatusRequest
@@ -40,10 +54,6 @@ def register(root: typer.Typer) -> None:
         yes: bool = typer.Option(False, "--yes", "-y", help="Assume yes for prompts."),
     ) -> None:
         """Idempotent first-run: provision config, storage, daemon, default pot, skills."""
-        from pathlib import Path
-
-        from adapters.inbound.cli.ui import setup_ux
-
         with contract():
             host = get_host()
             # --backend selects the storage profile for this run. Backend
@@ -58,7 +68,8 @@ def register(root: typer.Typer) -> None:
                     backend=build_backend(backend), profile=host.profile
                 )
                 set_host(host)
-            use_rich = setup_ux.rich_enabled(as_json=is_json()) and not yes
+            json_output = is_json()
+            use_rich = setup_ux.rich_enabled(as_json=json_output) and not yes
             plan = SetupPlan(
                 mode=host.profile if host.profile in ("local", "managed") else "local",
                 host_mode="in_process"
@@ -73,13 +84,35 @@ def register(root: typer.Typer) -> None:
                 defer_default_pot=use_rich,
                 defer_skills=use_rich,
             )
+            setup_started_ms = now_ms()
+            begin_setup_run()
+            host.setup.set_observer(CliSetupAnalyticsObserver())
+            capture_setup_started(
+                plan,
+                interactive=use_rich,
+                json_output=json_output,
+            )
 
             if dry_run:
                 preview = host.setup.preview(plan)
+                capture_setup_dry_run_completed(
+                    plan=plan,
+                    planned_step_count=len(preview.steps),
+                    hard_step_count=sum(1 for step in preview.steps if step.hard),
+                )
                 emit(preview.to_dict(), human=_preview_human(preview))
                 return
 
             report = host.setup.run(plan)
+            capture_setup_completed(
+                plan=plan,
+                ok=report.ok,
+                duration_ms=elapsed_ms(setup_started_ms),
+                hard_failed_step=_first_hard_failed_step(report),
+                soft_warning_count=_soft_warning_count(report),
+            )
+            if report.ok and not use_rich:
+                _capture_plain_project_binding(report)
 
             # Animated wizard for interactive TTYs; --json and --yes/non-interactive
             # fall through to the plain, machine-readable emit path.
@@ -132,7 +165,9 @@ def register(root: typer.Typer) -> None:
         ),
     ) -> None:
         """Integration auth status by default; use --host for daemon/pot readiness."""
-        host_status = host or pot is not None or intent != "feature" or harness != "claude"
+        host_status = (
+            host or pot is not None or intent != "feature" or harness != "claude"
+        )
         if not host_status:
             from adapters.inbound.cli.auth.auth_commands import integration_status
 
@@ -140,11 +175,12 @@ def register(root: typer.Typer) -> None:
             return
 
         with contract():
-            host = get_host()
-            pot_id = resolve_pot_id(host, pot)
-            report = host.agent_context.status(
+            shell = get_host()
+            pot_id = resolve_pot_id(shell, pot)
+            report = shell.agent_context.status(
                 StatusRequest(pot_id=pot_id, intent=intent, harness=harness)
             )
+            _capture_host_status_activation()
             emit(
                 {
                     "profile": report.profile,
@@ -241,7 +277,7 @@ def register(root: typer.Typer) -> None:
     root.add_typer(config_app, name="config")
 
 
-def _nudge_dict(nudge) -> dict | None:
+def _nudge_dict(nudge) -> dict[str, object] | None:
     if nudge is None:
         return None
     return {
@@ -299,3 +335,54 @@ def _status_human(report) -> str:
 
 
 __all__ = ["register"]
+
+
+def _first_hard_failed_step(report) -> str | None:
+    for step in report.steps:
+        if step.hard and not step.ok:
+            return step.step
+    return None
+
+
+def _soft_warning_count(report) -> int:
+    return sum(1 for step in report.steps if not step.hard and not step.ok)
+
+
+def _capture_plain_project_binding(report) -> None:
+    source = _step_state(report, "source")
+    skills = _step_state(report, "skills")
+    if source is None and skills is None:
+        return
+    capture_project_binding_event(
+        "cli_onboarding_project_binding_started",
+        entrypoint="setup",
+        properties={
+            "repo_provided": report.plan.repo is not None,
+            "agent": report.plan.agent,
+        },
+    )
+    completed = source in {"done", "skipped"} and skills in {"done", "skipped"}
+    capture_project_binding_event(
+        "cli_onboarding_project_binding_completed"
+        if completed
+        else "cli_onboarding_project_binding_incomplete",
+        entrypoint="setup",
+        properties={
+            "source_state": source or "missing",
+            "skills_state": skills or "missing",
+        },
+    )
+
+
+def _step_state(report, step_id: str) -> str | None:
+    for step in report.steps:
+        if step.step == step_id:
+            return step.state
+    return None
+
+
+def _capture_host_status_activation() -> None:
+    capture_activation_succeeded(
+        command="status --host",
+        result_kind="status_result",
+    )

--- a/potpie/context-engine/adapters/inbound/cli/commands/ingest.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/ingest.py
@@ -19,6 +19,10 @@ from adapters.inbound.cli.commands._common import (
     get_host,
     resolve_pot_id,
 )
+from adapters.inbound.cli.telemetry.onboarding_events import (
+    capture_activation_succeeded,
+    capture_onboarding_event,
+)
 from domain.errors import CapabilityNotImplemented
 
 ingest_app = typer.Typer(help="Scanner ingestion + run history.")
@@ -52,6 +56,11 @@ def ingest_scan(
         run_id = f"scan:{uuid.uuid4().hex}"
         result = host.ingest.scan_path(
             pot_id=pot_id, root=path, run_id=run_id, repo_name=repo_name
+        )
+        _capture_ingest_scan_activation(
+            scanners_run=len(result.scanners_run),
+            entities_upserted=result.entities_upserted,
+            edges_upserted=result.edges_upserted,
         )
         emit(
             {
@@ -129,3 +138,23 @@ def ingest_dead_letter_retry(event_id: str) -> None:
 
 
 __all__ = ["ingest_app"]
+
+
+def _capture_ingest_scan_activation(
+    *, scanners_run: int, entities_upserted: int, edges_upserted: int
+) -> None:
+    capture_onboarding_event(
+        "cli_onboarding_ingest_scan_completed",
+        phase="activation",
+        entrypoint="direct_command",
+        properties={
+            "command": "ingest scan",
+            "scanners_run_count": scanners_run,
+            "entities_upserted": entities_upserted,
+            "edges_upserted": edges_upserted,
+        },
+    )
+    capture_activation_succeeded(
+        command="ingest scan",
+        result_kind="scan_result",
+    )

--- a/potpie/context-engine/adapters/inbound/cli/commands/pots.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/pots.py
@@ -14,6 +14,12 @@ from adapters.inbound.cli.commands._common import (
     get_host,
     resolve_pot_id,
 )
+from adapters.inbound.cli.telemetry.onboarding_events import (
+    capture_project_binding_event,
+    elapsed_ms,
+    now_ms,
+    sanitized_failure_kind,
+)
 from adapters.outbound.cli_auth.potpie_api_config import (
     resolve_potpie_api_base_url,
     resolve_potpie_auth_config,
@@ -75,9 +81,7 @@ def pot_list(
                 for p in pots
             ],
         }
-        pot_rows = [
-            f"{'*' if p.active else ' '} {p.name} ({p.pot_id})" for p in pots
-        ]
+        pot_rows = [f"{'*' if p.active else ' '} {p.name} ({p.pot_id})" for p in pots]
         human_lines = ["Local", *(pot_rows or ["(no pots)"])]
         if all_:
             payload["managed_pending"] = True
@@ -288,8 +292,35 @@ def source_add(
     with contract():
         host = get_host()
         pot_id = resolve_pot_id(host, pot)
-        src = host.pots.add_source(
-            pot_id=pot_id, kind=kind, location=location, name=name
+        started_ms = now_ms()
+        capture_project_binding_event(
+            "cli_onboarding_repo_source_add_started",
+            entrypoint="direct_command",
+            properties={"source_kind": kind},
+        )
+        try:
+            src = host.pots.add_source(
+                pot_id=pot_id, kind=kind, location=location, name=name
+            )
+        except Exception as exc:  # noqa: BLE001
+            capture_project_binding_event(
+                "cli_onboarding_repo_source_add_failed",
+                entrypoint="direct_command",
+                properties={
+                    "source_kind": kind,
+                    "failure_kind": sanitized_failure_kind(exc),
+                    "duration_ms": elapsed_ms(started_ms),
+                },
+            )
+            raise
+        capture_project_binding_event(
+            "cli_onboarding_repo_source_add_completed",
+            entrypoint="direct_command",
+            properties={
+                "source_kind": src.kind,
+                "step_state": "done",
+                "duration_ms": elapsed_ms(started_ms),
+            },
         )
         emit(
             {"source_id": src.source_id, "kind": src.kind, "name": src.name},

--- a/potpie/context-engine/adapters/inbound/cli/commands/query.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/query.py
@@ -15,6 +15,9 @@ from adapters.inbound.cli.commands._common import (
     get_host,
     resolve_pot_id,
 )
+from adapters.inbound.cli.telemetry.onboarding_events import (
+    capture_activation_succeeded,
+)
 from domain.ports.agent_context import RecordRequest, ResolveRequest, SearchRequest
 
 
@@ -50,6 +53,7 @@ def register(root: typer.Typer) -> None:
                     mode=mode,
                 )
             )
+            _capture_context_activation(command="resolve", item_count=len(env.items))
             emit(_envelope_payload(env), human=_envelope_human(env))
 
     @root.command()
@@ -65,6 +69,7 @@ def register(root: typer.Typer) -> None:
             env = host.agent_context.search(
                 SearchRequest(pot_id=pot_id, query=query, include=_split(include))
             )
+            _capture_context_activation(command="search", item_count=len(env.items))
             emit(_envelope_payload(env), human=_envelope_human(env))
 
     @root.command()
@@ -100,7 +105,7 @@ def register(root: typer.Typer) -> None:
             )
 
 
-def _parse_scope(scope: str | None) -> dict:
+def _parse_scope(scope: str | None) -> dict[str, str]:
     if not scope:
         return {}
     out: dict[str, str] = {}
@@ -111,7 +116,7 @@ def _parse_scope(scope: str | None) -> dict:
     return out
 
 
-def _envelope_payload(env) -> dict:
+def _envelope_payload(env) -> dict[str, object]:
     return {
         "pot_id": env.pot_id,
         "intent": env.intent,
@@ -140,3 +145,11 @@ def _envelope_human(env) -> str:
 
 
 __all__ = ["register"]
+
+
+def _capture_context_activation(*, command: str, item_count: int) -> None:
+    capture_activation_succeeded(
+        command=command,
+        result_kind="context_result",
+        item_count=item_count,
+    )

--- a/potpie/context-engine/adapters/inbound/cli/commands/skills.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/skills.py
@@ -9,6 +9,12 @@ from __future__ import annotations
 import typer
 
 from adapters.inbound.cli.commands._common import contract, emit, get_host
+from adapters.inbound.cli.telemetry.onboarding_events import (
+    capture_project_binding_event,
+    elapsed_ms,
+    now_ms,
+    sanitized_failure_kind,
+)
 
 skills_app = typer.Typer(help="CLI-managed agent skills.")
 
@@ -21,9 +27,7 @@ def skills_list(
 ) -> None:
     with contract():
         effective_scope = _effective_scope(scope=scope, path=path)
-        items = get_host().skills.list(
-            agent=agent, scope=effective_scope, path=path
-        )
+        items = get_host().skills.list(agent=agent, scope=effective_scope, path=path)
         emit(
             {
                 "agent": agent,
@@ -31,7 +35,7 @@ def skills_list(
                 "skills": [
                     {"id": s.id, "version": s.version, "installed": s.installed}
                     for s in items
-                ]
+                ],
             },
             human="\n".join(
                 f"  {'✓' if s.installed else ' '} {s.id} v{s.version}" for s in items
@@ -48,11 +52,40 @@ def skills_install(
 ) -> None:
     with contract():
         effective_scope = _effective_scope(scope=scope, path=path)
-        res = get_host().skills.install(
-            agent=agent,
-            skill_id=skill_id,
-            path=path,
-            scope=effective_scope,
+        started_ms = now_ms()
+        capture_project_binding_event(
+            "cli_onboarding_agent_skills_install_started",
+            entrypoint="direct_command",
+            properties={"agent": agent, "scope": effective_scope},
+        )
+        try:
+            res = get_host().skills.install(
+                agent=agent,
+                skill_id=skill_id,
+                path=path,
+                scope=effective_scope,
+            )
+        except Exception as exc:  # noqa: BLE001
+            capture_project_binding_event(
+                "cli_onboarding_agent_skills_install_failed",
+                entrypoint="direct_command",
+                properties={
+                    "agent": agent,
+                    "scope": effective_scope,
+                    "failure_kind": sanitized_failure_kind(exc),
+                    "duration_ms": elapsed_ms(started_ms),
+                },
+            )
+            raise
+        capture_project_binding_event(
+            "cli_onboarding_agent_skills_install_completed",
+            entrypoint="direct_command",
+            properties={
+                "agent": res.agent,
+                "scope": effective_scope,
+                "changed_count": len(res.changed),
+                "duration_ms": elapsed_ms(started_ms),
+            },
         )
         emit(
             {
@@ -146,9 +179,7 @@ def skills_add(source: str) -> None:
         emit({"detail": res.detail}, human=res.detail or "added")
 
 
-def _format_skill_operation(
-    *, verb: str, agent: str, changed: tuple[str, ...]
-) -> str:
+def _format_skill_operation(*, verb: str, agent: str, changed: tuple[str, ...]) -> str:
     if changed:
         return f"{verb} Potpie skills for {agent}: {', '.join(changed)}"
     if verb == "installed":

--- a/potpie/context-engine/adapters/inbound/cli/host_cli.py
+++ b/potpie/context-engine/adapters/inbound/cli/host_cli.py
@@ -19,6 +19,13 @@ from adapters.inbound.cli.commands import ingest as ingest_cmds
 from adapters.inbound.cli.commands import query as query_cmds
 from adapters.inbound.cli.commands import skills as skills_cmds
 from adapters.inbound.cli.commands._common import set_json, set_verbose
+from adapters.inbound.cli.telemetry.context import bind_telemetry_context
+from adapters.inbound.cli.telemetry.product_analytics import configure_product_analytics
+from adapters.inbound.cli.telemetry.sentry_runtime import configure_cli_sentry
+from adapters.inbound.cli.telemetry.settings import (
+    load_product_analytics_settings,
+    load_sentry_settings,
+)
 
 
 def build_app() -> typer.Typer:
@@ -48,12 +55,10 @@ def build_app() -> typer.Typer:
         configure_error_output(as_json=json_)
         configure_cli_logging(verbose)
         load_cli_env()
-        from adapters.inbound.cli.telemetry.context import bind_telemetry_context
-        from adapters.inbound.cli.telemetry.sentry_runtime import configure_cli_sentry
-        from adapters.inbound.cli.telemetry.settings import load_sentry_settings
 
         bind_telemetry_context(ctx, json_output=json_)
         configure_cli_sentry(load_sentry_settings())
+        configure_product_analytics(load_product_analytics_settings())
 
     # Top-level commands (the four-tool surface + bootstrap + auth/login).
     query_cmds.register(app)

--- a/potpie/context-engine/adapters/inbound/cli/telemetry/context.py
+++ b/potpie/context-engine/adapters/inbound/cli/telemetry/context.py
@@ -9,7 +9,7 @@ from typing import ClassVar
 import typer
 
 from .identity_store import load_or_create_identity
-from .settings import default_cli_release
+from .settings import default_cli_release, telemetry_environment
 
 _DAEMON_SESSION_ID = f"daemon_{uuid.uuid4().hex}"
 _CURRENT: ContextVar["TelemetryContext | None"] = ContextVar(
@@ -26,6 +26,7 @@ class TelemetryContext:
         "cli_version",
         "command",
         "daemon_session_id",
+        "environment",
         "invocation_id",
         "os",
         "output_mode",
@@ -36,6 +37,7 @@ class TelemetryContext:
     anonymous_install_id: str
     invocation_id: str
     daemon_session_id: str
+    environment: str
     command: str | None
     subcommand: str | None
     output_mode: str
@@ -51,6 +53,7 @@ class TelemetryContext:
                 "anonymous_install_id": self.anonymous_install_id,
                 "invocation_id": self.invocation_id,
                 "daemon_session_id": self.daemon_session_id,
+                "environment": self.environment,
                 "command": self.command,
                 "subcommand": self.subcommand,
                 "output_mode": self.output_mode,
@@ -60,6 +63,20 @@ class TelemetryContext:
                 "arch": self.arch,
             }.items()
             if value is not None
+        }
+
+    def analytics_properties(self) -> dict[str, str]:
+        return {
+            "anonymous_install_id": self.anonymous_install_id,
+            "invocation_id": self.invocation_id,
+            "daemon_session_id": self.daemon_session_id,
+            "environment": self.environment,
+            "output_mode": self.output_mode,
+            "cli_version": self.cli_version,
+            "python_version": self.python_version,
+            "platform": self.os,
+            "arch": self.arch,
+            **_optional_command_properties(self),
         }
 
 
@@ -72,6 +89,7 @@ def bind_telemetry_context(
         anonymous_install_id=identity.anonymous_install_id,
         invocation_id=f"invoke_{uuid.uuid4().hex}",
         daemon_session_id=_DAEMON_SESSION_ID,
+        environment=telemetry_environment(),
         command=command,
         subcommand=subcommand,
         output_mode="json" if json_output else "human",
@@ -103,3 +121,12 @@ def _string_parts(value: object) -> list[str]:
     if not isinstance(value, (list, tuple)):
         return []
     return [str(part) for part in value]
+
+
+def _optional_command_properties(telemetry: TelemetryContext) -> dict[str, str]:
+    properties: dict[str, str] = {}
+    if telemetry.command is not None:
+        properties["command"] = telemetry.command
+    if telemetry.subcommand is not None:
+        properties["subcommand"] = telemetry.subcommand
+    return properties

--- a/potpie/context-engine/adapters/inbound/cli/telemetry/onboarding_events.py
+++ b/potpie/context-engine/adapters/inbound/cli/telemetry/onboarding_events.py
@@ -156,7 +156,7 @@ def capture_github_prompt_outcome(outcome: str, *, duration_ms: int) -> None:
         "declined": "cli_onboarding_github_prompt_declined",
         "aborted": "cli_onboarding_github_prompt_aborted",
         "skipped": "cli_onboarding_github_prompt_skipped",
-    }[outcome]
+    }.get(outcome, "cli_onboarding_github_prompt_aborted")
     _capture(
         name,
         "integration_auth",

--- a/potpie/context-engine/adapters/inbound/cli/telemetry/onboarding_events.py
+++ b/potpie/context-engine/adapters/inbound/cli/telemetry/onboarding_events.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import time
+import uuid
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Iterator
+
+from domain.lifecycle import FAILED, SetupPlan, StepResult
+
+from .product_analytics import AnalyticsValue, capture_event
+
+_CURRENT_SETUP_RUN_ID: ContextVar[str | None] = ContextVar(
+    "potpie_cli_setup_run_id",
+    default=None,
+)
+_CURRENT_ENTRYPOINT: ContextVar[str | None] = ContextVar(
+    "potpie_cli_onboarding_entrypoint",
+    default=None,
+)
+
+
+def begin_setup_run() -> str:
+    setup_run_id = f"setup_{uuid.uuid4().hex}"
+    _CURRENT_SETUP_RUN_ID.set(setup_run_id)
+    return setup_run_id
+
+
+def current_setup_run_id() -> str | None:
+    return _CURRENT_SETUP_RUN_ID.get()
+
+
+@contextmanager
+def onboarding_entrypoint(entrypoint: str) -> Iterator[None]:
+    token = _CURRENT_ENTRYPOINT.set(entrypoint)
+    try:
+        yield
+    finally:
+        _CURRENT_ENTRYPOINT.reset(token)
+
+
+def current_entrypoint(default: str) -> str:
+    return _CURRENT_ENTRYPOINT.get() or default
+
+
+def now_ms() -> int:
+    return int(time.perf_counter() * 1000)
+
+
+def elapsed_ms(start_ms: int) -> int:
+    return max(now_ms() - start_ms, 0)
+
+
+def repo_location_kind(repo: str | None) -> str:
+    if repo is None or not repo.strip():
+        return "none"
+    if repo.strip() == ".":
+        return "current_directory"
+    return "explicit_path"
+
+
+def capture_setup_started(
+    plan: SetupPlan,
+    *,
+    interactive: bool,
+    json_output: bool,
+) -> None:
+    _capture(
+        "cli_onboarding_setup_started",
+        "base_setup",
+        "setup",
+        {
+            **_setup_plan_properties(plan),
+            "interactive": interactive,
+            "json_output": json_output,
+        },
+    )
+
+
+def capture_setup_dry_run_completed(
+    *, plan: SetupPlan, planned_step_count: int, hard_step_count: int
+) -> None:
+    _capture(
+        "cli_onboarding_setup_dry_run_completed",
+        "base_setup",
+        "setup",
+        {
+            **_setup_plan_properties(plan),
+            "planned_step_count": planned_step_count,
+            "hard_step_count": hard_step_count,
+        },
+    )
+
+
+def capture_setup_completed(
+    *,
+    plan: SetupPlan,
+    ok: bool,
+    duration_ms: int,
+    hard_failed_step: str | None,
+    soft_warning_count: int,
+) -> None:
+    name = "cli_onboarding_setup_completed" if ok else "cli_onboarding_setup_incomplete"
+    props: dict[str, AnalyticsValue] = {
+        **_setup_plan_properties(plan),
+        "duration_ms": duration_ms,
+        "soft_warning_count": soft_warning_count,
+    }
+    if hard_failed_step is not None:
+        props["failure_stage"] = hard_failed_step
+    _capture(name, "base_setup", "setup", props)
+
+
+def capture_wizard_event(
+    name: str, *, duration_ms: int | None = None, failed_step: str | None = None
+) -> None:
+    props: dict[str, AnalyticsValue] = {}
+    if duration_ms is not None:
+        props["duration_ms"] = duration_ms
+    if failed_step is not None:
+        props["failure_stage"] = failed_step
+    _capture(name, "base_setup", "setup", props)
+
+
+def capture_project_binding_event(
+    name: str,
+    *,
+    entrypoint: str,
+    properties: dict[str, AnalyticsValue] | None = None,
+) -> None:
+    _capture(name, "project_binding", entrypoint, properties or {})
+
+
+def capture_onboarding_event(
+    name: str,
+    *,
+    phase: str,
+    entrypoint: str,
+    properties: dict[str, AnalyticsValue] | None = None,
+) -> None:
+    _capture(name, phase, entrypoint, properties or {})
+
+
+def capture_github_prompt_shown(*, default_answer: bool) -> None:
+    _capture(
+        "cli_onboarding_github_prompt_shown",
+        "integration_auth",
+        "post_setup_github_prompt",
+        {"default_answer": default_answer},
+    )
+
+
+def capture_github_prompt_outcome(outcome: str, *, duration_ms: int) -> None:
+    name = {
+        "accepted": "cli_onboarding_github_prompt_accepted",
+        "declined": "cli_onboarding_github_prompt_declined",
+        "aborted": "cli_onboarding_github_prompt_aborted",
+        "skipped": "cli_onboarding_github_prompt_skipped",
+    }[outcome]
+    _capture(
+        name,
+        "integration_auth",
+        "post_setup_github_prompt",
+        {"duration_ms": duration_ms},
+    )
+
+
+def capture_integration_auth_event(
+    name: str,
+    *,
+    provider: str,
+    entrypoint: str,
+    duration_ms: int | None = None,
+    failure_kind: str | None = None,
+) -> None:
+    props: dict[str, AnalyticsValue] = {"provider": provider}
+    if duration_ms is not None:
+        props["duration_ms"] = duration_ms
+    if failure_kind is not None:
+        props["failure_kind"] = failure_kind
+    _capture(name, "integration_auth", entrypoint, props)
+
+
+def capture_github_auth_event(
+    name: str,
+    *,
+    entrypoint: str,
+    duration_ms: int | None = None,
+    failure_stage: str | None = None,
+    failure_kind: str | None = None,
+    browser_opened: bool | None = None,
+) -> None:
+    props: dict[str, AnalyticsValue] = {}
+    if duration_ms is not None:
+        props["duration_ms"] = duration_ms
+    if failure_stage is not None:
+        props["failure_stage"] = failure_stage
+    if failure_kind is not None:
+        props["failure_kind"] = failure_kind
+    if browser_opened is not None:
+        props["browser_opened"] = browser_opened
+    _capture(name, "integration_auth", entrypoint, props)
+
+
+def capture_activation_succeeded(
+    *, command: str, result_kind: str, item_count: int | None = None
+) -> None:
+    props: dict[str, AnalyticsValue] = {"command": command, "result_kind": result_kind}
+    if item_count is not None:
+        props["item_count"] = item_count
+    _capture(
+        "cli_onboarding_first_use_command_succeeded",
+        "activation",
+        "direct_command",
+        props,
+    )
+    if result_kind == "context_result":
+        _capture(
+            "cli_onboarding_first_context_result_returned",
+            "activation",
+            "direct_command",
+            props,
+        )
+
+
+def sanitized_failure_kind(exc: BaseException) -> str:
+    return type(exc).__name__
+
+
+class CliSetupAnalyticsObserver:
+    def step_started(self, *, step: str, hard: bool) -> None:
+        _capture(
+            "cli_onboarding_setup_step_started",
+            "base_setup",
+            "setup",
+            {"step": step, "step_hard": hard},
+        )
+
+    def step_completed(self, *, result: StepResult, duration_ms: int) -> None:
+        props: dict[str, AnalyticsValue] = {
+            "step": result.step,
+            "step_state": result.state,
+            "step_hard": result.hard,
+            "duration_ms": duration_ms,
+        }
+        _capture("cli_onboarding_setup_step_completed", "base_setup", "setup", props)
+        if result.state == FAILED:
+            _capture(
+                "cli_onboarding_setup_step_failed",
+                "base_setup",
+                "setup",
+                {**props, "failure_stage": result.step},
+            )
+
+
+def _setup_plan_properties(plan: SetupPlan) -> dict[str, AnalyticsValue]:
+    repo_kind = repo_location_kind(plan.repo)
+    return {
+        "mode": plan.mode,
+        "host_mode": plan.host_mode,
+        "backend": plan.backend,
+        "agent": plan.agent,
+        "agent_explicit": plan.agent != "claude",
+        "scan_requested": plan.scan,
+        "assume_yes": plan.assume_yes,
+        "repo_provided": repo_kind != "none",
+        "repo_explicit": repo_kind == "explicit_path",
+        "repo_location_kind": repo_kind,
+    }
+
+
+def _capture(
+    name: str,
+    phase: str,
+    entrypoint: str,
+    properties: dict[str, AnalyticsValue],
+) -> None:
+    props: dict[str, AnalyticsValue] = {
+        "onboarding_phase": phase,
+        "entrypoint": entrypoint,
+        **properties,
+    }
+    setup_run_id = current_setup_run_id()
+    if setup_run_id is not None:
+        props["setup_run_id"] = setup_run_id
+    capture_event(name, props)

--- a/potpie/context-engine/adapters/inbound/cli/telemetry/product_analytics.py
+++ b/potpie/context-engine/adapters/inbound/cli/telemetry/product_analytics.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import atexit
+import queue
 import threading
 from dataclasses import dataclass, field
 from typing import Final, Mapping, Protocol, TypeAlias
@@ -12,6 +14,9 @@ from .settings import ProductAnalyticsSettings
 AnalyticsValue: TypeAlias = str | int | float | bool | None | tuple[str, ...]
 AnalyticsProperties: TypeAlias = Mapping[str, AnalyticsValue]
 ProductAnalyticsPayload: TypeAlias = dict[str, str | AnalyticsProperties]
+_DISPATCH_QUEUE_MAX_SIZE: Final[int] = 128
+_DISPATCH_WORKER_IDLE_TIMEOUT_SECONDS: Final[float] = 0.1
+_DISPATCH_WORKER_JOIN_TIMEOUT_SECONDS: Final[float] = 5.0
 _CANONICAL_ANALYTICS_PROPERTY_KEYS: Final[frozenset[str]] = frozenset(
     {
         "anonymous_install_id",
@@ -43,6 +48,69 @@ class NoOpProductAnalyticsSink:
         del event
 
 
+class _QueuedProductAnalyticsPayload:
+    __slots__ = ("payload", "url")
+
+    def __init__(self, *, url: str, payload: Mapping[str, object]) -> None:
+        self.url = url
+        self.payload = payload
+
+
+class _ProductAnalyticsDispatcher:
+    def __init__(self) -> None:
+        self._queue: queue.Queue[_QueuedProductAnalyticsPayload] = queue.Queue(
+            maxsize=_DISPATCH_QUEUE_MAX_SIZE
+        )
+        self._lock = threading.Lock()
+        self._worker: threading.Thread | None = None
+
+    def dispatch(self, *, url: str, payload: Mapping[str, object]) -> None:
+        try:
+            self._queue.put_nowait(
+                _QueuedProductAnalyticsPayload(url=url, payload=payload)
+            )
+        except queue.Full:
+            return
+        self._ensure_worker()
+
+    def flush(self) -> None:
+        self._queue.join()
+        worker = self._worker
+        if worker is not None:
+            worker.join(timeout=_DISPATCH_WORKER_JOIN_TIMEOUT_SECONDS)
+
+    def _ensure_worker(self) -> None:
+        with self._lock:
+            if self._worker is not None and self._worker.is_alive():
+                return
+            self._worker = threading.Thread(
+                target=self._run,
+                daemon=False,
+                name="potpie-product-analytics",
+            )
+            self._worker.start()
+
+    def _run(self) -> None:
+        while True:
+            try:
+                queued_payload = self._queue.get(
+                    timeout=_DISPATCH_WORKER_IDLE_TIMEOUT_SECONDS
+                )
+            except queue.Empty:
+                with self._lock:
+                    if self._queue.empty():
+                        self._worker = None
+                        return
+                continue
+            try:
+                _post_product_analytics_payload(
+                    url=queued_payload.url,
+                    payload=queued_payload.payload,
+                )
+            finally:
+                self._queue.task_done()
+
+
 @dataclass(frozen=True, slots=True)
 class PostHogSink:
     settings: ProductAnalyticsSettings
@@ -60,6 +128,7 @@ class PostHogSink:
 
 
 _sink: ProductAnalyticsSink = NoOpProductAnalyticsSink()
+_dispatcher = _ProductAnalyticsDispatcher()
 
 
 def configure_product_analytics(settings: ProductAnalyticsSettings) -> None:
@@ -112,27 +181,28 @@ def _timeout() -> httpx.Timeout:
 
 def _send_product_analytics_payload(
     url: str,
-    payload: ProductAnalyticsPayload,
+    payload: Mapping[str, object],
 ) -> None:
-    thread = threading.Thread(
-        target=_post_product_analytics_payload,
-        kwargs={"url": url, "payload": payload},
-        daemon=True,
-        name="potpie-product-analytics",
-    )
-    thread.start()
+    _dispatcher.dispatch(url=url, payload=payload)
+
+
+def _flush_product_analytics_dispatcher() -> None:
+    _dispatcher.flush()
 
 
 def _post_product_analytics_payload(
     *,
     url: str,
-    payload: ProductAnalyticsPayload,
+    payload: Mapping[str, object],
 ) -> None:
     try:
         with httpx.Client(timeout=_timeout(), follow_redirects=True) as client:
             client.post(url, json=payload)
     except Exception:  # noqa: BLE001 - product analytics must never affect CLI work.
         return
+
+
+atexit.register(_flush_product_analytics_dispatcher)
 
 
 __all__ = [

--- a/potpie/context-engine/adapters/inbound/cli/telemetry/product_analytics.py
+++ b/potpie/context-engine/adapters/inbound/cli/telemetry/product_analytics.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass, field
-from typing import Mapping, Protocol, TypeAlias
+from typing import Final, Mapping, Protocol, TypeAlias
 
 import httpx
 
@@ -10,6 +11,20 @@ from .settings import ProductAnalyticsSettings
 
 AnalyticsValue: TypeAlias = str | int | float | bool | None | tuple[str, ...]
 AnalyticsProperties: TypeAlias = Mapping[str, AnalyticsValue]
+ProductAnalyticsPayload: TypeAlias = dict[str, str | AnalyticsProperties]
+_CANONICAL_ANALYTICS_PROPERTY_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "anonymous_install_id",
+        "invocation_id",
+        "daemon_session_id",
+        "environment",
+        "output_mode",
+        "cli_version",
+        "python_version",
+        "platform",
+        "arch",
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -35,14 +50,13 @@ class PostHogSink:
     def capture(self, event: ProductAnalyticsEvent) -> None:
         if not self.settings.enabled or self.settings.api_key is None:
             return
-        payload = {
+        payload: ProductAnalyticsPayload = {
             "api_key": self.settings.api_key,
             "event": event.name,
             "distinct_id": event.distinct_id,
             "properties": dict(event.properties),
         }
-        with httpx.Client(timeout=_timeout(), follow_redirects=True) as client:
-            client.post(_capture_url(self.settings.host), json=payload)
+        _send_product_analytics_payload(_capture_url(self.settings.host), payload)
 
 
 _sink: ProductAnalyticsSink = NoOpProductAnalyticsSink()
@@ -65,10 +79,18 @@ def capture_event(name: str, properties: AnalyticsProperties | None = None) -> N
     telemetry = current_telemetry_context()
     if telemetry is None:
         return
+    telemetry_properties = telemetry.analytics_properties()
     event_properties: dict[str, AnalyticsValue] = {
-        **telemetry.analytics_properties(),
+        **telemetry_properties,
         **dict(properties or {}),
     }
+    event_properties.update(
+        {
+            key: telemetry_properties[key]
+            for key in _CANONICAL_ANALYTICS_PROPERTY_KEYS
+            if key in telemetry_properties
+        }
+    )
     event = ProductAnalyticsEvent(
         name=name,
         distinct_id=telemetry.anonymous_install_id,
@@ -86,6 +108,31 @@ def _capture_url(host: str) -> str:
 
 def _timeout() -> httpx.Timeout:
     return httpx.Timeout(connect=1.0, read=2.0, write=1.0, pool=1.0)
+
+
+def _send_product_analytics_payload(
+    url: str,
+    payload: ProductAnalyticsPayload,
+) -> None:
+    thread = threading.Thread(
+        target=_post_product_analytics_payload,
+        kwargs={"url": url, "payload": payload},
+        daemon=True,
+        name="potpie-product-analytics",
+    )
+    thread.start()
+
+
+def _post_product_analytics_payload(
+    *,
+    url: str,
+    payload: ProductAnalyticsPayload,
+) -> None:
+    try:
+        with httpx.Client(timeout=_timeout(), follow_redirects=True) as client:
+            client.post(url, json=payload)
+    except Exception:  # noqa: BLE001 - product analytics must never affect CLI work.
+        return
 
 
 __all__ = [

--- a/potpie/context-engine/adapters/inbound/cli/telemetry/product_analytics.py
+++ b/potpie/context-engine/adapters/inbound/cli/telemetry/product_analytics.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Mapping, Protocol, TypeAlias
+
+import httpx
+
+from .context import current_telemetry_context
+from .settings import ProductAnalyticsSettings
+
+AnalyticsValue: TypeAlias = str | int | float | bool | None | tuple[str, ...]
+AnalyticsProperties: TypeAlias = Mapping[str, AnalyticsValue]
+
+
+@dataclass(frozen=True, slots=True)
+class ProductAnalyticsEvent:
+    name: str
+    distinct_id: str
+    properties: AnalyticsProperties = field(default_factory=dict)
+
+
+class ProductAnalyticsSink(Protocol):
+    def capture(self, event: ProductAnalyticsEvent) -> None: ...
+
+
+class NoOpProductAnalyticsSink:
+    def capture(self, event: ProductAnalyticsEvent) -> None:
+        del event
+
+
+@dataclass(frozen=True, slots=True)
+class PostHogSink:
+    settings: ProductAnalyticsSettings
+
+    def capture(self, event: ProductAnalyticsEvent) -> None:
+        if not self.settings.enabled or self.settings.api_key is None:
+            return
+        payload = {
+            "api_key": self.settings.api_key,
+            "event": event.name,
+            "distinct_id": event.distinct_id,
+            "properties": dict(event.properties),
+        }
+        with httpx.Client(timeout=_timeout(), follow_redirects=True) as client:
+            client.post(_capture_url(self.settings.host), json=payload)
+
+
+_sink: ProductAnalyticsSink = NoOpProductAnalyticsSink()
+
+
+def configure_product_analytics(settings: ProductAnalyticsSettings) -> None:
+    global _sink
+    if settings.enabled and settings.api_key is not None:
+        _sink = PostHogSink(settings)
+        return
+    _sink = NoOpProductAnalyticsSink()
+
+
+def set_product_analytics_sink(sink: ProductAnalyticsSink) -> None:
+    global _sink
+    _sink = sink
+
+
+def capture_event(name: str, properties: AnalyticsProperties | None = None) -> None:
+    telemetry = current_telemetry_context()
+    if telemetry is None:
+        return
+    event_properties: dict[str, AnalyticsValue] = {
+        **telemetry.analytics_properties(),
+        **dict(properties or {}),
+    }
+    event = ProductAnalyticsEvent(
+        name=name,
+        distinct_id=telemetry.anonymous_install_id,
+        properties=event_properties,
+    )
+    try:
+        _sink.capture(event)
+    except Exception:  # noqa: BLE001 - product analytics must never fail CLI work.
+        return
+
+
+def _capture_url(host: str) -> str:
+    return f"{host.rstrip('/')}/capture/"
+
+
+def _timeout() -> httpx.Timeout:
+    return httpx.Timeout(connect=1.0, read=2.0, write=1.0, pool=1.0)
+
+
+__all__ = [
+    "AnalyticsProperties",
+    "AnalyticsValue",
+    "NoOpProductAnalyticsSink",
+    "PostHogSink",
+    "ProductAnalyticsEvent",
+    "ProductAnalyticsSettings",
+    "ProductAnalyticsSink",
+    "capture_event",
+    "configure_product_analytics",
+    "set_product_analytics_sink",
+]

--- a/potpie/context-engine/adapters/inbound/cli/telemetry/product_analytics.py
+++ b/potpie/context-engine/adapters/inbound/cli/telemetry/product_analytics.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import atexit
 import queue
 import threading
+import time
 from dataclasses import dataclass, field
 from typing import Final, Mapping, Protocol, TypeAlias
 
@@ -74,10 +75,12 @@ class _ProductAnalyticsDispatcher:
         self._ensure_worker()
 
     def flush(self) -> None:
-        self._queue.join()
+        deadline = time.monotonic() + _DISPATCH_WORKER_JOIN_TIMEOUT_SECONDS
+        while self._queue.unfinished_tasks and time.monotonic() < deadline:
+            time.sleep(0.01)
         worker = self._worker
         if worker is not None:
-            worker.join(timeout=_DISPATCH_WORKER_JOIN_TIMEOUT_SECONDS)
+            worker.join(timeout=max(0.0, deadline - time.monotonic()))
 
     def _ensure_worker(self) -> None:
         with self._lock:

--- a/potpie/context-engine/adapters/inbound/cli/telemetry/settings.py
+++ b/potpie/context-engine/adapters/inbound/cli/telemetry/settings.py
@@ -25,6 +25,19 @@ class SentrySettings:
     dist: str | None
 
 
+@dataclass(frozen=True)
+class ProductAnalyticsSettings:
+    __slots__: ClassVar[tuple[str, ...]] = (
+        "api_key",
+        "enabled",
+        "host",
+    )
+
+    enabled: bool
+    api_key: str | None
+    host: str
+
+
 def load_sentry_settings() -> SentrySettings:
     dsn = _env("POTPIE_SENTRY_DSN") or _env("SENTRY_DSN")
     telemetry_disabled = _is_truthy_flag("POTPIE_TELEMETRY_DISABLED")
@@ -32,13 +45,24 @@ def load_sentry_settings() -> SentrySettings:
     return SentrySettings(
         enabled=dsn is not None and not telemetry_disabled and not sentry_disabled,
         dsn=dsn,
-        environment=(
-            _env("POTPIE_SENTRY_ENVIRONMENT") or _env("SENTRY_ENVIRONMENT") or "dev"
-        ),
+        environment=telemetry_environment(),
         release=_env("POTPIE_SENTRY_RELEASE")
         or _env("SENTRY_RELEASE")
         or default_cli_release(),
         dist=_env("POTPIE_SENTRY_DIST") or _env("SENTRY_DIST"),
+    )
+
+
+def load_product_analytics_settings() -> ProductAnalyticsSettings:
+    api_key = _env("POTPIE_POSTHOG_API_KEY")
+    telemetry_disabled = _is_truthy_flag("POTPIE_TELEMETRY_DISABLED")
+    product_disabled = _is_falsey_flag("POTPIE_POSTHOG_ENABLED") or _is_falsey_flag(
+        "POTPIE_PRODUCT_ANALYTICS_ENABLED"
+    )
+    return ProductAnalyticsSettings(
+        enabled=api_key is not None and not telemetry_disabled and not product_disabled,
+        api_key=api_key,
+        host=_env("POTPIE_POSTHOG_HOST") or "https://us.i.posthog.com",
     )
 
 
@@ -48,6 +72,10 @@ def default_cli_release() -> str:
     except metadata.PackageNotFoundError:
         version = "0.1.0"
     return f"potpie-cli@{version}"
+
+
+def telemetry_environment() -> str:
+    return _env("POTPIE_SENTRY_ENVIRONMENT") or _env("SENTRY_ENVIRONMENT") or "dev"
 
 
 def _env(name: str) -> str | None:

--- a/potpie/context-engine/adapters/inbound/cli/ui/setup_ux.py
+++ b/potpie/context-engine/adapters/inbound/cli/ui/setup_ux.py
@@ -14,6 +14,17 @@ import time
 from pathlib import Path
 from typing import Any
 
+from adapters.inbound.cli.telemetry.onboarding_events import (
+    capture_github_prompt_outcome,
+    capture_github_prompt_shown,
+    capture_onboarding_event,
+    capture_project_binding_event,
+    capture_wizard_event,
+    elapsed_ms,
+    now_ms,
+    onboarding_entrypoint,
+    sanitized_failure_kind,
+)
 from adapters.inbound.cli.ui.setup_wizard_ui import (
     SetupWizardUI,
     StepStatus,
@@ -86,6 +97,8 @@ def render_setup_report(
     pot_name: str | None = None,
 ) -> None:
     """Replay a completed ``SetupReport`` through the animated checklist."""
+    started_ms = now_ms()
+    capture_wizard_event("cli_onboarding_wizard_shown")
     wizard = SetupWizardUI(use_rich=use_rich)
     visible_steps = [step for step in report.steps if _visible_in_checklist(step)]
     for step in visible_steps:
@@ -114,11 +127,22 @@ def render_setup_report(
 
     if failed_step_id is not None:
         wizard.print_failed(step_id=failed_step_id)
+        capture_wizard_event(
+            "cli_onboarding_wizard_failed_view_shown",
+            duration_ms=elapsed_ms(started_ms),
+            failed_step=failed_step_id,
+        )
         return
 
     wizard.print_complete_summary(
-        pot_name=None if report.plan.defer_default_pot else (pot_name or report.plan.pot),
+        pot_name=None
+        if report.plan.defer_default_pot
+        else (pot_name or report.plan.pot),
         already_setup=False,
+    )
+    capture_wizard_event(
+        "cli_onboarding_wizard_completed",
+        duration_ms=elapsed_ms(started_ms),
     )
 
 
@@ -147,7 +171,10 @@ POST_SETUP_AGENT_ORDER: tuple[str, ...] = tuple(
 
 def install_agents_to_repo(repo: Path, agents: list[str]) -> list[tuple[str, Any]]:
     """Copy packaged skill bundles into *repo* for each harness id."""
-    from adapters.outbound.skills.agent_installer import AGENT_TYPES, install_agent_bundle
+    from adapters.outbound.skills.agent_installer import (
+        AGENT_TYPES,
+        install_agent_bundle,
+    )
 
     results: list[tuple[str, Any]] = []
     for agent in agents:
@@ -201,7 +228,10 @@ def _install_agents_globally_with_progress(agents: list[str]) -> list[tuple[str,
                 lines.append(Text(f"  ✓ {label} ({status})", style=LOGO_STYLE))
             if active_label:
                 lines.append(
-                    Text(f"  Installing {active_label} skills{dots}", style=UI_MUTED_STYLE)
+                    Text(
+                        f"  Installing {active_label} skills{dots}",
+                        style=UI_MUTED_STYLE,
+                    )
                 )
             return Group(*lines)
 
@@ -260,9 +290,7 @@ def _agent_usage_hint(agent_ids: list[str]) -> str | None:
     if not agent_ids:
         return None
     labels = [_agent_label(agent_id) for agent_id in agent_ids]
-    return (
-        f"Open {_format_agent_list(labels)} — Potpie skills are ready to use."
-    )
+    return f"Open {_format_agent_list(labels)} — Potpie skills are ready to use."
 
 
 def _globally_installed_harnesses() -> list[str]:
@@ -326,7 +354,32 @@ def _maybe_prompt_agent_skills(*, setup_agent: str) -> None:
         for agent in POST_SETUP_AGENT_ORDER
         if agent in selected_set and agent != "default"
     ]
-    _install_agents_globally_with_progress(agents)
+    started_ms = now_ms()
+    capture_project_binding_event(
+        "cli_onboarding_agent_skills_install_started",
+        entrypoint="post_setup_agent_skills",
+        properties={"agent_count": len(agents)},
+    )
+    try:
+        result = _install_agents_globally_with_progress(agents)
+    except Exception as exc:  # noqa: BLE001
+        capture_project_binding_event(
+            "cli_onboarding_agent_skills_install_failed",
+            entrypoint="post_setup_agent_skills",
+            properties={
+                "duration_ms": elapsed_ms(started_ms),
+                "failure_kind": sanitized_failure_kind(exc),
+            },
+        )
+        raise
+    capture_project_binding_event(
+        "cli_onboarding_agent_skills_install_completed",
+        entrypoint="post_setup_agent_skills",
+        properties={
+            "changed": _result_changed(result),
+            "duration_ms": elapsed_ms(started_ms),
+        },
+    )
 
 
 def maybe_prompt_github_login(
@@ -337,6 +390,7 @@ def maybe_prompt_github_login(
 ) -> None:
     """After setup: GitHub, integrations, global skills, then first pot naming."""
     if not is_interactive_tty():
+        capture_github_prompt_outcome("skipped", duration_ms=0)
         return
 
     from adapters.inbound.cli.auth.auth_commands import run_integration_login
@@ -345,16 +399,34 @@ def maybe_prompt_github_login(
 
     import typer
 
+    prompt_started_ms = now_ms()
+    capture_github_prompt_shown(default_answer=True)
     try:
         confirmed = typer.confirm(
             "Would you like to log in to GitHub now?",
             default=True,
         )
     except (KeyboardInterrupt, EOFError):
+        capture_github_prompt_outcome(
+            "aborted",
+            duration_ms=elapsed_ms(prompt_started_ms),
+        )
         confirmed = False
+    else:
+        capture_github_prompt_outcome(
+            "accepted" if confirmed else "declined",
+            duration_ms=elapsed_ms(prompt_started_ms),
+        )
     if confirmed:
-        _try_login(github_login_impl)
+        with onboarding_entrypoint("post_setup_github_prompt"):
+            _try_login(github_login_impl)
 
+    capture_onboarding_event(
+        "cli_onboarding_integration_picker_shown",
+        phase="integration_auth",
+        entrypoint="post_setup_integration_picker",
+        properties={"available_provider_count": len(POST_SETUP_INTEGRATION_OPTIONS)},
+    )
     try:
         selected = prompt_multi_checkbox(
             "Which integrations would you like to connect?",
@@ -362,31 +434,79 @@ def maybe_prompt_github_login(
         )
     except (KeyboardInterrupt, EOFError):
         selected = []
+    capture_onboarding_event(
+        "cli_onboarding_integration_picker_completed",
+        phase="integration_auth",
+        entrypoint="post_setup_integration_picker",
+        properties={
+            "selected_provider_count": len(selected),
+            "selected_providers": tuple(selected),
+        },
+    )
 
     if selected:
         selected_set = frozenset(selected)
         for provider in POST_SETUP_INTEGRATION_ORDER:
             if provider not in selected_set:
                 continue
-            _try_login(lambda p=provider: run_integration_login(p))
+            with onboarding_entrypoint("post_setup_integration_picker"):
+                _try_login(lambda p=provider: run_integration_login(p))
 
     if repo is not None:
+        capture_project_binding_event(
+            "cli_onboarding_project_binding_started",
+            entrypoint="post_setup_first_pot",
+            properties={"repo_provided": True, "agent": setup_agent},
+        )
         _maybe_prompt_agent_skills(setup_agent=setup_agent)
 
     _maybe_prompt_first_pot(repo=repo, default_pot_name=default_pot_name)
 
 
-def _register_repo_source(*, repo: str) -> None:
+def _register_repo_source(*, repo: str) -> str:
     from adapters.inbound.cli.commands._common import get_host
 
+    started_ms = now_ms()
+    capture_project_binding_event(
+        "cli_onboarding_repo_source_add_started",
+        entrypoint="post_setup_first_pot",
+        properties={"source_kind": "repo"},
+    )
     host = get_host()
     active = host.pots.active_pot()
     if active is None:
-        return
+        capture_project_binding_event(
+            "cli_onboarding_repo_source_add_completed",
+            entrypoint="post_setup_first_pot",
+            properties={"step_state": "skipped", "duration_ms": elapsed_ms(started_ms)},
+        )
+        return "skipped"
     existing = host.pots.list_sources(pot_id=active.pot_id)
     if any(s.kind == "repo" and s.name == repo for s in existing):
-        return
-    host.pots.add_source(pot_id=active.pot_id, kind="repo", location=repo)
+        capture_project_binding_event(
+            "cli_onboarding_repo_source_add_completed",
+            entrypoint="post_setup_first_pot",
+            properties={"step_state": "skipped", "duration_ms": elapsed_ms(started_ms)},
+        )
+        return "skipped"
+    try:
+        host.pots.add_source(pot_id=active.pot_id, kind="repo", location=repo)
+    except Exception as exc:  # noqa: BLE001
+        capture_project_binding_event(
+            "cli_onboarding_repo_source_add_failed",
+            entrypoint="post_setup_first_pot",
+            properties={
+                "failure_kind": sanitized_failure_kind(exc),
+                "duration_ms": elapsed_ms(started_ms),
+            },
+        )
+        raise
+    capture_project_binding_event(
+        "cli_onboarding_repo_source_add_completed",
+        entrypoint="post_setup_first_pot",
+        properties={"step_state": "done", "duration_ms": elapsed_ms(started_ms)},
+    )
+    return "done"
 
 
 def _maybe_prompt_first_pot(
@@ -399,17 +519,39 @@ def _maybe_prompt_first_pot(
     from adapters.inbound.cli.ui.potpie_logo_anim import play_setup_finish
     from adapters.inbound.cli.ui.setup_wizard_ui import stderr_console
 
+    capture_project_binding_event(
+        "cli_onboarding_first_pot_prompt_shown",
+        entrypoint="post_setup_first_pot",
+        properties={"repo_provided": repo is not None},
+    )
     try:
         name = prompt_first_pot_name(default=default_pot_name).strip()
     except (KeyboardInterrupt, EOFError):
+        capture_project_binding_event(
+            "cli_onboarding_project_binding_incomplete",
+            entrypoint="post_setup_first_pot",
+            properties={"missing_piece": "first_pot"},
+        )
         return
     if not name:
         name = default_pot_name
 
     repo_str = str(repo.resolve()) if repo is not None else None
+    name_source = "default" if name == default_pot_name else "custom"
     pot = get_host().pots.create_pot(name=name, repo=repo_str, use=True)
+    capture_project_binding_event(
+        "cli_onboarding_first_pot_created",
+        entrypoint="post_setup_first_pot",
+        properties={"pot_name_source": name_source, "repo_provided": repo is not None},
+    )
+    source_state = "missing"
     if repo_str:
-        _register_repo_source(repo=repo_str)
+        source_state = _register_repo_source(repo=repo_str)
+    capture_project_binding_event(
+        "cli_onboarding_project_binding_completed",
+        entrypoint="post_setup_first_pot",
+        properties={"source_state": source_state},
+    )
 
     play_setup_finish(
         stderr_console(),

--- a/potpie/context-engine/application/services/setup_orchestrator.py
+++ b/potpie/context-engine/application/services/setup_orchestrator.py
@@ -16,7 +16,8 @@ and skipped for an in-process host.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 from typing import Callable
 
 from domain.errors import CapabilityNotImplemented
@@ -39,6 +40,7 @@ from domain.ports.services.config import ConfigService
 from domain.ports.services.pot_management import PotManagementService
 from domain.ports.services.skill_manager import SkillManager
 from domain.ports.services.state_store import MigrationPort, StateStorePort
+from domain.ports.services.setup import NoOpSetupObserver, SetupObserver
 from host.daemon import Daemon
 
 # Dependency-ordered seam plan: (step, owner, action template). Mirrors the
@@ -142,6 +144,10 @@ class DefaultSetupOrchestrator:
     daemon: Daemon
     auth: AuthService
     skills: SkillManager
+    observer: SetupObserver = field(default_factory=NoOpSetupObserver)
+
+    def set_observer(self, observer: SetupObserver) -> None:
+        self.observer = observer
 
     def preview(self, plan: SetupPlan) -> SetupPreview:
         """Dry-run: the ordered steps ``run`` would execute, unexecuted."""
@@ -207,18 +213,42 @@ class DefaultSetupOrchestrator:
 
     # --- step runner --------------------------------------------------------
     def _step(self, name: str, hard: bool, fn: Callable[[], object]) -> StepResult:
+        self._notify_step_started(step=name, hard=hard)
+        started = time.perf_counter()
         try:
             result = fn()
+            if isinstance(result, StepResult):
+                # Preserve the component's own state/detail; enforce this step's name + hard flag.
+                step_result = StepResult(
+                    name,
+                    result.state,
+                    result.detail,
+                    hard=hard,
+                    metadata=result.metadata,
+                )
+            else:
+                step_result = StepResult(name, DONE, _describe(result), hard=hard)
         except CapabilityNotImplemented as exc:
-            return StepResult(name, NOT_IMPLEMENTED, exc.detail or str(exc), hard=hard)
-        except Exception as exc:  # never let one component crash the whole run
-            return StepResult(name, FAILED, str(exc), hard=hard)
-        if isinstance(result, StepResult):
-            # Preserve the component's own state/detail; enforce this step's name + hard flag.
-            return StepResult(
-                name, result.state, result.detail, hard=hard, metadata=result.metadata
+            step_result = StepResult(
+                name, NOT_IMPLEMENTED, exc.detail or str(exc), hard=hard
             )
-        return StepResult(name, DONE, _describe(result), hard=hard)
+        except Exception as exc:  # never let one component crash the whole run
+            step_result = StepResult(name, FAILED, str(exc), hard=hard)
+        duration_ms = int((time.perf_counter() - started) * 1000)
+        self._notify_step_completed(result=step_result, duration_ms=duration_ms)
+        return step_result
+
+    def _notify_step_started(self, *, step: str, hard: bool) -> None:
+        try:
+            self.observer.step_started(step=step, hard=hard)
+        except Exception:  # noqa: BLE001 - setup analytics must not affect setup.
+            return
+
+    def _notify_step_completed(self, *, result: StepResult, duration_ms: int) -> None:
+        try:
+            self.observer.step_completed(result=result, duration_ms=duration_ms)
+        except Exception:  # noqa: BLE001 - setup analytics must not affect setup.
+            return
 
     # --- step bodies --------------------------------------------------------
     def _config(self, plan: SetupPlan) -> str:

--- a/potpie/context-engine/domain/ports/services/setup.py
+++ b/potpie/context-engine/domain/ports/services/setup.py
@@ -17,8 +17,24 @@ from typing import Protocol
 from domain.lifecycle import SetupPlan, SetupPreview, SetupReport, StepResult
 
 
+class SetupObserver(Protocol):
+    def step_started(self, *, step: str, hard: bool) -> None: ...
+
+    def step_completed(self, *, result: StepResult, duration_ms: int) -> None: ...
+
+
+class NoOpSetupObserver:
+    def step_started(self, *, step: str, hard: bool) -> None:
+        del step, hard
+
+    def step_completed(self, *, result: StepResult, duration_ms: int) -> None:
+        del result, duration_ms
+
+
 class SetupOrchestrator(Protocol):
     """Sequences the bespoke per-component lifecycle methods."""
+
+    def set_observer(self, observer: SetupObserver) -> None: ...
 
     def preview(self, plan: SetupPlan) -> SetupPreview:
         """Dry-run: the ordered steps ``run`` would execute (owner, hard/soft,
@@ -37,4 +53,4 @@ class SetupOrchestrator(Protocol):
         ...
 
 
-__all__ = ["SetupOrchestrator"]
+__all__ = ["NoOpSetupObserver", "SetupObserver", "SetupOrchestrator"]

--- a/potpie/context-engine/tests/unit/test_onboarding_analytics.py
+++ b/potpie/context-engine/tests/unit/test_onboarding_analytics.py
@@ -134,6 +134,19 @@ def test_github_prompt_events_record_prompt_outcome(fake_sink: _FakeSink) -> Non
     assert fake_sink.events[1].properties["duration_ms"] == 25
 
 
+def test_github_prompt_unknown_outcome_falls_back_to_aborted(
+    fake_sink: _FakeSink,
+) -> None:
+    begin_setup_run()
+
+    capture_github_prompt_outcome("unexpected", duration_ms=25)
+
+    assert [event.name for event in fake_sink.events] == [
+        "cli_onboarding_github_prompt_aborted"
+    ]
+    assert fake_sink.events[0].properties["duration_ms"] == 25
+
+
 def test_activation_event_marks_context_results(fake_sink: _FakeSink) -> None:
     begin_setup_run()
 
@@ -171,6 +184,30 @@ def test_direct_linear_login_records_integration_funnel(
     ]
     assert fake_sink.events[0].properties["provider"] == "linear"
     assert fake_sink.events[0].properties["entrypoint"] == "direct_integration_auth"
+
+
+def test_integration_login_records_unexpected_failure(
+    fake_sink: _FakeSink,
+) -> None:
+    class _IntegrationFailure(RuntimeError):
+        pass
+
+    def _run() -> None:
+        raise _IntegrationFailure("boom")
+
+    with pytest.raises(_IntegrationFailure):
+        auth_commands._run_tracked_integration_login(
+            "linear",
+            entrypoint="direct_integration_auth",
+            runner=_run,
+        )
+
+    assert [event.name for event in fake_sink.events] == [
+        "cli_onboarding_integration_auth_started",
+        "cli_onboarding_integration_auth_failed",
+    ]
+    assert fake_sink.events[1].properties["provider"] == "linear"
+    assert fake_sink.events[1].properties["failure_kind"] == "_IntegrationFailure"
 
 
 def test_setup_picker_login_preserves_entrypoint(

--- a/potpie/context-engine/tests/unit/test_onboarding_analytics.py
+++ b/potpie/context-engine/tests/unit/test_onboarding_analytics.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from adapters.inbound.cli.auth import auth_commands
+from adapters.inbound.cli.telemetry.onboarding_events import (
+    CliSetupAnalyticsObserver,
+    begin_setup_run,
+    capture_activation_succeeded,
+    capture_github_prompt_outcome,
+    capture_github_prompt_shown,
+    capture_setup_completed,
+    capture_setup_started,
+    current_setup_run_id,
+    onboarding_entrypoint,
+    repo_location_kind,
+)
+from adapters.inbound.cli.telemetry.product_analytics import (
+    ProductAnalyticsEvent,
+    set_product_analytics_sink,
+)
+from adapters.outbound.graph.backends.in_memory_backend import InMemoryGraphBackend
+from bootstrap.host_wiring import build_host_shell
+from domain.lifecycle import SetupPlan
+
+
+@dataclass
+class _FakeSink:
+    events: list[ProductAnalyticsEvent] = field(default_factory=list)
+
+    def capture(self, event: ProductAnalyticsEvent) -> None:
+        self.events.append(event)
+
+
+@pytest.fixture()
+def fake_sink(monkeypatch: pytest.MonkeyPatch) -> _FakeSink:
+    sink = _FakeSink()
+    set_product_analytics_sink(sink)
+    monkeypatch.setattr(
+        "adapters.inbound.cli.telemetry.product_analytics.current_telemetry_context",
+        lambda: _telemetry_context(),
+    )
+    return sink
+
+
+def _telemetry_context():
+    from adapters.inbound.cli.telemetry.context import TelemetryContext
+
+    return TelemetryContext(
+        anonymous_install_id="install_123",
+        invocation_id="invoke_456",
+        daemon_session_id="daemon_789",
+        environment="staging",
+        command="setup",
+        subcommand=None,
+        output_mode="json",
+        cli_version="0.1.0",
+        python_version="3.13.0",
+        os="darwin",
+        arch="arm64",
+    )
+
+
+def test_repo_location_kind_does_not_expose_paths() -> None:
+    assert repo_location_kind(None) == "none"
+    assert repo_location_kind(".") == "current_directory"
+    assert repo_location_kind("/Users/dsantra/private/repo") == "explicit_path"
+
+
+def test_setup_events_share_one_setup_run_id(fake_sink: _FakeSink) -> None:
+    plan = SetupPlan(repo=".", agent="claude", scan=True, assume_yes=True)
+
+    setup_run_id = begin_setup_run()
+    capture_setup_started(plan, interactive=False, json_output=True)
+    capture_setup_completed(
+        plan=plan,
+        ok=True,
+        duration_ms=12,
+        hard_failed_step=None,
+        soft_warning_count=1,
+    )
+
+    assert current_setup_run_id() == setup_run_id
+    assert [event.name for event in fake_sink.events] == [
+        "cli_onboarding_setup_started",
+        "cli_onboarding_setup_completed",
+    ]
+    assert fake_sink.events[0].properties["setup_run_id"] == setup_run_id
+    assert fake_sink.events[0].properties["repo_location_kind"] == "current_directory"
+    assert fake_sink.events[0].properties["scan_requested"] is True
+    assert fake_sink.events[1].properties["duration_ms"] == 12
+    assert "repo" not in fake_sink.events[0].properties
+
+
+def test_setup_observer_emits_step_timing(
+    fake_sink: _FakeSink, tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("CONTEXT_ENGINE_HOME", str(tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    host = build_host_shell(backend=InMemoryGraphBackend())
+    host.setup.set_observer(CliSetupAnalyticsObserver())
+    begin_setup_run()
+
+    report = host.setup.run(SetupPlan(repo=".", agent="claude", defer_default_pot=True))
+
+    assert report.ok is True
+    names = [event.name for event in fake_sink.events]
+    assert "cli_onboarding_setup_step_started" in names
+    assert "cli_onboarding_setup_step_completed" in names
+    source_events = [
+        event
+        for event in fake_sink.events
+        if event.properties.get("step") == "source"
+        and event.name == "cli_onboarding_setup_step_completed"
+    ]
+    assert source_events[0].properties["step_state"] == "skipped"
+    duration_ms = source_events[0].properties["duration_ms"]
+    assert isinstance(duration_ms, int)
+    assert duration_ms >= 0
+
+
+def test_github_prompt_events_record_prompt_outcome(fake_sink: _FakeSink) -> None:
+    begin_setup_run()
+
+    capture_github_prompt_shown(default_answer=True)
+    capture_github_prompt_outcome("accepted", duration_ms=25)
+
+    assert [event.name for event in fake_sink.events] == [
+        "cli_onboarding_github_prompt_shown",
+        "cli_onboarding_github_prompt_accepted",
+    ]
+    assert fake_sink.events[1].properties["duration_ms"] == 25
+
+
+def test_activation_event_marks_context_results(fake_sink: _FakeSink) -> None:
+    begin_setup_run()
+
+    capture_activation_succeeded(
+        command="resolve",
+        result_kind="context_result",
+        item_count=3,
+    )
+
+    assert [event.name for event in fake_sink.events] == [
+        "cli_onboarding_first_use_command_succeeded",
+        "cli_onboarding_first_context_result_returned",
+    ]
+    assert fake_sink.events[0].properties["command"] == "resolve"
+    assert fake_sink.events[1].properties["item_count"] == 3
+
+
+def test_direct_linear_login_records_integration_funnel(
+    fake_sink: _FakeSink,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[bool, bool]] = []
+
+    def _fake_linear_login(*, force: bool = False, add: bool = False) -> None:
+        calls.append((force, add))
+
+    monkeypatch.setattr(auth_commands, "_run_linear_oauth_flow", _fake_linear_login)
+
+    auth_commands.linear_login(force=True, add=True)
+
+    assert calls == [(True, True)]
+    assert [event.name for event in fake_sink.events] == [
+        "cli_onboarding_integration_auth_started",
+        "cli_onboarding_integration_auth_completed",
+    ]
+    assert fake_sink.events[0].properties["provider"] == "linear"
+    assert fake_sink.events[0].properties["entrypoint"] == "direct_integration_auth"
+
+
+def test_setup_picker_login_preserves_entrypoint(
+    fake_sink: _FakeSink,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        auth_commands,
+        "_run_linear_oauth_flow",
+        lambda *, force=False, add=False: None,
+    )
+
+    with onboarding_entrypoint("post_setup_integration_picker"):
+        auth_commands.run_integration_login("linear")
+
+    assert fake_sink.events[0].properties["provider"] == "linear"
+    assert (
+        fake_sink.events[0].properties["entrypoint"] == "post_setup_integration_picker"
+    )
+
+
+def test_direct_atlassian_login_records_funnel_without_credentials(
+    fake_sink: _FakeSink,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def _fake_atlassian_login(product: str, **kwargs: object) -> None:
+        calls.append({"product": product, **kwargs})
+
+    monkeypatch.setattr(auth_commands, "load_cli_env", lambda: None)
+    monkeypatch.setattr(
+        auth_commands,
+        "run_atlassian_api_token_auth",
+        _fake_atlassian_login,
+    )
+
+    auth_commands.jira_login(
+        force=True,
+        email="developer@example.com",
+        api_token="secret-token",
+        site_subdomain="potpie",
+    )
+
+    assert calls[0]["product"] == "jira"
+    assert [event.name for event in fake_sink.events] == [
+        "cli_onboarding_integration_auth_started",
+        "cli_onboarding_integration_auth_completed",
+    ]
+    for event in fake_sink.events:
+        assert event.properties["provider"] == "jira"
+        assert "email" not in event.properties
+        assert "api_token" not in event.properties
+        assert "site_subdomain" not in event.properties

--- a/potpie/context-engine/tests/unit/test_product_analytics.py
+++ b/potpie/context-engine/tests/unit/test_product_analytics.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from adapters.inbound.cli.telemetry import product_analytics
 from adapters.inbound.cli.telemetry.context import TelemetryContext
 from adapters.inbound.cli.telemetry.product_analytics import (
     ProductAnalyticsEvent,
@@ -66,7 +67,15 @@ def test_capture_event_uses_existing_telemetry_identity(monkeypatch) -> None:
         _telemetry_context,
     )
 
-    capture_event("cli_onboarding_setup_started", {"repo_provided": True})
+    capture_event(
+        "cli_onboarding_setup_started",
+        {
+            "anonymous_install_id": "callsite_install",
+            "environment": "callsite_env",
+            "invocation_id": "callsite_invocation",
+            "repo_provided": True,
+        },
+    )
 
     assert len(sink.events) == 1
     event = sink.events[0]
@@ -92,9 +101,13 @@ def test_capture_event_is_noop_without_telemetry_context(monkeypatch) -> None:
     assert sink.events == []
 
 
-def test_configure_product_analytics_uses_noop_when_disabled() -> None:
+def test_configure_product_analytics_uses_noop_when_disabled(monkeypatch) -> None:
     sink = _FakeSink()
     set_product_analytics_sink(sink)
+    monkeypatch.setattr(
+        "adapters.inbound.cli.telemetry.product_analytics.current_telemetry_context",
+        _telemetry_context,
+    )
 
     configure_product_analytics(
         ProductAnalyticsSettings(
@@ -114,20 +127,10 @@ def test_posthog_sink_payload_excludes_secrets(monkeypatch) -> None:
 
     calls: list[_PostCall] = []
 
-    class _Client:
-        def __enter__(self) -> "_Client":
-            return self
+    def _send(url: str, payload: dict[str, object]) -> None:
+        calls.append(_PostCall(url=url, payload=payload))
 
-        def __exit__(self, exc_type, exc, tb) -> None:
-            return None
-
-        def post(self, url: str, *, json: dict[str, object]) -> None:
-            calls.append(_PostCall(url=url, payload=json))
-
-    monkeypatch.setattr(
-        "adapters.inbound.cli.telemetry.product_analytics.httpx.Client",
-        lambda **_kwargs: _Client(),
-    )
+    monkeypatch.setattr(product_analytics, "_send_product_analytics_payload", _send)
     sink = PostHogSink(
         ProductAnalyticsSettings(
             enabled=True,
@@ -152,3 +155,51 @@ def test_posthog_sink_payload_excludes_secrets(monkeypatch) -> None:
     properties = payload["properties"]
     assert isinstance(properties, dict)
     assert properties == {"repo_location_kind": "explicit_path"}
+
+
+def test_posthog_sink_schedules_delivery_in_background(monkeypatch) -> None:
+    @dataclass
+    class _ScheduledThread:
+        target_name: str
+        url: str
+        daemon: bool
+        name: str
+        started: bool = False
+
+    scheduled: list[_ScheduledThread] = []
+
+    class _Thread:
+        def __init__(self, *, target, kwargs, daemon: bool, name: str) -> None:
+            scheduled.append(
+                _ScheduledThread(
+                    target_name=target.__name__,
+                    url=kwargs["url"],
+                    daemon=daemon,
+                    name=name,
+                )
+            )
+
+        def start(self) -> None:
+            scheduled[0].started = True
+
+    monkeypatch.setattr(product_analytics.threading, "Thread", _Thread)
+
+    product_analytics._send_product_analytics_payload(
+        "https://us.i.posthog.com/capture/",
+        {
+            "api_key": "phc_test",
+            "event": "cli_onboarding_setup_started",
+            "distinct_id": "install_123",
+            "properties": {"repo_location_kind": "explicit_path"},
+        },
+    )
+
+    assert scheduled == [
+        _ScheduledThread(
+            target_name="_post_product_analytics_payload",
+            url="https://us.i.posthog.com/capture/",
+            daemon=True,
+            name="potpie-product-analytics",
+            started=True,
+        )
+    ]

--- a/potpie/context-engine/tests/unit/test_product_analytics.py
+++ b/potpie/context-engine/tests/unit/test_product_analytics.py
@@ -214,3 +214,26 @@ def test_product_analytics_dispatcher_flushes_queued_events(monkeypatch) -> None
     assert thread_names == ["potpie-product-analytics", "potpie-product-analytics"]
     assert daemon_flags == [False, False]
     assert len(set(thread_ids)) == 1
+
+
+def test_product_analytics_dispatcher_flush_uses_bounded_drain(monkeypatch) -> None:
+    dispatcher = product_analytics._ProductAnalyticsDispatcher()
+    dispatcher._queue.put_nowait(
+        product_analytics._QueuedProductAnalyticsPayload(
+            url="https://us.i.posthog.com/capture/",
+            payload={
+                "api_key": "phc_test",
+                "event": "cli_onboarding_setup_completed",
+                "distinct_id": "install_123",
+                "properties": {},
+            },
+        )
+    )
+    monkeypatch.setattr(
+        dispatcher._queue,
+        "join",
+        lambda: (_ for _ in ()).throw(AssertionError("unbounded queue.join()")),
+    )
+    monkeypatch.setattr(product_analytics, "_DISPATCH_WORKER_JOIN_TIMEOUT_SECONDS", 0.0)
+
+    dispatcher.flush()

--- a/potpie/context-engine/tests/unit/test_product_analytics.py
+++ b/potpie/context-engine/tests/unit/test_product_analytics.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from adapters.inbound.cli.telemetry.context import TelemetryContext
+from adapters.inbound.cli.telemetry.product_analytics import (
+    ProductAnalyticsEvent,
+    ProductAnalyticsSettings,
+    PostHogSink,
+    capture_event,
+    configure_product_analytics,
+    set_product_analytics_sink,
+)
+from adapters.inbound.cli.telemetry.settings import load_product_analytics_settings
+
+
+@dataclass
+class _FakeSink:
+    events: list[ProductAnalyticsEvent] = field(default_factory=list)
+
+    def capture(self, event: ProductAnalyticsEvent) -> None:
+        self.events.append(event)
+
+
+def _telemetry_context() -> TelemetryContext:
+    return TelemetryContext(
+        anonymous_install_id="install_123",
+        invocation_id="invoke_456",
+        daemon_session_id="daemon_789",
+        environment="staging",
+        command="setup",
+        subcommand=None,
+        output_mode="json",
+        cli_version="0.1.0",
+        python_version="3.13.0",
+        os="darwin",
+        arch="arm64",
+    )
+
+
+def test_product_analytics_settings_require_api_key(monkeypatch) -> None:
+    monkeypatch.delenv("POTPIE_POSTHOG_API_KEY", raising=False)
+    monkeypatch.delenv("POTPIE_TELEMETRY_DISABLED", raising=False)
+
+    settings = load_product_analytics_settings()
+
+    assert settings.enabled is False
+    assert settings.api_key is None
+
+
+def test_product_analytics_settings_respect_kill_switch(monkeypatch) -> None:
+    monkeypatch.setenv("POTPIE_POSTHOG_API_KEY", "phc_test")
+    monkeypatch.setenv("POTPIE_TELEMETRY_DISABLED", "1")
+
+    settings = load_product_analytics_settings()
+
+    assert settings.enabled is False
+    assert settings.api_key == "phc_test"
+
+
+def test_capture_event_uses_existing_telemetry_identity(monkeypatch) -> None:
+    sink = _FakeSink()
+    set_product_analytics_sink(sink)
+    monkeypatch.setattr(
+        "adapters.inbound.cli.telemetry.product_analytics.current_telemetry_context",
+        _telemetry_context,
+    )
+
+    capture_event("cli_onboarding_setup_started", {"repo_provided": True})
+
+    assert len(sink.events) == 1
+    event = sink.events[0]
+    assert event.name == "cli_onboarding_setup_started"
+    assert event.distinct_id == "install_123"
+    assert event.properties["anonymous_install_id"] == "install_123"
+    assert event.properties["invocation_id"] == "invoke_456"
+    assert event.properties["daemon_session_id"] == "daemon_789"
+    assert event.properties["environment"] == "staging"
+    assert event.properties["repo_provided"] is True
+
+
+def test_capture_event_is_noop_without_telemetry_context(monkeypatch) -> None:
+    sink = _FakeSink()
+    set_product_analytics_sink(sink)
+    monkeypatch.setattr(
+        "adapters.inbound.cli.telemetry.product_analytics.current_telemetry_context",
+        lambda: None,
+    )
+
+    capture_event("cli_onboarding_setup_started", {"repo_provided": True})
+
+    assert sink.events == []
+
+
+def test_configure_product_analytics_uses_noop_when_disabled() -> None:
+    sink = _FakeSink()
+    set_product_analytics_sink(sink)
+
+    configure_product_analytics(
+        ProductAnalyticsSettings(
+            enabled=False, api_key=None, host="https://us.i.posthog.com"
+        )
+    )
+    capture_event("cli_onboarding_setup_started", {"repo_provided": True})
+
+    assert sink.events == []
+
+
+def test_posthog_sink_payload_excludes_secrets(monkeypatch) -> None:
+    @dataclass
+    class _PostCall:
+        url: str
+        payload: dict[str, object]
+
+    calls: list[_PostCall] = []
+
+    class _Client:
+        def __enter__(self) -> "_Client":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def post(self, url: str, *, json: dict[str, object]) -> None:
+            calls.append(_PostCall(url=url, payload=json))
+
+    monkeypatch.setattr(
+        "adapters.inbound.cli.telemetry.product_analytics.httpx.Client",
+        lambda **_kwargs: _Client(),
+    )
+    sink = PostHogSink(
+        ProductAnalyticsSettings(
+            enabled=True,
+            api_key="phc_test",
+            host="https://us.i.posthog.com",
+        )
+    )
+
+    sink.capture(
+        ProductAnalyticsEvent(
+            name="cli_onboarding_setup_started",
+            distinct_id="install_123",
+            properties={"repo_location_kind": "explicit_path"},
+        )
+    )
+
+    assert calls[0].url == "https://us.i.posthog.com/capture/"
+    payload = calls[0].payload
+    assert payload["api_key"] == "phc_test"
+    assert payload["event"] == "cli_onboarding_setup_started"
+    assert payload["distinct_id"] == "install_123"
+    properties = payload["properties"]
+    assert isinstance(properties, dict)
+    assert properties == {"repo_location_kind": "explicit_path"}

--- a/potpie/context-engine/tests/unit/test_product_analytics.py
+++ b/potpie/context-engine/tests/unit/test_product_analytics.py
@@ -157,49 +157,60 @@ def test_posthog_sink_payload_excludes_secrets(monkeypatch) -> None:
     assert properties == {"repo_location_kind": "explicit_path"}
 
 
-def test_posthog_sink_schedules_delivery_in_background(monkeypatch) -> None:
-    @dataclass
-    class _ScheduledThread:
-        target_name: str
-        url: str
-        daemon: bool
-        name: str
-        started: bool = False
+def test_product_analytics_dispatcher_flushes_queued_events(monkeypatch) -> None:
+    calls: list[tuple[str, str]] = []
+    thread_names: list[str] = []
+    daemon_flags: list[bool] = []
+    thread_ids: list[int | None] = []
+    release_worker = product_analytics.threading.Event()
 
-    scheduled: list[_ScheduledThread] = []
+    def _post(
+        *,
+        url: str,
+        payload: dict[str, str | dict[str, str]],
+    ) -> None:
+        worker_thread = product_analytics.threading.current_thread()
+        thread_names.append(worker_thread.name)
+        daemon_flags.append(worker_thread.daemon)
+        thread_ids.append(worker_thread.ident)
+        calls.append((url, str(payload["event"])))
+        if len(calls) == 1:
+            release_worker.wait(timeout=1.0)
 
-    class _Thread:
-        def __init__(self, *, target, kwargs, daemon: bool, name: str) -> None:
-            scheduled.append(
-                _ScheduledThread(
-                    target_name=target.__name__,
-                    url=kwargs["url"],
-                    daemon=daemon,
-                    name=name,
-                )
-            )
-
-        def start(self) -> None:
-            scheduled[0].started = True
-
-    monkeypatch.setattr(product_analytics.threading, "Thread", _Thread)
+    monkeypatch.setattr(product_analytics, "_post_product_analytics_payload", _post)
 
     product_analytics._send_product_analytics_payload(
         "https://us.i.posthog.com/capture/",
         {
             "api_key": "phc_test",
-            "event": "cli_onboarding_setup_started",
+            "event": "cli_onboarding_setup_completed",
             "distinct_id": "install_123",
             "properties": {"repo_location_kind": "explicit_path"},
         },
     )
+    product_analytics._send_product_analytics_payload(
+        "https://us.i.posthog.com/capture/",
+        {
+            "api_key": "phc_test",
+            "event": "cli_onboarding_integration_auth_failed",
+            "distinct_id": "install_123",
+            "properties": {"provider": "github"},
+        },
+    )
+    release_worker.set()
 
-    assert scheduled == [
-        _ScheduledThread(
-            target_name="_post_product_analytics_payload",
-            url="https://us.i.posthog.com/capture/",
-            daemon=True,
-            name="potpie-product-analytics",
-            started=True,
-        )
+    product_analytics._flush_product_analytics_dispatcher()
+
+    assert calls == [
+        (
+            "https://us.i.posthog.com/capture/",
+            "cli_onboarding_setup_completed",
+        ),
+        (
+            "https://us.i.posthog.com/capture/",
+            "cli_onboarding_integration_auth_failed",
+        ),
     ]
+    assert thread_names == ["potpie-product-analytics", "potpie-product-analytics"]
+    assert daemon_flags == [False, False]
+    assert len(set(thread_ids)) == 1

--- a/potpie/context-engine/tests/unit/test_sentry_runtime.py
+++ b/potpie/context-engine/tests/unit/test_sentry_runtime.py
@@ -103,6 +103,7 @@ def test_capture_unexpected_cli_error_sets_allowlisted_scope(monkeypatch) -> Non
         anonymous_install_id="install_123",
         invocation_id="invoke_456",
         daemon_session_id="daemon_789",
+        environment="staging",
         command="daemon",
         subcommand="status",
         output_mode="json",

--- a/potpie/context-engine/tests/unit/test_telemetry_context.py
+++ b/potpie/context-engine/tests/unit/test_telemetry_context.py
@@ -13,6 +13,7 @@ def test_cli_invocations_share_install_and_daemon_session_ids(
     tmp_path,
 ) -> None:
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("POTPIE_SENTRY_ENVIRONMENT", "staging")
     monkeypatch.delenv("SENTRY_DSN", raising=False)
     monkeypatch.delenv("POTPIE_SENTRY_DSN", raising=False)
     runner = CliRunner()
@@ -31,6 +32,8 @@ def test_cli_invocations_share_install_and_daemon_session_ids(
     assert first_ctx.daemon_session_id == second_ctx.daemon_session_id
     assert first_ctx.command == "daemon"
     assert first_ctx.subcommand is None
+    assert first_ctx.environment == "staging"
+    assert first_ctx.analytics_properties()["environment"] == "staging"
     assert first_ctx.output_mode == "json"
     assert (
         load_or_create_identity().anonymous_install_id == first_ctx.anonymous_install_id

--- a/potpie/context-engine/tests/unit/test_telemetry_settings.py
+++ b/potpie/context-engine/tests/unit/test_telemetry_settings.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from adapters.inbound.cli.telemetry.settings import load_sentry_settings
+from adapters.inbound.cli.telemetry.settings import (
+    load_sentry_settings,
+    telemetry_environment,
+)
 
 
 def test_sentry_settings_disabled_without_dsn(monkeypatch) -> None:
@@ -47,6 +50,7 @@ def test_potpie_sentry_env_wins_over_generic_sentry_env(monkeypatch) -> None:
     assert settings.enabled is True
     assert settings.dsn == "https://potpie@example.invalid/1"
     assert settings.environment == "staging"
+    assert telemetry_environment() == "staging"
     assert settings.release == "potpie-cli@test"
     assert settings.dist == "cli-dist"
 


### PR DESCRIPTION
## Summary
- Adds PostHog-compatible product analytics for CLI onboarding flows.
- Instruments setup, auth, integration login, source binding, skill install, and activation events with privacy-safe payloads.
- Keeps the PR branch clean by replaying only the PostHog implementation commit on top of current `origin/main`.

## Validation
- `uv run pytest tests/unit/test_onboarding_analytics.py tests/unit/test_product_analytics.py tests/unit/test_telemetry_context.py tests/unit/test_telemetry_settings.py tests/unit/test_sentry_runtime.py tests/unit/test_setup_defer_pot.py`