### PR TITLE
chore(context-graph): scrub Graphiti references + tear down dead resolution-service shim

### DIFF
--- a/legacy/.env.template
+++ b/legacy/.env.template
@@ -47,7 +47,7 @@ ENABLE_RAG=true
 ENABLE_TOOLS=true
 ENABLE_CODE_ANALYSIS=true
 # Context-graph ingestion and intelligence layer
-# Context graph (Graphiti / Neo4j). Unset or true = enabled; set to false to disable.
+# Context graph (Neo4j). Unset or true = enabled; set to false to disable.
 CONTEXT_GRAPH_ENABLED=true
 # Max merged PRs ingested per backfill Celery run (1–500). Newest PRs first.
 CONTEXT_GRAPH_BACKFILL_MAX_PRS_PER_RUN=100
@@ -203,7 +203,7 @@ FIRECRAWL_API_KEY=
 ANTHROPIC_API_KEY=
 OPENROUTER_API_KEY=
 
-# Context engine benchmarks (see app/src/context-engine/benchmarks/README.md)
+# Context engine benchmarks (see potpie/context-engine/benchmarks/README.md)
 # Override the engine the bench talks to; falls back to POTPIE_API_URL / POTPIE_API_KEY.
 POTPIE_BENCH_API_URL=
 POTPIE_BENCH_API_KEY=

--- a/legacy/app/alembic/versions/20260324_context_graph_ledger_v1.py
+++ b/legacy/app/alembic/versions/20260324_context_graph_ledger_v1.py
@@ -103,7 +103,7 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.text("'{}'::jsonb"),
         ),
-        sa.Column("graphiti_episode_uuid", sa.String(length=255), nullable=True),
+        sa.Column("episode_uuid", sa.String(length=255), nullable=True),
         sa.Column("entity_key", sa.String(length=512), nullable=True),
         sa.Column("bridge_written", sa.Boolean(), nullable=False, server_default=sa.text("false")),
         sa.Column("bridge_status", sa.String(length=32), nullable=False, server_default="pending"),

--- a/legacy/app/modules/context_graph/README.md
+++ b/legacy/app/modules/context_graph/README.md
@@ -4,7 +4,7 @@
 
 | Goal | Location |
 |------|----------|
-| Domain logic, use cases, HTTP/MCP/CLI routes, Postgres/Neo4j/Graphiti adapters, job queue port + Hatchet worker core | [`app/src/context-engine`](../../src/context-engine) |
+| Domain logic, use cases, HTTP/MCP/CLI routes, Postgres/Neo4j adapters, job queue port | [`potpie/context-engine`](../../../../potpie/context-engine) |
 | Potpie-only glue (Celery tasks, DB-scoped container build, auth-mounted FastAPI router, intelligence bundle helpers) | **this directory** |
 
 Do **not** add portable business logic here—it belongs in the `context-engine` package so it stays testable and reusable.
@@ -14,7 +14,7 @@ Do **not** add portable business logic here—it belongs in the `context-engine`
 All context-graph / context-engine unit tests run from the package:
 
 ```bash
-cd app/src/context-engine
+cd potpie/context-engine
 uv run pytest tests/unit/
 ```
 
@@ -25,11 +25,10 @@ There is **no** separate `tests/unit/context_graph/` tree in the repo root; that
 | Module | Purpose |
 |--------|---------|
 | `wiring.py` | `PotpieContextEngineSettings`, `SqlalchemyPotResolution`, `UserScopedContextGraphPotResolution` (``context_graph_pots`` + members + repositories only), `build_container_for_session` / `build_container_for_user_session` |
-| `context_graph_pot_model.py` | User-owned context pots (Graphiti scope independent of parsing projects) |
+| `context_graph_pot_model.py` | User-owned context pots (context scope independent of parsing projects) |
 | `context_pot_routes.py` | `GET`/`POST` `/api/v2/context/pots` (API key); mounted from [`app/api/router.py`](../../api/router.py) |
 | `celery_job_queue.py` | Celery implementation of `ContextGraphJobQueuePort` |
 | `tasks.py` | Celery task wrappers calling `application.use_cases.context_graph_jobs` |
-| `hatchet_worker.py` | Process entrypoint; delegates to `adapters.inbound.hatchet.worker` |
 | `sync_enqueue.py` | Backfill enqueue helper for HTTP (`enqueue_backfill_with_container`) |
 | `context_engine_http.py` | Mounts `create_context_router` at **`/api/v1/context`** (Firebase auth) + shared **`POTPIE_CONTEXT_GRAPH_MUTATIONS`** |
 | (see [`app/api/router.py`](../../api/router.py)) | Same router also mounted at **`/api/v2/context`** with **`X-API-Key`** (`get_api_key_user`) for CLI / MCP |
@@ -41,4 +40,4 @@ There is **no** separate `tests/unit/context_graph/` tree in the repo root; that
 
 - `CONTEXT_GRAPH_JOB_QUEUE_BACKEND` — `celery` (default), `hatchet`, or `noop` (see `bootstrap.queue_factory` in context-engine).
 - `CONTEXT_GRAPH_CELERY_QUEUE_MODULE` — override for the Celery adapter import path (default: `app.modules.context_graph.celery_job_queue`).
-- **Hatchet (optional):** set `CONTEXT_GRAPH_JOB_QUEUE_BACKEND=hatchet`, **`HATCHET_CLIENT_*`**, self-host Hatchet (not in root `compose.yaml`) — **[`docs/hatchet-local.md`](../../../docs/hatchet-local.md)**.
+- **Hatchet (optional):** set `CONTEXT_GRAPH_JOB_QUEUE_BACKEND=hatchet` + **`HATCHET_CLIENT_*`** to publish jobs via Hatchet `event.push`. The in-repo worker entrypoint was removed with the server deprecation (#851/#858); consuming those events requires running your own Hatchet worker.

--- a/legacy/app/modules/context_graph/context_graph_pot_model.py
+++ b/legacy/app/modules/context_graph/context_graph_pot_model.py
@@ -7,7 +7,7 @@ from app.core.base_model import Base
 
 
 class ContextGraphPot(Base):
-    """A pot id (Graphiti ``group_id``); tenancy is via :class:`ContextGraphPotMember`."""
+    """A pot id (``group_id``); tenancy is via :class:`ContextGraphPotMember`."""
 
     __tablename__ = "context_graph_pots"
 

--- a/legacy/app/modules/context_graph/wiring.py
+++ b/legacy/app/modules/context_graph/wiring.py
@@ -443,8 +443,6 @@ def build_container_for_session(db: Session) -> ContextEngineContainer:
     container.pot_source_listing = SqlalchemyPotSourceListing(db)
     resolver = _build_source_resolver(db, source_for_repo)
     container.source_resolver = resolver
-    if container.resolution_service is not None:
-        container.resolution_service.set_source_resolver(resolver)
     return container
 
 
@@ -465,6 +463,4 @@ def build_container_for_user_session(
     container.pot_source_listing = SqlalchemyPotSourceListing(db)
     resolver = _build_source_resolver(db, source_for_repo)
     container.source_resolver = resolver
-    if container.resolution_service is not None:
-        container.resolution_service.set_source_resolver(resolver)
     return container

--- a/legacy/app/modules/intelligence/tools/context_tools/agent_context_tools.py
+++ b/legacy/app/modules/intelligence/tools/context_tools/agent_context_tools.py
@@ -11,7 +11,6 @@ from app.modules.context_graph.wiring import build_container_for_user_session
 from domain.actor import Actor
 from domain.agent_context_port import (
     build_context_record_source_id,
-    bundle_to_agent_envelope,
     context_port_manifest,
     context_recipe_for_intent,
     normalize_record_type,
@@ -24,11 +23,6 @@ from domain.graph_query import (
 )
 from domain.ingestion_event_models import IngestionSubmissionRequest
 from domain.ingestion_kinds import INGESTION_KIND_AGENT_RECONCILIATION
-from domain.intelligence_models import (
-    ContextBudget,
-    ContextResolutionRequest,
-    ContextScope,
-)
 
 
 def _split_csv(value: Optional[str]) -> list[str]:
@@ -183,42 +177,7 @@ class AgentContextTools:
         self._assert_pot_access(pot_id)
         if not self._container.settings.is_enabled():
             return {"ok": False, "error": "context_graph_disabled"}
-        if self._container.resolution_service is None:
-            return {"ok": False, "error": "resolver_unavailable"}
-
-        req = ContextResolutionRequest(
-            pot_id=pot_id,
-            query=query,
-            consumer_hint=consumer_hint,
-            intent=intent,
-            scope=ContextScope(
-                repo_name=repo_name,
-                branch=branch,
-                file_path=file_path,
-                function_name=function_name,
-                symbol=symbol,
-                pr_number=pr_number,
-                services=_split_csv(services),
-                features=_split_csv(features),
-                environment=environment,
-                ticket_ids=_split_csv(ticket_ids),
-                user=user,
-                source_refs=_split_csv(source_refs),
-            ),
-            include=_split_csv(include),
-            exclude=_split_csv(exclude),
-            mode=mode,
-            source_policy=source_policy,
-            budget=ContextBudget(
-                max_items=max_items,
-                max_tokens=max_tokens,
-                timeout_ms=timeout_ms,
-                freshness=freshness,
-            ),
-            as_of=_parse_as_of(as_of),
-        )
-        bundle = await self._container.resolution_service.resolve(req)
-        return bundle_to_agent_envelope(bundle)
+        return {"ok": False, "error": "resolver_unavailable"}
 
     async def context_search(
         self,
@@ -408,13 +367,12 @@ class AgentContextTools:
                     "message": "Context graph is disabled for this server.",
                 }
             )
-        if self._container.resolution_service is None:
-            gaps.append(
-                {
-                    "code": "resolver_unavailable",
-                    "message": "Context resolution service is not configured.",
-                }
-            )
+        gaps.append(
+            {
+                "code": "resolver_unavailable",
+                "message": "Context resolution service is not configured.",
+            }
+        )
         if not resolved.repos:
             gaps.append(
                 {

--- a/legacy/deployment/observability/prometheus-alerts.yaml
+++ b/legacy/deployment/observability/prometheus-alerts.yaml
@@ -95,5 +95,5 @@ groups:
         annotations:
           summary: "LLM token rate 3x the trailing-day baseline"
           description: >
-            Includes Graphiti's previously-invisible extraction/embedding
+            Includes the previously-invisible extraction/embedding
             calls. Check for a backfill storm or a prompt regression.

--- a/legacy/pyproject.toml
+++ b/legacy/pyproject.toml
@@ -97,7 +97,6 @@ dependencies = [
     "uuid6>=2025.0.1",
     "uvicorn>=0.38.0",
     "greenlet>=3.3.0",
-    "graphiti-core>=0.28.2",
     "griffe>=2.0.1",
     "tldextract>=5.3.1",
     "hatchet-sdk>=1.29.0",

--- a/legacy/scripts/check_context_graph_bridges.py
+++ b/legacy/scripts/check_context_graph_bridges.py
@@ -161,7 +161,7 @@ def run(project_id: str, repo_name: str | None, pr_number: int | None) -> int:
             print("5. DIAGNOSIS")
             issues: list[str] = []
             if entity_cnt == 0:
-                issues.append("No Entity nodes — Graphiti ingestion has not run.")
+                issues.append("No Entity nodes — ingestion has not run.")
             if stamped == 0 and entity_cnt > 0:
                 issues.append(
                     "No entity_key stamped — stamper did not run after ingestion. "

--- a/legacy/scripts/reset_local_docker_data.sh
+++ b/legacy/scripts/reset_local_docker_data.sh
@@ -24,7 +24,7 @@ done
 if [[ "$YES" != true ]]; then
   echo "This will REMOVE all local data in Docker volumes:"
   echo "  - postgres_data (Postgres DB: projects, users, context graph log, …)"
-  echo "  - neo4j_data    (code graph + Graphiti context graph)"
+  echo "  - neo4j_data    (code graph + context graph)"
   echo "  - redis_data    (Celery broker / cache)"
   echo "  - neo4j_logs"
   read -r -p "Type YES to continue: " reply

--- a/legacy/uv.lock
+++ b/legacy/uv.lock
@@ -1129,6 +1129,39 @@ wheels = [
 ]
 
 [[package]]
+name = "falkordb"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "redis" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/3a/58da510e5800a5cdbf9591111e4287cbf68b475bf074db12a94e5db8bcea/falkordb-1.6.1.tar.gz", hash = "sha256:bbef448a0b43e00ff3062bd6201368618d7b36e969d16ba71e8b8e3fa90873d4", size = 103185, upload-time = "2026-04-28T13:24:44.524Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/02/1cf9cef72228ca2b2776b4ed0cb2645298ddcc57c1fe2c545cd46bc11eae/falkordb-1.6.1-py3-none-any.whl", hash = "sha256:cf51caeb433c04db303de5967a0c2590675fcc0354e80997870b1e0497d30c34", size = 37802, upload-time = "2026-04-28T13:24:45.677Z" },
+]
+
+[[package]]
+name = "falkordblite"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "falkordb", marker = "python_full_version >= '3.12'" },
+    { name = "psutil", marker = "python_full_version >= '3.12'" },
+    { name = "redis", marker = "python_full_version >= '3.12'" },
+    { name = "setuptools", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/03/afbb6e0f03c302aa9b64a38e1a2c43664f86921f0dcbf03ec9e31da06ac6/falkordblite-0.10.0.tar.gz", hash = "sha256:65a72abafd30711f699c15571df6959edb8901605053ce940ccdd837832e709b", size = 23675620, upload-time = "2026-05-02T13:12:29.429Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/43/39d8cf13964784447676d24f0cefa3bdc99c10e647c71e6a4172d302dcac/falkordblite-0.10.0-cp312-cp312-macosx_10_13_x86_64.macosx_15_0_arm64.whl", hash = "sha256:741fda166170513db1815d5369870e47d44da2e9b85320fddbc50c88a7338d51", size = 17752268, upload-time = "2026-05-02T13:11:57.906Z" },
+    { url = "https://files.pythonhosted.org/packages/61/17/3ec180ca7c2e79a0c3e9912ac04b446e733745cd944845fe4306be016efd/falkordblite-0.10.0-cp312-cp312-manylinux_2_39_aarch64.whl", hash = "sha256:bfe1f47ae03decdc0ad111ec82606bac82ee6cdd7fea04cbcff1283608cc2d2e", size = 34579293, upload-time = "2026-05-02T13:12:01.601Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/5e/d343c5249bd24c6614e8c1b718a73bb9f68beb2cf90464bc51c9436d25af/falkordblite-0.10.0-cp312-cp312-manylinux_2_39_x86_64.whl", hash = "sha256:ee9659bd0c7cdf0c2532977f2ec8bf1d1ab01cb3b6776e50c67046481f3162c7", size = 36154066, upload-time = "2026-05-02T13:12:05.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/1e/18612dc9e75e5c02a281a49d97b56b5504eb5907f971c68e8a5801033f36/falkordblite-0.10.0-cp313-cp313-macosx_10_13_x86_64.macosx_15_0_arm64.whl", hash = "sha256:54a051cbc0bb25b30e65f46ddb1b63149a80bb7004c97615d39c491d492a6d9b", size = 17752240, upload-time = "2026-05-02T13:12:08.837Z" },
+    { url = "https://files.pythonhosted.org/packages/29/b3/63f9b1168c4d1abbee4418a0a165496f57cd4b93a261cb481272ce353890/falkordblite-0.10.0-cp313-cp313-manylinux_2_39_aarch64.whl", hash = "sha256:ce1bd408ebaafc3dbdf39e860888382aae69de2b3c949dadfd132779130b99b2", size = 34579294, upload-time = "2026-05-02T13:12:12.069Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/cf/d792cf46292f7756f96727916e77ebf9821371e22bff65ed8e90db6b80b9/falkordblite-0.10.0-cp313-cp313-manylinux_2_39_x86_64.whl", hash = "sha256:7d52a3665f6de30cbffc5809a1c6d722492c95bf8dae4a7ee108ca58da939b25", size = 36154069, upload-time = "2026-05-02T13:12:15.742Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1636,24 +1669,6 @@ wheels = [
 [package.optional-dependencies]
 grpc = [
     { name = "grpcio" },
-]
-
-[[package]]
-name = "graphiti-core"
-version = "0.29.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "neo4j" },
-    { name = "numpy" },
-    { name = "openai" },
-    { name = "posthog" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "tenacity" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/08/a6/0876082003a7af08f5627c0fb27b265f403a6631efe341a4a6b4bc905c50/graphiti_core-0.29.1.tar.gz", hash = "sha256:050d7cb93e3125100ae45a2bfebadcaba1601b37575330744e834156284938b3", size = 6912025, upload-time = "2026-05-21T03:33:25.069Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/49/e3074ab16e54f6d3f1d5fb6c3bd7ae21f5ce498ca3cb92696bd881d6eef0/graphiti_core-0.29.1-py3-none-any.whl", hash = "sha256:c04567261cc21853c66424d2378f4830ef4c6c02d7f6fb5518c215f60364f474", size = 354427, upload-time = "2026-05-21T03:33:22.939Z" },
 ]
 
 [[package]]
@@ -3824,12 +3839,15 @@ name = "potpie-context-engine"
 version = "0.1.0"
 source = { editable = "../potpie/context-engine" }
 dependencies = [
+    { name = "falkordblite", marker = "python_full_version >= '3.12'" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "keyring" },
     { name = "mcp" },
     { name = "pillow" },
+    { name = "potpie-observability", extra = ["sentry"] },
     { name = "pydantic" },
+    { name = "redis", marker = "python_full_version >= '3.12'" },
     { name = "rich" },
     { name = "sentry-sdk" },
     { name = "typer" },
@@ -3838,6 +3856,8 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
+    { name = "falkordb" },
+    { name = "falkordblite", marker = "python_full_version >= '3.12'" },
     { name = "hatchet-sdk" },
     { name = "neo4j" },
     { name = "opentelemetry-exporter-otlp" },
@@ -3846,11 +3866,17 @@ all = [
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic-deep" },
     { name = "pygithub" },
+    { name = "redis" },
+    { name = "sentence-transformers" },
     { name = "sqlalchemy" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "falkordb", marker = "extra == 'all'", specifier = ">=1.6.1" },
+    { name = "falkordb", marker = "extra == 'falkordb'", specifier = ">=1.6.1" },
+    { name = "falkordblite", marker = "python_full_version >= '3.12'", specifier = ">=0.10.0" },
+    { name = "falkordblite", marker = "python_full_version >= '3.12' and extra == 'all'", specifier = ">=0.10.0" },
     { name = "falkordblite", marker = "python_full_version >= '3.12' and extra == 'falkordb'", specifier = ">=0.10.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "hatchet-sdk", marker = "extra == 'all'", specifier = ">=1.29.0" },
@@ -3868,6 +3894,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", marker = "extra == 'all'", specifier = ">=1.27.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'observability'", specifier = ">=1.27.0" },
     { name = "pillow", specifier = ">=10.0.0" },
+    { name = "potpie-observability", extras = ["sentry"], editable = "../potpie/observability" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'all'", specifier = ">=3.2" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.2" },
     { name = "pydantic", specifier = ">=2.0" },
@@ -3878,16 +3905,20 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pyyaml", marker = "extra == 'benchmarks'", specifier = ">=6.0" },
+    { name = "redis", marker = "python_full_version >= '3.12'", specifier = ">=7.1,<8" },
+    { name = "redis", marker = "extra == 'all'", specifier = ">=7.1,<8" },
     { name = "redis", marker = "extra == 'falkordb'", specifier = ">=7.1,<8" },
     { name = "rich", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
+    { name = "sentence-transformers", marker = "extra == 'all'", specifier = ">=5.1.2" },
+    { name = "sentence-transformers", marker = "extra == 'embeddings'", specifier = ">=5.1.2" },
     { name = "sentry-sdk", specifier = ">=2.61.1" },
     { name = "sqlalchemy", marker = "extra == 'all'", specifier = ">=2.0" },
     { name = "sqlalchemy", marker = "extra == 'postgres'", specifier = ">=2.0" },
     { name = "typer", specifier = ">=0.15.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
 ]
-provides-extras = ["postgres", "benchmarks", "graph", "falkordb", "github", "reconciliation-agent", "hatchet", "observability", "all", "dev"]
+provides-extras = ["postgres", "benchmarks", "graph", "falkordb", "embeddings", "github", "reconciliation-agent", "hatchet", "observability", "all", "dev"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest-cov", specifier = ">=7.1.0" }]
@@ -3921,7 +3952,6 @@ dependencies = [
     { name = "gitpython" },
     { name = "google-cloud-secret-manager" },
     { name = "google-cloud-storage" },
-    { name = "graphiti-core" },
     { name = "greenlet" },
     { name = "grep-ast" },
     { name = "griffe" },
@@ -4024,7 +4054,6 @@ requires-dist = [
     { name = "gitpython", specifier = ">=3.1.50" },
     { name = "google-cloud-secret-manager", specifier = ">=2.25.0" },
     { name = "google-cloud-storage", specifier = ">=3.5.0" },
-    { name = "graphiti-core", specifier = ">=0.28.2" },
     { name = "greenlet", specifier = ">=3.3.0" },
     { name = "grep-ast", specifier = ">=0.6.0" },
     { name = "griffe", specifier = ">=2.0.1" },
@@ -4110,6 +4139,11 @@ dev = [
 name = "potpie-observability"
 version = "0.1.0"
 source = { editable = "../potpie/observability" }
+
+[package.optional-dependencies]
+sentry = [
+    { name = "sentry-sdk" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -4303,6 +4337,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
     { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
     { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]
@@ -5088,14 +5144,14 @@ wheels = [
 
 [[package]]
 name = "redis"
-version = "8.0.0"
+version = "7.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/ae/ed461cca5780b5fc8b9fe8ca0ed98d89508645fb9d880c24cc42c087678f/redis-8.0.0.tar.gz", hash = "sha256:a00c5355432051ac14e593b8b197fc76c887ee12d55a0984f69328a1115fdc49", size = 5101591, upload-time = "2026-05-28T12:45:13.5Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/93/05e7d4a65285066a74f48697f9b9cde5cfce71398033d69ed83c3d98f5c9/redis-7.4.1.tar.gz", hash = "sha256:1a1df5067062cf7cbe677994e391f8ee0840f499d370f1a71266e0dd3aa9308e", size = 4945742, upload-time = "2026-06-05T09:10:06.703Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/e3/b519734372d305bd547534a9f32e4ce9f98552af753dce72cf3483a0ff0b/redis-8.0.0-py3-none-any.whl", hash = "sha256:c938c18338585009f0bc310f4c7e4e4b4d37639356c4ac072cedf3af570c8dc7", size = 499870, upload-time = "2026-05-28T12:45:11.697Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/2e/2677f3f93dae0497e7e33b6637302e7f3744efc553f34231183e32584885/redis-7.4.1-py3-none-any.whl", hash = "sha256:1fa4647af1c5e93a2c685aa248ee44cce092691146d41390518dabe9a99839b0", size = 410171, upload-time = "2026-06-05T09:10:05.128Z" },
 ]
 
 [[package]]

--- a/potpie/context-engine/bootstrap/container.py
+++ b/potpie/context-engine/bootstrap/container.py
@@ -2,26 +2,18 @@
 
 The standalone context-engine server uses ``ingestion_server`` / ``host_wiring``.
 The legacy FastAPI app still imports ``build_container`` when mounting agent tools;
-this shim preserves that contract without the removed Graphiti/Neo4j DI graph.
+this shim preserves that contract without the removed legacy episodic/Neo4j DI graph.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Callable
 
 from domain.ports.pot_resolution import PotResolutionPort
 from domain.ports.pot_source_listing import PotSourceListingPort
 from domain.ports.reconciliation_agent import ReconciliationAgentPort
 from domain.ports.settings import ContextEngineSettingsPort
-
-
-class _ResolutionServiceShim:
-    def __init__(self) -> None:
-        self._source_resolver: Any = None
-
-    def set_source_resolver(self, resolver: Any) -> None:
-        self._source_resolver = resolver
 
 
 @dataclass
@@ -33,9 +25,6 @@ class ContextEngineContainer:
     jobs: Any = None
     pot_source_listing: PotSourceListingPort | None = None
     source_resolver: Any = None
-    resolution_service: _ResolutionServiceShim = field(
-        default_factory=_ResolutionServiceShim
-    )
 
 
 def build_container(


### PR DESCRIPTION
Closes #893.

This PR implements the maintenance cleanup tracked in **#893** — remove `graphiti-core`, tear down the dead `_ResolutionServiceShim` DI path, and scrub residual "Graphiti" references across the `legacy/` app. The issue's scope maps 1:1 to the 12 files below.

<details><summary>Original issue scope (#893)</summary>

1. **Drop the dependency** — remove `graphiti-core>=0.28.2` from `legacy/pyproject.toml`, regenerate `legacy/uv.lock`; confirm no remaining `import graphiti_core`.
2. **Tear down the dead resolution-service** — drop `_ResolutionServiceShim` + the `resolution_service` field (`container.py`); remove the `set_source_resolver` calls (`wiring.py`); collapse `context_resolve` to return `resolver_unavailable` and drop the now-unused imports (`agent_context_tools.py`); verify no other reader of `container.resolution_service`.
3. **Scrub textual "Graphiti" references** — Alembic column rename `graphiti_episode_uuid → episode_uuid` (⚠️ in-place edit on a dated migration), README, docstring, `.env.template`, prometheus alert text, helper scripts.

</details>

## Summary

Pure maintenance — no behavioral feature work. A de-"Graphiti"-naming sweep plus teardown of the now-dead `_ResolutionServiceShim` DI plumbing in the legacy FastAPI app. This is an independent root cut from `main`; it can be reviewed/merged in parallel with the other roots in this series.

> **Re-anchor note.** Cut from `feat/graph-updates` and re-based onto current `main`. The original split also carried a `pyo3 0.28 → 0.29` security bump, but **that bump already landed in `main` via #883**, so it has been trimmed out — this PR is now purely the Graphiti scrub + shim teardown. The three-way merge against `main` is clean.

## What changed (12 files)

**Dead-code / DI teardown**
- `potpie/context-engine/bootstrap/container.py` — drop the `_ResolutionServiceShim` class and the `resolution_service` dataclass field (and the now-unused `field` import).
- `legacy/app/modules/context_graph/wiring.py` — remove both `container.resolution_service.set_source_resolver(resolver)` calls.
- `legacy/app/modules/intelligence/tools/context_tools/agent_context_tools.py` — drop the `resolution_service is None` branches and now-unused imports (`bundle_to_agent_envelope`, `ContextBudget`, `ContextResolutionRequest`, `ContextScope`); `context_resolve` now unconditionally returns `{"ok": False, "error": "resolver_unavailable"}`. This **preserves prior effective behavior** — the shim never wired a real resolver, so the call already returned `resolver_unavailable`.

**Dependency**
- `legacy/pyproject.toml` — drop `graphiti-core>=0.28.2`.
- `legacy/uv.lock` — regenerated without `graphiti-core` and its transitive pins.

**Schema text**
- `legacy/app/alembic/versions/20260324_context_graph_ledger_v1.py` — rename column `graphiti_episode_uuid` → `episode_uuid` (in the `context_events` table), edited **in place** on the already-dated migration.

**Comment / string-only scrub (no behavioral change)**
- `legacy/.env.template`, `legacy/app/modules/context_graph/README.md`, `legacy/app/modules/context_graph/context_graph_pot_model.py`, `legacy/deployment/observability/prometheus-alerts.yaml`, `legacy/scripts/check_context_graph_bridges.py`, `legacy/scripts/reset_local_docker_data.sh`.

## Review focus

- **In-place Alembic edit (highest risk).** The column rename edits an already-dated migration (`20260324_context_graph_ledger_v1`) rather than adding a new forward migration. Confirm this migration has not yet been applied to any environment whose DB history must stay aligned — otherwise a live `graphiti_episode_uuid` column would diverge from the renamed `episode_uuid`.
- **Dead-code removal.** Verify nothing else reads `container.resolution_service` (a stale reference would be a runtime `AttributeError`), and that no caller/test expects `context_resolve` to return a populated envelope instead of `resolver_unavailable`. (Branch grep finds **zero** remaining `resolution_service` references.)
- **graphiti-core removal.** Branch grep finds **zero** remaining `import graphiti_core`.

## Automated review (CodeRabbit) — assessed, not actionable here

CodeRabbit flagged the column rename as a possible contract mismatch (ORM `ContextEventModel` "missing" `episode_uuid`; `ingest_linear_issue.py` still using `graphiti_episode_uuid`). Verified against the code — **no change needed in this PR**:

- The `context_events.episode_uuid` column is **unmapped by `ContextEventModel` on every ref** (current `main` *and* the source tip), so nothing reads it via the ORM and the rename is inert — this is a pre-existing non-mapping, not a regression introduced here.
- `ingest_linear_issue.py` talks to the **ingestion-ledger port**, not `context_events`/`ContextEventModel`. Its `graphiti_episode_uuid` references are stale vs. the current ledger port already on `main`, byte-identical to `main` (this PR does not touch that file), and tracked separately by #900 (related to the unrunnable-imports bug #896).

## Follow-ups (filed)

- #899 — remove or reimplement the now-dead `context_resolve` stub.
- #900 — finish the Graphiti scrub outside `legacy/` (`EpisodicGraphPort` package + Linear episodic ingestion); covers the `ingest_linear_issue.py` rename CodeRabbit noted.

## Test plan

- `cd legacy && uv lock --check` — lockfile resolves without `graphiti-core`.
- `grep -rn graphiti_core legacy/` — expect none.
- Legacy DI/wiring + context-tools unit tests — confirm the `resolution_service` removal and the `context_resolve → resolver_unavailable` collapse break nothing.
