### PR TITLE
Add PostHog CLI usage instrumentation

### DIFF
--- a/potpie/context-engine/adapters/inbound/cli/auth/auth_commands.py
+++ b/potpie/context-engine/adapters/inbound/cli/auth/auth_commands.py
@@ -50,6 +50,9 @@ from adapters.inbound.cli.telemetry.onboarding_events import (
     now_ms,
     sanitized_failure_kind,
 )
+from adapters.inbound.cli.telemetry.usage_events import (
+    capture_usage_command_succeeded,
+)
 from adapters.inbound.cli.ui.output import emit_error, print_json_blob, print_plain_line
 from adapters.outbound.cli_auth.pkce import generate_pkce_pair
 from adapters.outbound.cli_auth.provider_config import (
@@ -718,6 +721,12 @@ def linear_ls(
     except LinearReadError as exc:
         emit_error("Linear workspace list failed", str(exc), verbose=v)
         raise typer.Exit(code=EXIT_UNAVAILABLE) from exc
+    capture_usage_command_succeeded(
+        command="linear ls",
+        result_kind="provider_list",
+        item_count=len(rows),
+        provider="linear",
+    )
     if j:
         print_json_blob(
             {"ok": True, "provider": "linear", "workspaces": rows}, as_json=True
@@ -896,8 +905,15 @@ def _run_product_use_result(
 ) -> None:
     load_cli_env()
     j, _ = _flags()
+    provider = _canonical_provider_for_json(str(result.get("product") or ""))
+    rows = result.get("items") or []
+    capture_usage_command_succeeded(
+        command=f"{provider} select",
+        result_kind="provider_selection",
+        item_count=len(rows),
+        provider=provider,
+    )
     if j:
-        provider = _canonical_provider_for_json(str(result.get("product") or ""))
         print_json_blob(
             {"ok": True, **result, "provider": provider},
             as_json=True,
@@ -912,7 +928,6 @@ def _run_product_use_result(
             f"{product_label} team: {_esc(result.get('team_key'))} "
             f"({_esc(result.get('team_name'))})",
         )
-    rows = result.get("items") or []
     print_plain_line(f"{len(rows)} item(s):", as_json=False)
     for row in rows:
         if result["product"] == "jira":
@@ -986,6 +1001,12 @@ def jira_ls(
     except AtlassianReadError as exc:
         emit_error("Jira workspace list failed", str(exc), verbose=v)
         raise typer.Exit(code=EXIT_UNAVAILABLE) from exc
+    capture_usage_command_succeeded(
+        command="jira ls",
+        result_kind="provider_list",
+        item_count=len(rows),
+        provider="jira",
+    )
     if j:
         print_json_blob(
             {"ok": True, "provider": "jira", "projects": rows}, as_json=True
@@ -1082,6 +1103,12 @@ def confluence_ls(
     except AtlassianReadError as exc:
         emit_error("Confluence workspace list failed", str(exc), verbose=v)
         raise typer.Exit(code=EXIT_UNAVAILABLE) from exc
+    capture_usage_command_succeeded(
+        command="confluence ls",
+        result_kind="provider_list",
+        item_count=len(rows),
+        provider="confluence",
+    )
     if j:
         print_json_blob(
             {"ok": True, "provider": "confluence", "spaces": rows}, as_json=True

--- a/potpie/context-engine/adapters/inbound/cli/auth/github_commands.py
+++ b/potpie/context-engine/adapters/inbound/cli/auth/github_commands.py
@@ -30,6 +30,9 @@ from adapters.inbound.cli.telemetry.onboarding_events import (
     now_ms,
     sanitized_failure_kind,
 )
+from adapters.inbound.cli.telemetry.usage_events import (
+    capture_usage_command_succeeded,
+)
 from adapters.inbound.cli.ui.output import emit_error, print_json_blob, print_plain_line
 
 github_app = typer.Typer(help="GitHub integration.")
@@ -327,6 +330,12 @@ def github_repos_impl() -> None:
             title="GitHub repository listing failed",
             verbose=v,
         )
+    capture_usage_command_succeeded(
+        command="github repos",
+        result_kind="provider_list",
+        item_count=len(repos),
+        provider="github",
+    )
 
     if j:
         print_json_blob(

--- a/potpie/context-engine/adapters/inbound/cli/commands/ingest.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/ingest.py
@@ -23,6 +23,9 @@ from adapters.inbound.cli.telemetry.onboarding_events import (
     capture_activation_succeeded,
     capture_onboarding_event,
 )
+from adapters.inbound.cli.telemetry.usage_events import (
+    capture_usage_command_succeeded,
+)
 from domain.errors import CapabilityNotImplemented
 
 ingest_app = typer.Typer(help="Scanner ingestion + run history.")
@@ -155,6 +158,10 @@ def _capture_ingest_scan_activation(
         },
     )
     capture_activation_succeeded(
+        command="ingest scan",
+        result_kind="scan_result",
+    )
+    capture_usage_command_succeeded(
         command="ingest scan",
         result_kind="scan_result",
     )

--- a/potpie/context-engine/adapters/inbound/cli/commands/query.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/query.py
@@ -18,6 +18,9 @@ from adapters.inbound.cli.commands._common import (
 from adapters.inbound.cli.telemetry.onboarding_events import (
     capture_activation_succeeded,
 )
+from adapters.inbound.cli.telemetry.usage_events import (
+    capture_usage_command_succeeded,
+)
 from domain.ports.agent_context import RecordRequest, ResolveRequest, SearchRequest
 
 
@@ -95,6 +98,11 @@ def register(root: typer.Typer) -> None:
                     scope=_parse_scope(scope),
                 )
             )
+            capture_usage_command_succeeded(
+                command="record",
+                result_kind="record_result",
+                item_count=receipt.mutations_applied,
+            )
             emit(
                 {
                     "status": receipt.status,
@@ -149,6 +157,11 @@ __all__ = ["register"]
 
 def _capture_context_activation(*, command: str, item_count: int) -> None:
     capture_activation_succeeded(
+        command=command,
+        result_kind="context_result",
+        item_count=item_count,
+    )
+    capture_usage_command_succeeded(
         command=command,
         result_kind="context_result",
         item_count=item_count,

--- a/potpie/context-engine/adapters/inbound/cli/telemetry/usage_events.py
+++ b/potpie/context-engine/adapters/inbound/cli/telemetry/usage_events.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from .product_analytics import capture_event
+
+
+def capture_usage_command_succeeded(
+    *,
+    command: str,
+    result_kind: str,
+    item_count: int | None = None,
+    provider: str | None = None,
+) -> None:
+    props: dict[str, str | int | float | bool | None | tuple[str, ...]] = {
+        "command": command,
+        "result_kind": result_kind,
+    }
+    if item_count is not None:
+        props["item_count"] = item_count
+    if provider is not None:
+        props["provider"] = provider
+    capture_event("cli_usage_command_succeeded", props)
+
+
+__all__ = ["capture_usage_command_succeeded"]

--- a/potpie/context-engine/tests/unit/test_usage_analytics.py
+++ b/potpie/context-engine/tests/unit/test_usage_analytics.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from adapters.inbound.cli.auth import auth_commands, github_commands
+from adapters.inbound.cli.commands import _common, bootstrap, ingest, query
+from adapters.inbound.cli.telemetry.context import TelemetryContext
+from adapters.inbound.cli.telemetry.product_analytics import (
+    ProductAnalyticsEvent,
+    set_product_analytics_sink,
+)
+from adapters.inbound.cli.telemetry.usage_events import (
+    capture_usage_command_succeeded,
+)
+
+
+@dataclass
+class _FakeSink:
+    events: list[ProductAnalyticsEvent] = field(default_factory=list)
+
+    def capture(self, event: ProductAnalyticsEvent) -> None:
+        self.events.append(event)
+
+
+@dataclass(frozen=True)
+class _FakeGitHubStore:
+    def get_provider_credentials(self, provider: str) -> dict[str, str]:
+        assert provider == "github"
+        return {"access_token": "gh_token"}
+
+
+@pytest.fixture()
+def fake_sink(monkeypatch: pytest.MonkeyPatch) -> _FakeSink:
+    sink = _FakeSink()
+    set_product_analytics_sink(sink)
+    monkeypatch.setattr(
+        "adapters.inbound.cli.telemetry.product_analytics.current_telemetry_context",
+        _telemetry_context,
+    )
+    return sink
+
+
+def _telemetry_context() -> TelemetryContext:
+    return TelemetryContext(
+        anonymous_install_id="install_123",
+        invocation_id="invoke_456",
+        daemon_session_id="daemon_789",
+        environment="staging",
+        command="resolve",
+        subcommand=None,
+        output_mode="json",
+        cli_version="0.1.0",
+        python_version="3.13.0",
+        os="darwin",
+        arch="arm64",
+    )
+
+
+def test_usage_event_uses_identity_without_onboarding_fields(
+    fake_sink: _FakeSink,
+) -> None:
+    capture_usage_command_succeeded(
+        command="resolve",
+        result_kind="context_result",
+        item_count=3,
+    )
+
+    assert len(fake_sink.events) == 1
+    event = fake_sink.events[0]
+    assert event.name == "cli_usage_command_succeeded"
+    assert event.distinct_id == "install_123"
+    assert event.properties["anonymous_install_id"] == "install_123"
+    assert event.properties["environment"] == "staging"
+    assert event.properties["command"] == "resolve"
+    assert event.properties["result_kind"] == "context_result"
+    assert event.properties["item_count"] == 3
+    assert "setup_run_id" not in event.properties
+    assert "onboarding_phase" not in event.properties
+    assert "entrypoint" not in event.properties
+
+
+def test_context_activation_also_records_usage(fake_sink: _FakeSink) -> None:
+    query._capture_context_activation(command="search", item_count=2)
+
+    assert [event.name for event in fake_sink.events] == [
+        "cli_onboarding_first_use_command_succeeded",
+        "cli_onboarding_first_context_result_returned",
+        "cli_usage_command_succeeded",
+    ]
+    assert fake_sink.events[-1].properties["command"] == "search"
+    assert fake_sink.events[-1].properties["result_kind"] == "context_result"
+    assert fake_sink.events[-1].properties["item_count"] == 2
+
+
+def test_ingest_scan_activation_also_records_usage(fake_sink: _FakeSink) -> None:
+    ingest._capture_ingest_scan_activation(
+        scanners_run=1,
+        entities_upserted=2,
+        edges_upserted=3,
+    )
+
+    assert [event.name for event in fake_sink.events] == [
+        "cli_onboarding_ingest_scan_completed",
+        "cli_onboarding_first_use_command_succeeded",
+        "cli_usage_command_succeeded",
+    ]
+    assert fake_sink.events[-1].properties["command"] == "ingest scan"
+    assert fake_sink.events[-1].properties["result_kind"] == "scan_result"
+
+
+def test_host_status_activation_does_not_record_usage(fake_sink: _FakeSink) -> None:
+    bootstrap._capture_host_status_activation()
+
+    assert [event.name for event in fake_sink.events] == [
+        "cli_onboarding_first_use_command_succeeded"
+    ]
+
+
+def test_github_repos_records_usage_after_success(
+    fake_sink: _FakeSink,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _common.set_json(True)
+    monkeypatch.setattr(github_commands, "get_store", lambda: _FakeGitHubStore())
+    monkeypatch.setattr(github_commands, "load_cli_env", lambda: None)
+    monkeypatch.setattr(
+        github_commands,
+        "list_user_owned_repositories",
+        lambda token: [{"full_name": "potpie/example"}, {"full_name": "potpie/docs"}],
+    )
+
+    github_commands.github_repos_impl()
+
+    assert [event.name for event in fake_sink.events] == ["cli_usage_command_succeeded"]
+    assert fake_sink.events[0].properties["command"] == "github repos"
+    assert fake_sink.events[0].properties["provider"] == "github"
+    assert fake_sink.events[0].properties["result_kind"] == "provider_list"
+    assert fake_sink.events[0].properties["item_count"] == 2
+
+
+@pytest.mark.parametrize(
+    ("command", "runner_name", "fetch_name"),
+    [
+        ("linear ls", "linear_ls", "fetch_linear_workspaces"),
+        ("jira ls", "jira_ls", "fetch_jira_projects"),
+        (
+            "confluence ls",
+            "confluence_ls",
+            "fetch_confluence_spaces_sample",
+        ),
+    ],
+)
+def test_provider_list_commands_record_usage_after_success(
+    fake_sink: _FakeSink,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    runner_name: str,
+    fetch_name: str,
+) -> None:
+    _common.set_json(True)
+    monkeypatch.setattr(auth_commands, "load_cli_env", lambda: None)
+    monkeypatch.setattr(
+        auth_commands,
+        fetch_name,
+        lambda limit: [{"key": "ONE"}, {"key": "TWO"}],
+    )
+
+    runner = getattr(auth_commands, runner_name)
+    runner(limit=2)
+
+    assert [event.name for event in fake_sink.events] == ["cli_usage_command_succeeded"]
+    event = fake_sink.events[0]
+    provider = command.split()[0]
+    assert event.properties["command"] == command
+    assert event.properties["provider"] == provider
+    assert event.properties["result_kind"] == "provider_list"
+    assert event.properties["item_count"] == 2
+
+
+@pytest.mark.parametrize(
+    ("product", "provider"),
+    [("linear", "linear"), ("jira", "jira"), ("wiki", "confluence")],
+)
+def test_provider_select_result_records_usage_after_success(
+    fake_sink: _FakeSink,
+    product: str,
+    provider: str,
+) -> None:
+    _common.set_json(True)
+
+    auth_commands._run_product_use_result(
+        {
+            "product": product,
+            "workspace_key": "ENG",
+            "workspace_name": "Engineering",
+            "items": [{"id": "one"}, {"id": "two"}],
+        },
+        product_label=provider.title(),
+    )
+
+    assert [event.name for event in fake_sink.events] == ["cli_usage_command_succeeded"]
+    assert fake_sink.events[0].properties["command"] == f"{provider} select"
+    assert fake_sink.events[0].properties["provider"] == provider
+    assert fake_sink.events[0].properties["result_kind"] == "provider_selection"
+    assert fake_sink.events[0].properties["item_count"] == 2

--- a/potpie/context-engine/tests/unit/test_usage_analytics.py
+++ b/potpie/context-engine/tests/unit/test_usage_analytics.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 
 import pytest
 
+import adapters.inbound.cli.telemetry.product_analytics as product_analytics
 from adapters.inbound.cli.auth import auth_commands, github_commands
 from adapters.inbound.cli.commands import _common, bootstrap, ingest, query
 from adapters.inbound.cli.telemetry.context import TelemetryContext
-from adapters.inbound.cli.telemetry.product_analytics import (
-    ProductAnalyticsEvent,
-    set_product_analytics_sink,
-)
+from adapters.inbound.cli.telemetry.product_analytics import ProductAnalyticsEvent
 from adapters.inbound.cli.telemetry.usage_events import (
     capture_usage_command_succeeded,
 )
@@ -34,12 +34,22 @@ class _FakeGitHubStore:
 @pytest.fixture()
 def fake_sink(monkeypatch: pytest.MonkeyPatch) -> _FakeSink:
     sink = _FakeSink()
-    set_product_analytics_sink(sink)
+    monkeypatch.setattr(product_analytics, "_sink", sink)
     monkeypatch.setattr(
         "adapters.inbound.cli.telemetry.product_analytics.current_telemetry_context",
         _telemetry_context,
     )
     return sink
+
+
+@contextmanager
+def _cli_json_mode() -> Iterator[None]:
+    previous = _common.is_json()
+    _common.set_json(True)
+    try:
+        yield
+    finally:
+        _common.set_json(previous)
 
 
 def _telemetry_context() -> TelemetryContext:
@@ -122,7 +132,6 @@ def test_github_repos_records_usage_after_success(
     fake_sink: _FakeSink,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _common.set_json(True)
     monkeypatch.setattr(github_commands, "get_store", lambda: _FakeGitHubStore())
     monkeypatch.setattr(github_commands, "load_cli_env", lambda: None)
     monkeypatch.setattr(
@@ -131,7 +140,8 @@ def test_github_repos_records_usage_after_success(
         lambda token: [{"full_name": "potpie/example"}, {"full_name": "potpie/docs"}],
     )
 
-    github_commands.github_repos_impl()
+    with _cli_json_mode():
+        github_commands.github_repos_impl()
 
     assert [event.name for event in fake_sink.events] == ["cli_usage_command_succeeded"]
     assert fake_sink.events[0].properties["command"] == "github repos"
@@ -159,7 +169,6 @@ def test_provider_list_commands_record_usage_after_success(
     runner_name: str,
     fetch_name: str,
 ) -> None:
-    _common.set_json(True)
     monkeypatch.setattr(auth_commands, "load_cli_env", lambda: None)
     monkeypatch.setattr(
         auth_commands,
@@ -168,7 +177,8 @@ def test_provider_list_commands_record_usage_after_success(
     )
 
     runner = getattr(auth_commands, runner_name)
-    runner(limit=2)
+    with _cli_json_mode():
+        runner(limit=2)
 
     assert [event.name for event in fake_sink.events] == ["cli_usage_command_succeeded"]
     event = fake_sink.events[0]
@@ -188,17 +198,16 @@ def test_provider_select_result_records_usage_after_success(
     product: str,
     provider: str,
 ) -> None:
-    _common.set_json(True)
-
-    auth_commands._run_product_use_result(
-        {
-            "product": product,
-            "workspace_key": "ENG",
-            "workspace_name": "Engineering",
-            "items": [{"id": "one"}, {"id": "two"}],
-        },
-        product_label=provider.title(),
-    )
+    with _cli_json_mode():
+        auth_commands._run_product_use_result(
+            {
+                "product": product,
+                "workspace_key": "ENG",
+                "workspace_name": "Engineering",
+                "items": [{"id": "one"}, {"id": "two"}],
+            },
+            product_label=provider.title(),
+        )
 
     assert [event.name for event in fake_sink.events] == ["cli_usage_command_succeeded"]
     assert fake_sink.events[0].properties["command"] == f"{provider} select"


### PR DESCRIPTION
## Summary

Adds usage-only PostHog analytics for successful CLI commands so the usage dashboard can track active command usage separately from onboarding events.

## Changes

- Adds `cli_usage_command_succeeded` capture helper.
- Records usage events for query/context activation, ingest scan results, provider list commands, provider selection commands, and GitHub repo listing.
- Keeps onboarding-only fields out of usage events while preserving canonical telemetry context properties such as install identity, environment, CLI version, platform, and architecture.
- Adds focused unit coverage for the usage event paths.

## Validation

- `uv run pytest tests/unit/test_usage_analytics.py`
- `uv run ruff check adapters/inbound/cli/auth/auth_commands.py adapters/inbound/cli/auth/github_commands.py adapters/inbound/cli/commands/ingest.py adapters/inbound/cli/commands/query.py adapters/inbound/cli/telemetry/usage_events.py tests/unit/test_usage_analytics.py`

## Notes

This PR branch was created from latest `origin/main` and contains only the latest local commit from `feat/posthog-cli-usage`. The cherry-pick applied cleanly with no merge conflicts.
