### PR TITLE
fix(setup): resolve README and start script discrepancies

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,36 +122,6 @@ To stop all services:
 ./legacy/scripts/stop.sh
 ```
 
-### Troubleshooting
-
-#### Port already in use
-If you see errors like `address already in use` for ports `5432` (Postgres) or `6379` (Redis), you likely already have services bound to those ports. Edit `legacy/compose.yaml` to map to different host ports, for example:
-
-```yaml
-# In legacy/compose.yaml
-services:
-  postgres:
-    ports:
-      - "5433:5432"   # change the host side
-  redis:
-    ports:
-      - "6380:6379"   # change the host side
-```
-
-Then update your `legacy/.env` accordingly:
-
-```bash
-POSTGRES_SERVER=postgresql://postgres:mysecretpassword@localhost:5433/momentum
-REDISPORT=6380
-BROKER_URL=redis://127.0.0.1:6380/0
-```
-
-#### `alembic: command not found`
-The `legacy` folder is not part of the uv workspace (`members = ["potpie/*"]`), so running `uv sync --all-packages` from the repo root does not install legacy dependencies (gunicorn, celery, alembic). Ensure you run `uv sync --project legacy/` before starting, or use the `legacy/scripts/start.sh` script which handles this for you.
-
-#### `.env: line N: yourGithubUsername: No such file or directory`
-The `.env.template` contains `PRIVATE_TEST_REPO_NAME=<yourGithubUsername>/potpie-private-test-repo`. Because `.env` is sourced by bash, the `<>` characters are interpreted as redirection operators. Edit your `.env` to comment out or remove that line, or escape the value in quotes.
-
 #### Now set up Potpie Frontend
 
 Clone the UI repo separately (it is no longer a submodule of this repository):

--- a/README.md
+++ b/README.md
@@ -122,6 +122,36 @@ To stop all services:
 ./legacy/scripts/stop.sh
 ```
 
+### Troubleshooting
+
+#### Port already in use
+If you see errors like `address already in use` for ports `5432` (Postgres) or `6379` (Redis), you likely already have services bound to those ports. Edit `legacy/compose.yaml` to map to different host ports, for example:
+
+```yaml
+# In legacy/compose.yaml
+services:
+  postgres:
+    ports:
+      - "5433:5432"   # change the host side
+  redis:
+    ports:
+      - "6380:6379"   # change the host side
+```
+
+Then update your `legacy/.env` accordingly:
+
+```bash
+POSTGRES_SERVER=postgresql://postgres:mysecretpassword@localhost:5433/momentum
+REDISPORT=6380
+BROKER_URL=redis://127.0.0.1:6380/0
+```
+
+#### `alembic: command not found`
+The `legacy` folder is not part of the uv workspace (`members = ["potpie/*"]`), so running `uv sync --all-packages` from the repo root does not install legacy dependencies (gunicorn, celery, alembic). Ensure you run `uv sync --project legacy/` before starting, or use the `legacy/scripts/start.sh` script which handles this for you.
+
+#### `.env: line N: yourGithubUsername: No such file or directory`
+The `.env.template` contains `PRIVATE_TEST_REPO_NAME=<yourGithubUsername>/potpie-private-test-repo`. Because `.env` is sourced by bash, the `<>` characters are interpreted as redirection operators. Edit your `.env` to comment out or remove that line, or escape the value in quotes.
+
 #### Now set up Potpie Frontend
 
 Clone the UI repo separately (it is no longer a submodule of this repository):

--- a/legacy/.env.template
+++ b/legacy/.env.template
@@ -261,7 +261,7 @@ CODE_PROVIDER_TOKEN=
 # CODE_PROVIDER_TOKEN=your_token
 
 # Testing
-# PRIVATE_TEST_REPO_NAME=<yourGithubUsername>/potpie-private-test-repo
+PRIVATE_TEST_REPO_NAME=<yourGithubUsername>/potpie-private-test-repo
 
 # Linear OAuth (backend / web integrations; CLI ships a default client id in provider_config.py)
 # LINEAR_CLIENT_ID=  # optional override for CLI or required for API server Linear OAuth

--- a/legacy/.env.template
+++ b/legacy/.env.template
@@ -86,7 +86,7 @@ CONTEXT_GRAPH_JOB_QUEUE_BACKEND=celery
 
 # Database Configuration
 POSTGRES_PASSWORD=your_password_here
-POSTGRES_SERVER=postgresql://postgres:${POSTGRES_PASSWORD}@localhost:5432/momentum_dev
+POSTGRES_SERVER=postgresql://postgres:${POSTGRES_PASSWORD}@localhost:5432/momentum
 
 NEO4J_URI=bolt://127.0.0.1:7687
 NEO4J_USERNAME=neo4j
@@ -261,7 +261,7 @@ CODE_PROVIDER_TOKEN=
 # CODE_PROVIDER_TOKEN=your_token
 
 # Testing
-PRIVATE_TEST_REPO_NAME=<yourGithubUsername>/potpie-private-test-repo
+# PRIVATE_TEST_REPO_NAME=<yourGithubUsername>/potpie-private-test-repo
 
 # Linear OAuth (backend / web integrations; CLI ships a default client id in provider_config.py)
 # LINEAR_CLIENT_ID=  # optional override for CLI or required for API server Linear OAuth

--- a/legacy/scripts/start.sh
+++ b/legacy/scripts/start.sh
@@ -43,7 +43,11 @@ fi
 # Synchronize and create the managed virtual environment if needed
 echo "Syncing Python environment with uv..."
 if ! (cd "$REPO_ROOT" && uv sync --all-packages); then
-  echo "Error: Failed to synchronize Python dependencies"
+  echo "Error: Failed to synchronize root Python dependencies"
+  exit 1
+fi
+if ! (cd "$REPO_ROOT" && uv sync --project "$LEGACY_ROOT"); then
+  echo "Error: Failed to synchronize legacy Python dependencies"
   exit 1
 fi
 
@@ -81,14 +85,13 @@ if [[ "$OSTYPE" == "darwin"* ]] || [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == 
   fi
 fi
 
-cd "$REPO_ROOT"
-source .venv/bin/activate
 cd "$LEGACY_ROOT"
 
-alembic -c alembic.ini upgrade heads
+echo "Applying database migrations..."
+uv run --project "$LEGACY_ROOT" alembic -c alembic.ini upgrade heads
 
 echo "Starting momentum application..."
-gunicorn --worker-class uvicorn.workers.UvicornWorker --workers 1 --timeout 1800 --bind 0.0.0.0:8001 --log-level debug app.main:app &
+uv run --project "$LEGACY_ROOT" gunicorn --worker-class uvicorn.workers.UvicornWorker --workers 1 --timeout 1800 --bind 0.0.0.0:8001 --log-level debug app.main:app &
 GUNICORN_PID=$!
 
 echo "Starting Celery worker..."
@@ -99,7 +102,7 @@ _cg_lc=$(printf '%s' "$_cg" | tr '[:upper:]' '[:lower:]')
 if [[ "$_cg_lc" != "false" && "$_cg_lc" != "0" && "$_cg_lc" != "no" && "$_cg_lc" != "off" && "$_cg_lc" != "" ]]; then
   CELERY_QUEUES="${CELERY_QUEUES},context-graph-etl"
 fi
-celery -A app.celery.celery_app worker --loglevel=debug -Q "${CELERY_QUEUES}" -E --concurrency=1 --pool=solo -B --schedule=.celerybeat-schedule &
+uv run --project "$LEGACY_ROOT" celery -A app.celery.celery_app worker --loglevel=debug -Q "${CELERY_QUEUES}" -E --concurrency=1 --pool=solo -B --schedule=.celerybeat-schedule &
 CELERY_PID=$!
 
 # Keep this script in the foreground and forward Ctrl+C to app workers.


### PR DESCRIPTION
Fixes the following issues discovered during setup:

1. Database name mismatch: .env.template used 'momentum_dev' but compose.yaml creates 'momentum', causing migration failures.

2. Shell syntax error in .env.template: PRIVATE_TEST_REPO_NAME contained <>
characters which bash interprets as redirection operators when .env is sourced.

3. start.sh used root .venv but legacy deps (alembic, gunicorn, celery) are not installed there because legacy/ is not in the uv workspace. Now uses 'uv run --project "$LEGACY_ROOT"' for all legacy commands.