### PR TITLE
feat: add Sentry metrics instrumentation

### DIFF
--- a/potpie/context-engine/adapters/inbound/cli/commands/_common.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/_common.py
@@ -15,8 +15,9 @@ This module owns the cross-cutting concerns so the command bodies stay thin:
 from __future__ import annotations
 
 import json
+import time
 from contextlib import contextmanager
-from typing import Any, Iterator
+from typing import Any, Final, Iterator
 
 import typer
 
@@ -35,6 +36,18 @@ EXIT_DEGRADED = 3
 EXIT_AUTH = 4
 
 _state: dict[str, Any] = {"json": False, "verbose": False, "host": None, "store": None}
+_CLI_METRIC_ATTRIBUTE_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "arch",
+        "cli_version",
+        "command",
+        "error_code",
+        "os",
+        "output_mode",
+        "result",
+        "subcommand",
+    }
+)
 
 
 def set_json(value: bool) -> None:
@@ -137,9 +150,14 @@ def contract() -> Iterator[None]:
     No command should leak a traceback; an unbuilt capability returns the
     structured not-implemented contract (exit 2) rather than crashing.
     """
+    start = time.perf_counter()
+    result = "ok"
+    error_code = "none"
     try:
         yield
     except CapabilityNotImplemented as exc:
+        result = "not_implemented"
+        error_code = "not_implemented"
         fail(
             code="not_implemented",
             message=str(exc),
@@ -148,6 +166,8 @@ def contract() -> Iterator[None]:
             exit_code=EXIT_UNAVAILABLE,
         )
     except ContextEngineDisabled as exc:
+        result = "unavailable"
+        error_code = "unavailable"
         fail(
             code="unavailable",
             message=str(exc),
@@ -155,6 +175,8 @@ def contract() -> Iterator[None]:
             exit_code=EXIT_UNAVAILABLE,
         )
     except PotNotFound as exc:
+        result = "pot_not_found"
+        error_code = "pot_not_found"
         fail(
             code="pot_not_found",
             message=str(exc),
@@ -162,10 +184,16 @@ def contract() -> Iterator[None]:
             exit_code=EXIT_VALIDATION,
         )
     except ValueError as exc:
+        result = "validation_error"
+        error_code = "validation_error"
         fail(code="validation_error", message=str(exc), exit_code=EXIT_VALIDATION)
     except typer.Exit:
+        result = "exit"
+        error_code = "exit"
         raise
     except Exception as exc:  # noqa: BLE001
+        result = "unexpected"
+        error_code = "unexpected_cli_error"
         from adapters.inbound.cli.telemetry.sentry_runtime import (
             capture_unexpected_cli_error,
         )
@@ -180,6 +208,62 @@ def contract() -> Iterator[None]:
             message="Unexpected internal error.",
             exit_code=EXIT_VALIDATION,
         )
+    finally:
+        _record_cli_contract_metrics(
+            started_at=start,
+            result=result,
+            error_code=error_code,
+        )
+
+
+def _record_cli_contract_metrics(
+    *,
+    started_at: float,
+    result: str,
+    error_code: str,
+) -> None:
+    from bootstrap import sentry_metrics_runtime
+
+    attributes = _cli_metric_attributes(result=result, error_code=error_code)
+    duration_ms = max((time.perf_counter() - started_at) * 1000.0, 0.0)
+    try:
+        sentry_metrics_runtime.count(
+            "ce.cli.invocations_total",
+            attributes=attributes,
+        )
+        sentry_metrics_runtime.distribution(
+            "ce.cli.duration_ms",
+            duration_ms,
+            unit="millisecond",
+            attributes=attributes,
+        )
+    except Exception:  # noqa: BLE001
+        pass
+    finally:
+        try:
+            sentry_metrics_runtime.flush(timeout=2.0)
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def _cli_metric_attributes(
+    *,
+    result: str,
+    error_code: str,
+) -> dict[str, str | int | float | bool]:
+    from adapters.inbound.cli.telemetry.context import current_telemetry_context
+
+    telemetry = current_telemetry_context()
+    attributes: dict[str, str | int | float | bool] = {
+        "error_code": error_code,
+        "result": result,
+    }
+    if telemetry is None:
+        return attributes
+    for key, value in telemetry.fields().items():
+        if key in _CLI_METRIC_ATTRIBUTE_KEYS:
+            attributes[key] = value
+    return attributes
 
 
 def resolve_pot_id(host: Any, explicit: str | None = None) -> str:

--- a/potpie/context-engine/adapters/inbound/cli/commands/bootstrap.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/bootstrap.py
@@ -17,8 +17,9 @@ from adapters.inbound.cli.commands._common import (
     is_json,
     resolve_pot_id,
 )
+from bootstrap import sentry_metrics_runtime
 from domain.errors import CapabilityNotImplemented
-from domain.lifecycle import SetupPlan
+from domain.lifecycle import SetupPlan, SetupReport
 from domain.ports.agent_context import StatusRequest
 
 
@@ -77,9 +78,16 @@ def register(root: typer.Typer) -> None:
             if dry_run:
                 preview = host.setup.preview(plan)
                 emit(preview.to_dict(), human=_preview_human(preview))
+                _emit_setup_run_metric(plan, result="dry_run", dry_run=True)
                 return
 
             report = host.setup.run(plan)
+            _emit_setup_run_metric(
+                report.plan,
+                result="ok" if report.ok else "degraded",
+                dry_run=False,
+            )
+            _emit_setup_step_metrics(report)
 
             # Animated wizard for interactive TTYs; --json and --yes/non-interactive
             # fall through to the plain, machine-readable emit path.
@@ -132,7 +140,9 @@ def register(root: typer.Typer) -> None:
         ),
     ) -> None:
         """Integration auth status by default; use --host for daemon/pot readiness."""
-        host_status = host or pot is not None or intent != "feature" or harness != "claude"
+        host_status = (
+            host or pot is not None or intent != "feature" or harness != "claude"
+        )
         if not host_status:
             from adapters.inbound.cli.auth.auth_commands import integration_status
 
@@ -296,6 +306,31 @@ def _status_human(report) -> str:
     if report.recommended_next_action:
         lines.append(f"  next: {report.recommended_next_action}")
     return "\n".join(lines)
+
+
+def _emit_setup_run_metric(plan: SetupPlan, *, result: str, dry_run: bool) -> None:
+    sentry_metrics_runtime.count(
+        "ce.setup.runs_total",
+        attributes={
+            "result": result,
+            "backend": plan.backend,
+            "host_mode": plan.host_mode,
+            "scan": plan.scan,
+            "dry_run": dry_run,
+        },
+    )
+
+
+def _emit_setup_step_metrics(report: SetupReport) -> None:
+    for step in report.steps:
+        sentry_metrics_runtime.count(
+            "ce.setup.step_total",
+            attributes={
+                "step": step.step,
+                "state": step.state,
+                "hard": step.hard,
+            },
+        )
 
 
 __all__ = ["register"]

--- a/potpie/context-engine/adapters/inbound/cli/host_cli.py
+++ b/potpie/context-engine/adapters/inbound/cli/host_cli.py
@@ -51,9 +51,12 @@ def build_app() -> typer.Typer:
         from adapters.inbound.cli.telemetry.context import bind_telemetry_context
         from adapters.inbound.cli.telemetry.sentry_runtime import configure_cli_sentry
         from adapters.inbound.cli.telemetry.settings import load_sentry_settings
+        from bootstrap.sentry_metrics_runtime import configure_metrics
 
         bind_telemetry_context(ctx, json_output=json_)
-        configure_cli_sentry(load_sentry_settings())
+        settings = load_sentry_settings()
+        configure_cli_sentry(settings)
+        configure_metrics(settings)
 
     # Top-level commands (the four-tool surface + bootstrap + auth/login).
     query_cmds.register(app)

--- a/potpie/context-engine/adapters/inbound/cli/telemetry/sentry_runtime.py
+++ b/potpie/context-engine/adapters/inbound/cli/telemetry/sentry_runtime.py
@@ -4,13 +4,11 @@ import importlib
 from types import ModuleType
 from typing import Protocol
 
+from bootstrap.sentry_metrics_runtime import configure_metrics, metrics_configured
+
 from .context import (
     TelemetryContext,
     current_telemetry_context,
-)
-from .sentry_privacy import (
-    scrub_sentry_breadcrumb,
-    scrub_sentry_event,
 )
 from .settings import SentrySettings
 
@@ -25,24 +23,10 @@ class _SentryScope(Protocol):
 
 def configure_cli_sentry(settings: SentrySettings) -> None:
     global _configured
-    if not settings.enabled or settings.dsn is None or _configured:
+    if _configured:
         return
-    try:
-        sentry_sdk = _load_sentry_sdk()
-        sentry_sdk.init(
-            dsn=settings.dsn,
-            environment=settings.environment,
-            release=settings.release,
-            dist=settings.dist,
-            send_default_pii=False,
-            include_local_variables=False,
-            max_request_body_size="never",
-            before_send=scrub_sentry_event,
-            before_breadcrumb=scrub_sentry_breadcrumb,
-        )
-        _configured = True
-    except Exception:  # noqa: BLE001
-        return
+    configure_metrics(settings)
+    _configured = metrics_configured()
 
 
 def capture_unexpected_cli_error(

--- a/potpie/context-engine/adapters/inbound/cli/telemetry/settings.py
+++ b/potpie/context-engine/adapters/inbound/cli/telemetry/settings.py
@@ -1,68 +1,9 @@
 from __future__ import annotations
 
-import os
-from dataclasses import dataclass
-from importlib import metadata
-from typing import ClassVar, Final
+from bootstrap.sentry_settings import (
+    SentrySettings,
+    default_cli_release,
+    load_sentry_settings,
+)
 
-_FALSE_VALUES: Final[frozenset[str]] = frozenset({"0", "false", "no", "off"})
-
-
-@dataclass(frozen=True)
-class SentrySettings:
-    __slots__: ClassVar[tuple[str, ...]] = (
-        "dist",
-        "dsn",
-        "enabled",
-        "environment",
-        "release",
-    )
-
-    enabled: bool
-    dsn: str | None
-    environment: str
-    release: str
-    dist: str | None
-
-
-def load_sentry_settings() -> SentrySettings:
-    dsn = _env("POTPIE_SENTRY_DSN") or _env("SENTRY_DSN")
-    telemetry_disabled = _is_truthy_flag("POTPIE_TELEMETRY_DISABLED")
-    sentry_disabled = _is_falsey_flag("POTPIE_SENTRY_ENABLED")
-    return SentrySettings(
-        enabled=dsn is not None and not telemetry_disabled and not sentry_disabled,
-        dsn=dsn,
-        environment=(
-            _env("POTPIE_SENTRY_ENVIRONMENT") or _env("SENTRY_ENVIRONMENT") or "dev"
-        ),
-        release=_env("POTPIE_SENTRY_RELEASE")
-        or _env("SENTRY_RELEASE")
-        or default_cli_release(),
-        dist=_env("POTPIE_SENTRY_DIST") or _env("SENTRY_DIST"),
-    )
-
-
-def default_cli_release() -> str:
-    try:
-        version = metadata.version("potpie-context-engine")
-    except metadata.PackageNotFoundError:
-        version = "0.1.0"
-    return f"potpie-cli@{version}"
-
-
-def _env(name: str) -> str | None:
-    value = os.getenv(name)
-    if value is None:
-        return None
-    stripped = value.strip()
-    return stripped or None
-
-
-def _is_falsey_flag(name: str) -> bool:
-    value = os.getenv(name)
-    return value is not None and value.strip().lower() in _FALSE_VALUES
-
-
-def _is_truthy_flag(name: str) -> bool:
-    value = os.getenv(name)
-    return value is not None and value.strip().lower() not in _FALSE_VALUES
+__all__ = ["SentrySettings", "default_cli_release", "load_sentry_settings"]

--- a/potpie/context-engine/adapters/outbound/reconciliation/pydantic_deep_agent.py
+++ b/potpie/context-engine/adapters/outbound/reconciliation/pydantic_deep_agent.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
+from bootstrap import sentry_metrics_runtime
 from domain.context_events import ContextEvent, EventRef
 from domain.event_playbooks import (
     EventPlaybook,
@@ -929,6 +930,11 @@ class PydanticDeepReconciliationAgent:
                 )
             except Exception:  # noqa: BLE001 — never break failure handling
                 pass
+            sentry_metrics_runtime.count(
+                "ce.agent.timeout_total",
+                1,
+                attributes={"result": "timeout"},
+            )
             logger.error(
                 "agent.run() timed out after %.0fs for batch %s",
                 run_timeout,

--- a/potpie/context-engine/application/services/ingestion_submission_service.py
+++ b/potpie/context-engine/application/services/ingestion_submission_service.py
@@ -14,6 +14,7 @@ from uuid import uuid4
 
 from application.services.event_admission import admit_event
 from application.services.ingestion_wait import wait_for_terminal_ingestion_event
+from bootstrap import sentry_metrics_runtime
 from bootstrap.observability_context import bind_correlation, correlation_scope
 from bootstrap.observability_runtime import get_observability
 from domain.ports.observability import SPAN_KIND_SERVER
@@ -202,10 +203,18 @@ class DefaultIngestionSubmissionService(IngestionSubmissionService):
                     exc_info=True,
                 )
             obs.counter("ce.ingest.events_total", 1, attributes=metric_attrs)
+            sentry_metrics_runtime.count(
+                "ce.ingest.events_total",
+                attributes={"result": "inserted"},
+            )
             if outcome.batch_id:
                 bind_correlation(batch_id=outcome.batch_id)
         else:
             obs.counter("ce.ingest.dedup_total", 1, attributes=metric_attrs)
+            sentry_metrics_runtime.count(
+                "ce.ingest.dedup_total",
+                attributes={"result": "duplicate"},
+            )
 
         if not outcome.inserted:
             ev = self._events.get_event(outcome.event_id)

--- a/potpie/context-engine/application/use_cases/context_graph_jobs.py
+++ b/potpie/context-engine/application/use_cases/context_graph_jobs.py
@@ -19,6 +19,7 @@ from typing import Any
 from sqlalchemy.orm import Session
 
 from application.use_cases.process_batch import process_batch
+from bootstrap import sentry_metrics_runtime
 from bootstrap.ingestion_server import IngestionServerContainer
 from bootstrap.observability_context import correlation_scope
 from bootstrap.observability_runtime import get_observability
@@ -58,10 +59,20 @@ def handle_process_batch(
     """
     container = build_ingestion_server(db)
     if container.reconciliation_agent is None:
+        sentry_metrics_runtime.count(
+            "ce.batch.finished_total",
+            1,
+            attributes={"result": "skipped_no_reconciliation_agent"},
+        )
         return {"status": "skipped", "reason": "no_reconciliation_agent"}
     batches_repo = container.batch_repository(db)
     batch = batches_repo.claim_batch_by_id(batch_id)
     if batch is None:
+        sentry_metrics_runtime.count(
+            "ce.batch.finished_total",
+            1,
+            attributes={"result": "skipped_not_pending"},
+        )
         return {"status": "skipped", "reason": "not_pending", "batch_id": batch_id}
 
     reco_ledger = container.reconciliation_ledger(db)
@@ -79,6 +90,11 @@ def handle_process_batch(
             obs.counter(
                 "ce.batch.started_total", 1, attributes={"pot_id": batch.pot_id}
             )
+            sentry_metrics_runtime.count(
+                "ce.batch.started_total",
+                1,
+                attributes={"result": "started"},
+            )
             # Time-in-pending: the windowed-5min canary. If the flusher
             # wedges, this is what screams before anything else.
             try:
@@ -90,6 +106,12 @@ def handle_process_batch(
                         "ce.batch.time_in_pending_ms",
                         wait_ms,
                         attributes={"pot_id": batch.pot_id},
+                    )
+                    sentry_metrics_runtime.distribution(
+                        "ce.batch.time_in_pending_ms",
+                        wait_ms,
+                        unit="millisecond",
+                        attributes={"result": "started"},
                     )
             except Exception:  # noqa: BLE001 — best-effort metric
                 pass
@@ -118,6 +140,11 @@ def handle_process_batch(
                     "pot_id": batch.pot_id,
                     "result": "ok" if outcome.ok else "failed",
                 },
+            )
+            sentry_metrics_runtime.count(
+                "ce.batch.finished_total",
+                1,
+                attributes={"result": "ok" if outcome.ok else "failed"},
             )
     return {
         "status": "ok" if outcome.ok else "failed",

--- a/potpie/context-engine/application/use_cases/process_batch.py
+++ b/potpie/context-engine/application/use_cases/process_batch.py
@@ -24,6 +24,7 @@ from application.services.agent_work_events import (
     WorkEventRecord,
     build_work_events,
 )
+from bootstrap import sentry_metrics_runtime
 from bootstrap.observability_context import correlation_scope
 from bootstrap.observability_runtime import get_observability
 from domain.actor import SYSTEM_ACTOR
@@ -402,9 +403,19 @@ def process_batch(
                 float(chunk_outcome.tool_call_count),
                 attributes={"pot_id": batch.pot_id},
             )
+            sentry_metrics_runtime.distribution(
+                "ce.agent.tool_calls",
+                float(chunk_outcome.tool_call_count),
+                attributes={"result": "ok" if chunk_outcome.ok else "failed"},
+            )
         except Exception as exc:
             logger.exception(
                 "batch %s chunk %d/%d agent run failed", batch.id, idx, chunks_total
+            )
+            sentry_metrics_runtime.distribution(
+                "ce.agent.tool_calls",
+                0,
+                attributes={"result": "failed"},
             )
             failure_outcome = BatchAgentOutcome(ok=False, error=str(exc))
             # The crashed agent may have streamed records up to its last
@@ -491,6 +502,11 @@ def process_batch(
             len(completed),
             attributes={"pot_id": batch.pot_id},
         )
+        sentry_metrics_runtime.count(
+            "ce.events.reconciled_total",
+            len(completed),
+            attributes={"result": "reconciled"},
+        )
         return ProcessBatchOutcome(
             batch_id=batch.id,
             ok=True,
@@ -528,10 +544,20 @@ def process_batch(
             len(aggregated_completed),
             attributes={"pot_id": batch.pot_id},
         )
+        sentry_metrics_runtime.count(
+            "ce.events.reconciled_total",
+            len(aggregated_completed),
+            attributes={"result": "reconciled"},
+        )
     _obs_fin.counter(
         "ce.events.failed_total",
         len(failed_event_ids),
         attributes={"pot_id": batch.pot_id},
+    )
+    sentry_metrics_runtime.count(
+        "ce.events.failed_total",
+        len(failed_event_ids),
+        attributes={"result": "failed"},
     )
     _safe_publish_status(
         stream,

--- a/potpie/context-engine/application/use_cases/reap_stale_batches.py
+++ b/potpie/context-engine/application/use_cases/reap_stale_batches.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
+from bootstrap import sentry_metrics_runtime
 from domain.ports.batch_repository import BatchRepositoryPort
 from domain.ports.reconciliation_ledger import ReconciliationLedgerPort
 
@@ -89,6 +90,14 @@ def reap_stale_batches(
                     "ce.batch.reaped_total",
                     1,
                     attributes={"pot_id": batch.pot_id},
+                )
+            except Exception:  # noqa: BLE001 — never break the reaper
+                pass
+            try:
+                sentry_metrics_runtime.count(
+                    "ce.batch.reaped_total",
+                    1,
+                    attributes={"result": "reaped"},
                 )
             except Exception:  # noqa: BLE001 — never break the reaper
                 pass

--- a/potpie/context-engine/bootstrap/ingestion_server.py
+++ b/potpie/context-engine/bootstrap/ingestion_server.py
@@ -54,6 +54,8 @@ from adapters.outbound.postgres.reconciliation_ledger import (
 )
 from adapters.outbound.settings_env import EnvContextEngineSettings
 from application.services.source_connector_registry import SourceConnectorRegistry
+from bootstrap.sentry_metrics_runtime import configure_metrics
+from bootstrap.sentry_settings import load_sentry_settings
 from domain.ports.event_query_service import EventQueryService
 from domain.ports.event_stream import (
     EventStreamPublisherPort,
@@ -201,6 +203,7 @@ def build_ingestion_server(
     event_stream_publisher: EventStreamPublisherPort | None = None,
 ) -> IngestionServerContainer:
     s = settings or EnvContextEngineSettings()
+    configure_metrics(load_sentry_settings())
     telemetry_sink = telemetry or _default_telemetry()
     observability_sink = observability or _default_observability()
     # Publish to the process-global accessor so middleware / the Celery

--- a/potpie/context-engine/bootstrap/sentry_metrics_runtime.py
+++ b/potpie/context-engine/bootstrap/sentry_metrics_runtime.py
@@ -193,6 +193,7 @@ def _is_path_like(value: str) -> bool:
         value.startswith("/")
         or value.startswith("./")
         or value.startswith("../")
+        or "/" in value
         or "\\" in value
     )
 

--- a/potpie/context-engine/bootstrap/sentry_metrics_runtime.py
+++ b/potpie/context-engine/bootstrap/sentry_metrics_runtime.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import importlib
+from collections.abc import Callable, Mapping, Sequence
+from types import ModuleType
+from typing import Final, Optional, Union
+
+from adapters.inbound.cli.telemetry.sentry_privacy import (
+    scrub_sentry_breadcrumb,
+    scrub_sentry_event,
+)
+from bootstrap.sentry_settings import SentrySettings
+
+_ALLOWED_ATTRIBUTE_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "arch",
+        "backend",
+        "cli_version",
+        "command",
+        "dry_run",
+        "error_code",
+        "hard",
+        "host_mode",
+        "os",
+        "output_mode",
+        "result",
+        "scan",
+        "state",
+        "step",
+        "subcommand",
+    },
+)
+
+_configured = False
+_enabled = False
+_sentry_sdk: ModuleType | None = None
+
+_MetricValue = Union[int, float]
+_SafeMetricAttribute = Union[str, int, float, bool]
+_MetricAttribute = Union[str, int, float, bool, Sequence[str], Mapping[str, str], None]
+_MetricAttributes = Mapping[str, _MetricAttribute]
+_MetricTags = dict[str, _SafeMetricAttribute]
+_SentryInit = Callable[..., object]
+_SentryMetric = Callable[..., object]
+_SentryFlush = Callable[..., object]
+
+
+def configure_metrics(settings: SentrySettings) -> None:
+    global _configured, _enabled, _sentry_sdk
+    if _configured:
+        return
+    if not settings.enabled or settings.dsn is None:
+        _enabled = False
+        return
+    sentry_sdk = _load_sentry_sdk()
+    if sentry_sdk is None:
+        _enabled = False
+        return
+    try:
+        sentry_init = _get_sentry_init(sentry_sdk)
+        if sentry_init is None:
+            _enabled = False
+            return
+        _ = sentry_init(
+            dsn=settings.dsn,
+            environment=settings.environment,
+            release=settings.release,
+            dist=settings.dist,
+            send_default_pii=False,
+            include_local_variables=False,
+            max_request_body_size="never",
+            before_send=scrub_sentry_event,
+            before_breadcrumb=scrub_sentry_breadcrumb,
+        )
+        _sentry_sdk = sentry_sdk
+        _configured = True
+        _enabled = True
+    # Sentry SDK failures must never affect context-engine control flow.
+    except Exception:  # noqa: BLE001
+        _enabled = False
+
+
+def metrics_configured() -> bool:
+    return _configured
+
+
+def count(
+    name: str,
+    value: _MetricValue = 1,
+    *,
+    unit: Optional[str] = None,
+    attributes: Optional[_MetricAttributes] = None,
+) -> None:
+    if not _enabled or _sentry_sdk is None:
+        return
+    safe_attributes = _safe_attributes(attributes)
+    try:
+        metric = _get_metric(_sentry_sdk, "count")
+        if metric is not None:
+            _ = metric(name, value, unit, attributes=safe_attributes)
+    # Sentry SDK failures must never affect context-engine control flow.
+    except Exception:  # noqa: BLE001
+        return
+
+
+def distribution(
+    name: str,
+    value: _MetricValue,
+    *,
+    unit: Optional[str] = None,
+    attributes: Optional[_MetricAttributes] = None,
+) -> None:
+    if not _enabled or _sentry_sdk is None:
+        return
+    safe_attributes = _safe_attributes(attributes)
+    try:
+        metric = _get_metric(_sentry_sdk, "distribution")
+        if metric is not None:
+            _ = metric(name, value, unit, attributes=safe_attributes)
+    # Sentry SDK failures must never affect context-engine control flow.
+    except Exception:  # noqa: BLE001
+        return
+
+
+def gauge(
+    name: str,
+    value: _MetricValue,
+    *,
+    unit: Optional[str] = None,
+    attributes: Optional[_MetricAttributes] = None,
+) -> None:
+    if not _enabled or _sentry_sdk is None:
+        return
+    safe_attributes = _safe_attributes(attributes)
+    try:
+        metric = _get_metric(_sentry_sdk, "gauge")
+        if metric is not None:
+            _ = metric(name, value, unit, attributes=safe_attributes)
+    # Sentry SDK failures must never affect context-engine control flow.
+    except Exception:  # noqa: BLE001
+        return
+
+
+def flush(timeout: float = 2.0) -> None:
+    if not _enabled or _sentry_sdk is None:
+        return
+    try:
+        sentry_flush = _get_sentry_flush(_sentry_sdk)
+        if sentry_flush is not None:
+            _ = sentry_flush(timeout=timeout)
+    # Sentry SDK failures must never affect context-engine control flow.
+    except Exception:  # noqa: BLE001
+        return
+
+
+def _load_sentry_sdk() -> ModuleType | None:
+    try:
+        return importlib.import_module("sentry_sdk")
+    # Importing the external SDK can run package code outside this project.
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _safe_attributes(
+    attributes: Optional[_MetricAttributes],
+) -> Optional[_MetricTags]:
+    if attributes is None:
+        return None
+    safe: _MetricTags = {}
+    for key, value in attributes.items():
+        if key not in _ALLOWED_ATTRIBUTE_KEYS:
+            continue
+        safe_value = _safe_attribute_value(value)
+        if safe_value is not None:
+            safe[key] = safe_value
+    return safe or None
+
+
+def _safe_attribute_value(
+    value: _MetricAttribute,
+) -> Optional[_SafeMetricAttribute]:
+    if isinstance(value, str):
+        if _is_path_like(value):
+            return None
+        return value
+    if isinstance(value, (bool, int, float)):
+        return value
+    return None
+
+
+def _is_path_like(value: str) -> bool:
+    return (
+        value.startswith("/")
+        or value.startswith("./")
+        or value.startswith("../")
+        or "\\" in value
+    )
+
+
+def _get_sentry_init(sentry_sdk: ModuleType) -> Optional[_SentryInit]:
+    sentry_init = getattr(sentry_sdk, "init", None)
+    if callable(sentry_init):
+        return sentry_init
+    return None
+
+
+def _get_sentry_flush(sentry_sdk: ModuleType) -> Optional[_SentryFlush]:
+    sentry_flush = getattr(sentry_sdk, "flush", None)
+    if callable(sentry_flush):
+        return sentry_flush
+    return None
+
+
+def _get_metric(
+    sentry_sdk: ModuleType,
+    metric_name: str,
+) -> Optional[_SentryMetric]:
+    sentry_metrics = getattr(sentry_sdk, "metrics", None)
+    metric = getattr(sentry_metrics, metric_name, None)
+    if callable(metric):
+        return metric
+    return None

--- a/potpie/context-engine/bootstrap/sentry_settings.py
+++ b/potpie/context-engine/bootstrap/sentry_settings.py
@@ -65,4 +65,7 @@ def _is_falsey_flag(name: str) -> bool:
 
 def _is_truthy_flag(name: str) -> bool:
     value = os.getenv(name)
-    return value is not None and value.strip().lower() not in _FALSE_VALUES
+    if value is None:
+        return False
+    normalized = value.strip().lower()
+    return normalized != "" and normalized not in _FALSE_VALUES

--- a/potpie/context-engine/bootstrap/sentry_settings.py
+++ b/potpie/context-engine/bootstrap/sentry_settings.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from importlib import metadata
+from typing import ClassVar, Final
+
+_FALSE_VALUES: Final[frozenset[str]] = frozenset({"0", "false", "no", "off"})
+
+
+@dataclass(frozen=True)
+class SentrySettings:
+    __slots__: ClassVar[tuple[str, ...]] = (
+        "dist",
+        "dsn",
+        "enabled",
+        "environment",
+        "release",
+    )
+
+    enabled: bool
+    dsn: str | None
+    environment: str
+    release: str
+    dist: str | None
+
+
+def load_sentry_settings() -> SentrySettings:
+    dsn = _env("POTPIE_SENTRY_DSN") or _env("SENTRY_DSN")
+    telemetry_disabled = _is_truthy_flag("POTPIE_TELEMETRY_DISABLED")
+    sentry_disabled = _is_falsey_flag("POTPIE_SENTRY_ENABLED")
+    return SentrySettings(
+        enabled=dsn is not None and not telemetry_disabled and not sentry_disabled,
+        dsn=dsn,
+        environment=(
+            _env("POTPIE_SENTRY_ENVIRONMENT") or _env("SENTRY_ENVIRONMENT") or "dev"
+        ),
+        release=_env("POTPIE_SENTRY_RELEASE")
+        or _env("SENTRY_RELEASE")
+        or default_cli_release(),
+        dist=_env("POTPIE_SENTRY_DIST") or _env("SENTRY_DIST"),
+    )
+
+
+def default_cli_release() -> str:
+    try:
+        version = metadata.version("potpie-context-engine")
+    except metadata.PackageNotFoundError:
+        version = "0.1.0"
+    return f"potpie-cli@{version}"
+
+
+def _env(name: str) -> str | None:
+    value = os.getenv(name)
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _is_falsey_flag(name: str) -> bool:
+    value = os.getenv(name)
+    return value is not None and value.strip().lower() in _FALSE_VALUES
+
+
+def _is_truthy_flag(name: str) -> bool:
+    value = os.getenv(name)
+    return value is not None and value.strip().lower() not in _FALSE_VALUES

--- a/potpie/context-engine/tests/unit/test_cli_bootstrap_status.py
+++ b/potpie/context-engine/tests/unit/test_cli_bootstrap_status.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Union
 from unittest.mock import MagicMock
 
 import pytest
@@ -9,9 +11,30 @@ from typer.testing import CliRunner
 
 from adapters.inbound.cli import host_cli as cli_main
 from adapters.inbound.cli.commands import bootstrap
+from adapters.inbound.cli.commands._common import EXIT_DEGRADED
 from domain.ports.agent_context import StatusReport, StatusRequest
+from domain.lifecycle import DONE, FAILED, SetupPlan, SetupReport, StepResult
 
 runner = CliRunner()
+
+
+@dataclass(frozen=True)
+class _MetricCall:
+    name: str
+    attributes: dict[str, Union[str, bool]]
+
+
+class _FakeSetupMetrics:
+    def __init__(self) -> None:
+        self.calls: list[_MetricCall] = []
+
+    def count(
+        self,
+        name: str,
+        *,
+        attributes: dict[str, Union[str, bool]] | None = None,
+    ) -> None:
+        self.calls.append(_MetricCall(name, {} if attributes is None else attributes))
 
 
 def test_status_host_path_emits_report(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -28,7 +51,9 @@ def test_status_host_path_emits_report(monkeypatch: pytest.MonkeyPatch) -> None:
     mock_host.agent_context.status.return_value = report
 
     monkeypatch.setattr(bootstrap, "get_host", lambda: mock_host)
-    monkeypatch.setattr(bootstrap, "resolve_pot_id", lambda _host, pot: pot or "foo-pot")
+    monkeypatch.setattr(
+        bootstrap, "resolve_pot_id", lambda _host, pot: pot or "foo-pot"
+    )
 
     result = runner.invoke(cli_main.app, ["status", "--host"])
 
@@ -99,6 +124,7 @@ def test_status_host_json_output(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_setup_dry_run_preview(monkeypatch: pytest.MonkeyPatch) -> None:
+    metrics = _FakeSetupMetrics()
     preview = MagicMock()
     preview.to_dict.return_value = {"steps": [{"name": "config", "status": "pending"}]}
 
@@ -113,12 +139,148 @@ def test_setup_dry_run_preview(monkeypatch: pytest.MonkeyPatch) -> None:
         "adapters.inbound.cli.ui.setup_ux.rich_enabled",
         lambda **_k: False,
     )
+    monkeypatch.setattr(bootstrap, "sentry_metrics_runtime", metrics, raising=False)
 
     result = runner.invoke(cli_main.app, ["setup", "--dry-run"])
 
     assert result.exit_code == 0, result.stdout
     mock_host.setup.preview.assert_called_once()
+    mock_host.setup.run.assert_not_called()
     assert "config" in result.stdout or "steps" in result.stdout
+    assert metrics.calls == [
+        _MetricCall(
+            "ce.setup.runs_total",
+            {
+                "result": "dry_run",
+                "backend": "falkordb",
+                "host_mode": "in_process",
+                "scan": False,
+                "dry_run": True,
+            },
+        ),
+    ]
+
+
+def test_setup_success_emits_run_and_step_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metrics = _FakeSetupMetrics()
+    plan = SetupPlan(
+        mode="local",
+        host_mode="daemon",
+        backend="falkordb",
+        repo="/private/project",
+        pot="customer-pot",
+        agent="gpt-9",
+        scan=True,
+    )
+    report = SetupReport(
+        plan=plan,
+        steps=(
+            StepResult("config", DONE, hard=True),
+            StepResult("source", DONE, hard=False),
+        ),
+    )
+    mock_host = MagicMock()
+    mock_host.profile = "local"
+    mock_host.backend.profile = "falkordb"
+    mock_host.daemon.in_process = False
+    mock_host.setup.run.return_value = report
+
+    monkeypatch.setattr(bootstrap, "get_host", lambda: mock_host)
+    monkeypatch.setattr(
+        "adapters.inbound.cli.ui.setup_ux.rich_enabled",
+        lambda **_k: False,
+    )
+    monkeypatch.setattr(bootstrap, "sentry_metrics_runtime", metrics, raising=False)
+
+    result = runner.invoke(
+        cli_main.app,
+        [
+            "setup",
+            "--repo",
+            "/private/project",
+            "--pot",
+            "customer-pot",
+            "--agent",
+            "gpt-9",
+            "--scan",
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert metrics.calls == [
+        _MetricCall(
+            "ce.setup.runs_total",
+            {
+                "result": "ok",
+                "backend": "falkordb",
+                "host_mode": "daemon",
+                "scan": True,
+                "dry_run": False,
+            },
+        ),
+        _MetricCall(
+            "ce.setup.step_total",
+            {"step": "config", "state": "done", "hard": True},
+        ),
+        _MetricCall(
+            "ce.setup.step_total",
+            {"step": "source", "state": "done", "hard": False},
+        ),
+    ]
+    for call in metrics.calls:
+        assert "repo" not in call.attributes
+        assert "pot" not in call.attributes
+        assert "agent" not in call.attributes
+        assert "/private/project" not in call.attributes.values()
+        assert "customer-pot" not in call.attributes.values()
+        assert "gpt-9" not in call.attributes.values()
+
+
+def test_setup_degraded_report_preserves_exit_code_and_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metrics = _FakeSetupMetrics()
+    plan = SetupPlan(mode="local", host_mode="daemon", backend="falkordb")
+    report = SetupReport(
+        plan=plan,
+        steps=(StepResult("backend.provision", FAILED, hard=True),),
+    )
+    assert not report.ok
+    mock_host = MagicMock()
+    mock_host.profile = "local"
+    mock_host.backend.profile = "falkordb"
+    mock_host.daemon.in_process = False
+    mock_host.setup.run.return_value = report
+
+    monkeypatch.setattr(bootstrap, "get_host", lambda: mock_host)
+    monkeypatch.setattr(
+        "adapters.inbound.cli.ui.setup_ux.rich_enabled",
+        lambda **_k: False,
+    )
+    monkeypatch.setattr(bootstrap, "sentry_metrics_runtime", metrics, raising=False)
+
+    result = runner.invoke(cli_main.app, ["setup", "--yes"])
+
+    assert result.exit_code == EXIT_DEGRADED, result.stdout
+    assert metrics.calls == [
+        _MetricCall(
+            "ce.setup.runs_total",
+            {
+                "result": "degraded",
+                "backend": "falkordb",
+                "host_mode": "daemon",
+                "scan": False,
+                "dry_run": False,
+            },
+        ),
+        _MetricCall(
+            "ce.setup.step_total",
+            {"step": "backend.provision", "state": "failed", "hard": True},
+        ),
+    ]
 
 
 def test_doctor_emits_diagnostics(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -128,9 +290,7 @@ def test_doctor_emits_diagnostics(monkeypatch: pytest.MonkeyPatch) -> None:
     mock_host.backend.profile = "falkordb"
     mock_host.backend.capabilities.return_value = mock_caps
     mock_host.daemon.status.return_value = {"mode": "in_process", "up": True}
-    mock_host.ledger.status.return_value = MagicMock(
-        available=True, binding="local"
-    )
+    mock_host.ledger.status.return_value = MagicMock(available=True, binding="local")
 
     monkeypatch.setattr(bootstrap, "get_host", lambda: mock_host)
 

--- a/potpie/context-engine/tests/unit/test_context_graph_jobs_metrics.py
+++ b/potpie/context-engine/tests/unit/test_context_graph_jobs_metrics.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from application.use_cases import context_graph_jobs
+from bootstrap.ingestion_server import IngestionServerContainer
+from bootstrap import sentry_metrics_runtime
+
+pytestmark = pytest.mark.unit
+
+
+def _batch() -> MagicMock:
+    batch = MagicMock()
+    batch.id = "batch-1"
+    batch.pot_id = "pot-1"
+    batch.created_at = datetime(2026, 5, 6, 9, 0, tzinfo=timezone.utc)
+    batch.claimed_at = datetime(2026, 5, 6, 9, 0, 2, tzinfo=timezone.utc)
+    return batch
+
+
+def _container(
+    *,
+    reconciliation_agent: object | None,
+    batch: MagicMock | None,
+) -> IngestionServerContainer:
+    container = MagicMock()
+    container.reconciliation_agent = reconciliation_agent
+    repo = MagicMock()
+    repo.claim_batch_by_id.return_value = batch
+    repo.list_events_for_batch.return_value = []
+    container.batch_repository.return_value = repo
+    container.reconciliation_ledger.return_value = MagicMock()
+    container.agent_checkpoint_store.return_value = MagicMock()
+    container.pots = MagicMock()
+    container.policy.return_value = None
+    container.event_stream_publisher = MagicMock()
+    container.agent_execution_log.return_value = MagicMock()
+    return container
+
+
+def test_skipped_jobs_mirror_finished_sentry_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    counts: list[tuple[str, int, dict[str, str]]] = []
+    monkeypatch.setattr(
+        sentry_metrics_runtime,
+        "count",
+        lambda name, value=1, *, attributes=None, unit=None: counts.append(
+            (name, value, dict(attributes or {}))
+        ),
+    )
+
+    no_agent = _container(reconciliation_agent=None, batch=_batch())
+    not_pending = _container(reconciliation_agent=object(), batch=None)
+
+    context_graph_jobs.handle_process_batch(
+        MagicMock(),
+        "batch-1",
+        build_ingestion_server=lambda _db: no_agent,
+    )
+    context_graph_jobs.handle_process_batch(
+        MagicMock(),
+        "batch-1",
+        build_ingestion_server=lambda _db: not_pending,
+    )
+
+    assert (
+        "ce.batch.finished_total",
+        1,
+        {"result": "skipped_no_reconciliation_agent"},
+    ) in counts
+    assert (
+        "ce.batch.finished_total",
+        1,
+        {"result": "skipped_not_pending"},
+    ) in counts
+
+
+def test_claimed_job_mirrors_batch_lifecycle_sentry_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    counts: list[tuple[str, int, dict[str, str]]] = []
+    distributions: list[tuple[str, float, str | None, dict[str, str]]] = []
+    monkeypatch.setattr(
+        sentry_metrics_runtime,
+        "count",
+        lambda name, value=1, *, attributes=None, unit=None: counts.append(
+            (name, value, dict(attributes or {}))
+        ),
+    )
+    monkeypatch.setattr(
+        sentry_metrics_runtime,
+        "distribution",
+        lambda name, value, *, attributes=None, unit=None: distributions.append(
+            (name, value, unit, dict(attributes or {}))
+        ),
+    )
+    monkeypatch.setattr(
+        context_graph_jobs,
+        "process_batch",
+        lambda **_: MagicMock(
+            batch_id="batch-1",
+            ok=True,
+            completed_event_ids=["e1"],
+            tool_call_count=2,
+            error=None,
+        ),
+    )
+
+    container = _container(reconciliation_agent=object(), batch=_batch())
+
+    context_graph_jobs.handle_process_batch(
+        MagicMock(),
+        "batch-1",
+        build_ingestion_server=lambda _db: container,
+    )
+
+    assert ("ce.batch.started_total", 1, {"result": "started"}) in counts
+    assert ("ce.batch.finished_total", 1, {"result": "ok"}) in counts
+    assert (
+        "ce.batch.time_in_pending_ms",
+        2000.0,
+        "millisecond",
+        {"result": "started"},
+    ) in distributions

--- a/potpie/context-engine/tests/unit/test_event_admission.py
+++ b/potpie/context-engine/tests/unit/test_event_admission.py
@@ -8,8 +8,15 @@ from unittest.mock import MagicMock
 import pytest
 
 from application.services.event_admission import admit_event
+from application.services.ingestion_submission_service import (
+    DefaultIngestionSubmissionService,
+)
+from bootstrap import sentry_metrics_runtime
+from domain.actor import Actor
 from domain.context_events import ContextEvent, EventScope
 from domain.ingestion_kinds import INGESTION_KIND_AGENT_RECONCILIATION
+from domain.ingestion_event_models import IngestionEvent, IngestionSubmissionRequest
+from domain.ports.pot_resolution import single_github_repo_pot
 
 pytestmark = pytest.mark.unit
 
@@ -93,3 +100,172 @@ def test_enqueue_failure_does_not_raise() -> None:
     assert out.inserted is True
     assert out.batch_id == "batch-abc"
     jobs.enqueue_batch.assert_called_once_with("batch-abc")
+
+
+def test_submission_service_mirrors_inserted_admission_to_sentry_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metric_calls: list[tuple[str, int, dict[str, str]]] = []
+
+    def record_count(
+        name: str,
+        value: int = 1,
+        *,
+        attributes: dict[str, str] | None = None,
+    ) -> None:
+        metric_calls.append((name, value, {} if attributes is None else attributes))
+
+    monkeypatch.setattr(sentry_metrics_runtime, "count", record_count)
+    service = _submission_service(inserted=True)
+
+    receipt = service.submit(_submission_request())
+
+    assert receipt.event_id == "evt-1"
+    assert receipt.status == "queued"
+    assert metric_calls == [
+        (
+            "ce.ingest.events_total",
+            1,
+            {"result": "inserted"},
+        )
+    ]
+
+
+def test_submission_service_mirrors_duplicate_admission_to_sentry_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metric_calls: list[tuple[str, int, dict[str, str]]] = []
+
+    def record_count(
+        name: str,
+        value: int = 1,
+        *,
+        attributes: dict[str, str] | None = None,
+    ) -> None:
+        metric_calls.append((name, value, {} if attributes is None else attributes))
+
+    monkeypatch.setattr(sentry_metrics_runtime, "count", record_count)
+    service = _submission_service(inserted=False)
+
+    receipt = service.submit(_submission_request())
+
+    assert receipt.event_id == "evt-1"
+    assert receipt.duplicate is True
+    assert metric_calls == [
+        (
+            "ce.ingest.dedup_total",
+            1,
+            {"result": "duplicate"},
+        )
+    ]
+
+
+def test_submission_service_does_not_export_request_taxonomy_to_sentry_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metric_calls: list[tuple[str, int, dict[str, str]]] = []
+
+    def record_count(
+        name: str,
+        value: int = 1,
+        *,
+        attributes: dict[str, str] | None = None,
+    ) -> None:
+        metric_calls.append((name, value, {} if attributes is None else attributes))
+
+    monkeypatch.setattr(sentry_metrics_runtime, "count", record_count)
+    service = _submission_service(inserted=True)
+
+    service.submit(
+        _submission_request(
+            source_system="github:user@example.com",
+            event_type="pull_request:secret-token-123",
+            action="merged:/src/secrets.py",
+        )
+    )
+
+    assert metric_calls == [
+        (
+            "ce.ingest.events_total",
+            1,
+            {"result": "inserted"},
+        )
+    ]
+
+
+def _submission_service(*, inserted: bool) -> DefaultIngestionSubmissionService:
+    settings = MagicMock()
+    settings.is_enabled.return_value = True
+    pots = MagicMock()
+    pots.resolve_pot.return_value = single_github_repo_pot("pot-1", "o/r")
+    reco = MagicMock()
+    reco.append_event.return_value = ("evt-1", inserted)
+    batches = MagicMock()
+    batches.upsert_open_batch_for_pot.return_value = "batch-abc"
+    jobs = MagicMock()
+    events = MagicMock()
+    events.get_event.return_value = _ingestion_event()
+    return DefaultIngestionSubmissionService(
+        settings=settings,
+        pots=pots,
+        reconciliation_agent=MagicMock(),
+        reco_ledger=reco,
+        events=events,
+        batches=batches,
+        jobs=jobs,
+    )
+
+
+def _submission_request(
+    *,
+    source_system: str = "github",
+    event_type: str = "pull_request",
+    action: str = "merged",
+) -> IngestionSubmissionRequest:
+    return IngestionSubmissionRequest(
+        pot_id="pot-1",
+        ingestion_kind=INGESTION_KIND_AGENT_RECONCILIATION,
+        source_channel="webhook",
+        source_system=source_system,
+        event_type=event_type,
+        action=action,
+        source_id="pr_42_merged",
+        repo_name="o/r",
+        event_id="evt-1",
+        payload={
+            "batch_id": "batch-abc",
+            "event_id": "evt-1",
+            "repo_name": "o/r",
+            "source_id": "pr_42_merged",
+            "title": "Merge X",
+        },
+        metadata={"source_id": "pr_42_merged"},
+        actor=Actor(
+            user_id="user-1",
+            surface="webhook",
+            client_name="github-webhook",
+            auth_method="webhook_signature",
+        ),
+    )
+
+
+def _ingestion_event() -> IngestionEvent:
+    return IngestionEvent(
+        event_id="evt-1",
+        pot_id="pot-1",
+        ingestion_kind=INGESTION_KIND_AGENT_RECONCILIATION,
+        source_channel="webhook",
+        source_system="github",
+        event_type="pull_request",
+        action="merged",
+        source_id="pr_42_merged",
+        dedup_key=None,
+        status="queued",
+        stage="accepted",
+        submitted_at=datetime(2026, 5, 6, 9, 0, tzinfo=timezone.utc),
+        started_at=None,
+        completed_at=None,
+        error=None,
+        payload={},
+        repo_name="o/r",
+    )

--- a/potpie/context-engine/tests/unit/test_process_batch.py
+++ b/potpie/context-engine/tests/unit/test_process_batch.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from adapters.outbound.reconciliation.noop_agent import NoOpReconciliationAgent
+from bootstrap import sentry_metrics_runtime
 from application.use_cases.process_batch import process_batch
 from domain.ports.reconciliation_ledger import ContextEventRow
 from domain.ports.pot_resolution import ResolvedPot, ResolvedPotRepo
@@ -111,6 +112,46 @@ def test_processes_pending_events_and_marks_batch_done() -> None:
     # that contract is covered in test_agent_execution_log.py.
 
 
+def test_success_mirrors_agent_and_event_sentry_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    counts: list[tuple[str, int, dict[str, str]]] = []
+    distributions: list[tuple[str, float, str | None, dict[str, str]]] = []
+    monkeypatch.setattr(
+        sentry_metrics_runtime,
+        "count",
+        lambda name, value=1, *, attributes=None, unit=None: counts.append(
+            (name, value, dict(attributes or {}))
+        ),
+    )
+    monkeypatch.setattr(
+        sentry_metrics_runtime,
+        "distribution",
+        lambda name, value, *, attributes=None, unit=None: distributions.append(
+            (name, value, unit, dict(attributes or {}))
+        ),
+    )
+    batches = MagicMock()
+    batches.list_events_for_batch.return_value = [
+        BatchEventRef(event_id="e1", added_at=_now()),
+    ]
+    ledger = MagicMock()
+    ledger.get_event_by_id.side_effect = lambda eid: _event_row(eid)
+    checkpoints = MagicMock()
+
+    process_batch(
+        batch=_batch(),
+        agent=NoOpReconciliationAgent(),
+        batches=batches,
+        reco_ledger=ledger,
+        checkpoints=checkpoints,
+        pots=_pots(),
+    )
+
+    assert ("ce.events.reconciled_total", 1, {"result": "reconciled"}) in counts
+    assert ("ce.agent.tool_calls", 0, None, {"result": "ok"}) in distributions
+
+
 def test_skips_already_processed_events() -> None:
     batches = MagicMock()
     batches.list_events_for_batch.return_value = [
@@ -209,6 +250,54 @@ def test_agent_exception_marks_batch_failed_and_events_failed() -> None:
     ledger.record_events_failed.assert_called_once()
     (failed_ids, _err), _ = ledger.record_events_failed.call_args
     assert sorted(failed_ids) == ["e1"]
+
+
+def test_failure_mirrors_agent_and_event_sentry_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    counts: list[tuple[str, int, dict[str, str]]] = []
+    distributions: list[tuple[str, float, str | None, dict[str, str]]] = []
+    monkeypatch.setattr(
+        sentry_metrics_runtime,
+        "count",
+        lambda name, value=1, *, attributes=None, unit=None: counts.append(
+            (name, value, dict(attributes or {}))
+        ),
+    )
+    monkeypatch.setattr(
+        sentry_metrics_runtime,
+        "distribution",
+        lambda name, value, *, attributes=None, unit=None: distributions.append(
+            (name, value, unit, dict(attributes or {}))
+        ),
+    )
+    batches = MagicMock()
+    batches.list_events_for_batch.return_value = [
+        BatchEventRef(event_id="e1", added_at=_now()),
+    ]
+    ledger = MagicMock()
+    ledger.get_event_by_id.return_value = _event_row("e1")
+    checkpoints = MagicMock()
+
+    class _Boom:
+        def run_batch(self, ctx, *, checkpoints=None, execution_log=None):
+            del ctx, checkpoints, execution_log
+            raise RuntimeError("kaboom")
+
+        def capability_metadata(self):
+            return {}
+
+    process_batch(
+        batch=_batch(),
+        agent=_Boom(),
+        batches=batches,
+        reco_ledger=ledger,
+        checkpoints=checkpoints,
+        pots=_pots(),
+    )
+
+    assert ("ce.events.failed_total", 1, {"result": "failed"}) in counts
+    assert ("ce.agent.tool_calls", 0, None, {"result": "failed"}) in distributions
 
 
 def test_opens_runs_and_fans_work_events_across_events() -> None:

--- a/potpie/context-engine/tests/unit/test_pydantic_deep_agent_batch.py
+++ b/potpie/context-engine/tests/unit/test_pydantic_deep_agent_batch.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import sys
 from datetime import datetime, timezone
+from types import ModuleType
 
+import anyio
 import pytest
 
 from adapters.outbound.reconciliation.pydantic_deep_agent import (
     PydanticDeepReconciliationAgent,
 )
+from bootstrap import sentry_metrics_runtime
 from domain.context_events import ContextEvent
 from domain.reconciliation_batch import BatchAgentContext
 
@@ -125,3 +129,53 @@ def test_run_batch_short_circuits_for_empty_event_list() -> None:
     out = agent.run_batch(ctx)
     assert out.ok is True
     assert out.completed_event_ids == []
+
+
+def test_run_batch_timeout_mirrors_sentry_metric(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    counts: list[tuple[str, int, dict[str, str]]] = []
+    monkeypatch.setattr(
+        sentry_metrics_runtime,
+        "count",
+        lambda name, value=1, *, attributes=None, unit=None: counts.append(
+            (name, value, dict(attributes or {}))
+        ),
+    )
+    monkeypatch.setenv("CONTEXT_ENGINE_AGENT_RUN_TIMEOUT_SECS", "0.001")
+
+    class _SlowAgent:
+        def tool_plain(self, **_kwargs):
+            def _decorator(fn):
+                return fn
+
+            return _decorator
+
+        async def run(self, *_args, **_kwargs):
+            await anyio.sleep(1)
+
+    fake_deep = ModuleType("pydantic_deep")
+    fake_deep.CheckpointMiddleware = lambda **_kwargs: object()
+    fake_deep.create_deep_agent = lambda **_kwargs: _SlowAgent()
+    fake_deep.create_default_deps = lambda: object()
+    monkeypatch.setitem(sys.modules, "pydantic_deep", fake_deep)
+    monkeypatch.setitem(
+        sys.modules, "pydantic_ai.usage", ModuleType("pydantic_ai.usage")
+    )
+
+    agent = PydanticDeepReconciliationAgent()
+    agent.set_context_graph(object())
+    monkeypatch.setattr(agent, "_build_read_tools", lambda _ctx: [])
+    monkeypatch.setattr(agent, "_build_mutation_tools", lambda _state: [])
+    monkeypatch.setattr(agent, "_build_control_tools", lambda _state: [])
+    ctx = BatchAgentContext(
+        batch_id="batch-1",
+        pot_id="pot-1",
+        repo_name="o/r",
+        events=[_event("e1")],
+    )
+
+    out = agent.run_batch(ctx)
+
+    assert out.ok is False
+    assert ("ce.agent.timeout_total", 1, {"result": "timeout"}) in counts

--- a/potpie/context-engine/tests/unit/test_reap_stale_batches.py
+++ b/potpie/context-engine/tests/unit/test_reap_stale_batches.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
+import pytest
+
 from application.use_cases.reap_stale_batches import reap_stale_batches
+from bootstrap import sentry_metrics_runtime
 from domain.reconciliation_batch import BatchEventRef, ReconciliationBatch
 
 
@@ -42,7 +45,17 @@ class TestReapStaleBatches:
         batches.mark_batch_failed.assert_not_called()
         ledger.fail_inflight_events.assert_not_called()
 
-    def test_reaps_each_stale_batch_events_first_then_batch(self) -> None:
+    def test_reaps_each_stale_batch_events_first_then_batch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sentry_counts: list[tuple[str, int, dict[str, str]]] = []
+        monkeypatch.setattr(
+            sentry_metrics_runtime,
+            "count",
+            lambda name, value=1, *, attributes=None, unit=None: sentry_counts.append(
+                (name, value, dict(attributes or {}))
+            ),
+        )
         batches = MagicMock()
         batches.list_stale_in_flight_batches.return_value = [
             _batch("b1"),
@@ -74,6 +87,10 @@ class TestReapStaleBatches:
         ledger.fail_inflight_events.assert_any_call(
             ["b1-e1"], ledger.fail_inflight_events.call_args_list[0].args[1]
         )
+        assert sentry_counts == [
+            ("ce.batch.reaped_total", 1, {"result": "reaped"}),
+            ("ce.batch.reaped_total", 1, {"result": "reaped"}),
+        ]
 
     def test_lease_is_passed_through_to_the_repo_query(self) -> None:
         batches = MagicMock()

--- a/potpie/context-engine/tests/unit/test_sentry_cli.py
+++ b/potpie/context-engine/tests/unit/test_sentry_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from typing import Final, NamedTuple
 
 import pytest
 import typer
@@ -8,11 +9,82 @@ from typer.testing import CliRunner
 
 from adapters.inbound.cli import host_cli
 from adapters.inbound.cli.commands import _common
+from adapters.inbound.cli.telemetry.settings import SentrySettings
 from adapters.inbound.cli.telemetry_context import (
     current_telemetry_context,
     load_anonymous_install_id,
 )
 from adapters.inbound.cli.telemetry.identity_store import identity_path
+from domain.errors import CapabilityNotImplemented, ContextEngineDisabled, PotNotFound
+
+_SAFE_CLI_ATTRS: Final[frozenset[str]] = frozenset(
+    {
+        "arch",
+        "cli_version",
+        "command",
+        "error_code",
+        "os",
+        "output_mode",
+        "result",
+        "subcommand",
+    }
+)
+
+
+class _MetricCall(NamedTuple):
+    name: str
+    value: int | float
+    unit: str | None
+    attributes: dict[str, str | int | float | bool]
+
+
+class _FakeMetricsRuntime:
+    def __init__(self) -> None:
+        self.count_calls: list[_MetricCall] = []
+        self.distribution_calls: list[_MetricCall] = []
+        self.flush_calls: list[float] = []
+
+    def count(
+        self,
+        name: str,
+        value: int | float = 1,
+        *,
+        unit: str | None = None,
+        attributes: dict[str, str | int | float | bool] | None = None,
+    ) -> None:
+        self.count_calls.append(_MetricCall(name, value, unit, dict(attributes or {})))
+
+    def distribution(
+        self,
+        name: str,
+        value: int | float,
+        *,
+        unit: str | None = None,
+        attributes: dict[str, str | int | float | bool] | None = None,
+    ) -> None:
+        self.distribution_calls.append(
+            _MetricCall(name, value, unit, dict(attributes or {}))
+        )
+
+    def flush(self, timeout: float = 2.0) -> None:
+        self.flush_calls.append(timeout)
+
+
+@pytest.fixture
+def fake_metrics(monkeypatch: pytest.MonkeyPatch) -> _FakeMetricsRuntime:
+    fake = _FakeMetricsRuntime()
+    monkeypatch.setattr("bootstrap.sentry_metrics_runtime.count", fake.count)
+    monkeypatch.setattr(
+        "bootstrap.sentry_metrics_runtime.distribution", fake.distribution
+    )
+    monkeypatch.setattr("bootstrap.sentry_metrics_runtime.flush", fake.flush)
+    return fake
+
+
+@pytest.fixture(autouse=True)
+def reset_cli_state() -> None:
+    _common.set_json(False)
+    _common.set_verbose(False)
 
 
 def test_in_process_cli_invocations_share_install_and_daemon_session_ids(
@@ -42,6 +114,42 @@ def test_in_process_cli_invocations_share_install_and_daemon_session_ids(
     assert not (tmp_path / "context-home" / "telemetry" / "identity.json").exists()
 
 
+def test_cli_root_configures_sentry_errors_and_metrics_with_one_settings_load(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    settings = SentrySettings(
+        enabled=True,
+        dsn="https://public@example.invalid/1",
+        environment="test",
+        release="potpie-cli@test",
+        dist=None,
+    )
+    loaded: list[None] = []
+    error_settings: list[SentrySettings] = []
+    metric_settings: list[SentrySettings] = []
+    monkeypatch.setattr(
+        "adapters.inbound.cli.telemetry.settings.load_sentry_settings",
+        lambda: loaded.append(None) or settings,
+    )
+    monkeypatch.setattr(
+        "adapters.inbound.cli.telemetry.sentry_runtime.configure_cli_sentry",
+        error_settings.append,
+    )
+    monkeypatch.setattr(
+        "bootstrap.sentry_metrics_runtime.configure_metrics", metric_settings.append
+    )
+    runner = CliRunner()
+
+    result = runner.invoke(host_cli.app, ["--json", "daemon", "status"])
+
+    assert result.exit_code == 0, result.output
+    assert loaded == [None]
+    assert error_settings == [settings]
+    assert metric_settings == [settings]
+
+
 def test_expected_contract_error_does_not_capture_sentry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -59,9 +167,58 @@ def test_expected_contract_error_does_not_capture_sentry(
     assert captured == []
 
 
+def test_contract_records_success_metrics_without_command_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_metrics: _FakeMetricsRuntime,
+) -> None:
+    monkeypatch.setattr(
+        "adapters.inbound.cli.telemetry.context.current_telemetry_context", lambda: None
+    )
+
+    with _common.contract():
+        pass
+
+    _assert_metric_outcome(fake_metrics, result="ok", error_code="none")
+    attrs = fake_metrics.count_calls[0].attributes
+    assert "command" not in attrs
+    assert "subcommand" not in attrs
+    assert attrs == {"error_code": "none", "result": "ok"}
+
+
+@pytest.mark.parametrize(
+    ("raised", "result", "error_code", "exit_code"),
+    [
+        (ValueError("bad input"), "validation_error", "validation_error", 1),
+        (
+            CapabilityNotImplemented("graph.inspect", detail="not wired"),
+            "not_implemented",
+            "not_implemented",
+            2,
+        ),
+        (PotNotFound("missing pot"), "pot_not_found", "pot_not_found", 1),
+        (ContextEngineDisabled("disabled"), "unavailable", "unavailable", 2),
+        (typer.Exit(code=7), "exit", "exit", 7),
+    ],
+)
+def test_contract_records_expected_error_metrics(
+    raised: BaseException,
+    result: str,
+    error_code: str,
+    exit_code: int,
+    fake_metrics: _FakeMetricsRuntime,
+) -> None:
+    with pytest.raises(typer.Exit) as exc_info:
+        with _common.contract():
+            raise raised
+
+    assert exc_info.value.exit_code == exit_code
+    _assert_metric_outcome(fake_metrics, result=result, error_code=error_code)
+
+
 def test_contract_preserves_expected_typer_exit_from_fail(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
+    fake_metrics: _FakeMetricsRuntime,
 ) -> None:
     captured: list[BaseException] = []
     monkeypatch.setattr(
@@ -82,11 +239,13 @@ def test_contract_preserves_expected_typer_exit_from_fail(
     assert exc_info.value.exit_code == _common.EXIT_VALIDATION
     assert payload["code"] == "no_active_pot"
     assert captured == []
+    _assert_metric_outcome(fake_metrics, result="exit", error_code="exit")
 
 
 def test_unexpected_contract_error_is_captured_and_rendered_json(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
+    fake_metrics: _FakeMetricsRuntime,
 ) -> None:
     captured: list[tuple[str, str, str]] = []
     monkeypatch.setattr(
@@ -106,6 +265,9 @@ def test_unexpected_contract_error_is_captured_and_rendered_json(
     assert payload["code"] == "unexpected_cli_error"
     assert payload["message"] == "Unexpected internal error."
     assert captured == [("RuntimeError", "unexpected_cli_error", "unexpected")]
+    _assert_metric_outcome(
+        fake_metrics, result="unexpected", error_code="unexpected_cli_error"
+    )
 
 
 def test_cli_telemetry_identity_write_failure_is_nonfatal(
@@ -123,3 +285,25 @@ def test_cli_telemetry_identity_write_failure_is_nonfatal(
     assert install_id.startswith("install_")
     assert result.exit_code == 0, result.output
     assert "NotADirectoryError" not in result.output
+
+
+def _assert_metric_outcome(
+    fake_metrics: _FakeMetricsRuntime, *, result: str, error_code: str
+) -> None:
+    assert len(fake_metrics.count_calls) == 1
+    count_call = fake_metrics.count_calls[0]
+    assert count_call.name == "ce.cli.invocations_total"
+    assert count_call.value == 1
+    assert count_call.unit is None
+    assert count_call.attributes["error_code"] == error_code
+    assert count_call.attributes["result"] == result
+    assert set(count_call.attributes).issubset(_SAFE_CLI_ATTRS)
+    assert len(fake_metrics.distribution_calls) == 1
+    duration = fake_metrics.distribution_calls[0]
+    assert duration.name == "ce.cli.duration_ms"
+    assert isinstance(duration.value, (int, float))
+    assert duration.value >= 0
+    assert duration.unit == "millisecond"
+    assert duration.attributes == count_call.attributes
+    assert fake_metrics.flush_calls == [2.0]
+    assert set(duration.attributes).issubset(_SAFE_CLI_ATTRS)

--- a/potpie/context-engine/tests/unit/test_sentry_metrics_container_init.py
+++ b/potpie/context-engine/tests/unit/test_sentry_metrics_container_init.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from types import ModuleType
+
+import pytest
+
+from adapters.inbound.cli.telemetry.settings import SentrySettings
+from adapters.outbound.graph import Neo4jGraphWriter
+from application.services.source_connector_registry import SourceConnectorRegistry
+from bootstrap import ingestion_server, sentry_metrics_runtime, standalone_container
+from bootstrap.http_projects import ExplicitPotResolution
+from domain.ports.observability import NoOpObservability
+from domain.ports.telemetry import NoOpTelemetry
+
+
+class _FakeSentry(ModuleType):
+    def __init__(self) -> None:
+        super().__init__("sentry_sdk")
+        self.init_calls: list[dict[str, str | bool | None]] = []
+
+    def init(self, **kwargs: str | bool | None) -> None:
+        self.init_calls.append(dict(kwargs))
+
+
+@dataclass(frozen=True)
+class _Settings:
+    def is_enabled(self) -> bool:
+        return False
+
+    def neo4j_uri(self) -> str | None:
+        return None
+
+    def neo4j_user(self) -> str | None:
+        return None
+
+    def neo4j_password(self) -> str | None:
+        return None
+
+    def graph_db_backend(self) -> str:
+        return "neo4j"
+
+    def falkordb_url(self) -> str | None:
+        return None
+
+    def falkordb_graph_name(self) -> str:
+        return "context_graph"
+
+    def falkordb_mode(self) -> str:
+        return "lite"
+
+    def falkordb_lite_path(self) -> str:
+        return ".potpie/context_graph/falkordb.db"
+
+    def backfill_max_prs_per_run(self) -> int:
+        return 25
+
+
+@dataclass(frozen=True)
+class _GraphBackend:
+    settings: _Settings
+    writer: Neo4jGraphWriter
+
+
+@dataclass(frozen=True)
+class _ContextGraph:
+    backend: _GraphBackend
+    backed_includes: frozenset[str] = frozenset()
+
+
+@pytest.fixture(autouse=True)
+def reset_metrics_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delitem(sys.modules, "sentry_sdk", raising=False)
+    monkeypatch.setattr(sentry_metrics_runtime, "_enabled", False)
+    monkeypatch.setattr(sentry_metrics_runtime, "_configured", False)
+    monkeypatch.setattr(sentry_metrics_runtime, "_sentry_sdk", None)
+
+
+def test_build_ingestion_server_configures_sentry_metrics_once_when_repeated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeSentry()
+    settings = SentrySettings(
+        enabled=True,
+        dsn="https://public@example.invalid/1",
+        environment="worker-test",
+        release="potpie-worker@test",
+        dist=None,
+    )
+
+    monkeypatch.setitem(sys.modules, "sentry_sdk", fake)
+    monkeypatch.setattr(ingestion_server, "load_sentry_settings", lambda: settings)
+    _patch_container_graph(monkeypatch)
+
+    for _ in range(2):
+        ingestion_server.build_ingestion_server(
+            settings=_Settings(),
+            pots=ExplicitPotResolution({"pot": "owner/repo"}),
+            connectors=SourceConnectorRegistry(),
+            telemetry=NoOpTelemetry(),
+            observability=NoOpObservability(),
+        )
+
+    assert len(fake.init_calls) == 1
+    assert fake.init_calls[0]["environment"] == "worker-test"
+
+
+def test_standalone_container_delegates_to_ingestion_server_build(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    container = ingestion_server.IngestionServerContainer(
+        settings=_Settings(),
+        graph_writer=Neo4jGraphWriter(_Settings()),
+        pots=ExplicitPotResolution({"pot": "owner/repo"}),
+    )
+    calls: list[dict[str, bool]] = []
+
+    def build(**_kwargs: object) -> ingestion_server.IngestionServerContainer:
+        calls.append({"called": True})
+        return container
+
+    monkeypatch.setattr(
+        standalone_container,
+        "merged_pot_repo_map",
+        lambda: {"pot": "owner/repo"},
+    )
+    monkeypatch.setattr(
+        standalone_container, "get_context_graph_job_queue", lambda: None
+    )
+    monkeypatch.setattr(
+        standalone_container,
+        "try_pydantic_deep_reconciliation_agent",
+        lambda: None,
+    )
+    monkeypatch.delenv("CONTEXT_ENGINE_GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr(standalone_container, "build_ingestion_server", build)
+
+    built = standalone_container.build_standalone_context_engine_container()
+
+    assert built is container
+    assert calls == [{"called": True}]
+
+
+def _patch_container_graph(monkeypatch: pytest.MonkeyPatch) -> None:
+    import domain.coherence as coherence
+
+    monkeypatch.setattr(
+        ingestion_server,
+        "Neo4jGraphWriter",
+        lambda settings: Neo4jGraphWriter(settings),
+    )
+    monkeypatch.setattr(
+        ingestion_server,
+        "Neo4jGraphBackend",
+        lambda settings, *, writer: _GraphBackend(settings=settings, writer=writer),
+    )
+    monkeypatch.setattr(
+        ingestion_server,
+        "ContextGraphService",
+        lambda backend: _ContextGraph(backend=backend),
+    )
+    monkeypatch.setattr(
+        coherence,
+        "assert_runtime_coherence",
+        lambda *, reader_backed_includes: None,
+    )

--- a/potpie/context-engine/tests/unit/test_sentry_metrics_runtime.py
+++ b/potpie/context-engine/tests/unit/test_sentry_metrics_runtime.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from importlib import import_module
+import sys
+from types import ModuleType
+from typing import Optional, Union
+
+import pytest
+
+from adapters.inbound.cli.telemetry.settings import SentrySettings
+
+sentry_metrics_runtime = import_module("bootstrap.sentry_metrics_runtime")
+runtime_importlib = getattr(sentry_metrics_runtime, "importlib")
+configure_metrics = getattr(sentry_metrics_runtime, "configure_metrics")
+count = getattr(sentry_metrics_runtime, "count")
+distribution = getattr(sentry_metrics_runtime, "distribution")
+gauge = getattr(sentry_metrics_runtime, "gauge")
+flush = getattr(sentry_metrics_runtime, "flush")
+
+
+@dataclass(frozen=True)
+class _MetricCall:
+    name: str
+    value: Union[int, float]
+    unit: Optional[str]
+    attributes: Mapping[str, Union[str, int, float, bool]]
+
+
+class _FakeMetrics:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.count_calls: list[_MetricCall] = []
+        self.distribution_calls: list[_MetricCall] = []
+        self.gauge_calls: list[_MetricCall] = []
+
+    def count(
+        self,
+        name: str,
+        value: Union[int, float],
+        unit: Optional[str] = None,
+        attributes: Optional[dict[str, Union[str, int, float, bool]]] = None,
+    ) -> None:
+        if self.fail:
+            raise RuntimeError("sdk counter failed")
+        self.count_calls.append(_call(name, value, unit, attributes))
+
+    def distribution(
+        self,
+        name: str,
+        value: Union[int, float],
+        unit: Optional[str] = None,
+        attributes: Optional[dict[str, Union[str, int, float, bool]]] = None,
+    ) -> None:
+        if self.fail:
+            raise RuntimeError("sdk distribution failed")
+        self.distribution_calls.append(_call(name, value, unit, attributes))
+
+    def gauge(
+        self,
+        name: str,
+        value: Union[int, float],
+        unit: Optional[str] = None,
+        attributes: Optional[dict[str, Union[str, int, float, bool]]] = None,
+    ) -> None:
+        if self.fail:
+            raise RuntimeError("sdk gauge failed")
+        self.gauge_calls.append(_call(name, value, unit, attributes))
+
+
+class _FakeSentry(ModuleType):
+    def __init__(
+        self,
+        *,
+        fail_metrics: bool = False,
+        fail_flush: bool = False,
+    ) -> None:
+        super().__init__("sentry_sdk")
+        self.metrics = _FakeMetrics(fail=fail_metrics)
+        self.fail_flush = fail_flush
+        self.init_calls: list[dict[str, object]] = []
+        self.flush_calls: list[float] = []
+
+    def init(self, **kwargs: object) -> None:
+        self.init_calls.append(dict(kwargs))
+
+    def flush(self, *, timeout: float) -> None:
+        if self.fail_flush:
+            raise RuntimeError("sdk flush failed")
+        self.flush_calls.append(timeout)
+
+
+@pytest.fixture(autouse=True)
+def reset_metrics_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delitem(sys.modules, "sentry_sdk", raising=False)
+    monkeypatch.setattr(sentry_metrics_runtime, "_enabled", False)
+    monkeypatch.setattr(sentry_metrics_runtime, "_configured", False)
+    monkeypatch.setattr(sentry_metrics_runtime, "_sentry_sdk", None)
+
+
+def test_configure_metrics_disabled_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_import(name: str) -> ModuleType:
+        raise AssertionError(f"unexpected import: {name}")
+
+    monkeypatch.setattr(runtime_importlib, "import_module", fail_import)
+    settings = _settings(enabled=False)
+
+    configure_metrics(settings)
+    count("ce.disabled")
+    distribution("ce.disabled.duration", 12.0)
+    gauge("ce.disabled.current", 7)
+    flush()
+
+    assert "sentry_sdk" not in sys.modules
+
+
+def test_configure_metrics_missing_sdk_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def missing_sdk(name: str) -> ModuleType:
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(runtime_importlib, "import_module", missing_sdk)
+    settings = _settings(enabled=True)
+
+    configure_metrics(settings)
+    count("ce.missing", attributes={"result": "ok"})
+    flush()
+
+
+def test_sdk_failures_are_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeSentry(fail_metrics=True, fail_flush=True)
+    monkeypatch.setitem(sys.modules, "sentry_sdk", fake)
+
+    configure_metrics(_settings(enabled=True))
+    count("ce.sdk.count", attributes={"result": "ok"})
+    distribution("ce.sdk.duration", 1.5)
+    gauge("ce.sdk.gauge", 1)
+    flush()
+
+    assert fake.metrics.count_calls == []
+    assert fake.metrics.distribution_calls == []
+    assert fake.metrics.gauge_calls == []
+    assert fake.flush_calls == []
+
+
+def test_configure_metrics_initializes_sentry_once_with_privacy_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeSentry()
+    monkeypatch.setitem(sys.modules, "sentry_sdk", fake)
+    settings = _settings(enabled=True)
+
+    configure_metrics(settings)
+    configure_metrics(settings)
+    count("ce.init", attributes={"result": "ok"})
+
+    assert len(fake.init_calls) == 1
+    call = fake.init_calls[0]
+    assert call["dsn"] == "https://public@example.invalid/1"
+    assert call["environment"] == "test"
+    assert call["release"] == "potpie-cli@test"
+    assert call["dist"] is None
+    assert call["send_default_pii"] is False
+    assert call["include_local_variables"] is False
+    assert call["max_request_body_size"] == "never"
+    assert callable(call["before_send"])
+    assert callable(call["before_breadcrumb"])
+    assert fake.metrics.count_calls == [
+        _MetricCall("ce.init", 1, None, {"result": "ok"}),
+    ]
+
+
+def test_count_distribution_and_gauge_emit_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeSentry()
+    monkeypatch.setitem(sys.modules, "sentry_sdk", fake)
+
+    configure_metrics(_settings(enabled=True))
+    count("ce.count", value=3, attributes={"result": "ok"})
+    distribution(
+        "ce.duration_ms",
+        12.5,
+        unit="millisecond",
+        attributes={"result": "ok"},
+    )
+    gauge("ce.active", 4, attributes={"state": "done"})
+
+    assert fake.metrics.count_calls == [
+        _MetricCall("ce.count", 3, None, {"result": "ok"}),
+    ]
+    assert fake.metrics.distribution_calls == [
+        _MetricCall("ce.duration_ms", 12.5, "millisecond", {"result": "ok"}),
+    ]
+    assert fake.metrics.gauge_calls == [
+        _MetricCall("ce.active", 4, None, {"state": "done"}),
+    ]
+
+
+def test_flush_is_noop_when_disabled_and_calls_sdk_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeSentry()
+    monkeypatch.setitem(sys.modules, "sentry_sdk", fake)
+
+    configure_metrics(_settings(enabled=False))
+    flush()
+    assert fake.flush_calls == []
+
+    configure_metrics(_settings(enabled=True))
+    flush()
+
+    assert fake.flush_calls == [2.0]
+
+
+def test_repeated_configuration_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeSentry()
+    import_calls = 0
+
+    def import_fake(name: str) -> ModuleType:
+        nonlocal import_calls
+        import_calls += 1
+        assert name == "sentry_sdk"
+        return fake
+
+    monkeypatch.setattr(runtime_importlib, "import_module", import_fake)
+    settings = _settings(enabled=True)
+
+    configure_metrics(settings)
+    configure_metrics(settings)
+    count("ce.once", attributes={"result": "ok"})
+
+    assert import_calls == 1
+    assert fake.metrics.count_calls == [
+        _MetricCall("ce.once", 1, None, {"result": "ok"}),
+    ]
+
+
+def _settings(*, enabled: bool) -> SentrySettings:
+    return SentrySettings(
+        enabled=enabled,
+        dsn="https://public@example.invalid/1",
+        environment="test",
+        release="potpie-cli@test",
+        dist=None,
+    )
+
+
+def _call(
+    name: str,
+    value: Union[int, float],
+    unit: Optional[str],
+    attributes: Optional[dict[str, Union[str, int, float, bool]]],
+) -> _MetricCall:
+    return _MetricCall(
+        name=name,
+        value=value,
+        unit=unit,
+        attributes={} if attributes is None else dict(attributes),
+    )

--- a/potpie/context-engine/tests/unit/test_sentry_metrics_runtime_attrs.py
+++ b/potpie/context-engine/tests/unit/test_sentry_metrics_runtime_attrs.py
@@ -123,6 +123,7 @@ def test_count_drops_high_cardinality_attributes(
         "command": "scan",
         "result": "ok",
         "dry_run": True,
+        "state": "src/main.py",
         "nested": {"result": "ok"},
         "items": ["one", "two"],
         "none": None,

--- a/potpie/context-engine/tests/unit/test_sentry_metrics_runtime_attrs.py
+++ b/potpie/context-engine/tests/unit/test_sentry_metrics_runtime_attrs.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import ast
+from collections.abc import Mapping
+from dataclasses import dataclass
+from importlib import import_module
+import inspect
+import sys
+from types import ModuleType
+from typing import Optional, Union
+
+import pytest
+
+from adapters.inbound.cli.telemetry.settings import SentrySettings
+
+sentry_metrics_runtime = import_module("bootstrap.sentry_metrics_runtime")
+configure_metrics = getattr(sentry_metrics_runtime, "configure_metrics")
+count = getattr(sentry_metrics_runtime, "count")
+
+
+@dataclass(frozen=True)
+class _MetricCall:
+    name: str
+    value: Union[int, float]
+    unit: Optional[str]
+    attributes: Mapping[str, Union[str, int, float, bool]]
+
+
+class _FakeMetrics:
+    def __init__(self) -> None:
+        self.count_calls: list[_MetricCall] = []
+
+    def count(
+        self,
+        name: str,
+        value: Union[int, float],
+        unit: Optional[str] = None,
+        attributes: Optional[dict[str, Union[str, int, float, bool]]] = None,
+    ) -> None:
+        self.count_calls.append(_call(name, value, unit, attributes))
+
+
+class _FakeSentry(ModuleType):
+    def __init__(self) -> None:
+        super().__init__("sentry_sdk")
+        self.metrics = _FakeMetrics()
+        self.init_calls: list[dict[str, object]] = []
+
+    def init(self, **kwargs: object) -> None:
+        self.init_calls.append(dict(kwargs))
+
+
+@pytest.fixture(autouse=True)
+def reset_metrics_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delitem(sys.modules, "sentry_sdk", raising=False)
+    monkeypatch.setattr(sentry_metrics_runtime, "_enabled", False)
+    monkeypatch.setattr(sentry_metrics_runtime, "_configured", False)
+    monkeypatch.setattr(sentry_metrics_runtime, "_sentry_sdk", None)
+
+
+def test_runtime_helper_stays_plain_functions_without_protocol_abstractions() -> None:
+    source = inspect.getsource(sentry_metrics_runtime)
+    tree = ast.parse(source)
+
+    class_defs = [
+        node.name for node in ast.walk(tree) if isinstance(node, ast.ClassDef)
+    ]
+
+    assert class_defs == []
+    assert "Proto" + "col" not in source
+    assert "runtime" + "_checkable" not in source
+    assert "Metric" + "Sink" not in source
+
+
+def test_count_keeps_only_low_cardinality_allowlisted_attributes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeSentry()
+    monkeypatch.setitem(sys.modules, "sentry_sdk", fake)
+    expected_attrs: dict[str, Union[str, int, float, bool]] = {
+        "command": "setup",
+        "subcommand": "run",
+        "output_mode": "json",
+        "cli_version": "0.1.0",
+        "os": "darwin",
+        "arch": "arm64",
+        "result": "ok",
+        "error_code": "none",
+        "backend": "falkordb",
+        "host_mode": "daemon",
+        "scan": "repo",
+        "dry_run": False,
+        "step": "workspace",
+        "state": "done",
+        "hard": True,
+    }
+
+    configure_metrics(_settings(enabled=True))
+    count(
+        "ce.cli.invocations_total",
+        attributes={
+            **expected_attrs,
+            "pot_id": "pot-1",
+            "source_channel": "github",
+            "source_system": "pull_request",
+            "event_type": "comment",
+            "action": "created",
+            "ingestion_kind": "diff_sync",
+        },
+    )
+
+    assert fake.metrics.count_calls == [
+        _MetricCall("ce.cli.invocations_total", 1, None, expected_attrs),
+    ]
+
+
+def test_count_drops_high_cardinality_attributes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeSentry()
+    monkeypatch.setitem(sys.modules, "sentry_sdk", fake)
+    attrs = {
+        "command": "scan",
+        "result": "ok",
+        "dry_run": True,
+        "nested": {"result": "ok"},
+        "items": ["one", "two"],
+        "none": None,
+    }
+    banned_keys = (
+        "pot_id",
+        "event_id",
+        "batch_id",
+        "invocation_id",
+        "daemon_session_id",
+        "anonymous_install_id",
+        "repo_name",
+        "source_id",
+        "file_path",
+        "path",
+        "prompt",
+        "exception_message",
+        "raw_exception_message",
+        "auth_subject",
+        "user_id",
+        "org_id",
+        "token",
+        "access_token",
+        "refresh_token",
+    )
+    attrs.update(dict.fromkeys(banned_keys, "sensitive"))
+
+    configure_metrics(_settings(enabled=True))
+    count("ce.test", attributes=attrs)
+
+    safe_attrs = {"command": "scan", "result": "ok", "dry_run": True}
+    assert fake.metrics.count_calls == [_MetricCall("ce.test", 1, None, safe_attrs)]
+
+
+def _settings(*, enabled: bool) -> SentrySettings:
+    return SentrySettings(
+        enabled=enabled,
+        dsn="https://public@example.invalid/1",
+        environment="test",
+        release="potpie-cli@test",
+        dist=None,
+    )
+
+
+def _call(
+    name: str,
+    value: Union[int, float],
+    unit: Optional[str],
+    attributes: Optional[dict[str, Union[str, int, float, bool]]],
+) -> _MetricCall:
+    return _MetricCall(
+        name=name,
+        value=value,
+        unit=unit,
+        attributes={} if attributes is None else dict(attributes),
+    )

--- a/potpie/context-engine/tests/unit/test_sentry_runtime.py
+++ b/potpie/context-engine/tests/unit/test_sentry_runtime.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 
 from adapters.inbound.cli.telemetry import sentry_runtime
+from bootstrap import sentry_metrics_runtime
 from adapters.inbound.cli.telemetry.context import TelemetryContext
 from adapters.inbound.cli.telemetry.sentry_runtime import (
     capture_unexpected_cli_error,
@@ -55,6 +56,9 @@ class _FakeSentry(ModuleType):
 @pytest.fixture(autouse=True)
 def reset_sentry_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sentry_runtime, "_configured", False)
+    monkeypatch.setattr(sentry_metrics_runtime, "_configured", False)
+    monkeypatch.setattr(sentry_metrics_runtime, "_enabled", False)
+    monkeypatch.setattr(sentry_metrics_runtime, "_sentry_sdk", None)
 
 
 def test_configure_cli_sentry_uses_privacy_hooks(monkeypatch) -> None:
@@ -78,6 +82,28 @@ def test_configure_cli_sentry_uses_privacy_hooks(monkeypatch) -> None:
     assert call["max_request_body_size"] == "never"
     assert callable(call["before_send"])
     assert callable(call["before_breadcrumb"])
+
+
+def test_configure_cli_sentry_delegates_to_neutral_runtime(monkeypatch) -> None:
+    settings = SentrySettings(
+        enabled=True,
+        dsn="https://public@example.invalid/1",
+        environment="staging",
+        release="potpie-cli@test",
+        dist="cli-dist",
+    )
+    configured: list[SentrySettings] = []
+
+    def configure(settings_arg: SentrySettings) -> None:
+        configured.append(settings_arg)
+
+    monkeypatch.setattr(sentry_runtime, "configure_metrics", configure)
+    monkeypatch.setattr(sentry_runtime, "metrics_configured", lambda: True)
+
+    configure_cli_sentry(settings)
+
+    assert configured == [settings]
+    assert sentry_runtime._configured is True
 
 
 def test_configure_cli_sentry_disabled_does_not_import(monkeypatch) -> None:

--- a/potpie/context-engine/tests/unit/test_telemetry_settings.py
+++ b/potpie/context-engine/tests/unit/test_telemetry_settings.py
@@ -23,6 +23,16 @@ def test_sentry_settings_respects_global_kill_switch(monkeypatch) -> None:
     assert settings.dsn == "https://public@example.invalid/1"
 
 
+def test_sentry_settings_ignores_blank_global_kill_switch(monkeypatch) -> None:
+    monkeypatch.setenv("POTPIE_SENTRY_DSN", "https://public@example.invalid/1")
+    monkeypatch.setenv("POTPIE_TELEMETRY_DISABLED", "   ")
+
+    settings = load_sentry_settings()
+
+    assert settings.enabled is True
+    assert settings.dsn == "https://public@example.invalid/1"
+
+
 def test_sentry_settings_respects_sentry_kill_switch(monkeypatch) -> None:
     monkeypatch.setenv("POTPIE_SENTRY_DSN", "https://public@example.invalid/1")
     monkeypatch.setenv("POTPIE_SENTRY_ENABLED", "0")

--- a/potpie/context-engine/tests/unit/test_telemetry_settings.py
+++ b/potpie/context-engine/tests/unit/test_telemetry_settings.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import pytest
+
 from adapters.inbound.cli.telemetry.settings import load_sentry_settings
 
 
-def test_sentry_settings_disabled_without_dsn(monkeypatch) -> None:
+def test_sentry_settings_disabled_without_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("POTPIE_SENTRY_DSN", raising=False)
     monkeypatch.delenv("SENTRY_DSN", raising=False)
 
@@ -13,7 +15,9 @@ def test_sentry_settings_disabled_without_dsn(monkeypatch) -> None:
     assert settings.dsn is None
 
 
-def test_sentry_settings_respects_global_kill_switch(monkeypatch) -> None:
+def test_sentry_settings_respects_global_kill_switch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("POTPIE_SENTRY_DSN", "https://public@example.invalid/1")
     monkeypatch.setenv("POTPIE_TELEMETRY_DISABLED", "1")
 
@@ -23,9 +27,13 @@ def test_sentry_settings_respects_global_kill_switch(monkeypatch) -> None:
     assert settings.dsn == "https://public@example.invalid/1"
 
 
-def test_sentry_settings_ignores_blank_global_kill_switch(monkeypatch) -> None:
+def test_sentry_settings_ignores_blank_global_kill_switch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("POTPIE_SENTRY_DSN", "https://public@example.invalid/1")
     monkeypatch.setenv("POTPIE_TELEMETRY_DISABLED", "   ")
+    monkeypatch.setenv("POTPIE_SENTRY_ENABLED", "")
+    monkeypatch.setenv("SENTRY_ENABLED", "")
 
     settings = load_sentry_settings()
 
@@ -33,7 +41,9 @@ def test_sentry_settings_ignores_blank_global_kill_switch(monkeypatch) -> None:
     assert settings.dsn == "https://public@example.invalid/1"
 
 
-def test_sentry_settings_respects_sentry_kill_switch(monkeypatch) -> None:
+def test_sentry_settings_respects_sentry_kill_switch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("POTPIE_SENTRY_DSN", "https://public@example.invalid/1")
     monkeypatch.setenv("POTPIE_SENTRY_ENABLED", "0")
 
@@ -42,7 +52,9 @@ def test_sentry_settings_respects_sentry_kill_switch(monkeypatch) -> None:
     assert settings.enabled is False
 
 
-def test_potpie_sentry_env_wins_over_generic_sentry_env(monkeypatch) -> None:
+def test_potpie_sentry_env_wins_over_generic_sentry_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("POTPIE_SENTRY_DSN", "https://potpie@example.invalid/1")
     monkeypatch.setenv("SENTRY_DSN", "https://generic@example.invalid/1")
     monkeypatch.setenv("POTPIE_SENTRY_ENVIRONMENT", "staging")
@@ -61,7 +73,9 @@ def test_potpie_sentry_env_wins_over_generic_sentry_env(monkeypatch) -> None:
     assert settings.dist == "cli-dist"
 
 
-def test_sentry_settings_default_release_is_potpie_cli(monkeypatch) -> None:
+def test_sentry_settings_default_release_is_potpie_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("SENTRY_DSN", "https://public@example.invalid/1")
     monkeypatch.delenv("POTPIE_SENTRY_RELEASE", raising=False)
     monkeypatch.delenv("SENTRY_RELEASE", raising=False)


### PR DESCRIPTION
## Summary
- Add a context-engine Sentry metrics runtime and shared Sentry settings loader.
- Instrument CLI command execution, ingestion admission, context graph jobs, batch processing, stale batch reaping, and deep-agent timeout paths.
- Keep metric tags low-cardinality by allowlisting safe attributes and dropping high-cardinality/path-like values.

## Why
This adds lightweight operational visibility for what is working and failing across the context-engine without sending request-specific identifiers or sensitive values as metric attributes.

## Implementation notes
- Metrics initialization is separate from Sentry error capture and is safe to call repeatedly.
- Sentry SDK import, emit, and flush failures are treated as no-ops so metrics cannot interrupt context-engine control flow.
- The CLI contract records invocation count and duration across success, expected errors, exits, and unexpected failures.

## Validation
- `uv run ruff check` on all changed context-engine Python files
- `uv run pytest` on the focused 65 changed/touched context-engine unit tests
- LSP diagnostics clean for `sentry_metrics_runtime.py` and `sentry_settings.py`