### PR TITLE
feat: CE v2 envelope + workbench ontology + read-surface contract + setup defaults + global instructions

### DIFF
--- a/potpie/context-engine/adapters/inbound/cli/commands/skills.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/skills.py
@@ -127,7 +127,12 @@ def skills_update(
 
 @skills_app.command("remove")
 def skills_remove(
-    skill_id: str,
+    skill_id: str | None = typer.Argument(None),
+    all_: bool = typer.Option(
+        False,
+        "--all",
+        help="Remove every installed Potpie skill for the selected agent and scope.",
+    ),
     agent: str = typer.Option("claude", "--agent"),
     path: str = typer.Option(None, "--path"),
     scope: str = typer.Option("global", "--scope"),
@@ -135,7 +140,11 @@ def skills_remove(
     with contract():
         effective_scope = _effective_scope(scope=scope, path=path)
         res = get_host().skills.remove(
-            agent=agent, skill_id=skill_id, path=path, scope=effective_scope
+            agent=agent,
+            skill_id=skill_id,
+            all_=all_,
+            path=path,
+            scope=effective_scope,
         )
         emit(
             {
@@ -144,7 +153,7 @@ def skills_remove(
                 "removed": list(res.changed),
                 "metadata": dict(res.metadata),
             },
-            human=f"removed {skill_id}",
+            human=_format_skill_remove(agent=res.agent, removed=res.changed),
         )
 
 
@@ -185,6 +194,12 @@ def _format_skill_operation(*, verb: str, agent: str, changed: tuple[str, ...]) 
     if verb == "installed":
         return f"Potpie skills for {agent} are already installed"
     return f"Potpie skills for {agent} are already up to date"
+
+
+def _format_skill_remove(*, agent: str, removed: tuple[str, ...]) -> str:
+    if removed:
+        return f"removed Potpie skills for {agent}: {', '.join(removed)}"
+    return f"Potpie skills for {agent} are already removed"
 
 
 def _effective_scope(*, scope: str, path: str | None) -> str:

--- a/potpie/context-engine/adapters/outbound/skills/agent_installer.py
+++ b/potpie/context-engine/adapters/outbound/skills/agent_installer.py
@@ -9,13 +9,17 @@ from importlib import resources
 from pathlib import Path
 from typing import Iterable
 
-_CLAUDE_MARKER_RE = re.compile(
+_MANAGED_MARKER_RE = re.compile(
     r"<!-- (?:context-engine|potpie)-start -->.*?<!-- (?:context-engine|potpie)-end -->",
     re.DOTALL,
 )
+_DEFAULT_MERGE_FILES = frozenset({"CLAUDE.md"})
 
-AGENT_TYPES = ("default", "codex", "claude", "cursor", "opencode")
+AGENT_TYPES = ("default", "codex", "claude", "claude-plugin", "cursor", "opencode")
 _SOURCE_SKILLS_PREFIX = ".agents/skills/"
+# The Claude Code plugin installs as a self-contained directory so its
+# ``.claude-plugin/plugin.json`` stays the plugin root for ``/plugin marketplace add``.
+_CLAUDE_PLUGIN_PREFIX = ".claude/potpie-plugin"
 
 
 @dataclass
@@ -53,7 +57,13 @@ def _iter_bundle_files(bundle_name: str) -> list[tuple[Path, str]]:
         for child in current.iterdir():
             child_rel = rel / child.name
             if child.is_dir():
+                # Never install compiled-bytecode caches that may sit beside the
+                # template sources (e.g. a stray ``__pycache__`` from a test run).
+                if child.name == "__pycache__":
+                    continue
                 stack.append((child, child_rel))
+                continue
+            if child.name.endswith((".pyc", ".pyo")):
                 continue
             out.append((child_rel, child.read_text(encoding="utf-8")))
     return sorted(out, key=lambda item: item[0].as_posix())
@@ -64,10 +74,12 @@ def iter_template_files() -> list[tuple[Path, str]]:
     return _iter_bundle_files("agent_bundle")
 
 
-def _merge_claude_md(existing: str, section: str, *, force: bool) -> tuple[str, str]:
+def _merge_managed_markdown(
+    existing: str, section: str, *, force: bool
+) -> tuple[str, str]:
     """Return (merged_content, action) where action is 'unchanged'|'updated'|'created'."""
-    if _CLAUDE_MARKER_RE.search(existing):
-        merged = _CLAUDE_MARKER_RE.sub(section.strip(), existing)
+    if _MANAGED_MARKER_RE.search(existing):
+        merged = _MANAGED_MARKER_RE.sub(section.strip(), existing)
         if merged == existing:
             return existing, "unchanged"
         if not force:
@@ -142,6 +154,7 @@ def _install_bundle(
     force: bool,
     include: Callable[[Path], bool] | None = None,
     remap: Callable[[Path], Path | None] | None = None,
+    merge_files: frozenset[str] = _DEFAULT_MERGE_FILES,
 ) -> None:
     for rel_path, content in _iter_bundle_files(bundle_name):
         if include is not None and not include(rel_path):
@@ -151,11 +164,12 @@ def _install_bundle(
             continue
         target = install_root / out_path
 
-        # Special handling: merge CLAUDE.md section instead of overwriting
-        if out_path.name == "CLAUDE.md":
+        # Special handling: merge managed markdown sections instead of overwriting
+        # the whole user-authored file.
+        if out_path.name in merge_files:
             section = content
             existing = target.read_text(encoding="utf-8") if target.exists() else ""
-            merged, action = _merge_claude_md(existing, section, force=force)
+            merged, action = _merge_managed_markdown(existing, section, force=force)
             if action == "skipped":
                 result.skipped.append(out_path.as_posix())
                 continue
@@ -195,6 +209,11 @@ def _claude_skills_bundle_remap(rel_path: Path) -> Path | None:
     return _remap_skills_path(rel_path, ".claude/skills")
 
 
+def _claude_plugin_remap(rel_path: Path) -> Path | None:
+    # Install the whole plugin under one directory, preserving its internal layout.
+    return Path(_CLAUDE_PLUGIN_PREFIX) / rel_path
+
+
 def install_skill_bundle(
     skills_root: str | Path,
     *,
@@ -220,6 +239,38 @@ def install_skill_bundle(
     return result
 
 
+def install_global_agent_instructions(
+    root: str | Path,
+    *,
+    agent: str = "default",
+    force: bool = True,
+) -> InstallResult:
+    """Install compact global instructions for harnesses with file-based rules.
+
+    The project bundle is intentionally detailed. This global bundle stays tiny
+    because it can be loaded into every prompt across repositories.
+    """
+    install_root = Path(root).expanduser().resolve()
+    result = InstallResult(root=str(install_root))
+    normalized = agent.strip().lower() if agent else "default"
+    if normalized == "claude":
+        filename = "CLAUDE.md"
+    elif normalized in {"default", "codex"}:
+        filename = "AGENTS.md"
+    else:
+        return result
+
+    _install_bundle(
+        install_root,
+        "global_agent_bundle",
+        result,
+        force=force,
+        include=lambda rel: rel.as_posix() == filename,
+        merge_files=frozenset({filename}),
+    )
+    return result
+
+
 def install_agent_bundle(
     path: str | Path = ".",
     *,
@@ -231,6 +282,7 @@ def install_agent_bundle(
 
     - ``default`` / ``codex``: ``AGENTS.md`` + ``.agents/skills/``
     - ``claude``: ``CLAUDE.md`` (+ ``.claude/`` when present in bundle)
+    - ``claude-plugin``: the Claude Code plugin under ``.claude/potpie-plugin/``
     - ``cursor``: ``AGENTS.md`` + ``.cursor/skills/``
     - ``opencode``: ``.opencode/skills/``
     """
@@ -253,6 +305,20 @@ def install_agent_bundle(
             force=force,
             include=lambda rel: _include_selected_skills(rel, selected),
             remap=_claude_skills_bundle_remap,
+        )
+    elif normalized == "claude-plugin":
+        # Works from a source checkout. NB for wheel distribution: the monorepo
+        # .gitignore ignores ``*.json``, and Hatchling's VCS-aware selector then
+        # omits the plugin's plugin.json/marketplace.json/hooks.json from the wheel
+        # even with an ``include`` glob. Shipping those in a wheel needs a
+        # ``[tool.hatch.build] artifacts`` override or a .gitignore exception
+        # (deliberately deferred: plugin install is dev/source only for now).
+        _install_bundle(
+            root,
+            "claude_plugin",
+            result,
+            force=force,
+            remap=_claude_plugin_remap,
         )
     elif normalized == "cursor":
         _install_bundle(

--- a/potpie/context-engine/adapters/outbound/skills/claude_target.py
+++ b/potpie/context-engine/adapters/outbound/skills/claude_target.py
@@ -10,6 +10,7 @@ from typing import Mapping
 
 from adapters.outbound.pots.local_pot_store import default_home
 from adapters.outbound.skills.agent_installer import (
+    install_global_agent_instructions,
     install_agent_bundle,
     install_skill_bundle,
     project_skill_path,
@@ -23,6 +24,8 @@ class FileBackedAgentTarget:
 
     agent: str
     skills_root: Path
+    instructions_root: Path | None = None
+    instructions_agent: str | None = None
     home: Path = field(default_factory=default_home)
     scope: str = "global"
 
@@ -56,11 +59,21 @@ class FileBackedAgentTarget:
 
     def install(self, *, skill_id: str, version: str, path: str | None = None) -> None:
         root = Path(path).expanduser() if path else self.skills_root
-        install_skill_bundle(root, skill_ids=(skill_id,))
+        install_skill_bundle(root, skill_ids=(skill_id,), force=True)
         data = self._load()
         if (root / skill_id / "SKILL.md").exists():
             data[skill_id] = version
         self._save(data)
+
+    def install_support_files(self, *, path: str | None = None) -> None:
+        del path
+        if self.instructions_root is None:
+            return
+        install_global_agent_instructions(
+            self.instructions_root,
+            agent=self.instructions_agent or self.agent,
+            force=True,
+        )
 
     def remove(self, *, skill_id: str) -> None:
         shutil.rmtree(self.skills_root.expanduser() / skill_id, ignore_errors=True)
@@ -104,11 +117,15 @@ class ProjectAgentTarget:
 
     def install(self, *, skill_id: str, version: str, path: str | None = None) -> None:
         root = Path(path) if path else self.path
-        install_agent_bundle(root, agent=self.agent, skill_ids=(skill_id,))
+        install_agent_bundle(root, agent=self.agent, skill_ids=(skill_id,), force=True)
         data = self._load()
         if project_skill_path(root, agent=self.agent, skill_id=skill_id).exists():
             data[skill_id] = version
         self._save(data)
+
+    def install_support_files(self, *, path: str | None = None) -> None:
+        root = Path(path) if path else self.path
+        install_agent_bundle(root, agent=self.agent, skill_ids=(), force=True)
 
     def remove(self, *, skill_id: str) -> None:
         shutil.rmtree(
@@ -136,6 +153,8 @@ class ClaudeAgentTarget(FileBackedAgentTarget):
         super().__init__(
             agent="claude",
             skills_root=Path.home() / ".claude" / "skills",
+            instructions_root=Path.home() / ".claude",
+            instructions_agent="claude",
             **kwargs,
         )
 
@@ -156,6 +175,8 @@ class CodexAgentTarget(FileBackedAgentTarget):
         super().__init__(
             agent="codex",
             skills_root=Path.home() / ".agents" / "skills",
+            instructions_root=Path.home() / ".codex",
+            instructions_agent="codex",
             **kwargs,
         )
 

--- a/potpie/context-engine/application/services/skill_manager.py
+++ b/potpie/context-engine/application/services/skill_manager.py
@@ -155,10 +155,11 @@ class DefaultSkillManager:
         if not all_ and not skill_id:
             raise ValueError("pass a skill id or --all")
         target = self._target_for_scope(agent=agent, scope=scope, path=path)
-        ids = list(target.installed()) if all_ else [skill_id]
+        installed = set(target.installed())
+        ids = list(installed) if all_ else [skill_id]
         changed: list[str] = []
         for sid in ids:
-            if sid is None:
+            if sid is None or sid not in installed:
                 continue
             target.remove(skill_id=sid)
             changed.append(sid)

--- a/potpie/context-engine/application/services/skill_manager.py
+++ b/potpie/context-engine/application/services/skill_manager.py
@@ -55,6 +55,14 @@ class DefaultSkillManager:
             metadata["target_root"] = str(root)
         return metadata
 
+    @staticmethod
+    def _install_support_files(
+        target: AgentTargetPort, *, path: str | None = None
+    ) -> None:
+        installer = getattr(target, "install_support_files", None)
+        if callable(installer):
+            installer(path=path)
+
     def list(
         self, *, agent: str = "claude", scope: str = "global", path: str | None = None
     ) -> list[SkillInfo]:
@@ -98,6 +106,7 @@ class DefaultSkillManager:
                 continue
             target.install(skill_id=sid, version=info.version, path=path)
             changed.append(sid)
+        self._install_support_files(target, path=path)
         return SkillOperationResult(
             agent=agent,
             operation="install",
@@ -124,6 +133,7 @@ class DefaultSkillManager:
             if info and installed.get(sid) != info.version:
                 target.install(skill_id=sid, version=info.version)
                 changed.append(sid)
+        self._install_support_files(target, path=path)
         return SkillOperationResult(
             agent=agent,
             operation="update",
@@ -135,16 +145,27 @@ class DefaultSkillManager:
         self,
         *,
         agent: str,
-        skill_id: str,
+        skill_id: str | None = None,
+        all_: bool = False,
         path: str | None = None,
         scope: str = "global",
     ) -> SkillOperationResult:
+        if all_ and skill_id:
+            raise ValueError("pass either a skill id or --all, not both")
+        if not all_ and not skill_id:
+            raise ValueError("pass a skill id or --all")
         target = self._target_for_scope(agent=agent, scope=scope, path=path)
-        target.remove(skill_id=skill_id)
+        ids = list(target.installed()) if all_ else [skill_id]
+        changed: list[str] = []
+        for sid in ids:
+            if sid is None:
+                continue
+            target.remove(skill_id=sid)
+            changed.append(sid)
         return SkillOperationResult(
             agent=agent,
             operation="remove",
-            changed=(skill_id,),
+            changed=tuple(changed),
             metadata=self._metadata(target, scope=scope),
         )
 

--- a/potpie/context-engine/application/services/skill_manager.py
+++ b/potpie/context-engine/application/services/skill_manager.py
@@ -155,7 +155,7 @@ class DefaultSkillManager:
         if not all_ and not skill_id:
             raise ValueError("pass a skill id or --all")
         target = self._target_for_scope(agent=agent, scope=scope, path=path)
-        installed = set(target.installed())
+        installed = target.installed()
         ids = list(installed) if all_ else [skill_id]
         changed: list[str] = []
         for sid in ids:

--- a/potpie/context-engine/domain/agent_envelope.py
+++ b/potpie/context-engine/domain/agent_envelope.py
@@ -64,6 +64,39 @@ class AgentEnvelope:
     as_of: datetime | None = None
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise the canonical envelope to a JSON-shaped dict."""
+        return {
+            "pot_id": self.pot_id,
+            "intent": self.intent,
+            "items": [
+                {
+                    "include": item.include,
+                    "candidate_key": item.candidate_key,
+                    "score": item.score,
+                    "payload": dict(item.payload),
+                    "coverage_status": item.coverage_status,
+                    "breakdown": dict(item.breakdown),
+                }
+                for item in self.items
+            ],
+            "coverage": [
+                {
+                    "include": report.include,
+                    "status": report.status,
+                    "candidate_pool": report.candidate_pool,
+                }
+                for report in self.coverage
+            ],
+            "unsupported_includes": [
+                {"name": unsupported.name, "reason": unsupported.reason}
+                for unsupported in self.unsupported_includes
+            ],
+            "overall_confidence": self.overall_confidence,
+            "as_of": self.as_of.isoformat() if self.as_of else None,
+            "metadata": dict(self.metadata),
+        }
+
 
 def derive_overall_confidence(*, coverage: Sequence[CoverageReport]) -> str:
     """Map per-include coverage into the envelope's overall_confidence (F5)."""

--- a/potpie/context-engine/domain/graph_workbench.py
+++ b/potpie/context-engine/domain/graph_workbench.py
@@ -1,0 +1,174 @@
+"""Graph V2 workbench command envelope DTOs.
+
+These DTOs describe the CLI workbench protocol. They deliberately sit above the
+V1.5 data plane: the outer envelope can be V2 while a wrapped result still
+contains data-plane fields produced by the existing graph service.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from domain.graph_contract import ONTOLOGY_VERSION
+
+GRAPH_WORKBENCH_CONTRACT_VERSION = "v2"
+GRAPH_WORKBENCH_ONTOLOGY_VERSION = ONTOLOGY_VERSION
+
+GRAPH_WORKBENCH_COMMANDS: tuple[str, ...] = (
+    "status",
+    "catalog",
+    "describe",
+    "search-entities",
+    "read",
+    "neighborhood",
+    "propose",
+    "commit",
+    "bulk",
+    "history",
+    "inbox",
+    "quality",
+)
+
+GRAPH_WORKBENCH_ADMIN_COMMANDS: tuple[str, ...] = (
+    "repair",
+    "export",
+    "import",
+)
+
+GRAPH_WORKBENCH_LEGACY_COMMANDS: tuple[str, ...] = (
+    "mutate",
+    "inspect",
+    "mutation-template",
+    "nudge",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class GraphCommandError:
+    code: str
+    message: str
+    detail: Any = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out = {
+            "code": self.code,
+            "message": self.message,
+            "detail": self.detail,
+        }
+        return out
+
+
+@dataclass(frozen=True, slots=True)
+class GraphUnsupported:
+    name: str
+    reason: str
+    detail: Any = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "name": self.name,
+            "reason": self.reason,
+        }
+        if self.detail is not None:
+            out["detail"] = self.detail
+        return out
+
+
+@dataclass(frozen=True, slots=True)
+class GraphRecommendedAction:
+    action: str
+    command: str | None = None
+    reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"action": self.action}
+        if self.command:
+            out["command"] = self.command
+        if self.reason:
+            out["reason"] = self.reason
+        return out
+
+
+@dataclass(frozen=True, slots=True)
+class GraphWorkbenchStatus:
+    host: Mapping[str, Any] = field(default_factory=dict)
+    pot: Mapping[str, Any] = field(default_factory=dict)
+    graph_service: Mapping[str, Any] = field(default_factory=dict)
+    backend: Mapping[str, Any] = field(default_factory=dict)
+    ledger: Mapping[str, Any] = field(default_factory=dict)
+    skills: Mapping[str, Any] = field(default_factory=dict)
+    quality: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "host": dict(self.host),
+            "pot": dict(self.pot),
+            "graph_service": dict(self.graph_service),
+            "backend": dict(self.backend),
+            "ledger": dict(self.ledger),
+            "skills": dict(self.skills),
+            "quality": dict(self.quality),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class GraphUnsupportedResult:
+    status: str
+    command: str
+    detail: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out = {"status": self.status, "command": self.command}
+        if self.detail:
+            out["detail"] = self.detail
+        return out
+
+
+@dataclass(frozen=True, slots=True)
+class GraphCommandEnvelope:
+    ok: bool
+    command: str
+    request_id: str
+    pot_id: str | None
+    graph_contract_version: str = GRAPH_WORKBENCH_CONTRACT_VERSION
+    ontology_version: str = GRAPH_WORKBENCH_ONTOLOGY_VERSION
+    subgraph_versions: Mapping[str, int] = field(default_factory=dict)
+    result: Mapping[str, Any] | None = None
+    warnings: tuple[str, ...] = ()
+    unsupported: tuple[GraphUnsupported, ...] = ()
+    recommended_next_action: str | Mapping[str, Any] | None = None
+    error: GraphCommandError | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "ok": self.ok,
+            "command": self.command,
+            "request_id": self.request_id,
+            "pot_id": self.pot_id,
+            "graph_contract_version": self.graph_contract_version,
+            "ontology_version": self.ontology_version,
+            "subgraph_versions": dict(self.subgraph_versions),
+            "result": dict(self.result) if self.result is not None else None,
+            "warnings": list(self.warnings),
+            "unsupported": [u.to_dict() for u in self.unsupported],
+            "recommended_next_action": self.recommended_next_action,
+        }
+        if self.error is not None:
+            out["error"] = self.error.to_dict()
+        return out
+
+
+__all__ = [
+    "GRAPH_WORKBENCH_ADMIN_COMMANDS",
+    "GRAPH_WORKBENCH_COMMANDS",
+    "GRAPH_WORKBENCH_CONTRACT_VERSION",
+    "GRAPH_WORKBENCH_LEGACY_COMMANDS",
+    "GRAPH_WORKBENCH_ONTOLOGY_VERSION",
+    "GraphCommandEnvelope",
+    "GraphCommandError",
+    "GraphRecommendedAction",
+    "GraphUnsupported",
+    "GraphUnsupportedResult",
+    "GraphWorkbenchStatus",
+]

--- a/potpie/context-engine/domain/graph_workbench.py
+++ b/potpie/context-engine/domain/graph_workbench.py
@@ -152,7 +152,11 @@ class GraphCommandEnvelope:
             "result": dict(self.result) if self.result is not None else None,
             "warnings": list(self.warnings),
             "unsupported": [u.to_dict() for u in self.unsupported],
-            "recommended_next_action": self.recommended_next_action,
+            "recommended_next_action": (
+                dict(self.recommended_next_action)
+                if isinstance(self.recommended_next_action, Mapping)
+                else self.recommended_next_action
+            ),
         }
         if self.error is not None:
             out["error"] = self.error.to_dict()

--- a/potpie/context-engine/domain/graph_workbench_ontology.py
+++ b/potpie/context-engine/domain/graph_workbench_ontology.py
@@ -800,7 +800,7 @@ def rank_views_for_task(
     task_tokens = _tokens(task or "")
     if not task_tokens:
         return []
-    selected_views = list(views or _catalog_view_entries())
+    selected_views = list(_catalog_view_entries() if views is None else views)
     by_name = {
         view.name: view
         for subgraph in _ONTOLOGY_CONTRACT.subgraphs
@@ -906,8 +906,8 @@ def _build_contract() -> WorkbenchOntologyContract:
 
 def _view_contract(spec: GraphViewSpec) -> ViewContract:
     override = _VIEW_OVERRIDES.get(spec.name, {})
-    optional_scope = tuple(override.get("optional_scope") or spec.inputs)
-    supported_filters = tuple(override.get("supported_filters") or spec.inputs)
+    optional_scope = tuple(override.get("optional_scope", spec.inputs))
+    supported_filters = tuple(override.get("supported_filters", spec.inputs))
     if spec.backed and "source_ref" not in supported_filters:
         supported_filters = (*supported_filters, "source_ref")
     if spec.backed and "source_ref" not in optional_scope:

--- a/potpie/context-engine/domain/graph_workbench_ontology.py
+++ b/potpie/context-engine/domain/graph_workbench_ontology.py
@@ -1,0 +1,1191 @@
+"""Executable Graph V2 ontology/workbench contract.
+
+This module is the static contract layer above the V1.5 data plane. It turns
+the existing view map, ontology catalogs, and mutation-operation partitions into
+objects that ``graph catalog`` and ``graph describe`` can return directly.
+Reader behavior still lives in :mod:`application.services.graph_service`.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field, replace
+from typing import Any, Mapping, Sequence
+
+from domain.agent_context_port import CONTEXT_INCLUDE_VALUES
+from domain.graph_contract import (
+    APPLICABLE_MUTATION_OPS,
+    DEFERRED_OPS,
+    KNOWN_MUTATION_OPS,
+    ONTOLOGY_VERSION,
+    REVIEW_REQUIRED_OPS,
+    SOURCE_AUTHORITIES,
+    STRONG_AUTHORITIES,
+    TRUTH_CLASSES,
+)
+from domain.graph_views import GRAPH_VIEWS, GraphViewSpec
+from domain.ontology import EDGE_TYPES, ENTITY_TYPES
+
+_TOKEN_RE = re.compile(r"[a-z0-9_]+")
+
+
+@dataclass(frozen=True, slots=True)
+class ExampleCommand:
+    command: str
+    description: str
+    json: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "command": self.command,
+            "description": self.description,
+            "json": self.json,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class IdentityPolicy:
+    entity_type: str
+    key_prefix: str
+    identity_class: str
+    identity_policy: str
+    authoritative_source: str | None = None
+    scope: bool = False
+    canonical_prefix_rule: str = (
+        "Entity-key prefixes are exact; underscore prefixes are canonical and "
+        "hyphenated prefixes are not aliases."
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "entity_type": self.entity_type,
+            "key_prefix": self.key_prefix,
+            "identity_class": self.identity_class,
+            "identity_policy": self.identity_policy,
+            "scope": self.scope,
+            "canonical_prefix_rule": self.canonical_prefix_rule,
+        }
+        if self.authoritative_source:
+            out["authoritative_source"] = self.authoritative_source
+        return out
+
+
+@dataclass(frozen=True, slots=True)
+class EntityTypeContract:
+    label: str
+    category: str
+    description: str
+    identity: IdentityPolicy
+    patchable_properties: tuple[str, ...] = ()
+    lifecycle_states: tuple[str, ...] = ()
+    lifecycle_transitions: Mapping[str, tuple[str, ...]] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "label": self.label,
+            "category": self.category,
+            "description": self.description,
+            "identity": self.identity.to_dict(),
+            "patchable_properties": list(self.patchable_properties),
+            "lifecycle_states": list(self.lifecycle_states),
+            "lifecycle_transitions": {
+                key: list(values) for key, values in self.lifecycle_transitions.items()
+            },
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RelationTypeContract:
+    name: str
+    category: str
+    description: str
+    allowed_pairs: tuple[tuple[str, str], ...]
+    required_properties: tuple[str, ...] = ()
+    singleton: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "category": self.category,
+            "description": self.description,
+            "allowed_pairs": [list(pair) for pair in self.allowed_pairs],
+            "required_properties": list(self.required_properties),
+            "singleton": self.singleton,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SourceAuthorityPolicy:
+    authority: str
+    strength: str
+    description: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "authority": self.authority,
+            "strength": self.strength,
+            "description": self.description,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class MutationPolicy:
+    operation: str
+    availability: str
+    description: str
+    requires_review: bool = False
+    applies_to_subgraphs: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "operation": self.operation,
+            "availability": self.availability,
+            "description": self.description,
+            "requires_review": self.requires_review,
+            "applies_to_subgraphs": list(self.applies_to_subgraphs),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ViewContract:
+    name: str
+    subgraph: str
+    view: str
+    purpose: str
+    when_to_use: tuple[str, ...]
+    v1_include: str
+    backed: bool
+    required_scope: tuple[str, ...] = ()
+    required_any_scope: tuple[str, ...] = ()
+    optional_scope: tuple[str, ...] = ()
+    result_shape: str = "flat_claims"
+    ranking_inputs: tuple[str, ...] = ()
+    supported_filters: tuple[str, ...] = ()
+    inline_relations: tuple[str, ...] = ()
+    traversal: bool = False
+    examples: tuple[ExampleCommand, ...] = ()
+    keywords: tuple[str, ...] = ()
+    extra: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self, *, include_examples: bool = False) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "name": self.name,
+            "subgraph": self.subgraph,
+            "view": self.view,
+            "purpose": self.purpose,
+            "when_to_use": list(self.when_to_use),
+            "v1_include": self.v1_include,
+            "backed": self.backed,
+            "required_scope": list(self.required_scope),
+            "required_any_scope": list(self.required_any_scope),
+            "optional_scope": list(self.optional_scope),
+            "result_shape": self.result_shape,
+            "ranking_inputs": list(self.ranking_inputs),
+            "supported_filters": list(self.supported_filters),
+            "inline_relations": list(self.inline_relations),
+            "traversal": self.traversal,
+            "extra": dict(self.extra),
+        }
+        if include_examples:
+            out["examples"] = [example.to_dict() for example in self.examples]
+        else:
+            out["example_count"] = len(self.examples)
+        return out
+
+
+@dataclass(frozen=True, slots=True)
+class SubgraphContract:
+    name: str
+    purpose: str
+    when_to_use: tuple[str, ...]
+    entity_types: tuple[str, ...]
+    relation_types: tuple[str, ...]
+    views: tuple[ViewContract, ...]
+    keywords: tuple[str, ...] = ()
+    examples: tuple[ExampleCommand, ...] = ()
+
+    def to_dict(
+        self,
+        *,
+        include_examples: bool = False,
+        view_filter: str | None = None,
+    ) -> dict[str, Any]:
+        views = self.views
+        if view_filter:
+            views = tuple(view for view in views if view.name == view_filter)
+        out: dict[str, Any] = {
+            "name": self.name,
+            "purpose": self.purpose,
+            "when_to_use": list(self.when_to_use),
+            "entity_types": [
+                _entity_type_contract(label).to_dict()
+                for label in self.entity_types
+                if label in ENTITY_TYPES
+            ],
+            "relation_types": [
+                _relation_type_contract(name).to_dict()
+                for name in self.relation_types
+                if name in EDGE_TYPES
+            ],
+            "views": [
+                view.to_dict(include_examples=include_examples) for view in views
+            ],
+            "mutation_policies": [
+                policy.to_dict() for policy in mutation_policies_for_subgraph(self.name)
+            ],
+            "source_authority_rules": [
+                policy.to_dict() for policy in source_authority_policies()
+            ],
+            "truth_classes": list(TRUTH_CLASSES),
+        }
+        if include_examples:
+            out["examples"] = [example.to_dict() for example in self.examples]
+        else:
+            out["example_count"] = len(self.examples)
+        return out
+
+
+@dataclass(frozen=True, slots=True)
+class WorkbenchOntologyContract:
+    ontology_version: str
+    subgraphs: tuple[SubgraphContract, ...]
+    mutation_policies: tuple[MutationPolicy, ...]
+    source_authority_policies: tuple[SourceAuthorityPolicy, ...]
+    identity_policies: tuple[IdentityPolicy, ...]
+
+    def subgraph(self, name: str) -> SubgraphContract | None:
+        normalized = (name or "").strip()
+        return next((s for s in self.subgraphs if s.name == normalized), None)
+
+    def view(self, name: str) -> ViewContract | None:
+        normalized = (name or "").strip()
+        return next(
+            (
+                view
+                for subgraph in self.subgraphs
+                for view in subgraph.views
+                if view.name == normalized
+            ),
+            None,
+        )
+
+    def to_dict(self, *, include_examples: bool = False) -> dict[str, Any]:
+        return {
+            "ontology_version": self.ontology_version,
+            "subgraphs": [
+                subgraph.to_dict(include_examples=include_examples)
+                for subgraph in self.subgraphs
+            ],
+            "mutation_policies": [
+                policy.to_dict() for policy in self.mutation_policies
+            ],
+            "source_authority_rules": [
+                policy.to_dict() for policy in self.source_authority_policies
+            ],
+            "identity_policies": [
+                policy.to_dict() for policy in self.identity_policies
+            ],
+        }
+
+
+_SUBGRAPH_DEFINITIONS: dict[str, dict[str, Any]] = {
+    "debugging": {
+        "purpose": "Recall prior failures, symptoms, attempted fixes, and verifications.",
+        "when_to_use": (
+            "Use before investigating bugs, failing tests, alerts, incidents, or regressions.",
+        ),
+        "entity_types": ("BugPattern", "Fix", "Activity", "Service", "CodeAsset"),
+        "relation_types": (
+            "REPRODUCES",
+            "RESOLVED",
+            "ATTEMPTED_FIX_FAILED",
+            "VERIFIED",
+        ),
+        "keywords": (
+            "debug",
+            "debugging",
+            "bug",
+            "failure",
+            "failing",
+            "fix",
+            "incident",
+            "regression",
+            "timeout",
+            "error",
+            "exception",
+            "flaky",
+            "test",
+        ),
+        "examples": (
+            ExampleCommand(
+                command='potpie graph read --subgraph debugging --view prior_occurrences --query "timeout" --json',
+                description="Find prior bug/fix memories for a symptom.",
+            ),
+        ),
+    },
+    "recent_changes": {
+        "purpose": "Read recent activity such as PRs, deploys, incidents, and decisions.",
+        "when_to_use": (
+            "Use when a task asks what changed recently or a regression may have followed a change.",
+        ),
+        "entity_types": (
+            "Activity",
+            "Period",
+            "Person",
+            "Team",
+            "Service",
+            "CodeAsset",
+        ),
+        "relation_types": ("TOUCHED", "PERFORMED", "AUTHORED", "IN_PERIOD", "MENTIONS"),
+        "keywords": (
+            "recent",
+            "change",
+            "changed",
+            "after",
+            "before",
+            "deploy",
+            "deployment",
+            "rollback",
+            "pr",
+            "merged",
+            "commit",
+            "release",
+            "timeline",
+        ),
+        "examples": (
+            ExampleCommand(
+                command="potpie graph read --subgraph recent_changes --view timeline --time-window 7d --json",
+                description="Read the recent project timeline.",
+            ),
+        ),
+    },
+    "infra_topology": {
+        "purpose": "Inspect services, environments, dependencies, adapters, config, and deployment edges.",
+        "when_to_use": (
+            "Use before changes that touch services, environments, integrations, dependencies, or deployment behavior.",
+        ),
+        "entity_types": (
+            "Service",
+            "Repository",
+            "Environment",
+            "DataStore",
+            "Cluster",
+            "Dependency",
+            "APIContract",
+            "Adapter",
+            "ConfigVariable",
+            "DeploymentTarget",
+        ),
+        "relation_types": (
+            "DEFINED_IN",
+            "DEPLOYED_TO",
+            "DEPENDS_ON",
+            "USES",
+            "USES_ADAPTER",
+            "CONFIGURES",
+            "DEPLOYED_WITH",
+            "EXPOSES",
+            "HOSTED_ON",
+            "OWNED_BY",
+            "PROVIDES",
+        ),
+        "keywords": (
+            "infra",
+            "topology",
+            "service",
+            "dependency",
+            "depends",
+            "environment",
+            "env",
+            "staging",
+            "production",
+            "deploy",
+            "deployment",
+            "config",
+            "adapter",
+            "backend",
+            "api",
+        ),
+        "examples": (
+            ExampleCommand(
+                command="potpie graph read --subgraph infra_topology --view service_neighborhood --scope service:payments-api --depth 2 --json",
+                description="Read a bounded service neighborhood.",
+            ),
+        ),
+    },
+    "decisions": {
+        "purpose": "Retrieve preferences, policies, and architectural decisions that apply to a scope.",
+        "when_to_use": (
+            "Use before writing code, reviewing risky changes, or checking policy and decision context.",
+        ),
+        "entity_types": (
+            "Preference",
+            "Policy",
+            "Decision",
+            "Repository",
+            "Service",
+            "CodeAsset",
+        ),
+        "relation_types": ("POLICY_APPLIES_TO", "DECIDED", "AFFECTS"),
+        "keywords": (
+            "decision",
+            "decisions",
+            "preference",
+            "preferences",
+            "policy",
+            "standard",
+            "guideline",
+            "architecture",
+            "choice",
+            "risk",
+            "debug",
+            "deployment",
+            "timeout",
+        ),
+        "examples": (
+            ExampleCommand(
+                command='potpie graph read --subgraph decisions --view preferences_for_scope --scope path:src/app.py --query "testing" --json',
+                description="Read active preferences for a coding scope.",
+            ),
+        ),
+    },
+    "features": {
+        "purpose": "Describe product or system capabilities a repo or service provides.",
+        "when_to_use": (
+            "Use when learning what a repository/service does or locating implementation context for a feature.",
+        ),
+        "entity_types": ("Feature", "Repository", "Service", "CodeAsset"),
+        "relation_types": ("PROVIDES", "IMPLEMENTED_IN"),
+        "keywords": (
+            "feature",
+            "capability",
+            "product",
+            "behavior",
+            "implements",
+            "functionality",
+        ),
+        "examples": (
+            ExampleCommand(
+                command="potpie graph read --subgraph features --view feature_context --scope repo:github.com/acme/app --json",
+                description="Read capabilities provided by a repo.",
+            ),
+        ),
+    },
+    "code_topology": {
+        "purpose": "Resolve ownership and code-anchor context.",
+        "when_to_use": (
+            "Use when routing code ownership questions or checking who owns a service/repo/path.",
+        ),
+        "entity_types": ("Repository", "Service", "CodeAsset", "Team", "Person"),
+        "relation_types": ("OWNED_BY", "MEMBER_OF", "DEFINED_IN"),
+        "keywords": ("owner", "ownership", "team", "person", "code", "path", "repo"),
+        "examples": (
+            ExampleCommand(
+                command="potpie graph read --subgraph code_topology --view ownership_by_path --scope path:src/app.py --json",
+                description="Read owners for a path or service scope.",
+            ),
+        ),
+    },
+    "knowledge": {
+        "purpose": "Locate durable documentation and notes for a scope.",
+        "when_to_use": (
+            "Use when looking for docs, runbooks, design notes, or written references.",
+        ),
+        "entity_types": (
+            "Document",
+            "Observation",
+            "Repository",
+            "Service",
+            "CodeAsset",
+        ),
+        "relation_types": ("RELATED_TO", "MENTIONS", "AFFECTS"),
+        "keywords": (
+            "doc",
+            "docs",
+            "document",
+            "runbook",
+            "note",
+            "reference",
+            "knowledge",
+        ),
+        "examples": (
+            ExampleCommand(
+                command="potpie graph read --subgraph knowledge --view document_context --scope service:payments-api --json",
+                description="Read documentation pointers for a scope.",
+            ),
+        ),
+    },
+    "admin": {
+        "purpose": "Operator-only inspection of the canonical graph slice.",
+        "when_to_use": (
+            "Use for graph explorer/admin inspection, not ordinary agent memory reads.",
+        ),
+        "entity_types": tuple(ENTITY_TYPES),
+        "relation_types": tuple(EDGE_TYPES),
+        "keywords": ("admin", "inspect", "raw", "graph", "operator", "visualization"),
+        "examples": (
+            ExampleCommand(
+                command="potpie graph read --subgraph admin --view inspection_slice --json",
+                description="Read an operator inspection slice.",
+            ),
+        ),
+    },
+}
+
+_VIEW_OVERRIDES: dict[str, dict[str, Any]] = {
+    "decisions.preferences_for_scope": {
+        "purpose": "Return active preferences and policy claims that apply to a repo, service, path, or code asset.",
+        "when_to_use": (
+            "Use before writing or reviewing code so local project preferences are visible.",
+        ),
+        "result_shape": "entity_relations",
+        "required_any_scope": ("repo", "scope", "service", "path", "query", "language"),
+        "optional_scope": (
+            "repo",
+            "scope",
+            "service",
+            "path",
+            "file_path",
+            "language",
+            "framework",
+            "query",
+        ),
+        "supported_filters": (
+            "repo",
+            "scope",
+            "service",
+            "path",
+            "file_path",
+            "language",
+            "framework",
+            "audience",
+            "query",
+        ),
+        "keywords": ("preference", "policy", "scope", "coding", "style"),
+        "examples": (
+            ExampleCommand(
+                command='potpie graph read --subgraph decisions --view preferences_for_scope --scope path:potpie/context-engine --query "testing" --json',
+                description="Read scoped coding preferences.",
+            ),
+        ),
+    },
+    "debugging.prior_occurrences": {
+        "purpose": "Return prior matching bug patterns with fix and verification relations inlined.",
+        "when_to_use": (
+            "Use before debugging a symptom so old fixes and failed attempts are not missed.",
+        ),
+        "result_shape": "entity_relations",
+        "required_any_scope": ("query", "service", "repo"),
+        "optional_scope": ("query", "service", "repo", "time_window"),
+        "supported_filters": (
+            "query",
+            "service",
+            "repo",
+            "since",
+            "until",
+            "time_window",
+            "path",
+            "file_path",
+        ),
+        "keywords": ("bug", "debug", "failure", "symptom", "fix", "timeout"),
+        "examples": (
+            ExampleCommand(
+                command='potpie graph read --subgraph debugging --view prior_occurrences --query "staging timeout" --json',
+                description="Read prior failures matching a symptom.",
+            ),
+        ),
+    },
+    "recent_changes.timeline": {
+        "purpose": "Return recent project activity ordered by event time.",
+        "when_to_use": (
+            "Use when diagnosing regressions or checking what changed in a time window.",
+        ),
+        "result_shape": "events",
+        "optional_scope": ("scope", "time_window", "query"),
+        "supported_filters": (
+            "scope",
+            "query",
+            "since",
+            "until",
+            "time_window",
+            "service",
+            "repo",
+            "path",
+            "file_path",
+        ),
+        "keywords": ("timeline", "recent", "change", "deploy", "merged", "after"),
+        "examples": (
+            ExampleCommand(
+                command="potpie graph read --subgraph recent_changes --view timeline --time-window 7d --json",
+                description="Read recent activity.",
+            ),
+        ),
+    },
+    "infra_topology.service_neighborhood": {
+        "purpose": "Return a bounded service neighborhood with dependency, deployment, config, ownership, and adapter edges.",
+        "when_to_use": (
+            "Use before touching service boundaries, deployment behavior, dependencies, adapters, or environment-specific config.",
+        ),
+        "result_shape": "entity_relations",
+        "required_any_scope": ("service", "anchor_entity_key"),
+        "optional_scope": (
+            "service",
+            "depth",
+            "direction",
+            "environment",
+            "include_unqualified_environment",
+        ),
+        "supported_filters": (
+            "service",
+            "anchor_entity_key",
+            "depth",
+            "direction",
+            "environment",
+            "include_unqualified_environment",
+        ),
+        "keywords": (
+            "service",
+            "dependency",
+            "environment",
+            "staging",
+            "deploy",
+            "config",
+        ),
+        "examples": (
+            ExampleCommand(
+                command="potpie graph read --subgraph infra_topology --view service_neighborhood --scope service:payments-api --environment staging --depth 2 --json",
+                description="Read a service neighborhood in one environment.",
+            ),
+        ),
+    },
+    "features.feature_context": {
+        "purpose": "Return capabilities a repository or service provides and where they are implemented.",
+        "when_to_use": (
+            "Use to learn what a repo/service does or to locate feature implementation anchors.",
+        ),
+        "result_shape": "entity_relations",
+        "required_any_scope": (
+            "scope",
+            "service",
+            "repo",
+            "anchor_entity_key",
+            "query",
+        ),
+        "optional_scope": ("scope", "service", "query"),
+        "supported_filters": (
+            "scope",
+            "service",
+            "repo",
+            "anchor_entity_key",
+            "query",
+        ),
+        "keywords": ("feature", "capability", "implements", "repo", "service"),
+    },
+    "decisions.active_decisions": {
+        "purpose": "Return active architectural decisions affecting a scope.",
+        "when_to_use": (
+            "Use before architecture-sensitive work, migrations, or behavior changes.",
+        ),
+        "result_shape": "flat_claims",
+        "required_any_scope": ("scope", "query", "service", "repo", "path"),
+        "optional_scope": ("scope", "query"),
+        "supported_filters": ("scope", "query", "service", "repo", "path", "file_path"),
+        "keywords": ("decision", "architecture", "adr", "choice", "migration"),
+    },
+    "code_topology.ownership_by_path": {
+        "purpose": "Return service/repo/path ownership and team context.",
+        "when_to_use": (
+            "Use before routing reviews, asking owners, or changing owned code.",
+        ),
+        "result_shape": "entity_relations",
+        "required_any_scope": ("scope", "path", "repo", "service", "anchor_entity_key"),
+        "optional_scope": ("scope",),
+        "supported_filters": (
+            "scope",
+            "path",
+            "file_path",
+            "repo",
+            "service",
+            "anchor_entity_key",
+        ),
+        "keywords": ("owner", "ownership", "team", "path", "repo"),
+    },
+    "knowledge.document_context": {
+        "purpose": "Return documentation pointers and reference notes for a scope.",
+        "when_to_use": (
+            "Use when source docs or runbooks may hold the authoritative answer.",
+        ),
+        "result_shape": "flat_claims",
+        "required_any_scope": ("scope", "query", "service", "repo", "path"),
+        "optional_scope": ("scope", "query"),
+        "supported_filters": ("scope", "query", "service", "repo", "path", "file_path"),
+        "keywords": ("docs", "document", "runbook", "reference", "note"),
+    },
+    "admin.inspection_slice": {
+        "purpose": "Return the raw canonical graph slice for operator inspection.",
+        "when_to_use": (
+            "Use for admin/debug visualization, not for ordinary task context.",
+        ),
+        "result_shape": "raw_graph",
+        "optional_scope": (),
+        "supported_filters": (),
+        "keywords": ("admin", "raw", "inspect", "graph"),
+    },
+}
+
+_SUBGRAPH_TIE_BREAKER: dict[str, int] = {
+    "debugging": 0,
+    "recent_changes": 1,
+    "infra_topology": 2,
+    "decisions": 3,
+    "features": 4,
+    "code_topology": 5,
+    "knowledge": 6,
+    "admin": 7,
+}
+
+
+def ontology_contract() -> WorkbenchOntologyContract:
+    return _ONTOLOGY_CONTRACT
+
+
+def describe_contract(
+    *,
+    subgraph: str,
+    view: str | None = None,
+    include_examples: bool = False,
+) -> dict[str, Any]:
+    """Return the executable contract for a subgraph or one of its views."""
+    contract = ontology_contract()
+    subgraph_name = (subgraph or "").strip()
+    if not subgraph_name:
+        raise ValueError("subgraph is required")
+    subgraph_contract = contract.subgraph(subgraph_name)
+    if subgraph_contract is None:
+        known = ", ".join(sorted(s.name for s in contract.subgraphs))
+        raise ValueError(
+            f"unknown graph subgraph {subgraph_name!r}. Known subgraphs: {known}"
+        )
+
+    view_name = _resolve_view_name(subgraph_name, view)
+    view_contract = None
+    if view_name:
+        view_contract = contract.view(view_name)
+        if view_contract is None or view_contract.subgraph != subgraph_name:
+            known = ", ".join(sorted(v.name for v in subgraph_contract.views))
+            raise ValueError(
+                f"unknown graph view {view_name!r} for subgraph {subgraph_name!r}. "
+                f"Known views: {known}"
+            )
+
+    payload = {
+        "contract_kind": "graph_workbench_ontology",
+        "ontology_version": contract.ontology_version,
+        "subgraph": subgraph_contract.to_dict(
+            include_examples=include_examples,
+            view_filter=view_contract.name if view_contract else None,
+        ),
+    }
+    if view_contract is not None:
+        payload["view"] = view_contract.to_dict(include_examples=include_examples)
+    return payload
+
+
+def rank_views_for_task(
+    task: str | None,
+    *,
+    views: Sequence[Mapping[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """Deterministically rank view contracts for a task string."""
+    task_tokens = _tokens(task or "")
+    if not task_tokens:
+        return []
+    selected_views = list(views or _catalog_view_entries())
+    by_name = {
+        view.name: view
+        for subgraph in _ONTOLOGY_CONTRACT.subgraphs
+        for view in subgraph.views
+    }
+    ranked: list[dict[str, Any]] = []
+    for index, entry in enumerate(selected_views):
+        name = str(entry.get("name") or "")
+        view = by_name.get(name)
+        if view is None:
+            continue
+        score, matched = _score_view_for_task(view, task_tokens)
+        ranked.append(
+            {
+                "view": view.name,
+                "subgraph": view.subgraph,
+                "score": score,
+                "matched_terms": sorted(matched),
+                "reason": _rank_reason(view, matched),
+                "_index": index,
+            }
+        )
+    ranked.sort(
+        key=lambda item: (
+            -int(item["score"]),
+            _SUBGRAPH_TIE_BREAKER.get(str(item["subgraph"]), 99),
+            int(item["_index"]),
+            str(item["view"]),
+        )
+    )
+    for item in ranked:
+        item.pop("_index", None)
+    return ranked
+
+
+def ranked_catalog_views(
+    views: Sequence[Mapping[str, Any]],
+    task: str | None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Return ``views`` sorted by task ranking plus the ranking explanation."""
+    view_entries = [dict(view) for view in views]
+    ranking = rank_views_for_task(task, views=view_entries)
+    if not ranking:
+        return view_entries, []
+    order = {str(entry["view"]): index for index, entry in enumerate(ranking)}
+    view_entries.sort(key=lambda view: order.get(str(view.get("name")), len(order)))
+    return view_entries, ranking
+
+
+def mutation_policies_for_subgraph(subgraph: str) -> tuple[MutationPolicy, ...]:
+    return tuple(
+        replace(policy, applies_to_subgraphs=(subgraph,))
+        for policy in _MUTATION_POLICIES
+    )
+
+
+def source_authority_policies() -> tuple[SourceAuthorityPolicy, ...]:
+    return _SOURCE_AUTHORITY_POLICIES
+
+
+def assert_ontology_contract_coherent(
+    contract: WorkbenchOntologyContract | None = None,
+) -> None:
+    errors = _ontology_contract_errors(contract or _ONTOLOGY_CONTRACT)
+    if errors:
+        raise RuntimeError(
+            "graph_workbench_ontology incoherent:\n  - " + "\n  - ".join(errors)
+        )
+
+
+def _build_contract() -> WorkbenchOntologyContract:
+    views_by_subgraph: dict[str, list[ViewContract]] = {
+        name: [] for name in _SUBGRAPH_DEFINITIONS
+    }
+    for spec in GRAPH_VIEWS.values():
+        views_by_subgraph.setdefault(spec.subgraph, []).append(_view_contract(spec))
+
+    subgraphs: list[SubgraphContract] = []
+    for name, data in _SUBGRAPH_DEFINITIONS.items():
+        subgraphs.append(
+            SubgraphContract(
+                name=name,
+                purpose=str(data["purpose"]),
+                when_to_use=tuple(data["when_to_use"]),
+                entity_types=tuple(data["entity_types"]),
+                relation_types=tuple(data["relation_types"]),
+                views=tuple(
+                    sorted(views_by_subgraph.get(name, ()), key=lambda v: v.name)
+                ),
+                keywords=tuple(data["keywords"]),
+                examples=tuple(data["examples"]),
+            )
+        )
+
+    return WorkbenchOntologyContract(
+        ontology_version=ONTOLOGY_VERSION,
+        subgraphs=tuple(subgraphs),
+        mutation_policies=_MUTATION_POLICIES,
+        source_authority_policies=_SOURCE_AUTHORITY_POLICIES,
+        identity_policies=_IDENTITY_POLICIES,
+    )
+
+
+def _view_contract(spec: GraphViewSpec) -> ViewContract:
+    override = _VIEW_OVERRIDES.get(spec.name, {})
+    optional_scope = tuple(override.get("optional_scope") or spec.inputs)
+    supported_filters = tuple(override.get("supported_filters") or spec.inputs)
+    if spec.backed and "source_ref" not in supported_filters:
+        supported_filters = (*supported_filters, "source_ref")
+    if spec.backed and "source_ref" not in optional_scope:
+        optional_scope = (*optional_scope, "source_ref")
+    return ViewContract(
+        name=spec.name,
+        subgraph=spec.subgraph,
+        view=spec.view,
+        purpose=str(override.get("purpose") or spec.description),
+        when_to_use=tuple(override.get("when_to_use") or (spec.description,)),
+        v1_include=spec.v1_include,
+        backed=spec.backed,
+        required_scope=tuple(override.get("required_scope") or ()),
+        required_any_scope=tuple(override.get("required_any_scope") or ()),
+        optional_scope=optional_scope,
+        result_shape=str(override.get("result_shape") or "flat_claims"),
+        ranking_inputs=tuple(spec.ranking_inputs),
+        supported_filters=supported_filters,
+        inline_relations=tuple(spec.inline_relations),
+        traversal=spec.traversal,
+        examples=tuple(override.get("examples") or ()),
+        keywords=tuple(override.get("keywords") or ()),
+        extra=dict(spec.extra),
+    )
+
+
+def _identity_policy(label: str) -> IdentityPolicy:
+    spec = ENTITY_TYPES[label]
+    identity_class = getattr(spec.identity_class, "value", str(spec.identity_class))
+    return IdentityPolicy(
+        entity_type=label,
+        key_prefix=spec.key_prefix,
+        identity_class=str(identity_class),
+        identity_policy=spec.identity_policy,
+        authoritative_source=spec.authoritative_source,
+        scope=spec.scope,
+    )
+
+
+def _entity_type_contract(label: str) -> EntityTypeContract:
+    spec = ENTITY_TYPES[label]
+    return EntityTypeContract(
+        label=label,
+        category=spec.category,
+        description=spec.description,
+        identity=_identity_policy(label),
+        patchable_properties=tuple(sorted(spec.patchable_properties)),
+        lifecycle_states=tuple(sorted(spec.lifecycle_states)),
+        lifecycle_transitions={
+            key: tuple(sorted(values))
+            for key, values in sorted(spec.lifecycle_transitions.items())
+        },
+    )
+
+
+def _relation_type_contract(name: str) -> RelationTypeContract:
+    spec = EDGE_TYPES[name]
+    return RelationTypeContract(
+        name=name,
+        category=spec.category,
+        description=spec.description,
+        allowed_pairs=tuple(spec.allowed_pairs),
+        required_properties=tuple(sorted(spec.required_properties)),
+        singleton=spec.singleton,
+    )
+
+
+def _resolve_view_name(subgraph: str, view: str | None) -> str | None:
+    if not view:
+        return None
+    value = view.strip()
+    if not value:
+        return None
+    return value if "." in value else f"{subgraph}.{value}"
+
+
+def _catalog_view_entries() -> list[dict[str, Any]]:
+    return [
+        view.to_dict(include_examples=False)
+        for subgraph in _ONTOLOGY_CONTRACT.subgraphs
+        for view in subgraph.views
+    ]
+
+
+def _score_view_for_task(
+    view: ViewContract, task_tokens: set[str]
+) -> tuple[int, set[str]]:
+    subgraph_keywords = set(_SUBGRAPH_DEFINITIONS[view.subgraph]["keywords"])
+    view_keywords = set(view.keywords)
+    description_tokens = _tokens(
+        " ".join(
+            (
+                view.name,
+                view.purpose,
+                " ".join(view.when_to_use),
+                " ".join(view.inline_relations),
+            )
+        )
+    )
+    matched: set[str] = set()
+    score = 0
+    for token in task_tokens:
+        if _matches_any(token, view_keywords):
+            score += 6
+            matched.add(token)
+            continue
+        if _matches_any(token, subgraph_keywords):
+            score += 3
+            matched.add(token)
+            continue
+        if _matches_any(token, description_tokens):
+            score += 1
+            matched.add(token)
+    if matched and view.backed:
+        score += 1
+    if view.subgraph == "admin":
+        score -= 2
+    return max(score, 0), matched
+
+
+def _rank_reason(view: ViewContract, matched: set[str]) -> str:
+    if matched:
+        return (
+            f"Matched {', '.join(sorted(matched))} against the "
+            f"{view.subgraph} contract and {view.name} view."
+        )
+    return (
+        f"No direct task keyword match; kept after more relevant {view.subgraph} views."
+    )
+
+
+def _tokens(text: str) -> set[str]:
+    return {match.group(0).lower() for match in _TOKEN_RE.finditer(text)}
+
+
+def _matches_any(token: str, candidates: set[str]) -> bool:
+    if token in candidates:
+        return True
+    return any(
+        (len(token) >= 5 and candidate.startswith(token))
+        or (len(candidate) >= 5 and token.startswith(candidate))
+        for candidate in candidates
+    )
+
+
+def _ontology_contract_errors(contract: WorkbenchOntologyContract) -> list[str]:
+    errors: list[str] = []
+    policy_by_op = {policy.operation: policy for policy in contract.mutation_policies}
+    for subgraph in contract.subgraphs:
+        for label in subgraph.entity_types:
+            if label not in ENTITY_TYPES:
+                errors.append(
+                    f"subgraph {subgraph.name!r} references unknown entity type {label!r}"
+                )
+        for relation in subgraph.relation_types:
+            if relation not in EDGE_TYPES:
+                errors.append(
+                    f"subgraph {subgraph.name!r} references unknown relation type {relation!r}"
+                )
+        for view in subgraph.views:
+            if view.v1_include not in CONTEXT_INCLUDE_VALUES:
+                errors.append(
+                    f"view {view.name!r} routes to unsupported include {view.v1_include!r}"
+                )
+            for relation in view.inline_relations:
+                if relation not in EDGE_TYPES:
+                    errors.append(
+                        f"view {view.name!r} inlines unknown relation {relation!r}"
+                    )
+            if view.subgraph != subgraph.name:
+                errors.append(
+                    f"view {view.name!r} is attached to subgraph {subgraph.name!r} "
+                    f"but declares {view.subgraph!r}"
+                )
+
+    for op in APPLICABLE_MUTATION_OPS:
+        if policy_by_op.get(op, None) is None:
+            errors.append(f"applicable mutation op {op!r} has no policy")
+        elif policy_by_op[op].availability != "applicable":
+            errors.append(
+                f"applicable mutation op {op!r} has wrong policy availability"
+            )
+    for op in REVIEW_REQUIRED_OPS:
+        if policy_by_op.get(op, None) is None:
+            errors.append(f"review-required mutation op {op!r} has no policy")
+        elif policy_by_op[op].availability != "review_required":
+            errors.append(
+                f"review-required mutation op {op!r} has wrong policy availability"
+            )
+    for op in DEFERRED_OPS:
+        if policy_by_op.get(op, None) is None:
+            errors.append(f"deferred mutation op {op!r} has no policy")
+        elif policy_by_op[op].availability != "deferred":
+            errors.append(f"deferred mutation op {op!r} has wrong policy availability")
+    for policy in contract.mutation_policies:
+        if policy.operation not in KNOWN_MUTATION_OPS:
+            errors.append(f"mutation policy advertises unknown op {policy.operation!r}")
+    return errors
+
+
+def _mutation_policy(
+    operation: str,
+    *,
+    availability: str,
+    description: str,
+    requires_review: bool = False,
+) -> MutationPolicy:
+    return MutationPolicy(
+        operation=operation,
+        availability=availability,
+        description=description,
+        requires_review=requires_review,
+    )
+
+
+_MUTATION_POLICIES: tuple[MutationPolicy, ...] = (
+    tuple(
+        _mutation_policy(
+            op,
+            availability="applicable",
+            description="Accepted by the semantic validator and directly applicable through the V1.5 write door when risk policy allows.",
+        )
+        for op in APPLICABLE_MUTATION_OPS
+    )
+    + tuple(
+        _mutation_policy(
+            op,
+            availability="review_required",
+            description="Recognized by the semantic validator but requires review; V1.5 has no auto-apply path.",
+            requires_review=True,
+        )
+        for op in REVIEW_REQUIRED_OPS
+    )
+    + tuple(
+        _mutation_policy(
+            op,
+            availability="deferred",
+            description="Reserved vocabulary; not applied by the current V1.5 data plane.",
+            requires_review=True,
+        )
+        for op in DEFERRED_OPS
+    )
+)
+
+_SOURCE_AUTHORITY_POLICIES: tuple[SourceAuthorityPolicy, ...] = tuple(
+    SourceAuthorityPolicy(
+        authority=authority,
+        strength="strong" if authority in STRONG_AUTHORITIES else "supporting",
+        description=(
+            "Can satisfy durable-write evidence requirements."
+            if authority in STRONG_AUTHORITIES
+            else "Useful as supporting evidence, but not strong enough alone for objective durable facts."
+        ),
+    )
+    for authority in sorted(SOURCE_AUTHORITIES)
+)
+
+_IDENTITY_POLICIES: tuple[IdentityPolicy, ...] = tuple(
+    _identity_policy(label) for label, spec in ENTITY_TYPES.items() if spec.public
+)
+
+_ONTOLOGY_CONTRACT = _build_contract()
+assert_ontology_contract_coherent(_ONTOLOGY_CONTRACT)
+
+
+__all__ = [
+    "EntityTypeContract",
+    "ExampleCommand",
+    "IdentityPolicy",
+    "MutationPolicy",
+    "RelationTypeContract",
+    "SourceAuthorityPolicy",
+    "SubgraphContract",
+    "ViewContract",
+    "WorkbenchOntologyContract",
+    "assert_ontology_contract_coherent",
+    "describe_contract",
+    "ontology_contract",
+    "rank_views_for_task",
+    "ranked_catalog_views",
+]

--- a/potpie/context-engine/domain/lifecycle.py
+++ b/potpie/context-engine/domain/lifecycle.py
@@ -14,6 +14,7 @@ their step independently.
 
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass, field
 from typing import Any, Mapping
 
@@ -27,15 +28,22 @@ PLANNED = "planned"
 _OK_STATES = frozenset({DONE, SKIPPED, PLANNED})
 
 
+def default_setup_backend() -> str:
+    """Default CLI setup backend for the current interpreter."""
+    if sys.version_info >= (3, 12):
+        return "falkordb_lite"
+    return "embedded"
+
+
 @dataclass(frozen=True, slots=True)
 class SetupPlan:
     """The first-run intent the orchestrator executes (built from CLI flags)."""
 
     mode: str = "local"  # local setup; managed auth uses LoginPlan
     host_mode: str = "daemon"  # daemon | in_process — flips daemon/installer hardness
-    backend: str = "embedded"  # embedded | postgres | neo4j | in_memory
+    backend: str = field(default_factory=default_setup_backend)
     repo: str | None = "."
-    pot: str = "foo-pot"
+    pot: str = "default"
     agent: str = "claude"
     scan: bool = False
     assume_yes: bool = False

--- a/potpie/context-engine/domain/ports/daemon/__init__.py
+++ b/potpie/context-engine/domain/ports/daemon/__init__.py
@@ -1,6 +1,7 @@
-"""Daemon-shell ports — transport-agnostic contracts for the local daemon host.
+"""Daemon shell ports: transport-agnostic contracts for the local daemon host.
 
 These are the hexagonal ports the in-process daemon runtime (``host.daemon_runtime``)
-and its adapters bind to: the operation contract (``operations``), the three runtime
-ports + health (``shell``), and the managed-service value objects (``service``).
+and its adapters bind to: the operation contract (``operations``), the three
+runtime ports plus health (``shell``), and the managed-service value objects
+(``service``).
 """

--- a/potpie/context-engine/domain/ports/daemon/operations.py
+++ b/potpie/context-engine/domain/ports/daemon/operations.py
@@ -1,9 +1,11 @@
-"""Operation contract — neutral, transport-agnostic ops served identically over any protocol."""
+"""Operation contract: neutral, transport-agnostic ops served identically over any protocol."""
 
 from __future__ import annotations
+
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Awaitable, Callable
+
 from pydantic import BaseModel
 
 
@@ -19,7 +21,7 @@ class OpKind(Enum):
 
 
 class OperationError(Exception):
-    """Uniform error for any operation handler. Transport adapters map ``code`` onto protocol-native error shapes."""
+    """Uniform error for operation handlers; transports map ``code`` to native errors."""
 
     def __init__(
         self,
@@ -48,7 +50,7 @@ class OperationContext:
     principal: Principal
     request_id: str
     deadline: float | None = None
-    deps: Any = None  # opaque; component-supplied wired deps
+    deps: Any = None
 
 
 @dataclass(frozen=True)

--- a/potpie/context-engine/domain/ports/daemon/service.py
+++ b/potpie/context-engine/domain/ports/daemon/service.py
@@ -1,6 +1,7 @@
 """Managed-service value objects: how the daemon describes a service it supervises."""
 
 from __future__ import annotations
+
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
@@ -23,10 +24,10 @@ class RestartPolicy(Enum):
 @dataclass
 class ServiceSpec:
     name: str
-    backend: str  # registry key
-    config: dict[str, Any]  # backend-specific
+    backend: str
+    config: dict[str, Any]
     ready: ReadyProbe
-    endpoint: str  # connection string consumers receive
+    endpoint: str
     restart: RestartPolicy = RestartPolicy.ON_FAILURE
     depends_on: list[str] = field(default_factory=list)
-    data_dir: str | None = None  # optional per-service writable dir
+    data_dir: str | None = None

--- a/potpie/context-engine/domain/ports/daemon/shell.py
+++ b/potpie/context-engine/domain/ports/daemon/shell.py
@@ -1,11 +1,12 @@
 """The three ports of the hexagonal daemon shell: Transport, Component, ServiceBackend."""
 
 from __future__ import annotations
+
 from enum import Enum
 from typing import Protocol, runtime_checkable
 
 from domain.ports.daemon.operations import OperationRegistry
-from domain.ports.daemon.service import ServiceSpec, ReadyProbe, RestartPolicy
+from domain.ports.daemon.service import ReadyProbe, RestartPolicy, ServiceSpec
 
 
 class HealthStatus(Enum):
@@ -30,7 +31,7 @@ class Component(Protocol):
     async def on_start(self, ctx: "ShellContext") -> None: ...  # type: ignore[name-defined]  # noqa: F821
     async def on_stop(self) -> None: ...
     def health(self) -> HealthStatus: ...
-    def operations(self) -> list: ...  # list[OperationSpec]
+    def operations(self) -> list: ...
 
 
 @runtime_checkable
@@ -40,8 +41,6 @@ class ServiceBackend(Protocol):
     async def probe(self, spec: ServiceSpec) -> HealthStatus: ...
 
 
-# Convenience re-exports: the service value objects live in ``service`` but are commonly
-# imported alongside these ports.
 __all__ = [
     "HealthStatus",
     "Transport",

--- a/potpie/context-engine/domain/ports/graph/backend.py
+++ b/potpie/context-engine/domain/ports/graph/backend.py
@@ -12,9 +12,10 @@ analytics, snapshot — as ``CapabilityNotImplemented`` until built.
 Profiles (``profile`` property) select the concrete backend:
 
     in_memory   real, used for tests + conformance
+    falkordb_lite OSS local default on Python >=3.12
+    embedded    JSON-persisted local fallback
+    falkordb    external FalkorDB profile
     neo4j       shape-first production target (delegates to existing Neo4j code)
-    embedded    OSS local default (TODO)
-    postgres    pgvector profile (TODO)
     hosted      managed profile (TODO)
 
 Adding a backend means implementing these six ports behind a new profile —

--- a/potpie/context-engine/domain/ports/services/graph_service.py
+++ b/potpie/context-engine/domain/ports/services/graph_service.py
@@ -10,11 +10,16 @@ assembly, and it talks to a ``GraphBackend`` (claim_query + mutation + semantic)
 halves being ``PotManagementService`` and ``SkillManager``). The two share the
 same request DTOs but sit at different altitudes: ``GraphService.resolve`` does
 the read work; ``AgentContextPort.resolve`` is the public binding to it.
+
+Graph Surface Lite (V1.5) adds four V2-shaped methods — ``catalog`` / ``read`` /
+``search_entities`` / ``mutate`` — that discover, query, and directly mutate the
+graph. They are CLI-only in V1.5 (the MCP surface stays at exactly four tools).
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any, Mapping, Protocol
 
 from domain.agent_envelope import AgentEnvelope
@@ -23,6 +28,10 @@ from domain.ports.agent_context import (
     RecordRequest,
     ResolveRequest,
     SearchRequest,
+)
+from domain.semantic_mutations import (
+    SemanticMutationRequest,
+    SemanticMutationResult,
 )
 
 
@@ -37,11 +46,213 @@ class DataPlaneStatus:
     counts: Mapping[str, int] = field(default_factory=dict)
     freshness: Mapping[str, Any] = field(default_factory=dict)
     quality: Mapping[str, Any] = field(default_factory=dict)
+    match_mode: str = "lexical"
+    """Active semantic-match mode (``vector`` | ``lexical``) so empty results
+    are debuggable, not mysterious (Retrieval Hardening / R1)."""
     detail: str | None = None
 
 
+# --- Graph Surface Lite DTOs ------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class GraphCatalogRequest:
+    """``graph catalog`` — discover the graph contract.
+
+    ``task`` is accepted now but ignored in V1.5 (V2 turns it into a
+    subgraph/view ranker); accepting it keeps that change additive.
+    """
+
+    pot_id: str
+    task: str | None = None
+    subgraph: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GraphCatalogResult:
+    """The static contract a harness needs to use the graph without docs."""
+
+    graph_contract_version: str
+    ontology_version: str
+    commands: tuple[str, ...]
+    truth_classes: tuple[str, ...]
+    mutation_operations: tuple[str, ...]
+    review_required_operations: tuple[str, ...]
+    deferred_operations: tuple[str, ...]
+    views: tuple[Mapping[str, Any], ...]
+    entity_types: tuple[Mapping[str, Any], ...]
+    predicates: tuple[Mapping[str, Any], ...]
+    match_mode: str = "lexical"
+    source_authorities: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": True,
+            "graph_contract_version": self.graph_contract_version,
+            "ontology_version": self.ontology_version,
+            "commands": list(self.commands),
+            "truth_classes": list(self.truth_classes),
+            "mutation_operations": list(self.mutation_operations),
+            "review_required_operations": list(self.review_required_operations),
+            "deferred_operations": list(self.deferred_operations),
+            "source_authorities": list(self.source_authorities),
+            "match_mode": self.match_mode,
+            "views": [dict(v) for v in self.views],
+            "entity_types": [dict(e) for e in self.entity_types],
+            "predicates": [dict(p) for p in self.predicates],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class GraphReadRequest:
+    """``graph read`` — a V2-style read over a named subgraph/view."""
+
+    pot_id: str
+    subgraph: str
+    view: str
+    query: str | None = None
+    scope: Mapping[str, Any] = field(default_factory=dict)
+    limit: int = 12
+    as_of: datetime | None = None
+    since: datetime | None = None
+    until: datetime | None = None
+    include_invalidated: bool = False
+    freshness_preference: str = "balanced"
+    depth: int | None = None
+    direction: str | None = None
+    environment: str | None = None
+    source_refs: tuple[str, ...] = ()
+    detail: str = "compact"
+    relations: str = "summary"
+
+
+@dataclass(frozen=True, slots=True)
+class GraphReadResult:
+    """Contract-shaped V2 read result.
+
+    This is the graph workbench read body. It intentionally does not expose the
+    internal ``AgentEnvelope`` used by lower-level readers.
+    """
+
+    view: str
+    subgraph: str
+    items: tuple[Mapping[str, Any], ...] = ()
+    coverage: tuple[Mapping[str, Any], ...] = ()
+    freshness: Mapping[str, Any] = field(default_factory=dict)
+    quality: Mapping[str, Any] = field(default_factory=dict)
+    source_refs: tuple[str, ...] = ()
+    match_mode: str = "lexical"
+    backed: bool = True
+    read_shape: str = "flat_claims"
+    inline_relations: tuple[str, ...] = ()
+    inline_relation_count: int = 0
+    graph_contract_version: str = ""
+    ontology_version: str = ""
+    subgraph_versions: Mapping[str, int] = field(default_factory=dict)
+    unsupported: tuple[Mapping[str, Any], ...] = ()
+    warnings: tuple[str, ...] = ()
+    as_of: datetime | None = None
+    detail: str = "compact"
+    relations: str = "summary"
+
+    def to_dict(self) -> dict[str, Any]:
+        detail = _normalize_read_detail(self.detail)
+        relations = _normalize_read_relations(self.relations)
+        return {
+            "ok": True,
+            "graph_contract_version": self.graph_contract_version,
+            "ontology_version": self.ontology_version,
+            "view": self.view,
+            "subgraph": self.subgraph,
+            "backed": self.backed,
+            "match_mode": self.match_mode,
+            "read_shape": self.read_shape,
+            "inline_relations": list(self.inline_relations),
+            "inline_relation_count": self.inline_relation_count,
+            "detail": detail,
+            "relations_detail": relations,
+            "items": [
+                _read_item_for_detail(item, detail=detail, relations=relations)
+                for item in self.items
+            ],
+            "coverage": [dict(report) for report in self.coverage],
+            "freshness": dict(self.freshness),
+            "quality": dict(self.quality),
+            "source_refs": list(self.source_refs),
+            "subgraph_versions": dict(self.subgraph_versions),
+            "unsupported": [dict(item) for item in self.unsupported],
+            "warnings": list(self.warnings),
+            "as_of": self.as_of.isoformat() if self.as_of else None,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class GraphEntityCandidate:
+    """One entity surfaced by ``search_entities``."""
+
+    key: str
+    labels: tuple[str, ...]
+    name: str | None = None
+    summary: str | None = None
+    description: str | None = None
+    score: float = 0.0
+    supporting_claims: tuple[Mapping[str, Any], ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class GraphEntitySearchRequest:
+    """``graph search-entities`` — typed structured lookup for identity resolution."""
+
+    pot_id: str
+    query: str
+    type: str | None = None
+    predicate: str | None = None
+    subgraph: str | None = None
+    scope: Mapping[str, Any] = field(default_factory=dict)
+    truth: str | None = None
+    source_system: str | None = None
+    source_family: str | None = None
+    since: datetime | None = None
+    until: datetime | None = None
+    environment: str | None = None
+    external_id: str | None = None
+    source_refs: tuple[str, ...] = ()
+    limit: int = 10
+    supporting_claims: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class GraphEntitySearchResult:
+    entities: tuple[GraphEntityCandidate, ...]
+    match_mode: str
+    graph_contract_version: str
+    ontology_version: str
+    subgraph_versions: Mapping[str, int] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": True,
+            "graph_contract_version": self.graph_contract_version,
+            "ontology_version": self.ontology_version,
+            "match_mode": self.match_mode,
+            "subgraph_versions": dict(self.subgraph_versions),
+            "entities": [
+                {
+                    "key": c.key,
+                    "labels": list(c.labels),
+                    "name": c.name,
+                    "summary": c.summary,
+                    "description": c.description,
+                    "score": c.score,
+                    "supporting_claims": [dict(s) for s in c.supporting_claims],
+                }
+                for c in self.entities
+            ],
+        }
+
+
 class GraphService(Protocol):
-    """Data plane for resolve/search/record over a ``GraphBackend``."""
+    """Data plane for resolve/search/record + Graph Surface Lite."""
 
     def resolve(self, request: ResolveRequest) -> AgentEnvelope:
         """Expand intent → includes, run readers over the backend, rank, and
@@ -53,13 +264,131 @@ class GraphService(Protocol):
         ...
 
     def record(self, request: RecordRequest) -> RecordReceipt:
-        """Lower a durable record into a mutation plan and apply it through the
-        backend's mutation port."""
+        """Lower a durable record into a semantic mutation and apply it."""
         ...
 
     def data_plane_status(self, pot_id: str) -> DataPlaneStatus:
         """Backend readiness + coverage for ``context_status``."""
         ...
 
+    # --- Graph Surface Lite (V1.5) -----------------------------------------
+    def catalog(self, request: GraphCatalogRequest) -> GraphCatalogResult:
+        """Return the V1.5 graph contract (versions, views, ops, ontology)."""
+        ...
 
-__all__ = ["DataPlaneStatus", "GraphService"]
+    def read(self, request: GraphReadRequest) -> GraphReadResult:
+        """V2-style read over a named view, routed through the read trunk."""
+        ...
+
+    def search_entities(
+        self, request: GraphEntitySearchRequest
+    ) -> GraphEntitySearchResult:
+        """Narrow entity/claim lookup for identity resolution before writes."""
+        ...
+
+    def mutate(self, request: SemanticMutationRequest) -> SemanticMutationResult:
+        """Validate, risk-classify, lower, and dry-run or apply semantic mutations."""
+        ...
+
+
+def _normalize_read_detail(value: str | None) -> str:
+    detail = (value or "compact").strip().lower()
+    if detail not in {"compact", "full"}:
+        raise ValueError("detail must be one of: compact, full")
+    return detail
+
+
+def _normalize_read_relations(value: str | None) -> str:
+    relations = (value or "summary").strip().lower()
+    if relations not in {"summary", "full"}:
+        raise ValueError("relations must be one of: summary, full")
+    return relations
+
+
+def _read_item_for_detail(
+    item: Mapping[str, Any], *, detail: str, relations: str
+) -> dict[str, Any]:
+    payload = dict(item)
+    relation_items = _relation_items(payload.get("relations"))
+
+    if detail == "full":
+        out = dict(payload)
+    else:
+        out = {
+            key: payload[key]
+            for key in (
+                "entity_key",
+                "entity_type",
+                "score",
+                "summary",
+                "status",
+                "source_refs",
+                "truth",
+                "coverage_status",
+            )
+            if key in payload
+        }
+        claim = payload.get("claim")
+        if isinstance(claim, Mapping):
+            compact_claim = {
+                key: claim.get(key)
+                for key in (
+                    "claim_key",
+                    "predicate",
+                    "subject_key",
+                    "object_key",
+                )
+                if claim.get(key) is not None
+            }
+            if compact_claim:
+                out["claim"] = compact_claim
+
+    if relations == "full":
+        out["relations"] = relation_items
+        return out
+
+    out.pop("relations", None)
+    out["relation_count"] = len(relation_items)
+    if relation_items:
+        out["relation_predicates"] = sorted(
+            {
+                str(rel.get("predicate") or rel.get("type"))
+                for rel in relation_items
+                if rel.get("predicate") or rel.get("type")
+            }
+        )
+        out["related_keys"] = _first_relation_keys(relation_items)
+    return out
+
+
+def _relation_items(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [dict(item) for item in value if isinstance(item, Mapping)]
+
+
+def _first_relation_keys(relations: list[Mapping[str, Any]]) -> list[str]:
+    keys: list[str] = []
+    seen: set[str] = set()
+    for rel in relations:
+        key = rel.get("related_key") or rel.get("to_key") or rel.get("from_key")
+        if not isinstance(key, str) or not key or key in seen:
+            continue
+        keys.append(key)
+        seen.add(key)
+        if len(keys) >= 10:
+            break
+    return keys
+
+
+__all__ = [
+    "DataPlaneStatus",
+    "GraphCatalogRequest",
+    "GraphCatalogResult",
+    "GraphEntityCandidate",
+    "GraphEntitySearchRequest",
+    "GraphEntitySearchResult",
+    "GraphReadRequest",
+    "GraphReadResult",
+    "GraphService",
+]

--- a/potpie/context-engine/domain/ports/services/pot_management.py
+++ b/potpie/context-engine/domain/ports/services/pot_management.py
@@ -35,6 +35,9 @@ class SourceInfo:
     source_id: str
     kind: str  # repo | github | linear | ...
     name: str
+    location: str | None = None
+    """Registered path / remote / owner-repo ref, so harnesses can verify a
+    path-or-remote mismatch against the current working tree."""
     last_sync_at: datetime | None = None
     sync_mode: str | None = None
     status: str = "unknown"  # ok | stale | error | unknown
@@ -94,6 +97,23 @@ class PotManagementService(Protocol):
     def source_status(self, *, pot_id: str, source_id: str) -> SourceInfo: ...
 
     def remove_source(self, *, pot_id: str, source_id: str) -> None: ...
+
+    # --- repo-local routing defaults ----------------------------------------
+    def repo_default(self, *, repo: str) -> str | None:
+        """Return the locally preferred pot id for a repo identity, if set."""
+        ...
+
+    def set_repo_default(self, *, repo: str, pot_id: str) -> None:
+        """Persist the locally preferred pot id for a repo identity."""
+        ...
+
+    def clear_repo_default(self, *, repo: str) -> bool:
+        """Clear the locally preferred pot id for a repo identity."""
+        ...
+
+    def list_repo_defaults(self) -> dict[str, str]:
+        """Return all locally persisted repo identity -> pot id defaults."""
+        ...
 
     # --- rollup -------------------------------------------------------------
     def aggregate_status(self, *, pot_id: str | None = None) -> PotAggregateStatus:

--- a/potpie/context-engine/domain/ports/services/skill_manager.py
+++ b/potpie/context-engine/domain/ports/services/skill_manager.py
@@ -110,11 +110,12 @@ class SkillManager(Protocol):
         self,
         *,
         agent: str,
-        skill_id: str,
+        skill_id: str | None = None,
+        all_: bool = False,
         path: str | None = None,
         scope: str = "global",
     ) -> SkillOperationResult:
-        """Remove an installed skill from an agent harness."""
+        """Remove one installed skill, or all installed skills when ``all_``."""
         ...
 
     def status(

--- a/potpie/context-engine/domain/ports/settings.py
+++ b/potpie/context-engine/domain/ports/settings.py
@@ -18,7 +18,7 @@ class ContextEngineSettingsPort(Protocol):
     # without change: anything that doesn't override these reports the
     # default ``neo4j`` backend, leaving production untouched.
     def graph_db_backend(self) -> str:
-        """Which graph backend to use: ``neo4j`` (default) or ``falkordb``."""
+        """Which graph backend to use: ``neo4j`` (default), ``falkordb``, etc."""
         return "neo4j"
 
     def falkordb_url(self) -> str | None:

--- a/potpie/context-engine/tests/conformance/test_host_shell_end_to_end.py
+++ b/potpie/context-engine/tests/conformance/test_host_shell_end_to_end.py
@@ -77,7 +77,7 @@ def test_setup_orchestrator_provisions_and_creates_default_pot(host):
     assert states["daemon"] == SKIPPED  # in-process host: nothing to start
     assert states["auth"] == NOT_IMPLEMENTED  # soft gap; does not fail setup
     active = host.pots.active_pot()
-    assert active is not None and active.name == "foo-pot"
+    assert active is not None and active.name == "default"
 
 
 def test_setup_is_idempotent(host):

--- a/potpie/context-engine/tests/unit/test_agent_installer.py
+++ b/potpie/context-engine/tests/unit/test_agent_installer.py
@@ -7,11 +7,14 @@ from pathlib import Path
 import pytest
 
 from adapters.outbound.skills.agent_installer import (
+    install_global_agent_instructions,
     install_agent_bundle,
     install_skill_bundle,
     iter_template_files,
     resolve_install_root,
 )
+from adapters.outbound.skills.claude_target import FileBackedAgentTarget
+from application.services.skill_manager import DefaultSkillManager
 from adapters.outbound.skills.bundle_catalog import catalog_by_id
 
 
@@ -59,7 +62,100 @@ def test_install_skill_bundle_writes_to_global_root(tmp_path: Path) -> None:
 
     assert "potpie-cli/SKILL.md" in result.created
     assert (root / "potpie-cli" / "SKILL.md").exists()
-    assert not (root / "potpie-agent-context" / "SKILL.md").exists()
+    assert {path.name for path in root.iterdir()} == {"potpie-cli"}
+
+
+def test_install_global_agent_instructions_merges_compact_agents_md(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "codex"
+    root.mkdir()
+    target = root / "AGENTS.md"
+    target.write_text("# Personal defaults\n", encoding="utf-8")
+
+    result = install_global_agent_instructions(root, agent="codex")
+
+    text = target.read_text(encoding="utf-8")
+    managed = text.split("<!-- potpie-start -->", 1)[1].split(
+        "<!-- potpie-end -->", 1
+    )[0]
+    assert result.created == ["AGENTS.md"]
+    assert "# Personal defaults" in text
+    assert "Potpie is durable project memory" in text
+    assert "potpie --json source list" in text
+    assert len([line for line in managed.splitlines() if line.strip()]) <= 6
+
+    rerun = install_global_agent_instructions(root, agent="codex")
+
+    assert rerun.unchanged == ["AGENTS.md"]
+
+
+def test_install_global_agent_instructions_updates_managed_claude_section(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "claude"
+    root.mkdir()
+    target = root / "CLAUDE.md"
+    target.write_text(
+        "# Personal defaults\n\n<!-- potpie-start -->\nold\n<!-- potpie-end -->\n",
+        encoding="utf-8",
+    )
+
+    result = install_global_agent_instructions(root, agent="claude")
+
+    text = target.read_text(encoding="utf-8")
+    assert result.updated == ["CLAUDE.md"]
+    assert "# Personal defaults" in text
+    assert "old" not in text
+    assert "Potpie is durable project memory" in text
+
+
+def test_file_backed_target_installs_global_support_files(tmp_path: Path) -> None:
+    target = FileBackedAgentTarget(
+        agent="codex",
+        skills_root=tmp_path / ".agents" / "skills",
+        instructions_root=tmp_path / ".codex",
+        instructions_agent="codex",
+        home=tmp_path / "potpie",
+    )
+
+    target.install_support_files()
+
+    text = (tmp_path / ".codex" / "AGENTS.md").read_text(encoding="utf-8")
+    assert "Potpie is durable project memory" in text
+
+
+def test_skill_manager_repairs_support_files_when_skill_is_current(
+    tmp_path: Path,
+) -> None:
+    catalog = catalog_by_id()
+    version = catalog["potpie-cli"].version
+    calls: list[str | None] = []
+
+    class _Target:
+        agent = "codex"
+        skills_root = tmp_path / ".agents" / "skills"
+
+        def installed(self) -> dict[str, str]:
+            return {"potpie-cli": version}
+
+        def install(
+            self, *, skill_id: str, version: str, path: str | None = None
+        ) -> None:
+            raise AssertionError("current skill should not be reinstalled")
+
+        def install_support_files(self, *, path: str | None = None) -> None:
+            calls.append(path)
+
+        def remove(self, *, skill_id: str) -> None:
+            raise AssertionError("remove should not be called")
+
+    manager = DefaultSkillManager(targets={"codex": _Target()})
+
+    result = manager.install(agent="codex", skill_id="potpie-cli")
+
+    assert result.changed == ()
+    assert calls == [None]
 
 
 def test_install_agent_bundle_skips_conflicting_files_without_force(
@@ -174,6 +270,22 @@ def test_install_agent_bundle_claude_skips_changed_section_without_force(
     assert "CLAUDE.md" in result.skipped
 
 
+def test_install_agent_bundle_claude_plugin_lays_out_plugin_dir(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    result = install_agent_bundle(repo, agent="claude-plugin")
+
+    base = repo / ".claude" / "potpie-plugin"
+    assert (base / ".claude-plugin" / "plugin.json").exists()
+    assert (base / "hooks" / "hooks.json").exists()
+    assert (base / "hooks" / "potpie_nudge.py").exists()
+    assert (base / "skills" / "potpie-graph" / "SKILL.md").exists()
+    # Everything is created on a fresh repo; nothing skipped.
+    assert ".claude/potpie-plugin/.claude-plugin/plugin.json" in result.created
+    assert not result.skipped
+
+
 def test_install_agent_bundle_cursor_writes_cursor_skills(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -200,7 +312,7 @@ def test_install_agent_bundle_opencode_writes_opencode_skills(tmp_path: Path) ->
     result = install_agent_bundle(repo, agent="opencode")
 
     assert "AGENTS.md" not in result.created
-    skill = repo / ".opencode" / "skills" / "potpie-agent-context" / "SKILL.md"
+    skill = repo / ".opencode" / "skills" / "potpie-graph" / "SKILL.md"
     assert skill.exists()
 
 

--- a/potpie/context-engine/tests/unit/test_bundle_catalog.py
+++ b/potpie/context-engine/tests/unit/test_bundle_catalog.py
@@ -18,7 +18,8 @@ def test_load_bundle_skills_matches_template_directories() -> None:
     }
     loaded = load_bundle_skills()
     assert {skill.id for skill in loaded} == skill_dirs
-    assert len(loaded) == 4
+    assert "potpie-graph" in skill_dirs
+    assert len(loaded) == len(skill_dirs)
 
 
 def test_catalog_fields_are_populated_from_skill_front_matter() -> None:
@@ -28,9 +29,9 @@ def test_catalog_fields_are_populated_from_skill_front_matter() -> None:
     assert cli.version == "1"
     assert "Potpie CLI" in cli.description or "potpie" in cli.description.lower()
 
-    agent_context = catalog["potpie-agent-context"]
-    assert agent_context.id == "potpie-agent-context"
-    assert agent_context.title == "Potpie Agent Context"
+    graph = catalog["potpie-graph"]
+    assert graph.id == "potpie-graph"
+    assert graph.title == "Potpie Graph Workbench"
 
 
 def test_recommended_skill_ids_matches_loaded_catalog() -> None:

--- a/potpie/context-engine/tests/unit/test_envelope.py
+++ b/potpie/context-engine/tests/unit/test_envelope.py
@@ -125,10 +125,13 @@ class TestEnvelopeBuilder:
             as_of=_NOW,
         )
         out = envelope_to_dict(envelope)
+        assert envelope.to_dict() == out
         assert out["pot_id"] == "pot-1"
         assert out["intent"] == "feature"
         assert out["items"][0]["include"] == "preferences"
+        assert out["items"][0]["candidate_key"] == "p"
         assert out["coverage"][0]["status"] == "complete"
+        assert out["coverage"][0]["candidate_pool"] == 3
         assert out["overall_confidence"] == "high"
         assert out["as_of"] == _NOW.isoformat()
 

--- a/potpie/context-engine/tests/unit/test_graph_workbench_ontology.py
+++ b/potpie/context-engine/tests/unit/test_graph_workbench_ontology.py
@@ -1,0 +1,105 @@
+"""Tests for the executable Graph V2 workbench ontology contract."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from domain.graph_contract import (
+    APPLICABLE_MUTATION_OPS,
+    DEFERRED_OPS,
+    REVIEW_REQUIRED_OPS,
+)
+from domain.graph_workbench_ontology import (
+    assert_ontology_contract_coherent,
+    describe_contract,
+    ontology_contract,
+    rank_views_for_task,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_describe_contract_teaches_backed_view_usage() -> None:
+    payload = describe_contract(
+        subgraph="debugging",
+        view="prior_occurrences",
+        include_examples=True,
+    )
+
+    assert payload["contract_kind"] == "graph_workbench_ontology"
+    assert payload["subgraph"]["name"] == "debugging"
+    assert payload["view"]["name"] == "debugging.prior_occurrences"
+    assert payload["view"]["backed"] is True
+    assert "query" in payload["view"]["supported_filters"]
+    assert "REPRODUCES" in payload["view"]["inline_relations"]
+    assert payload["view"]["examples"][0]["command"].startswith("potpie graph read")
+
+
+def test_task_ranking_prioritizes_debugging_workflow_context() -> None:
+    ranking = rank_views_for_task("debug staging timeout after deployment")
+
+    ranked_subgraphs = [entry["subgraph"] for entry in ranking]
+    assert ranked_subgraphs.index("debugging") < ranked_subgraphs.index("features")
+    assert ranked_subgraphs.index("recent_changes") < ranked_subgraphs.index("features")
+    assert ranked_subgraphs.index("infra_topology") < ranked_subgraphs.index("features")
+    assert ranked_subgraphs.index("decisions") < ranked_subgraphs.index("features")
+
+
+def test_mutation_policies_match_graph_contract_partitions() -> None:
+    policies = {
+        policy.operation: policy.availability
+        for policy in ontology_contract().mutation_policies
+    }
+
+    for op in APPLICABLE_MUTATION_OPS:
+        assert policies[op] == "applicable"
+    for op in REVIEW_REQUIRED_OPS:
+        assert policies[op] == "review_required"
+    for op in DEFERRED_OPS:
+        assert policies[op] == "deferred"
+
+
+def test_entity_contract_exposes_patch_and_lifecycle_rules() -> None:
+    payload = describe_contract(subgraph="decisions", include_examples=False)
+    entities = {item["label"]: item for item in payload["subgraph"]["entity_types"]}
+
+    decision = entities["Decision"]
+    assert "summary" in decision["patchable_properties"]
+    assert "description" in decision["patchable_properties"]
+    assert "accepted" in decision["lifecycle_states"]
+    assert decision["lifecycle_transitions"]["proposed"] == ["accepted", "rejected"]
+    assert decision["lifecycle_transitions"]["accepted"] == [
+        "deprecated",
+        "superseded",
+    ]
+
+
+def test_contract_check_rejects_unsupported_view_include() -> None:
+    contract = ontology_contract()
+    first_subgraph = contract.subgraphs[0]
+    bad_view = replace(first_subgraph.views[0], v1_include="not_an_include")
+    bad_subgraph = replace(
+        first_subgraph,
+        views=(bad_view, *first_subgraph.views[1:]),
+    )
+    bad_contract = replace(
+        contract,
+        subgraphs=(bad_subgraph, *contract.subgraphs[1:]),
+    )
+
+    with pytest.raises(RuntimeError, match="unsupported include"):
+        assert_ontology_contract_coherent(bad_contract)
+
+
+def test_contract_check_rejects_invalid_mutation_policy() -> None:
+    contract = ontology_contract()
+    bad_policy = replace(contract.mutation_policies[0], operation="unknown_op")
+    bad_contract = replace(
+        contract,
+        mutation_policies=(bad_policy, *contract.mutation_policies[1:]),
+    )
+
+    with pytest.raises(RuntimeError, match="unknown op"):
+        assert_ontology_contract_coherent(bad_contract)

--- a/potpie/context-engine/tests/unit/test_graph_workbench_ontology.py
+++ b/potpie/context-engine/tests/unit/test_graph_workbench_ontology.py
@@ -47,6 +47,14 @@ def test_task_ranking_prioritizes_debugging_workflow_context() -> None:
     assert ranked_subgraphs.index("decisions") < ranked_subgraphs.index("features")
 
 
+def test_rank_views_with_explicit_empty_views_ranks_nothing() -> None:
+    # Regression: an explicit empty ``views=[]`` must mean "rank no views", not be
+    # treated as ``None`` and silently replaced with the full catalog.
+    assert rank_views_for_task("debug staging timeout", views=[]) == []
+    # ``None`` still falls back to the full catalog.
+    assert rank_views_for_task("debug staging timeout") != []
+
+
 def test_mutation_policies_match_graph_contract_partitions() -> None:
     policies = {
         policy.operation: policy.availability

--- a/potpie/context-engine/tests/unit/test_skill_manager_global_targets.py
+++ b/potpie/context-engine/tests/unit/test_skill_manager_global_targets.py
@@ -127,6 +127,19 @@ def test_skill_manager_removes_all_global_harness_skills(
     assert host.skills.status(agent="codex").installed == ()
 
 
+def test_remove_uninstalled_skill_reports_no_change(
+    monkeypatch, tmp_path: Path
+) -> None:
+    # Regression: remove() previously appended the requested id to ``changed`` even
+    # when it was never installed, reporting false removals in CLI/API output.
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("CONTEXT_ENGINE_HOME", str(tmp_path / "potpie"))
+    host = build_host_shell(backend=InMemoryGraphBackend())
+
+    result = host.skills.remove(agent="codex", skill_id="potpie-cli")
+    assert result.changed == ()
+
+
 def test_skill_manager_rejects_ambiguous_remove(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
     monkeypatch.setenv("CONTEXT_ENGINE_HOME", str(tmp_path / "potpie"))

--- a/potpie/context-engine/tests/unit/test_skill_manager_global_targets.py
+++ b/potpie/context-engine/tests/unit/test_skill_manager_global_targets.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from adapters.outbound.graph.backends.in_memory_backend import InMemoryGraphBackend
+from adapters.outbound.skills.bundle_catalog import RECOMMENDED_SKILL_IDS
 from bootstrap.host_wiring import build_host_shell
 
 
@@ -30,6 +31,10 @@ def test_skill_manager_installs_global_harness_targets(
         "codex": home / ".agents" / "skills" / "potpie-cli" / "SKILL.md",
         "cursor": home / ".cursor" / "skills" / "potpie-cli" / "SKILL.md",
     }
+    expected_support = {
+        "claude": home / ".claude" / "CLAUDE.md",
+        "codex": home / ".codex" / "AGENTS.md",
+    }
 
     for agent, skill_file in expected.items():
         try:
@@ -41,6 +46,12 @@ def test_skill_manager_installs_global_harness_targets(
 
         assert result.metadata["scope"] == "global"
         assert skill_file.exists()
+        support_file = expected_support.get(agent)
+        if support_file is not None:
+            assert support_file.exists()
+            assert "Potpie is durable project memory" in support_file.read_text(
+                encoding="utf-8"
+            )
         status = host.skills.status(agent=agent)
         assert [s.id for s in status.installed] == ["potpie-cli"]
 
@@ -86,3 +97,43 @@ def test_skill_manager_installs_project_scope(monkeypatch, tmp_path: Path) -> No
         scope="project",
     )
     assert rerun.changed == ()
+
+
+def test_skill_manager_removes_all_global_harness_skills(
+    monkeypatch, tmp_path: Path
+) -> None:
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("CONTEXT_ENGINE_HOME", str(tmp_path / "potpie"))
+    host = build_host_shell(backend=InMemoryGraphBackend())
+
+    install_result = host.skills.install(agent="codex")
+    assert set(install_result.changed) == set(RECOMMENDED_SKILL_IDS)
+
+    skills_root = home / ".agents" / "skills"
+    assert all(
+        (skills_root / skill_id / "SKILL.md").exists()
+        for skill_id in RECOMMENDED_SKILL_IDS
+    )
+
+    remove_result = host.skills.remove(agent="codex", all_=True)
+
+    assert remove_result.metadata["scope"] == "global"
+    assert set(remove_result.changed) == set(RECOMMENDED_SKILL_IDS)
+    assert all(
+        not (skills_root / skill_id / "SKILL.md").exists()
+        for skill_id in RECOMMENDED_SKILL_IDS
+    )
+    assert host.skills.status(agent="codex").installed == ()
+
+
+def test_skill_manager_rejects_ambiguous_remove(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("CONTEXT_ENGINE_HOME", str(tmp_path / "potpie"))
+    host = build_host_shell(backend=InMemoryGraphBackend())
+
+    with pytest.raises(ValueError, match="either a skill id or --all"):
+        host.skills.remove(agent="codex", skill_id="potpie-cli", all_=True)
+
+    with pytest.raises(ValueError, match="pass a skill id or --all"):
+        host.skills.remove(agent="codex")

--- a/potpie/context-engine/tests/unit/test_skills_cli.py
+++ b/potpie/context-engine/tests/unit/test_skills_cli.py
@@ -5,10 +5,19 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 
+import pytest
 from typer.testing import CliRunner
 
 from adapters.inbound.cli.commands import _common, skills
 from domain.ports.services.skill_manager import SkillOperationResult
+
+
+@pytest.fixture(autouse=True)
+def _reset_cli_output_mode():
+    """Keep global CLI JSON mode from leaking across tests (order-independence)."""
+    _common.set_json(False)
+    yield
+    _common.set_json(False)
 
 
 @dataclass

--- a/potpie/context-engine/tests/unit/test_skills_cli.py
+++ b/potpie/context-engine/tests/unit/test_skills_cli.py
@@ -1,0 +1,85 @@
+"""CLI coverage for skill management commands."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+
+from typer.testing import CliRunner
+
+from adapters.inbound.cli.commands import _common, skills
+from domain.ports.services.skill_manager import SkillOperationResult
+
+
+@dataclass
+class _Skills:
+    calls: list[dict[str, object]] = field(default_factory=list)
+
+    def remove(
+        self,
+        *,
+        agent: str,
+        skill_id: str | None = None,
+        all_: bool = False,
+        path: str | None = None,
+        scope: str = "global",
+    ) -> SkillOperationResult:
+        self.calls.append(
+            {
+                "agent": agent,
+                "skill_id": skill_id,
+                "all_": all_,
+                "path": path,
+                "scope": scope,
+            }
+        )
+        return SkillOperationResult(
+            agent=agent,
+            operation="remove",
+            changed=("potpie-graph", "potpie-cli"),
+            metadata={"scope": scope},
+        )
+
+
+@dataclass
+class _Host:
+    skills: _Skills
+
+
+def test_skills_remove_all_defaults_to_global_scope() -> None:
+    fake_skills = _Skills()
+    _common.set_host(_Host(skills=fake_skills))
+
+    result = CliRunner().invoke(
+        skills.skills_app,
+        ["remove", "--all", "--agent", "codex"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert fake_skills.calls == [
+        {
+            "agent": "codex",
+            "skill_id": None,
+            "all_": True,
+            "path": None,
+            "scope": "global",
+        }
+    ]
+    assert "removed Potpie skills for codex" in result.output
+
+
+def test_skills_remove_all_json_output() -> None:
+    fake_skills = _Skills()
+    _common.set_host(_Host(skills=fake_skills))
+    _common.set_json(True)
+
+    result = CliRunner().invoke(
+        skills.skills_app,
+        ["remove", "--all", "--agent", "codex"],
+    )
+
+    assert result.exit_code == 0, result.output
+    emitted = json.loads(result.output)
+    assert emitted["agent"] == "codex"
+    assert emitted["scope"] == "global"
+    assert emitted["removed"] == ["potpie-graph", "potpie-cli"]


### PR DESCRIPTION
## Summary

Second link in the CE stack and the **repair for `main`'s currently-red CI**. PR #904 (cg-12) merged the new 8-skill agent bundle *templates* onto `main`, but the matching installer source and bundle tests live here in cg-04 — so since #904 landed, `main`'s regression job has been failing on `test_bundle_catalog` / `test_agent_installer` (49d2c54d ❌ vs #903 5f5b5b49 ✅). This PR reunites the two halves and turns `main` green again.

On top of the repair it introduces the CE **v2 agent envelope** (`domain/agent_envelope.py`), the **graph-workbench ontology + contract** (`domain/graph_workbench.py`, `domain/graph_workbench_ontology.py`), the read-surface additions on the graph-service port, the daemon-port shape used by later stack branches, the **setup defaults** (`policy/default.py`), and **global agent-instruction install** (`agent_installer.py` / `claude_target.py` / `skill_manager.py`).

Base is current `main` (includes #903 cg-03 domain foundation + #898 cg-02). Owned files are byte-identical to `feat/graph-updates` for everything cg-04 owns; rebased cleanly onto `main` with no conflicts.

## What changed (grouped)

**Bundle installer + tests (the `main` repair)**
- `adapters/outbound/skills/agent_installer.py` — adds `install_global_agent_instructions` + global-bundle install path.
- `adapters/outbound/skills/claude_target.py` — global-target rendering for the new bundle.
- `application/services/skill_manager.py`, `domain/ports/services/skill_manager.py` — repair-support-files-when-current path.
- `adapters/inbound/cli/commands/skills.py` — wires the global-install surface.
- `tests/unit/test_bundle_catalog.py`, `tests/unit/test_agent_installer.py`, `tests/unit/test_skill_manager_global_targets.py`, `tests/unit/test_skills_cli.py` — assert the shipped 8-skill bundle (`potpie-graph` + use-case skills) instead of the old 4-skill `potpie-agent-context` set.

**v2 envelope + workbench**
- `domain/agent_envelope.py` — v2 envelope fields.
- `domain/graph_workbench.py` (new), `domain/graph_workbench_ontology.py` (new) — workbench ontology + contract surface; `tests/unit/test_graph_workbench_ontology.py`, `tests/unit/test_envelope.py`.

**Read-surface + ports**
- `domain/ports/services/graph_service.py` — read-surface contract additions (catalog/describe/read/neighborhood shapes the V2 CLI in cg-07 consumes).
- `domain/ports/services/pot_management.py`, `domain/ports/daemon/*`, `domain/ports/graph/backend.py`, `domain/ports/settings.py`, `domain/lifecycle.py` — daemon-port shape + lifecycle used by later stack branches.

## Review focus

- **`main` repair correctness.** Confirm the new bundle tests assert the 8-skill shipped set and that `install_global_agent_instructions` lines up with cg-12's templates already on `main` — that pairing is what flips the regression job back to green.
- **Port shape vs. later stack.** `graph_service.py` / `daemon/*` define contracts cg-05…cg-09 import; verify no symbol the later stack expects is renamed out from under it.
- **Setup defaults** (`policy/default.py`) — confirm it composes with #903's contract version constants rather than re-declaring them.

## Stack / rollout

- Base: `main` (cg-03 #903 ✅ merged, cg-02 #898 ✅ merged, cg-12 #904 ✅ merged).
- This is **cg-04**, first link of the linear stack `cg-04 → cg-05 → cg-06 → cg-07 → cg-08 → cg-09 → cg-11`.
- Merging this restores `main`'s regression CI (red since #904).

> Note: this does **not** close #896 — that's a separate pre-existing `legacy/`→`context-engine` import break (`bundle_to_agent_envelope` / `handle_apply_episode`), which cg-04 does not touch.
