### PR TITLE
feat(ce): CE backends — deps, embedding/claim-query, write DTOs, FalkorDB, mutation pipeline

### DIFF
--- a/potpie/context-engine/adapters/outbound/graph/__init__.py
+++ b/potpie/context-engine/adapters/outbound/graph/__init__.py
@@ -1,18 +1,16 @@
-"""The graph layer.
+"""The graph adapter layer.
 
-One layer, two contracts: the writer side mutates the graph through
-``GraphWriterPort`` (Neo4j + FalkorDB implementations), the reader side
-queries canonical ``:RELATES_TO`` claims through ``ClaimQueryPort`` (Neo4j +
-FalkorDB + in-memory implementations). ``ContextGraphService`` is the
-application façade that composes both with the read orchestrator + optional
-LLM answer / investigate paths. The active backend is selected in
-``build_container`` via ``GRAPH_DB_BACKEND`` (default ``neo4j``).
+Backends expose ``ClaimQueryPort`` for reads and ``GraphMutationPort`` /
+``GraphWriterPort`` for writes. ``DefaultGraphService`` is the canonical
+application data plane; ``ContextGraphService`` is only a legacy DTO shim over
+that service for managed callers that have not migrated yet.
 """
 
 from adapters.outbound.graph.context_graph_service import ContextGraphService
 from adapters.outbound.graph.in_memory_reader import InMemoryClaimQueryStore
 from adapters.outbound.graph.neo4j_reader import Neo4jClaimQueryStore
-from adapters.outbound.graph.neo4j_writer import GraphWriterPort, Neo4jGraphWriter
+from adapters.outbound.graph.neo4j_writer import Neo4jGraphWriter
+from adapters.outbound.graph.writer_port import GraphWriterPort
 
 __all__ = [
     "ContextGraphService",
@@ -25,5 +23,5 @@ __all__ = [
 # FalkorDB adapters are imported lazily (optional ``falkordb`` extra); they are
 # intentionally NOT imported at module load so the default Neo4j install does
 # not require the FalkorDB client. Import them directly from their modules
-# (``adapters.outbound.graph.falkordb_writer`` / ``...falkordb_reader``) or let
-# ``build_container`` select them via ``GRAPH_DB_BACKEND=falkordb``.
+# (``adapters.outbound.graph.falkordb_writer`` / ``...falkordb_reader``), or
+# through the ``falkordb`` / ``falkordb_lite`` GraphBackend profiles.

--- a/potpie/context-engine/adapters/outbound/graph/apply_plan.py
+++ b/potpie/context-engine/adapters/outbound/graph/apply_plan.py
@@ -1,6 +1,6 @@
-"""Apply a validated :class:`ReconciliationPlan` to the graph.
+"""Apply a validated :class:`MutationBatch` to the graph.
 
-One function, one async path. The agent produced the plan; this routine
+One function, one async path. The caller produced the batch; this routine
 generates a per-apply ``mutation_id``, stamps it into provenance, and
 runs the four mutation verbs in order against the single
 :class:`GraphWriterPort`. No episodic narrative, no sync→async bridge.
@@ -11,21 +11,21 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from uuid import uuid4
 
-from adapters.outbound.graph.neo4j_writer import GraphWriterPort
+from adapters.outbound.graph.writer_port import GraphWriterPort
 from application.services.reconciliation_validation import (
     validate_reconciliation_plan,
 )
 from domain.errors import ReconciliationApplyError
 from domain.graph_mutations import ProvenanceContext, ProvenanceRef
 from domain.reconciliation import (
+    MutationBatch,
+    MutationResult,
     MutationSummary,
-    ReconciliationPlan,
-    ReconciliationResult,
 )
 
 
 def _build_provenance(
-    plan: ReconciliationPlan,
+    plan: MutationBatch,
     *,
     pot_id: str,
     mutation_id: str,
@@ -33,11 +33,20 @@ def _build_provenance(
     graph_updated_at: datetime,
 ) -> ProvenanceRef:
     ctx = context or ProvenanceContext()
+    # ``event_ref`` is optional now. Non-event writes can still provide a
+    # deterministic source id through ProvenanceContext without fabricating an
+    # EventRef; otherwise the per-apply mutation id is the fallback source.
+    source_event_id = (
+        plan.event_ref.event_id
+        if plan.event_ref
+        else ctx.source_event_id or f"mutation:{mutation_id}"
+    )
+    source_system = plan.event_ref.source_system if plan.event_ref else ctx.source_system
     return ProvenanceRef(
         pot_id=pot_id,
-        source_event_id=plan.event_ref.event_id,
+        source_event_id=source_event_id,
         mutation_id=mutation_id,
-        source_system=plan.event_ref.source_system or None,
+        source_system=source_system or None,
         source_kind=ctx.source_kind,
         source_ref=ctx.source_ref,
         event_occurred_at=ctx.event_occurred_at,
@@ -55,16 +64,16 @@ def _build_provenance(
     )
 
 
-async def apply_reconciliation_plan(
+async def apply_mutation_batch(
     graph_writer: GraphWriterPort,
-    plan: ReconciliationPlan,
+    plan: MutationBatch,
     *,
     expected_pot_id: str,
     provenance_context: ProvenanceContext | None = None,
-) -> ReconciliationResult:
-    """Validate the plan, stamp provenance, and run the four mutation verbs.
+) -> MutationResult:
+    """Validate the batch, stamp provenance, and run the four mutation verbs.
 
-    Returns a :class:`ReconciliationResult` carrying the ``mutation_id``
+    Returns a :class:`MutationResult` carrying the ``mutation_id``
     (a per-apply UUID) so callers can later trace every produced edge
     back to this apply.
     """
@@ -97,10 +106,15 @@ async def apply_reconciliation_plan(
     except Exception as exc:
         raise ReconciliationApplyError(str(exc)) from exc
 
-    return ReconciliationResult(
+    return MutationResult(
         ok=True,
         mutation_id=mutation_id,
         mutation_summary=summary,
         error=None,
         downgrades=list(plan.ontology_downgrades),
     )
+
+
+# Back-compat alias (Step 5a rename): callers that still import the old name
+# keep working while new code uses ``apply_mutation_batch``.
+apply_reconciliation_plan = apply_mutation_batch

--- a/potpie/context-engine/adapters/outbound/graph/apply_plan.py
+++ b/potpie/context-engine/adapters/outbound/graph/apply_plan.py
@@ -8,6 +8,7 @@ runs the four mutation verbs in order against the single
 
 from __future__ import annotations
 
+import hashlib
 from datetime import datetime, timezone
 from uuid import uuid4
 
@@ -24,6 +25,31 @@ from domain.reconciliation import (
 )
 
 
+def _stable_batch_source_id(plan: MutationBatch) -> str:
+    """Deterministic provenance source id for an event-ref-less, context-less batch.
+
+    The per-apply ``mutation_id`` is a fresh ``uuid4`` every call, so using it as
+    the provenance ``source_event_id`` makes a retried batch look like a brand-new
+    event — and the edge writer (which derives its default ``source_ref`` from
+    ``source_event_id``) mints duplicate claims instead of MERGE-updating the same
+    edge. Fingerprint the batch content instead: a genuine retry of the same batch
+    carries the same source id and stays idempotent.
+    """
+    parts: list[str] = [plan.summary or ""]
+    for e in plan.entity_upserts:
+        parts.append(f"E:{e.entity_key}:{','.join(e.labels)}")
+    for d in plan.edge_upserts:
+        parts.append(f"U:{d.edge_type}:{d.from_entity_key}->{d.to_entity_key}")
+    for d in plan.edge_deletes:
+        parts.append(f"D:{d.edge_type}:{d.from_entity_key}->{d.to_entity_key}")
+    for inv in plan.invalidations:
+        parts.append(f"I:{inv.target_entity_key}:{inv.target_edge}")
+    digest = hashlib.blake2b(
+        "\n".join(parts).encode("utf-8"), digest_size=16
+    ).hexdigest()
+    return f"mutation:{digest}"
+
+
 def _build_provenance(
     plan: MutationBatch,
     *,
@@ -35,11 +61,13 @@ def _build_provenance(
     ctx = context or ProvenanceContext()
     # ``event_ref`` is optional now. Non-event writes can still provide a
     # deterministic source id through ProvenanceContext without fabricating an
-    # EventRef; otherwise the per-apply mutation id is the fallback source.
+    # EventRef; otherwise fall back to a *stable* content fingerprint so a
+    # retried batch reuses the same source id and stays idempotent (never the
+    # per-apply uuid, which would fabricate a fresh event on every retry).
     source_event_id = (
         plan.event_ref.event_id
         if plan.event_ref
-        else ctx.source_event_id or f"mutation:{mutation_id}"
+        else ctx.source_event_id or _stable_batch_source_id(plan)
     )
     source_system = plan.event_ref.source_system if plan.event_ref else ctx.source_system
     return ProvenanceRef(

--- a/potpie/context-engine/adapters/outbound/graph/apply_plan.py
+++ b/potpie/context-engine/adapters/outbound/graph/apply_plan.py
@@ -9,6 +9,7 @@ runs the four mutation verbs in order against the single
 from __future__ import annotations
 
 import hashlib
+import json
 from datetime import datetime, timezone
 from uuid import uuid4
 
@@ -18,6 +19,7 @@ from application.services.reconciliation_validation import (
 )
 from domain.errors import ReconciliationApplyError
 from domain.graph_mutations import ProvenanceContext, ProvenanceRef
+from domain.graph_plans import mutation_batch_to_dict
 from domain.reconciliation import (
     MutationBatch,
     MutationResult,
@@ -32,21 +34,20 @@ def _stable_batch_source_id(plan: MutationBatch) -> str:
     the provenance ``source_event_id`` makes a retried batch look like a brand-new
     event — and the edge writer (which derives its default ``source_ref`` from
     ``source_event_id``) mints duplicate claims instead of MERGE-updating the same
-    edge. Fingerprint the batch content instead: a genuine retry of the same batch
-    carries the same source id and stays idempotent.
+    edge. Fingerprint the *full* batch payload instead: a genuine retry of the same
+    batch carries the same source id and stays idempotent, while two batches that
+    share graph shape but differ in claim properties / evidence / confidence /
+    invalidation timestamps get distinct ids (no provenance conflation). Reuse the
+    canonical ``mutation_batch_to_dict`` serializer so the digest never drifts from
+    the batch schema.
     """
-    parts: list[str] = [plan.summary or ""]
-    for e in plan.entity_upserts:
-        parts.append(f"E:{e.entity_key}:{','.join(e.labels)}")
-    for d in plan.edge_upserts:
-        parts.append(f"U:{d.edge_type}:{d.from_entity_key}->{d.to_entity_key}")
-    for d in plan.edge_deletes:
-        parts.append(f"D:{d.edge_type}:{d.from_entity_key}->{d.to_entity_key}")
-    for inv in plan.invalidations:
-        parts.append(f"I:{inv.target_entity_key}:{inv.target_edge}")
-    digest = hashlib.blake2b(
-        "\n".join(parts).encode("utf-8"), digest_size=16
-    ).hexdigest()
+    encoded = json.dumps(
+        mutation_batch_to_dict(plan),
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    digest = hashlib.blake2b(encoded.encode("utf-8"), digest_size=16).hexdigest()
     return f"mutation:{digest}"
 
 

--- a/potpie/context-engine/adapters/outbound/graph/backends/__init__.py
+++ b/potpie/context-engine/adapters/outbound/graph/backends/__init__.py
@@ -7,6 +7,8 @@ ports behind it — never changing the services that depend on ``GraphBackend``.
     in_memory   real, tests + conformance + POC          (InMemoryGraphBackend)
     embedded    OSS local default (real, JSON-persisted)  (EmbeddedGraphBackend)
     neo4j       shape-first production target            (Neo4jGraphBackend)
+    falkordb    lightweight graph profile                (FalkorDBGraphBackend)
+    falkordb_lite embedded FalkorDBLite profile          (FalkorDBLiteGraphBackend)
     postgres    pgvector profile (registered stub)       (StubGraphBackend)
     chroma      vector profile (registered stub)         (StubGraphBackend)
     hosted      managed profile (registered stub)        (StubGraphBackend)
@@ -31,6 +33,8 @@ KNOWN_PROFILES: tuple[str, ...] = (
     "in_memory",
     "embedded",
     "neo4j",
+    "falkordb",
+    "falkordb_lite",
     "postgres",
     "chroma",
     "hosted",
@@ -40,19 +44,38 @@ KNOWN_PROFILES: tuple[str, ...] = (
 _STUB_PROFILES: frozenset[str] = frozenset({"postgres", "chroma", "hosted"})
 
 
-def build_backend(profile: str, *, settings: Any = None) -> GraphBackend:
+def build_backend(
+    profile: str, *, settings: Any = None, embedder: Any = None
+) -> GraphBackend:
     """Construct the ``GraphBackend`` for a profile name.
 
-    ``in_memory`` and ``embedded`` need no settings; ``neo4j`` needs the engine
-    settings (lazy-imported so the neo4j driver is optional). ``postgres`` /
-    ``chroma`` / ``hosted`` resolve to a fail-closed ``StubGraphBackend``.
+    ``in_memory`` and ``embedded`` need no settings; ``neo4j`` / ``falkordb`` /
+    ``falkordb_lite`` need engine settings (lazy-imported so the graph drivers are optional).
+    ``postgres`` / ``chroma`` / ``hosted`` resolve to a fail-closed
+    ``StubGraphBackend``.
     Unknown profiles raise ``ValueError`` — the CLI maps that to a validation error.
+
+    ``embedder`` (an :class:`EmbedderPort`) powers semantic retrieval on graph
+    backends; when omitted the bundled local embedder is built by default so
+    retrieval needs no API key (``CONTEXT_ENGINE_EMBEDDER=none`` disables it).
     """
-    name = (profile or "").strip().lower()
+    name = (profile or "").strip().lower().replace("-", "_")
+    if name == "falkordblite":
+        name = "falkordb_lite"
+    if embedder is None and name in (
+        "in_memory",
+        "embedded",
+        "neo4j",
+        "falkordb",
+        "falkordb_lite",
+    ):
+        from adapters.outbound.intelligence.local_embedder import build_embedder
+
+        embedder = build_embedder()
     if name == "in_memory":
-        return InMemoryGraphBackend()
+        return InMemoryGraphBackend(embedder=embedder)
     if name == "embedded":
-        return EmbeddedGraphBackend()
+        return EmbeddedGraphBackend(embedder=embedder)
     if name == "neo4j":
         # Lazy import keeps the neo4j driver optional for other profiles.
         from adapters.outbound.graph.backends.neo4j_backend import Neo4jGraphBackend
@@ -61,7 +84,29 @@ def build_backend(profile: str, *, settings: Any = None) -> GraphBackend:
             from adapters.outbound.settings_env import EnvContextEngineSettings
 
             settings = EnvContextEngineSettings()
-        return Neo4jGraphBackend(settings)
+        return Neo4jGraphBackend(settings, embedder=embedder)
+    if name == "falkordb":
+        # Lazy import keeps FalkorDB/FalkorDBLite optional for other profiles.
+        from adapters.outbound.graph.backends.falkordb_backend import (
+            FalkorDBGraphBackend,
+        )
+
+        if settings is None:
+            from adapters.outbound.settings_env import EnvContextEngineSettings
+
+            settings = EnvContextEngineSettings()
+        return FalkorDBGraphBackend(settings, embedder=embedder)
+    if name == "falkordb_lite":
+        # Explicit Lite profile: same adapter bundle, mode pinned to embedded Lite.
+        from adapters.outbound.graph.backends.falkordb_backend import (
+            FalkorDBLiteGraphBackend,
+        )
+
+        if settings is None:
+            from adapters.outbound.settings_env import EnvContextEngineSettings
+
+            settings = EnvContextEngineSettings()
+        return FalkorDBLiteGraphBackend(settings, embedder=embedder)
     if name in _STUB_PROFILES:
         return StubGraphBackend(name)
     raise ValueError(

--- a/potpie/context-engine/adapters/outbound/graph/backends/_unimplemented.py
+++ b/potpie/context-engine/adapters/outbound/graph/backends/_unimplemented.py
@@ -16,13 +16,13 @@ from dataclasses import dataclass
 from typing import Any, Iterable, Mapping, Sequence
 
 from domain.errors import CapabilityNotImplemented
+from domain.graph_mutations import ProvenanceContext
 from domain.ports.claim_query import ClaimQueryFilter, ClaimRow
 from domain.ports.graph.analytics import RepairReport
 from domain.ports.graph.inspection import GraphSlice
 from domain.ports.graph.mutation import BackendReadiness
 from domain.ports.graph.snapshot import SnapshotManifest
-from domain.graph_mutations import ProvenanceContext
-from domain.reconciliation import ReconciliationPlan, ReconciliationResult
+from domain.reconciliation import MutationBatch, MutationResult
 
 
 def _raise(profile: str, capability: str, method: str) -> Any:
@@ -52,11 +52,11 @@ class UnimplementedMutation:
 
     def apply(
         self,
-        plan: ReconciliationPlan,
+        plan: MutationBatch,
         *,
         expected_pot_id: str,
         provenance_context: ProvenanceContext | None = None,
-    ) -> ReconciliationResult:
+    ) -> MutationResult:
         return _raise(self.profile, "mutation", "apply")
 
     def invalidate(
@@ -95,8 +95,16 @@ class UnimplementedInspection:
     profile: str
 
     def neighborhood(
-        self, *, pot_id: str, entity_key: str, depth: int = 1
+        self,
+        *,
+        pot_id: str,
+        entity_key: str,
+        depth: int = 1,
+        direction: str = "both",
+        predicates: tuple[str, ...] = (),
+        limit: int | None = None,
     ) -> GraphSlice:
+        del direction, predicates, limit
         return _raise(self.profile, "inspection", "neighborhood")
 
     def path(

--- a/potpie/context-engine/adapters/outbound/graph/backends/claim_query_analytics.py
+++ b/potpie/context-engine/adapters/outbound/graph/backends/claim_query_analytics.py
@@ -2,8 +2,9 @@
 
 ``counts``/``freshness``/``quality`` are derivable from the claim rows, so any
 backend with a real ``claim_query`` (in_memory, embedded, neo4j) gets a working
-analytics projection without a backend-specific rebuild. ``repair`` is a no-op
-here because these projections are computed on read, never materialised.
+analytics projection without a backend-specific rebuild. ``repair`` is usually a
+no-op because these projections are computed on read, but writable backends can
+inject a narrow entity-summary repair callback.
 
 This keeps ``graph status`` / ``data_plane_status`` honest on the neo4j profile
 while the richer native projections (vector semantic, cypher inspection,
@@ -13,8 +14,12 @@ portable snapshot) remain backend-specific TODOs.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Mapping, Sequence
+from typing import Any, Callable, Mapping, Sequence
 
+from adapters.outbound.graph.entity_summary_repair import (
+    ENTITY_SUMMARY_TARGET,
+    wants_entity_summary_repair,
+)
 from domain.ports.claim_query import ClaimQueryFilter, ClaimQueryPort, ClaimRow
 from domain.ports.graph.analytics import RepairReport
 
@@ -28,6 +33,7 @@ class ClaimQueryAnalytics:
     """``GraphAnalyticsPort`` over a backend's canonical claim store."""
 
     claim_query: ClaimQueryPort
+    entity_summary_repair: Callable[[str], int] | None = None
 
     def _rows(self, pot_id: str) -> list[ClaimRow]:
         return list(
@@ -66,6 +72,16 @@ class ClaimQueryAnalytics:
         }
 
     def repair(self, pot_id: str, *, targets: Sequence[str] = ()) -> RepairReport:
+        if self.entity_summary_repair is not None and wants_entity_summary_repair(
+            targets
+        ):
+            repaired = self.entity_summary_repair(pot_id)
+            return RepairReport(
+                pot_id=pot_id,
+                targets=tuple(targets),
+                repaired={ENTITY_SUMMARY_TARGET: repaired},
+                detail=f"repaired {repaired} entity summaries",
+            )
         return RepairReport(
             pot_id=pot_id,
             targets=tuple(targets),

--- a/potpie/context-engine/adapters/outbound/graph/backends/claim_query_semantic.py
+++ b/potpie/context-engine/adapters/outbound/graph/backends/claim_query_semantic.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from domain.ports.claim_query import ClaimQueryFilter, ClaimQueryPort, ClaimRow
 
@@ -22,23 +22,10 @@ class ClaimQuerySemanticSearch:
         filter_: ClaimQueryFilter | None = None,
     ) -> list[ClaimRow]:
         base = filter_ or ClaimQueryFilter(pot_id=pot_id)
+        # Preserve every incoming filter axis (claim_key_in / subgraph_in /
+        # mutation_id_in included); only override pot_id + the semantic anchor.
         return self.claim_query.find_claims(
-            ClaimQueryFilter(
-                pot_id=pot_id,
-                predicate_in=base.predicate_in,
-                subject_key_in=base.subject_key_in,
-                object_key_in=base.object_key_in,
-                source_ref_in=base.source_ref_in,
-                subject_label=base.subject_label,
-                object_label=base.object_label,
-                valid_at_after=base.valid_at_after,
-                valid_at_before=base.valid_at_before,
-                include_invalidated=base.include_invalidated,
-                as_of=base.as_of,
-                source_system_in=base.source_system_in,
-                fact_query=query,
-                limit=k,
-            )
+            replace(base, pot_id=pot_id, fact_query=query, limit=k)
         )
 
 

--- a/potpie/context-engine/adapters/outbound/graph/backends/claim_query_semantic.py
+++ b/potpie/context-engine/adapters/outbound/graph/backends/claim_query_semantic.py
@@ -1,0 +1,45 @@
+"""SemanticSearchPort backed by a ClaimQueryPort."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from domain.ports.claim_query import ClaimQueryFilter, ClaimQueryPort, ClaimRow
+
+
+@dataclass(slots=True)
+class ClaimQuerySemanticSearch:
+    """Route explicit semantic search through ``ClaimQueryFilter.fact_query``."""
+
+    claim_query: ClaimQueryPort
+
+    def search(
+        self,
+        *,
+        pot_id: str,
+        query: str,
+        k: int = 10,
+        filter_: ClaimQueryFilter | None = None,
+    ) -> list[ClaimRow]:
+        base = filter_ or ClaimQueryFilter(pot_id=pot_id)
+        return self.claim_query.find_claims(
+            ClaimQueryFilter(
+                pot_id=pot_id,
+                predicate_in=base.predicate_in,
+                subject_key_in=base.subject_key_in,
+                object_key_in=base.object_key_in,
+                source_ref_in=base.source_ref_in,
+                subject_label=base.subject_label,
+                object_label=base.object_label,
+                valid_at_after=base.valid_at_after,
+                valid_at_before=base.valid_at_before,
+                include_invalidated=base.include_invalidated,
+                as_of=base.as_of,
+                source_system_in=base.source_system_in,
+                fact_query=query,
+                limit=k,
+            )
+        )
+
+
+__all__ = ["ClaimQuerySemanticSearch"]

--- a/potpie/context-engine/adapters/outbound/graph/backends/embedded_backend.py
+++ b/potpie/context-engine/adapters/outbound/graph/backends/embedded_backend.py
@@ -29,6 +29,7 @@ from adapters.outbound.graph.backends.in_memory_backend import (
 from adapters.outbound.graph.in_memory_reader import InMemoryClaimQueryStore
 from adapters.outbound.pots.local_pot_store import default_home
 from domain.lifecycle import DONE, SetupPlan, StepResult
+from domain.ports.embedder import EmbedderPort
 from domain.ports.graph.backend import BackendCapabilities
 
 _PROFILE = "embedded"
@@ -40,13 +41,22 @@ class EmbeddedGraphBackend:
     adapters and saves the store after each mutation."""
 
     home: Path = field(default_factory=default_home)
+    embedder: EmbedderPort | None = None
     _inner: InMemoryGraphBackend = field(init=False)
 
     def __post_init__(self) -> None:
         store = self._load_store()
+        store.embedder = self.embedder
         self._inner = InMemoryGraphBackend(
-            store=store, profile_name=_PROFILE, on_change=self._save_store
+            store=store,
+            profile_name=_PROFILE,
+            on_change=self._save_store,
+            embedder=self.embedder,
         )
+
+    @property
+    def match_mode(self) -> str:
+        return self._inner.match_mode
 
     @property
     def _path(self) -> Path:

--- a/potpie/context-engine/adapters/outbound/graph/backends/falkordb_backend.py
+++ b/potpie/context-engine/adapters/outbound/graph/backends/falkordb_backend.py
@@ -1,0 +1,299 @@
+"""FalkorDB ``GraphBackend`` profile.
+
+This backend wraps the existing FalkorDB reader/writer adapters behind the same
+capability bundle used by Neo4j. Application services see only
+``GraphBackend``; Falkor-specific graph handles, Lite/server mode, and Cypher
+shim details stay in outbound adapters.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from adapters.outbound.graph.apply_plan import apply_mutation_batch
+from adapters.outbound.graph.backends._unimplemented import (
+    UnimplementedSnapshot,
+)
+from adapters.outbound.graph.backends.claim_query_analytics import ClaimQueryAnalytics
+from adapters.outbound.graph.backends.claim_query_semantic import ClaimQuerySemanticSearch
+from adapters.outbound.graph.falkordb_inspection import FalkorDBInspection
+from adapters.outbound.graph.falkordb_reader import FalkorDBClaimQueryStore
+from adapters.outbound.graph.falkordb_writer import (
+    FalkorDBGraphProvider,
+    FalkorDBGraphWriter,
+    _records_from_result,
+)
+from adapters.outbound.graph.entity_summary_repair import (
+    ENTITY_SUMMARY_REPAIR_LIMIT,
+    ENTITY_SUMMARY_SCAN_CYPHER,
+    ENTITY_SUMMARY_UPDATE_CYPHER,
+    repaired_entity_properties,
+)
+from adapters.outbound.graph.writer_port import GraphWriterPort
+from domain.errors import CapabilityNotImplemented
+from domain.graph_mutations import ProvenanceContext
+from domain.lifecycle import DONE, FAILED, SetupPlan, StepResult
+from domain.ports.claim_query import ClaimQueryPort
+from domain.ports.graph.backend import BackendCapabilities
+from domain.ports.graph.mutation import BackendReadiness
+from domain.reconciliation import MutationBatch, MutationResult
+
+_PROFILE = "falkordb"
+_LITE_PROFILE = "falkordb_lite"
+
+
+class _FalkorDBModeSettings:
+    """Settings adapter that pins FalkorDB runtime mode for a backend profile."""
+
+    def __init__(self, base: Any, mode: str) -> None:
+        self._base = base
+        self._mode = mode
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._base, name)
+
+    def falkordb_mode(self) -> str:
+        return self._mode
+
+
+def _run_sync(coro: Any) -> Any:
+    """Drive an async writer call from a sync backend port."""
+    import asyncio
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    coro.close()
+    raise RuntimeError(
+        "FalkorDBGraphBackend sync mutation cannot run inside an event loop; "
+        "use the async door (mutation.apply_async)."
+    )
+
+
+@dataclass(slots=True)
+class _FalkorDBMutation:
+    settings: Any
+    writer: GraphWriterPort
+    profile: str = _PROFILE
+
+    async def apply_async(
+        self,
+        plan: MutationBatch,
+        *,
+        expected_pot_id: str,
+        provenance_context: ProvenanceContext | None = None,
+    ) -> MutationResult:
+        return await apply_mutation_batch(
+            self.writer,
+            plan,
+            expected_pot_id=expected_pot_id,
+            provenance_context=provenance_context,
+        )
+
+    def apply(
+        self,
+        plan: MutationBatch,
+        *,
+        expected_pot_id: str,
+        provenance_context: ProvenanceContext | None = None,
+    ) -> MutationResult:
+        return _run_sync(
+            self.apply_async(
+                plan,
+                expected_pot_id=expected_pot_id,
+                provenance_context=provenance_context,
+            )
+        )
+
+    def invalidate(
+        self, *, pot_id: str, claim_keys: Any, reason: str | None = None
+    ) -> int:
+        raise CapabilityNotImplemented(
+            f"graph.{self.profile}.mutation.invalidate",
+            detail=f"claim-key invalidation is not implemented for {self.profile} yet",
+            recommended_next_action="use mutation.apply with InvalidationOp, or implement claim-key Cypher invalidation",
+        )
+
+    def reset_pot(self, pot_id: str) -> dict[str, Any]:
+        return _run_sync(self.writer.reset_pot(pot_id))
+
+    def readiness(self, pot_id: str) -> BackendReadiness:
+        ready = bool(getattr(self.writer, "enabled", False))
+        return BackendReadiness(
+            profile=self.profile,
+            ready=ready,
+            detail=(
+                f"{self.profile} claim_query + mutation + semantic + analytics + "
+                "inspection wired; snapshot pending"
+                if ready
+                else f"{self.profile} backend is not configured or context graph is disabled"
+            ),
+            capability_ready={
+                "mutation": ready,
+                "claim_query": ready,
+                "analytics": ready,
+                "semantic": ready,
+                "inspection": ready,
+                "snapshot": False,
+            },
+        )
+
+
+@dataclass(slots=True)
+class FalkorDBGraphBackend:
+    """FalkorDB-backed ``GraphBackend``."""
+
+    settings: Any
+    writer: GraphWriterPort | None = None
+    graph_provider: FalkorDBGraphProvider | None = None
+    embedder: Any = None
+    profile_name: str = _PROFILE
+    force_mode: str | None = None
+    _claim_query: ClaimQueryPort = field(init=False)
+    _mutation: _FalkorDBMutation = field(init=False)
+    _semantic: ClaimQuerySemanticSearch = field(init=False)
+
+    def __post_init__(self) -> None:
+        if self.force_mode is not None:
+            self.settings = _FalkorDBModeSettings(self.settings, self.force_mode)
+        provider = self.graph_provider or FalkorDBGraphProvider(self.settings)
+        writer = self.writer or FalkorDBGraphWriter(
+            self.settings, graph_provider=provider, embedder=self.embedder
+        )
+        self.graph_provider = provider
+        self.writer = writer
+        self._claim_query = FalkorDBClaimQueryStore(
+            self.settings, graph_provider=provider, embedder=self.embedder
+        )
+        self._mutation = _FalkorDBMutation(
+            self.settings, writer, profile=self.profile_name
+        )
+        self._semantic = ClaimQuerySemanticSearch(self._claim_query)
+
+    @property
+    def enabled(self) -> bool:
+        return bool(getattr(self.writer, "enabled", False))
+
+    @property
+    def profile(self) -> str:
+        return self.profile_name
+
+    @property
+    def graph_writer(self) -> GraphWriterPort:
+        """Compatibility alias for old ingestion paths that seed via writer."""
+        assert self.writer is not None
+        return self.writer
+
+    @property
+    def claim_query(self) -> ClaimQueryPort:
+        return self._claim_query
+
+    @property
+    def mutation(self) -> _FalkorDBMutation:
+        return self._mutation
+
+    @property
+    def semantic(self) -> ClaimQuerySemanticSearch:
+        return self._semantic
+
+    @property
+    def inspection(self) -> FalkorDBInspection:
+        return FalkorDBInspection(
+            self.settings,
+            graph_provider=self.graph_provider,
+            embedder=self.embedder,
+        )
+
+    @property
+    def analytics(self) -> ClaimQueryAnalytics:
+        return ClaimQueryAnalytics(
+            self._claim_query,
+            entity_summary_repair=self._repair_entity_summaries,
+        )
+
+    @property
+    def snapshot(self) -> UnimplementedSnapshot:
+        return UnimplementedSnapshot(self.profile_name)
+
+    def capabilities(self) -> BackendCapabilities:
+        return BackendCapabilities(
+            profile=self.profile_name,
+            mutation=True,
+            claim_query=True,
+            analytics=True,
+            semantic=True,
+            inspection=True,
+            snapshot=False,
+        )
+
+    def provision(self, plan: SetupPlan) -> StepResult:
+        if not self.enabled:
+            return StepResult(
+                step="backend.provision",
+                state=FAILED,
+                detail=f"{self.profile_name} backend is not configured or context graph is disabled",
+                metadata={"profile": self.profile_name},
+            )
+        try:
+            ok = bool(_run_sync(self.graph_writer.ensure_indexes()))
+        except Exception as exc:  # noqa: BLE001
+            return StepResult(
+                step="backend.provision",
+                state=FAILED,
+                detail=str(exc),
+                metadata={"profile": self.profile_name},
+            )
+        return StepResult(
+            step="backend.provision",
+            state=DONE if ok else FAILED,
+            detail=(
+                f"{self.profile_name} backend ready"
+                if ok
+                else f"{self.profile_name} index setup failed"
+            ),
+            metadata={"profile": self.profile_name},
+        )
+
+    def _repair_entity_summaries(self, pot_id: str) -> int:
+        graph = self.graph_provider()
+        rows = _records_from_result(
+            graph.query(
+                ENTITY_SUMMARY_SCAN_CYPHER,
+                params={"gid": pot_id, "limit": ENTITY_SUMMARY_REPAIR_LIMIT},
+            )
+        )
+        repaired = 0
+        for row in rows:
+            key = str(row.get("key") or "").strip()
+            if not key:
+                continue
+            raw_props = row.get("props")
+            fixed = repaired_entity_properties(
+                key, raw_props if isinstance(raw_props, Mapping) else {}
+            )
+            if fixed is None:
+                continue
+            result = graph.query(
+                ENTITY_SUMMARY_UPDATE_CYPHER,
+                params={"gid": pot_id, "key": key, "props": fixed},
+            )
+            records = _records_from_result(result)
+            if not records:
+                repaired += 1
+                continue
+            repaired += int(records[0].get("cnt") or 0)
+        return repaired
+
+
+class FalkorDBLiteGraphBackend(FalkorDBGraphBackend):
+    """FalkorDBLite-backed profile using the same Falkor adapter bundle."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        kwargs.setdefault("profile_name", _LITE_PROFILE)
+        kwargs.setdefault("force_mode", "lite")
+        super().__init__(*args, **kwargs)
+
+
+__all__ = ["FalkorDBGraphBackend", "FalkorDBLiteGraphBackend"]

--- a/potpie/context-engine/adapters/outbound/graph/backends/in_memory_backend.py
+++ b/potpie/context-engine/adapters/outbound/graph/backends/in_memory_backend.py
@@ -28,6 +28,9 @@ from adapters.outbound.graph.entity_summary_repair import (
     repaired_entity_properties,
     wants_entity_summary_repair,
 )
+from application.services.reconciliation_validation import (
+    validate_reconciliation_plan,
+)
 from domain.graph_contract import evidence_strength_for_truth
 from domain.graph_entity_summary import (
     merge_entity_display_properties,
@@ -69,6 +72,10 @@ class _Mutation:
         expected_pot_id: str,
         provenance_context: ProvenanceContext | None = None,
     ) -> MutationResult:
+        # Validate before mutating, exactly like the Neo4j/FalkorDB writers do
+        # (both route apply through apply_mutation_batch → this validator). Keeps
+        # the substrate from silently accepting malformed or cross-pot batches.
+        validate_reconciliation_plan(plan, expected_pot_id)
         summary = MutationSummary()
         mutation_id = uuid.uuid4().hex
         for ent in plan.entity_upserts:
@@ -88,7 +95,7 @@ class _Mutation:
             )
             summary.entity_upserts_applied += 1
         for edge in plan.edge_upserts:
-            self.store.add(
+            self._upsert_claim_row(
                 self._build_claim_row(
                     edge,
                     pot_id=expected_pot_id,
@@ -97,6 +104,9 @@ class _Mutation:
                 )
             )
             summary.edge_upserts_applied += 1
+        summary.edge_deletes_applied = self._apply_edge_deletes(
+            plan, pot_id=expected_pot_id
+        )
         summary.invalidations_applied = self._apply_invalidations(
             plan, pot_id=expected_pot_id
         )
@@ -150,27 +160,81 @@ class _Mutation:
             row = _with_embedding(row, self.embedder.embed(card_for_row(row)))
         return row
 
+    def _upsert_claim_row(self, row: ClaimRow) -> None:
+        """MERGE the claim by identity instead of blindly appending.
+
+        The canonical Neo4j/FalkorDB writers ``MERGE`` on claim identity, so
+        re-applying the same batch updates the same edge. Mirror that here: an
+        existing live row with the same ``claim_key`` (or the same
+        source_ref + predicate + endpoints) is replaced, not duplicated.
+        """
+        for i, existing in enumerate(self.store.rows):
+            if existing.pot_id != row.pot_id or existing.invalid_at is not None:
+                continue
+            same_claim = bool(row.claim_key and existing.claim_key == row.claim_key)
+            same_source_edge = bool(
+                row.source_ref
+                and existing.source_ref == row.source_ref
+                and existing.predicate == row.predicate
+                and existing.subject_key == row.subject_key
+                and existing.object_key == row.object_key
+            )
+            if same_claim or same_source_edge:
+                self.store.rows[i] = row
+                return
+        self.store.add(row)
+
+    def _apply_edge_deletes(self, plan: MutationBatch, *, pot_id: str) -> int:
+        """Drop claims targeted by ``plan.edge_deletes``.
+
+        The shared application path records ``summary.edge_deletes_applied``
+        after the writer deletes edges; the substrate must actually remove the
+        rows so it does not keep stale claims the canonical backends would drop.
+        """
+        if not plan.edge_deletes:
+            return 0
+        targets = {
+            (edge.edge_type.upper(), edge.from_entity_key, edge.to_entity_key)
+            for edge in plan.edge_deletes
+        }
+        before = len(self.store.rows)
+        self.store.rows = [
+            row
+            for row in self.store.rows
+            if not (
+                row.pot_id == pot_id
+                and (row.predicate.upper(), row.subject_key, row.object_key) in targets
+            )
+        ]
+        return before - len(self.store.rows)
+
     def _apply_invalidations(self, plan: MutationBatch, *, pot_id: str) -> int:
         if not plan.invalidations:
             return 0
         now = datetime.now(timezone.utc)
-        edge_targets: set[tuple[str, str, str]] = set()
-        entity_targets: set[str] = set()
+        # Preserve each op's own ``valid_to`` (the canonical writers stamp it when
+        # present); fall back to apply-time ``now`` only when it is missing.
+        edge_targets: dict[tuple[str, str, str], datetime] = {}
+        entity_targets: dict[str, datetime] = {}
         for inv in plan.invalidations:
+            invalid_at = _coerce_dt(inv.valid_to) or now
             if inv.target_edge:
                 pred, subj, obj = inv.target_edge
-                edge_targets.add((pred.upper(), subj, obj))
+                edge_targets[(pred.upper(), subj, obj)] = invalid_at
             if inv.target_entity_key:
-                entity_targets.add(inv.target_entity_key)
+                entity_targets[inv.target_entity_key] = invalid_at
         count = 0
         for i, row in enumerate(self.store.rows):
             if row.pot_id != pot_id or row.invalid_at is not None:
                 continue
             triple = (row.predicate.upper(), row.subject_key, row.object_key)
-            if triple in edge_targets or (
-                entity_targets & {row.subject_key, row.object_key}
-            ):
-                self.store.rows[i] = _with_invalid_at(row, now)
+            invalid_at = edge_targets.get(triple)
+            if invalid_at is None:
+                invalid_at = entity_targets.get(row.subject_key) or entity_targets.get(
+                    row.object_key
+                )
+            if invalid_at is not None:
+                self.store.rows[i] = _with_invalid_at(row, invalid_at)
                 count += 1
         return count
 
@@ -297,6 +361,10 @@ class _Inspection:
             visited_frontier.update(current)
             for row in self.store.rows:
                 if row.pot_id != pot_id:
+                    continue
+                if row.invalid_at is not None:
+                    # Invalidated claims are history, not current structure; the
+                    # FalkorDB inspection path excludes them too.
                     continue
                 if predicate_set and row.predicate.upper() not in predicate_set:
                     continue

--- a/potpie/context-engine/adapters/outbound/graph/backends/in_memory_backend.py
+++ b/potpie/context-engine/adapters/outbound/graph/backends/in_memory_backend.py
@@ -18,19 +18,34 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Iterable, Mapping, Sequence
 
-from adapters.outbound.graph.in_memory_reader import InMemoryClaimQueryStore
+from adapters.outbound.graph.in_memory_reader import (
+    InMemoryClaimQueryStore,
+    card_for_row,
+)
+from adapters.outbound.graph.canonical_claim_query import CONTRACT_EDGE_KEYS
+from adapters.outbound.graph.entity_summary_repair import (
+    ENTITY_SUMMARY_TARGET,
+    repaired_entity_properties,
+    wants_entity_summary_repair,
+)
+from domain.graph_contract import evidence_strength_for_truth
+from domain.graph_entity_summary import (
+    merge_entity_display_properties,
+    normalize_entity_properties,
+)
 from domain.graph_mutations import ProvenanceContext
 from domain.lifecycle import DONE, SetupPlan, StepResult
 from domain.ports.claim_query import ClaimQueryFilter, ClaimRow
+from domain.ports.embedder import EmbedderPort
 from domain.ports.graph.analytics import RepairReport
 from domain.ports.graph.backend import BackendCapabilities
 from domain.ports.graph.inspection import GraphEdge, GraphNode, GraphSlice
 from domain.ports.graph.mutation import BackendReadiness
 from domain.ports.graph.snapshot import SnapshotManifest
 from domain.reconciliation import (
+    MutationBatch,
+    MutationResult,
     MutationSummary,
-    ReconciliationPlan,
-    ReconciliationResult,
 )
 
 _PROFILE = "in_memory"
@@ -41,6 +56,7 @@ class _Mutation:
     store: InMemoryClaimQueryStore
     on_change: Any = None
     profile: str = _PROFILE
+    embedder: EmbedderPort | None = None
 
     def _notify(self) -> None:
         if self.on_change is not None:
@@ -48,46 +64,123 @@ class _Mutation:
 
     def apply(
         self,
-        plan: ReconciliationPlan,
+        plan: MutationBatch,
         *,
         expected_pot_id: str,
         provenance_context: ProvenanceContext | None = None,
-    ) -> ReconciliationResult:
+    ) -> MutationResult:
         summary = MutationSummary()
+        mutation_id = uuid.uuid4().hex
         for ent in plan.entity_upserts:
             self.store.set_entity_label(
                 pot_id=expected_pot_id, entity_key=ent.entity_key, labels=ent.labels
             )
+            self.store.set_entity_properties(
+                pot_id=expected_pot_id,
+                entity_key=ent.entity_key,
+                properties=merge_entity_display_properties(
+                    ent.properties,
+                    existing=self.store.entity_properties(
+                        pot_id=expected_pot_id, entity_key=ent.entity_key
+                    ),
+                    entity_key=ent.entity_key,
+                ),
+            )
             summary.entity_upserts_applied += 1
         for edge in plan.edge_upserts:
-            props = dict(edge.properties)
             self.store.add(
-                ClaimRow(
+                self._build_claim_row(
+                    edge,
                     pot_id=expected_pot_id,
-                    predicate=edge.edge_type,
-                    subject_key=edge.from_entity_key,
-                    object_key=edge.to_entity_key,
-                    valid_at=props.get("valid_at"),
-                    evidence_strength=props.get("evidence_strength", "stated"),
-                    source_system=props.get("source_system"),
-                    source_ref=props.get("source_ref"),
-                    fact=props.get("fact") or plan.summary,
-                    properties=props,
+                    mutation_id=mutation_id,
+                    fallback_fact=plan.summary,
                 )
             )
             summary.edge_upserts_applied += 1
-        self._notify()
-        return ReconciliationResult(
-            ok=True, mutation_id=uuid.uuid4().hex, mutation_summary=summary
+        summary.invalidations_applied = self._apply_invalidations(
+            plan, pot_id=expected_pot_id
         )
+        self._notify()
+        return MutationResult(
+            ok=True, mutation_id=mutation_id, mutation_summary=summary
+        )
+
+    def _build_claim_row(
+        self,
+        edge: Any,
+        *,
+        pot_id: str,
+        mutation_id: str,
+        fallback_fact: str,
+    ) -> ClaimRow:
+        props = dict(edge.properties)
+        props.setdefault("mutation_id", mutation_id)
+        source_refs = props.get("source_refs")
+        truth = _coerce_str(props.get("truth"))
+        row = ClaimRow(
+            pot_id=pot_id,
+            predicate=edge.edge_type,
+            subject_key=edge.from_entity_key,
+            object_key=edge.to_entity_key,
+            valid_at=_coerce_dt(props.get("valid_at")),
+            evidence_strength=evidence_strength_for_truth(truth),
+            source_system=_coerce_str(props.get("source_system")),
+            source_ref=_coerce_str(props.get("source_ref")),
+            fact=_coerce_str(props.get("fact")) or fallback_fact or None,
+            properties=_reader_extras(props),
+            fact_embedding=_vector_tuple(props.get("fact_embedding")),
+            claim_key=_coerce_str(props.get("claim_key")),
+            subgraph=_coerce_str(props.get("subgraph")),
+            truth=truth,
+            confidence=_coerce_float(props.get("confidence")),
+            description=_coerce_str(props.get("description")),
+            environment=_coerce_str(props.get("environment")),
+            observed_at=_coerce_dt(props.get("observed_at")),
+            valid_until=_coerce_dt(props.get("valid_until")),
+            mutation_id=mutation_id,
+            source_refs=tuple(source_refs)
+            if isinstance(source_refs, (list, tuple))
+            else (),
+            evidence=_evidence_tuple(props.get("evidence")),
+            graph_contract_version=_coerce_str(props.get("graph_contract_version")),
+            ontology_version=_coerce_str(props.get("ontology_version")),
+        )
+        # Embed the retrieval card on write (R1/R2) so reads use a real vector.
+        if self.embedder is not None and row.fact_embedding is None:
+            row = _with_embedding(row, self.embedder.embed(card_for_row(row)))
+        return row
+
+    def _apply_invalidations(self, plan: MutationBatch, *, pot_id: str) -> int:
+        if not plan.invalidations:
+            return 0
+        now = datetime.now(timezone.utc)
+        edge_targets: set[tuple[str, str, str]] = set()
+        entity_targets: set[str] = set()
+        for inv in plan.invalidations:
+            if inv.target_edge:
+                pred, subj, obj = inv.target_edge
+                edge_targets.add((pred.upper(), subj, obj))
+            if inv.target_entity_key:
+                entity_targets.add(inv.target_entity_key)
+        count = 0
+        for i, row in enumerate(self.store.rows):
+            if row.pot_id != pot_id or row.invalid_at is not None:
+                continue
+            triple = (row.predicate.upper(), row.subject_key, row.object_key)
+            if triple in edge_targets or (
+                entity_targets & {row.subject_key, row.object_key}
+            ):
+                self.store.rows[i] = _with_invalid_at(row, now)
+                count += 1
+        return count
 
     async def apply_async(
         self,
-        plan: ReconciliationPlan,
+        plan: MutationBatch,
         *,
         expected_pot_id: str,
         provenance_context: ProvenanceContext | None = None,
-    ) -> ReconciliationResult:
+    ) -> MutationResult:
         # In-memory mutations are pure-sync CPU work (no I/O to await); the
         # async door just delegates so async callers get a uniform surface.
         return self.apply(
@@ -105,7 +198,12 @@ class _Mutation:
         for i, row in enumerate(self.store.rows):
             if row.pot_id != pot_id or row.invalid_at is not None:
                 continue
-            if row.subject_key in keys or row.object_key in keys:
+            # Match by first-class claim_key, or by endpoint key (legacy).
+            if (
+                (row.claim_key and row.claim_key in keys)
+                or row.subject_key in keys
+                or row.object_key in keys
+            ):
                 self.store.rows[i] = _with_invalid_at(row, now)
                 invalidated += 1
         self._notify()
@@ -116,6 +214,8 @@ class _Mutation:
         self.store.rows = [r for r in self.store.rows if r.pot_id != pot_id]
         for key in [k for k in self.store.entity_label_index if k[0] == pot_id]:
             self.store.entity_label_index.pop(key, None)
+        for key in [k for k in self.store.entity_property_index if k[0] == pot_id]:
+            self.store.entity_property_index.pop(key, None)
         self._notify()
         return {"removed_claims": before - len(self.store.rows)}
 
@@ -170,27 +270,65 @@ class _Inspection:
     store: InMemoryClaimQueryStore
 
     def neighborhood(
-        self, *, pot_id: str, entity_key: str, depth: int = 1
+        self,
+        *,
+        pot_id: str,
+        entity_key: str,
+        depth: int = 1,
+        direction: str = "both",
+        predicates: tuple[str, ...] = (),
+        limit: int | None = None,
     ) -> GraphSlice:
         seen_nodes: dict[str, GraphNode] = {}
         edges: list[GraphEdge] = []
+        seen_edges: set[tuple[str, str, str]] = set()
         frontier = {entity_key}
+        max_edges = max(0, int(limit)) if limit is not None else None
+        predicate_set = {p.upper() for p in predicates if p}
+        walk_out = direction in ("out", "both")
+        walk_in = direction in ("in", "both")
+        truncated = False
+        visited_frontier: set[str] = set()
         for _ in range(max(1, depth)):
             next_frontier: set[str] = set()
+            current = frontier - visited_frontier
+            if not current:
+                break
+            visited_frontier.update(current)
             for row in self.store.rows:
                 if row.pot_id != pot_id:
                     continue
-                if row.subject_key in frontier or row.object_key in frontier:
+                if predicate_set and row.predicate.upper() not in predicate_set:
+                    continue
+                follows_out = walk_out and row.subject_key in current
+                follows_in = walk_in and row.object_key in current
+                if not (follows_out or follows_in):
+                    continue
+                edge_key = (row.subject_key, row.predicate, row.object_key)
+                if edge_key not in seen_edges:
+                    seen_edges.add(edge_key)
                     edges.append(_edge(row))
-                    for key in (row.subject_key, row.object_key):
-                        if key not in seen_nodes:
-                            seen_nodes[key] = self._node(pot_id, key)
-                            next_frontier.add(key)
-            frontier = next_frontier - set(seen_nodes)
+                    if max_edges is not None and len(edges) >= max_edges:
+                        truncated = True
+                for key in (row.subject_key, row.object_key):
+                    if key not in seen_nodes:
+                        seen_nodes[key] = self._node(pot_id, key)
+                if follows_out:
+                    next_frontier.add(row.object_key)
+                if follows_in:
+                    next_frontier.add(row.subject_key)
+                if truncated:
+                    break
+            if truncated:
+                break
+            frontier = next_frontier - visited_frontier
             if not frontier:
                 break
         return GraphSlice(
-            pot_id=pot_id, nodes=tuple(seen_nodes.values()), edges=tuple(edges)
+            pot_id=pot_id,
+            nodes=tuple(seen_nodes.values()),
+            edges=tuple(edges),
+            truncated=truncated,
         )
 
     def path(
@@ -241,12 +379,17 @@ class _Inspection:
 
     def _node(self, pot_id: str, key: str) -> GraphNode:
         labels = self.store.entity_label_index.get((pot_id, key), ())
-        return GraphNode(key=key, labels=labels)
+        props = normalize_entity_properties(
+            self.store.entity_properties(pot_id=pot_id, entity_key=key),
+            entity_key=key,
+        )
+        return GraphNode(key=key, labels=labels, properties=props)
 
 
 @dataclass(slots=True)
 class _Analytics:
     store: InMemoryClaimQueryStore
+    on_change: Any = None
 
     def _rows(self, pot_id: str) -> list[ClaimRow]:
         return [r for r in self.store.rows if r.pot_id == pot_id]
@@ -279,13 +422,43 @@ class _Analytics:
         }
 
     def repair(self, pot_id: str, *, targets: Sequence[str] = ()) -> RepairReport:
-        # Projections are derived on read here, so repair is a no-op report.
+        if wants_entity_summary_repair(targets):
+            repaired = self._repair_entity_summaries(pot_id)
+            if repaired and self.on_change is not None:
+                self.on_change()
+            return RepairReport(
+                pot_id=pot_id,
+                targets=tuple(targets),
+                repaired={ENTITY_SUMMARY_TARGET: repaired},
+                detail=f"repaired {repaired} entity summaries",
+            )
         return RepairReport(
             pot_id=pot_id,
             targets=tuple(targets),
             repaired={},
             detail="in_memory projections are computed on read; nothing to rebuild",
         )
+
+    def _repair_entity_summaries(self, pot_id: str) -> int:
+        entity_keys = {
+            key
+            for row in self._rows(pot_id)
+            for key in (row.subject_key, row.object_key)
+        }
+        entity_keys.update(
+            key for pid, key in self.store.entity_property_index if pid == pot_id
+        )
+        repaired = 0
+        for entity_key in entity_keys:
+            props = self.store.entity_properties(pot_id=pot_id, entity_key=entity_key)
+            fixed = repaired_entity_properties(entity_key, props)
+            if fixed is None:
+                continue
+            self.store.set_entity_properties(
+                pot_id=pot_id, entity_key=entity_key, properties=fixed
+            )
+            repaired += 1
+        return repaired
 
 
 @dataclass(slots=True)
@@ -345,6 +518,7 @@ class InMemoryGraphBackend:
     store: InMemoryClaimQueryStore = field(default_factory=InMemoryClaimQueryStore)
     profile_name: str = _PROFILE
     on_change: Any = None
+    embedder: EmbedderPort | None = None
     _mutation: _Mutation = field(init=False)
     _semantic: _Semantic = field(init=False)
     _inspection: _Inspection = field(init=False)
@@ -352,13 +526,24 @@ class InMemoryGraphBackend:
     _snapshot: _Snapshot = field(init=False)
 
     def __post_init__(self) -> None:
+        # The embedder powers vector search on read and embed-on-write; share it
+        # with the store so ``find_claims`` and ``mutation.apply`` agree on mode.
+        if self.embedder is not None and self.store.embedder is None:
+            self.store.embedder = self.embedder
         self._mutation = _Mutation(
-            self.store, on_change=self.on_change, profile=self.profile_name
+            self.store,
+            on_change=self.on_change,
+            profile=self.profile_name,
+            embedder=self.store.embedder,
         )
         self._semantic = _Semantic(self.store)
         self._inspection = _Inspection(self.store)
-        self._analytics = _Analytics(self.store)
+        self._analytics = _Analytics(self.store, on_change=self.on_change)
         self._snapshot = _Snapshot(self.store)
+
+    @property
+    def match_mode(self) -> str:
+        return self.store.match_mode
 
     @property
     def profile(self) -> str:
@@ -410,29 +595,93 @@ class InMemoryGraphBackend:
 
 
 def _edge(row: ClaimRow) -> GraphEdge:
+    properties = {
+        **dict(row.properties),
+        "claim_key": row.claim_key,
+        "subgraph": row.subgraph,
+        "truth": row.truth,
+        "confidence": row.confidence,
+        "description": row.description,
+        "environment": row.environment,
+        "fact": row.fact,
+        "source_system": row.source_system,
+        "source_ref": row.source_ref,
+        "source_refs": list(row.source_refs),
+        "valid_at": _dt_iso(row.valid_at),
+        "valid_until": _dt_iso(row.valid_until),
+        "observed_at": _dt_iso(row.observed_at),
+        "mutation_id": row.mutation_id,
+    }
     return GraphEdge(
         predicate=row.predicate,
         from_key=row.subject_key,
         to_key=row.object_key,
-        properties=dict(row.properties),
+        properties={
+            key: value for key, value in properties.items() if value is not None
+        },
     )
 
 
 def _with_invalid_at(row: ClaimRow, when: datetime) -> ClaimRow:
-    return ClaimRow(
-        pot_id=row.pot_id,
-        predicate=row.predicate,
-        subject_key=row.subject_key,
-        object_key=row.object_key,
-        valid_at=row.valid_at,
-        invalid_at=when,
-        evidence_strength=row.evidence_strength,
-        source_system=row.source_system,
-        source_ref=row.source_ref,
-        fact=row.fact,
-        properties=row.properties,
-        fact_embedding=row.fact_embedding,
-    )
+    import dataclasses
+
+    return dataclasses.replace(row, invalid_at=when)
+
+
+def _with_embedding(row: ClaimRow, embedding: tuple[float, ...]) -> ClaimRow:
+    import dataclasses
+
+    return dataclasses.replace(row, fact_embedding=embedding)
+
+
+def _coerce_dt(value: Any) -> datetime | None:
+    """Coerce an ISO string or datetime into a tz-aware datetime (or None)."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    try:
+        return datetime.fromisoformat(str(value).strip().replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        return None
+
+
+def _coerce_str(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _vector_tuple(value: Any) -> tuple[float, ...] | None:
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        try:
+            return tuple(float(x) for x in value)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _evidence_tuple(value: Any) -> tuple[Mapping[str, Any], ...]:
+    if not isinstance(value, (list, tuple)):
+        return ()
+    return tuple(dict(item) for item in value if isinstance(item, Mapping))
+
+
+def _reader_extras(props: Mapping[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in props.items() if k not in CONTRACT_EDGE_KEYS}
+
+
+def _dt_iso(value: datetime | None) -> str | None:
+    return value.isoformat() if value else None
 
 
 def _row_to_dict(row: ClaimRow) -> dict[str, Any]:
@@ -440,39 +689,75 @@ def _row_to_dict(row: ClaimRow) -> dict[str, Any]:
         "predicate": row.predicate,
         "subject_key": row.subject_key,
         "object_key": row.object_key,
-        "valid_at": row.valid_at.isoformat() if row.valid_at else None,
-        "evidence_strength": row.evidence_strength,
+        "valid_at": _dt_iso(row.valid_at),
+        "invalid_at": _dt_iso(row.invalid_at),
         "source_system": row.source_system,
         "source_ref": row.source_ref,
         "fact": row.fact,
         "properties": dict(row.properties),
+        "fact_embedding": list(row.fact_embedding) if row.fact_embedding else None,
+        # V1.5 first-class metadata.
+        "claim_key": row.claim_key,
+        "subgraph": row.subgraph,
+        "truth": row.truth,
+        "confidence": row.confidence,
+        "description": row.description,
+        "environment": row.environment,
+        "observed_at": _dt_iso(row.observed_at),
+        "valid_until": _dt_iso(row.valid_until),
+        "mutation_id": row.mutation_id,
+        "source_refs": list(row.source_refs),
+        "evidence": [dict(item) for item in row.evidence],
+        "graph_contract_version": row.graph_contract_version,
+        "ontology_version": row.ontology_version,
     }
 
 
 def _row_from_dict(pot_id: str, raw: Mapping[str, Any]) -> ClaimRow:
-    valid_at = raw.get("valid_at")
+    embedding = raw.get("fact_embedding")
+    source_refs = raw.get("source_refs") or ()
+    truth = _coerce_str(raw.get("truth"))
     return ClaimRow(
         pot_id=pot_id,
         predicate=raw["predicate"],
         subject_key=raw["subject_key"],
         object_key=raw["object_key"],
-        valid_at=datetime.fromisoformat(valid_at) if valid_at else None,
-        evidence_strength=raw.get("evidence_strength", "stated"),
-        source_system=raw.get("source_system"),
-        source_ref=raw.get("source_ref"),
-        fact=raw.get("fact"),
+        valid_at=_coerce_dt(raw.get("valid_at")),
+        invalid_at=_coerce_dt(raw.get("invalid_at")),
+        evidence_strength=evidence_strength_for_truth(truth),
+        source_system=_coerce_str(raw.get("source_system")),
+        source_ref=_coerce_str(raw.get("source_ref")),
+        fact=_coerce_str(raw.get("fact")),
         properties=dict(raw.get("properties", {})),
+        fact_embedding=tuple(embedding) if embedding else None,
+        claim_key=_coerce_str(raw.get("claim_key")),
+        subgraph=_coerce_str(raw.get("subgraph")),
+        truth=truth,
+        confidence=_coerce_float(raw.get("confidence")),
+        description=_coerce_str(raw.get("description")),
+        environment=_coerce_str(raw.get("environment")),
+        observed_at=_coerce_dt(raw.get("observed_at")),
+        valid_until=_coerce_dt(raw.get("valid_until")),
+        mutation_id=_coerce_str(raw.get("mutation_id")),
+        source_refs=tuple(source_refs),
+        evidence=_evidence_tuple(raw.get("evidence")),
+        graph_contract_version=_coerce_str(raw.get("graph_contract_version")),
+        ontology_version=_coerce_str(raw.get("ontology_version")),
     )
 
 
 def dump_store(store: InMemoryClaimQueryStore) -> dict[str, Any]:
     """Serialize a whole (multi-pot) claim store for persistence."""
     return {
-        "format_version": "1",
+        "format_version": "2",
         "rows": [{"pot_id": r.pot_id, **_row_to_dict(r)} for r in store.rows],
         "labels": [
             [pot_id, key, list(labels)]
             for (pot_id, key), labels in store.entity_label_index.items()
+        ],
+        "entity_properties": [
+            [pot_id, key, props]
+            for (pot_id, key), props in store.entity_property_index.items()
         ],
     }
 
@@ -484,6 +769,8 @@ def load_store(data: dict[str, Any]) -> InMemoryClaimQueryStore:
         store.add(_row_from_dict(raw["pot_id"], raw))
     for pot_id, key, labels in data.get("labels", []):
         store.set_entity_label(pot_id=pot_id, entity_key=key, labels=labels)
+    for pot_id, key, props in data.get("entity_properties", []):
+        store.set_entity_properties(pot_id=pot_id, entity_key=key, properties=props)
     return store
 
 

--- a/potpie/context-engine/adapters/outbound/graph/backends/neo4j_backend.py
+++ b/potpie/context-engine/adapters/outbound/graph/backends/neo4j_backend.py
@@ -1,14 +1,15 @@
 """Neo4j ``GraphBackend`` — the shape-first production target.
 
-This is the canonical-store profile for the migration. The skeleton assembles
+This is the canonical-store profile for the migration. The backend assembles
 it from capability adapters and delegates the two *source-of-truth* ports to the
-existing, battle-tested Neo4j code; the four rebuildable-projection ports are
-wired to fail-closed stubs until they are built out.
+existing, battle-tested Neo4j code; semantic search is backed by Neo4j's native
+relationship vector index, while inspection/snapshot remain fail-closed stubs
+until they are built out.
 
     claim_query  -> Neo4jClaimQueryStore           (existing, real)
     mutation     -> existing apply path             # TODO(stage-N)
     analytics    -> ClaimQueryAnalytics             (computed from claim_query, real)
-    semantic     -> CapabilityNotImplemented        # TODO(stage-N): fold neo4j vector
+    semantic     -> ClaimQuerySemanticSearch        (native vector via claim_query)
     inspection   -> CapabilityNotImplemented        # TODO(stage-N): cypher traversal
     snapshot     -> CapabilityNotImplemented        # TODO(stage-N): portable export/import
 
@@ -20,20 +21,27 @@ is actually selected.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Mapping
 
 from adapters.outbound.graph.backends._unimplemented import (
     UnimplementedInspection,
-    UnimplementedSemantic,
     UnimplementedSnapshot,
 )
+from adapters.outbound.graph.backends.claim_query_semantic import ClaimQuerySemanticSearch
 from adapters.outbound.graph.backends.claim_query_analytics import ClaimQueryAnalytics
+from adapters.outbound.graph.cypher import _coerce_props_for_neo4j
+from adapters.outbound.graph.entity_summary_repair import (
+    ENTITY_SUMMARY_REPAIR_LIMIT,
+    ENTITY_SUMMARY_SCAN_CYPHER,
+    ENTITY_SUMMARY_UPDATE_CYPHER,
+    repaired_entity_properties,
+)
 from domain.graph_mutations import ProvenanceContext
 from domain.lifecycle import SetupPlan, StepResult
 from domain.ports.claim_query import ClaimQueryPort
 from domain.ports.graph.backend import BackendCapabilities
 from domain.ports.graph.mutation import BackendReadiness
-from domain.reconciliation import ReconciliationPlan, ReconciliationResult
+from domain.reconciliation import MutationBatch, MutationResult
 
 _PROFILE = "neo4j"
 
@@ -61,7 +69,7 @@ def _run_sync(coro: Any) -> Any:
 
 @dataclass(slots=True)
 class _Neo4jMutation:
-    """``GraphMutationPort`` over ``Neo4jGraphWriter`` + ``apply_reconciliation_plan``.
+    """``GraphMutationPort`` over ``Neo4jGraphWriter`` + ``apply_mutation_batch``.
 
     ``apply_async`` is the native door (it ``await``s the async writer directly);
     ``apply`` is a loop-aware sync bridge for CLI/tests. The writer is created
@@ -72,24 +80,25 @@ class _Neo4jMutation:
 
     settings: Any
     writer: Any = None  # injected (shared) or lazily created on first use
+    embedder: Any = None
 
     def _get_writer(self) -> Any:
         if self.writer is None:
             from adapters.outbound.graph import Neo4jGraphWriter
 
-            self.writer = Neo4jGraphWriter(self.settings)
+            self.writer = Neo4jGraphWriter(self.settings, embedder=self.embedder)
         return self.writer
 
     async def apply_async(
         self,
-        plan: ReconciliationPlan,
+        plan: MutationBatch,
         *,
         expected_pot_id: str,
         provenance_context: ProvenanceContext | None = None,
-    ) -> ReconciliationResult:
-        from adapters.outbound.graph.apply_plan import apply_reconciliation_plan
+    ) -> MutationResult:
+        from adapters.outbound.graph.apply_plan import apply_mutation_batch
 
-        return await apply_reconciliation_plan(
+        return await apply_mutation_batch(
             self._get_writer(),
             plan,
             expected_pot_id=expected_pot_id,
@@ -98,11 +107,11 @@ class _Neo4jMutation:
 
     def apply(
         self,
-        plan: ReconciliationPlan,
+        plan: MutationBatch,
         *,
         expected_pot_id: str,
         provenance_context: ProvenanceContext | None = None,
-    ) -> ReconciliationResult:
+    ) -> MutationResult:
         return _run_sync(
             self.apply_async(
                 plan,
@@ -130,12 +139,12 @@ class _Neo4jMutation:
         return BackendReadiness(
             profile=_PROFILE,
             ready=True,
-            detail="neo4j claim_query + mutation + analytics wired; semantic/inspection/snapshot pending",
+            detail="neo4j claim_query + mutation + semantic + analytics wired; inspection/snapshot pending",
             capability_ready={
                 "mutation": True,
                 "claim_query": True,
                 "analytics": True,
-                "semantic": False,
+                "semantic": True,
                 "inspection": False,
                 "snapshot": False,
             },
@@ -148,15 +157,22 @@ class Neo4jGraphBackend:
 
     settings: Any
     writer: Any = None  # optional shared Neo4jGraphWriter; reused by the mutation
+    embedder: Any = None
     _claim_query: ClaimQueryPort = field(init=False)
     _mutation: _Neo4jMutation = field(init=False)
+    _semantic: ClaimQuerySemanticSearch = field(init=False)
 
     def __post_init__(self) -> None:
         # Lazy: only touch neo4j when this profile is selected.
         from adapters.outbound.graph.neo4j_reader import Neo4jClaimQueryStore
 
-        self._claim_query = Neo4jClaimQueryStore(self.settings)
-        self._mutation = _Neo4jMutation(self.settings, writer=self.writer)
+        self._claim_query = Neo4jClaimQueryStore(
+            self.settings, embedder=self.embedder
+        )
+        self._mutation = _Neo4jMutation(
+            self.settings, writer=self.writer, embedder=self.embedder
+        )
+        self._semantic = ClaimQuerySemanticSearch(self._claim_query)
 
     @property
     def enabled(self) -> bool:
@@ -170,6 +186,11 @@ class Neo4jGraphBackend:
         return _PROFILE
 
     @property
+    def graph_writer(self) -> Any:
+        """Compatibility alias for old ingestion paths that seed via writer."""
+        return self._mutation._get_writer()
+
+    @property
     def claim_query(self) -> ClaimQueryPort:
         return self._claim_query
 
@@ -178,8 +199,8 @@ class Neo4jGraphBackend:
         return self._mutation
 
     @property
-    def semantic(self) -> UnimplementedSemantic:
-        return UnimplementedSemantic(_PROFILE)
+    def semantic(self) -> ClaimQuerySemanticSearch:
+        return self._semantic
 
     @property
     def inspection(self) -> UnimplementedInspection:
@@ -189,7 +210,10 @@ class Neo4jGraphBackend:
     def analytics(self) -> ClaimQueryAnalytics:
         # Real: counts/freshness/quality are computed from the canonical
         # claim store, which this profile already serves.
-        return ClaimQueryAnalytics(self._claim_query)
+        return ClaimQueryAnalytics(
+            self._claim_query,
+            entity_summary_repair=self._repair_entity_summaries,
+        )
 
     @property
     def snapshot(self) -> UnimplementedSnapshot:
@@ -201,19 +225,79 @@ class Neo4jGraphBackend:
             mutation=True,
             claim_query=True,
             analytics=True,
-            semantic=False,
+            semantic=True,
             inspection=False,
             snapshot=False,
         )
 
     def provision(self, plan: SetupPlan) -> StepResult:
-        from domain.errors import CapabilityNotImplemented
+        from domain.lifecycle import DONE, FAILED
 
-        raise CapabilityNotImplemented(
-            "graph.neo4j.provision",
-            detail="neo4j store provisioning (database create, indexes, native vector index) not implemented",
-            recommended_next_action="provision neo4j out-of-band, or run 'potpie setup --backend embedded'",
+        if not self.enabled:
+            return StepResult(
+                step="backend.provision",
+                state=FAILED,
+                detail="neo4j backend is not configured or context graph is disabled",
+                metadata={"profile": _PROFILE},
+            )
+        try:
+            ok = bool(_run_sync(self.graph_writer.ensure_indexes()))
+        except Exception as exc:  # noqa: BLE001
+            return StepResult(
+                step="backend.provision",
+                state=FAILED,
+                detail=str(exc),
+                metadata={"profile": _PROFILE},
+            )
+        return StepResult(
+            step="backend.provision",
+            state=DONE if ok else FAILED,
+            detail="neo4j backend ready" if ok else "neo4j index setup failed",
+            metadata={"profile": _PROFILE},
         )
+
+    def _repair_entity_summaries(self, pot_id: str) -> int:
+        from neo4j import GraphDatabase
+
+        uri = self.settings.neo4j_uri()
+        user = self.settings.neo4j_user()
+        password = self.settings.neo4j_password()
+        if not uri or user is None or password is None:
+            raise RuntimeError("neo4j_unavailable")
+
+        repaired = 0
+        driver = GraphDatabase.driver(uri, auth=(user, password))
+        try:
+            with driver.session() as session:
+                rows = list(
+                    session.run(
+                        ENTITY_SUMMARY_SCAN_CYPHER,
+                        gid=pot_id,
+                        limit=ENTITY_SUMMARY_REPAIR_LIMIT,
+                    )
+                )
+                for row in rows:
+                    key = str(row.get("key") or "").strip()
+                    if not key:
+                        continue
+                    raw_props = row.get("props")
+                    fixed = repaired_entity_properties(
+                        key, raw_props if isinstance(raw_props, Mapping) else {}
+                    )
+                    if fixed is None:
+                        continue
+                    result = session.run(
+                        ENTITY_SUMMARY_UPDATE_CYPHER,
+                        gid=pot_id,
+                        key=key,
+                        props=_coerce_props_for_neo4j(fixed),
+                    )
+                    rec = result.single()
+                    result.consume()
+                    repaired += int(rec["cnt"]) if rec is not None else 0
+        finally:
+            driver.close()
+        return repaired
 
 
 __all__ = ["Neo4jGraphBackend"]

--- a/potpie/context-engine/adapters/outbound/graph/canonical_claim_query.py
+++ b/potpie/context-engine/adapters/outbound/graph/canonical_claim_query.py
@@ -1,0 +1,259 @@
+"""Shared canonical claim-query helpers for Cypher graph adapters."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import math
+from datetime import datetime
+from typing import Any, Iterable, Mapping
+
+from domain.graph_contract import evidence_strength_for_truth
+from domain.ports.claim_query import ClaimRow
+
+# Edge properties that are part of the canonical V1.5 contract or backend system
+# frame. These are hydrated into first-class ``ClaimRow`` fields or intentionally
+# hidden from the reader extras bag. ``ClaimRow.properties`` is for non-contract
+# annotations only.
+CONTRACT_EDGE_KEYS = frozenset(
+    {
+        "created_at",
+        "created_by",
+        "claim_key",
+        "confidence",
+        "description",
+        "embedding_dim",
+        "embedding_model",
+        "environment",
+        "evidence",
+        "evidence_strength",
+        "expired_at",
+        "fact",
+        "fact_embedding",
+        "group_id",
+        "graph_contract_version",
+        "identity_key",
+        "idempotency_key",
+        "invalid_at",
+        "mutation_id",
+        "name",
+        "object_key",
+        "observed_at",
+        "ontology_version",
+        "source_ref",
+        "source_refs",
+        "source_system",
+        "subgraph",
+        "subject_key",
+        "truth",
+        "uuid",
+        "valid_at",
+        "valid_from",
+        "valid_until",
+    }
+)
+RESERVED_EDGE_KEYS = CONTRACT_EDGE_KEYS
+
+
+def parse_dt(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    # neo4j.time.DateTime -> native
+    to_native = getattr(value, "to_native", None)
+    if callable(to_native):
+        try:
+            native = to_native()
+        except Exception:  # noqa: BLE001
+            return None
+        return native if isinstance(native, datetime) else None
+    return None
+
+
+def iso(value: datetime | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+def vector_property(value: Any) -> tuple[float, ...] | None:
+    """Coerce a stored vector property into the ClaimRow tuple shape."""
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        try:
+            return tuple(float(x) for x in value)
+        except (TypeError, ValueError):
+            return None
+    try:
+        return tuple(float(x) for x in list(value))
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _decode_json_value(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    stripped = value.strip()
+    if not stripped or stripped[0] not in "[{":
+        return value
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        return value
+
+
+def _coerce_str(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _str_tuple(value: Any) -> tuple[str, ...]:
+    value = _decode_json_value(value)
+    if isinstance(value, str):
+        return (value,) if value else ()
+    if isinstance(value, (list, tuple)):
+        return tuple(str(item) for item in value if item is not None and str(item))
+    return ()
+
+
+def _evidence_tuple(value: Any) -> tuple[Mapping[str, Any], ...]:
+    value = _decode_json_value(value)
+    if not isinstance(value, (list, tuple)):
+        return ()
+    out: list[Mapping[str, Any]] = []
+    for item in value:
+        item = _decode_json_value(item)
+        if isinstance(item, Mapping):
+            out.append(dict(item))
+    return tuple(out)
+
+
+def _reader_extras(props: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        k: _decode_json_value(v)
+        for k, v in props.items()
+        if k not in CONTRACT_EDGE_KEYS
+    }
+
+
+def row_from_record(rec: Mapping[str, Any]) -> ClaimRow:
+    """Build a ``ClaimRow`` from one Cypher record containing ``props``."""
+    props = dict(rec.get("props") or {})
+    truth = _coerce_str(props.get("truth"))
+    source_refs = _str_tuple(props.get("source_refs"))
+    return ClaimRow(
+        pot_id=str(props.get("group_id") or rec.get("gid") or ""),
+        predicate=str(props.get("name") or ""),
+        subject_key=str(props.get("subject_key") or ""),
+        object_key=str(props.get("object_key") or ""),
+        valid_at=parse_dt(props.get("valid_at")),
+        invalid_at=parse_dt(props.get("invalid_at")),
+        evidence_strength=evidence_strength_for_truth(truth),
+        source_system=_coerce_str(props.get("source_system")),
+        source_ref=_coerce_str(props.get("source_ref")),
+        fact=_coerce_str(props.get("fact")),
+        properties=_reader_extras(props),
+        fact_embedding=vector_property(props.get("fact_embedding")),
+        claim_key=_coerce_str(props.get("claim_key")),
+        subgraph=_coerce_str(props.get("subgraph")),
+        truth=truth,
+        confidence=_coerce_float(props.get("confidence")),
+        description=_coerce_str(props.get("description")),
+        environment=_coerce_str(props.get("environment")),
+        observed_at=parse_dt(props.get("observed_at")),
+        valid_until=parse_dt(props.get("valid_until")),
+        mutation_id=_coerce_str(props.get("mutation_id")),
+        source_refs=source_refs,
+        evidence=_evidence_tuple(props.get("evidence")),
+        graph_contract_version=_coerce_str(props.get("graph_contract_version")),
+        ontology_version=_coerce_str(props.get("ontology_version")),
+    )
+
+
+def embedding_score(fact: str | None, query: str) -> float:
+    """Token-overlap stand-in for native vector similarity."""
+    if not fact:
+        return 0.0
+    a = set(query.lower().split())
+    b = set(fact.lower().split())
+    if not a or not b:
+        return 0.0
+    base = len(a & b) / len(a | b)
+    if a & b:
+        base = math.sqrt(base)
+    return max(0.0, min(1.0, base))
+
+
+def stamp_similarity(rows: Iterable[ClaimRow], query: str) -> list[ClaimRow]:
+    """Sort rows by lexical similarity and stamp ``semantic_similarity``."""
+    scored = sorted(
+        ((embedding_score(row.fact, query), row) for row in rows),
+        key=lambda pair: pair[0],
+        reverse=True,
+    )
+    return stamp_scored_rows(scored)
+
+
+def stamp_scored_rows(scored: Iterable[tuple[float, ClaimRow]]) -> list[ClaimRow]:
+    """Stamp precomputed scores onto rows, preserving score order."""
+    out: list[ClaimRow] = []
+    for score, row in scored:
+        props = dict(row.properties)
+        props["semantic_similarity"] = float(score)
+        out.append(dataclasses.replace(row, properties=props))
+    return out
+
+
+FIND_CLAIMS_CYPHER = """
+MATCH (a:Entity {group_id: $gid})-[r:RELATES_TO {group_id: $gid}]->(b:Entity {group_id: $gid})
+WHERE ($preds IS NULL OR r.name IN $preds)
+  AND ($subjects IS NULL OR r.subject_key IN $subjects)
+  AND ($objects IS NULL OR r.object_key IN $objects)
+  AND ($claim_keys IS NULL OR r.claim_key IN $claim_keys)
+  AND ($subgraphs IS NULL OR r.subgraph IN $subgraphs)
+  AND ($mutation_ids IS NULL OR r.mutation_id IN $mutation_ids)
+  AND ($source_refs IS NULL OR r.source_ref IN $source_refs OR any(ref IN coalesce(r.source_refs, []) WHERE ref IN $source_refs))
+  AND ($sources IS NULL OR r.source_system IN $sources)
+  AND ($include_invalid OR r.invalid_at IS NULL)
+  AND ($as_of IS NULL OR r.valid_at IS NULL OR r.valid_at <= $as_of)
+  AND ($va_after IS NULL OR (r.valid_at IS NOT NULL AND r.valid_at >= $va_after))
+  AND ($va_before IS NULL OR r.valid_at IS NULL OR r.valid_at <= $va_before)
+  AND ($subject_label IS NULL OR $subject_label IN labels(a))
+  AND ($object_label IS NULL OR $object_label IN labels(b))
+RETURN r{.*} AS props
+"""
+
+
+ENTITY_LABELS_CYPHER = """
+MATCH (e:Entity {group_id: $gid})
+WHERE e.entity_key IN $keys
+RETURN e.entity_key AS key, labels(e) AS labels
+"""
+
+
+__all__ = [
+    "ENTITY_LABELS_CYPHER",
+    "FIND_CLAIMS_CYPHER",
+    "CONTRACT_EDGE_KEYS",
+    "RESERVED_EDGE_KEYS",
+    "embedding_score",
+    "iso",
+    "parse_dt",
+    "row_from_record",
+    "stamp_similarity",
+    "stamp_scored_rows",
+    "vector_property",
+]

--- a/potpie/context-engine/adapters/outbound/graph/cypher.py
+++ b/potpie/context-engine/adapters/outbound/graph/cypher.py
@@ -219,11 +219,15 @@ def _neo4j_safe_value(value: Any) -> Any:
     if isinstance(value, _NEO4J_TEMPORAL_TYPES):
         return value
     if isinstance(value, (list, tuple)):
-        # Neo4j 5.x property arrays cannot contain null elements; only a list of
-        # pure primitives survives as a native array. A list carrying ``None``
-        # (or maps) must be JSON-encoded so the write does not fail.
+        # Neo4j 5.x property arrays must be *homogeneous* arrays of primitives —
+        # no nulls, no maps, and no mixed element types ([1, "x"] / [True, 1] are
+        # rejected at write time). Only a single-primitive-type list survives as a
+        # native array; anything else is JSON-encoded so the write does not fail.
+        # (bool is a subclass of int, so classify it separately.)
         if all(isinstance(v, (bool, int, float, str)) for v in value):
-            return list(value)
+            kinds = {bool if isinstance(v, bool) else type(v) for v in value}
+            if len(kinds) <= 1:  # empty or single-type
+                return list(value)
         return json.dumps(list(value), default=str, sort_keys=True)
     if isinstance(value, dict):
         return json.dumps(value, default=str, sort_keys=True)

--- a/potpie/context-engine/adapters/outbound/graph/cypher.py
+++ b/potpie/context-engine/adapters/outbound/graph/cypher.py
@@ -183,7 +183,13 @@ def _embedding_props(
     )
     if not card:
         return {}
-    embedding = embedder.embed(card)
+    # Embeddings are best-effort enrichment: a model/runtime error must not abort
+    # the structural edge write. Degrade to no embedding props and persist anyway.
+    try:
+        embedding = embedder.embed(card)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("claim embedding skipped: %s", exc)
+        return {}
     return {
         "fact_embedding": [float(x) for x in embedding],
         "embedding_model": getattr(embedder, "name", "unknown"),
@@ -213,9 +219,10 @@ def _neo4j_safe_value(value: Any) -> Any:
     if isinstance(value, _NEO4J_TEMPORAL_TYPES):
         return value
     if isinstance(value, (list, tuple)):
-        if all(
-            v is None or isinstance(v, (bool, int, float, str)) for v in value
-        ):
+        # Neo4j 5.x property arrays cannot contain null elements; only a list of
+        # pure primitives survives as a native array. A list carrying ``None``
+        # (or maps) must be JSON-encoded so the write does not fail.
+        if all(isinstance(v, (bool, int, float, str)) for v in value):
             return list(value)
         return json.dumps(list(value), default=str, sort_keys=True)
     if isinstance(value, dict):

--- a/potpie/context-engine/adapters/outbound/graph/cypher.py
+++ b/potpie/context-engine/adapters/outbound/graph/cypher.py
@@ -4,9 +4,9 @@ Rebuild plan P0 (Position B): every claim is one ``:RELATES_TO`` edge
 between entities keyed by deterministic ``(group_id, entity_key)``. The
 edge carries the predicate (``name``), bitemporal validity
 (``valid_at`` / ``invalid_at`` for event time, ``created_at`` /
-``expired_at`` for system time), source provenance (``source_system``,
-``source_ref``, ``evidence_strength``), and the natural-language fact
-text the agent reads + the vector index embeds.
+``expired_at`` for system time), V1.5 claim metadata (``truth``,
+``source_refs``, ``claim_key``), and the natural-language fact text the agent
+reads + the vector index embeds.
 
 Position B's MERGE key includes ``source_ref`` so two distinct sources
 making the same claim land as two corroborating edges, and a re-scan of
@@ -20,9 +20,10 @@ including supersession (T6), point-in-time queries (T4), corroboration
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import re
-from datetime import datetime, timezone
+from datetime import date, datetime, time, timezone
 from typing import Any
 
 from domain.graph_mutations import (
@@ -32,11 +33,15 @@ from domain.graph_mutations import (
     InvalidationOp,
     ProvenanceRef,
 )
+from domain.graph_entity_summary import compact_entity_summary
+from domain.graph_contract import evidence_strength_for_truth
 from domain.ontology import (
     CANONICAL_EDGE_TYPES,
     ENTITY_TYPES,
+    canonical_entity_labels,
     is_canonical_entity_label,
 )
+from domain.retrieval_card import build_retrieval_card
 from domain.singleton_predicates import is_singleton_predicate
 
 logger = logging.getLogger(__name__)
@@ -52,6 +57,7 @@ _RESERVED_EDGE_PROPERTY_KEYS: frozenset[str] = frozenset(
         "source_ref",
         "evidence_strength",
         "fact",
+        "fact_embedding",
         "confidence",
         "valid_at",
     }
@@ -97,12 +103,12 @@ def _is_valid_predicate(name: str) -> bool:
     return name in CANONICAL_EDGE_TYPES
 
 
-def _string_or_default(value: Any, default: str) -> str:
+def _clean_entity_text(value: Any) -> str:
+    """One-line-normalize an authored display field; '' when absent."""
     if value is None:
-        return default
-    if isinstance(value, str):
-        return value
-    return str(value)
+        return ""
+    text = value if isinstance(value, str) else str(value)
+    return " ".join(text.strip().split())
 
 
 def _stable_source_ref(
@@ -117,8 +123,8 @@ def _stable_source_ref(
     The MERGE key includes ``source_ref`` so corroborating writes from
     different sources stay distinct; without it every claim from the
     same predicate triple would collide and look like a single source.
-    When the caller (LLM agent or scanner) provides ``source_ref``
-    explicitly via ``EdgeUpsert.properties``, we honor that.
+    When the caller provides ``source_ref`` explicitly via
+    ``EdgeUpsert.properties``, we honor that.
 
     The fallback is ``provenance.source_ref`` if set, else a hash over the
     source_event_id + the edge triple. This stays stable across re-scans
@@ -152,6 +158,75 @@ def _render_fact(
     if extra and isinstance(extra.get("fact"), str) and extra["fact"]:
         return extra["fact"]
     return f"{from_key} {predicate} {to_key}"
+
+
+def _embedding_props(
+    *,
+    embedder: Any | None,
+    predicate: str,
+    from_key: str,
+    to_key: str,
+    edge_props: dict[str, Any],
+) -> dict[str, Any]:
+    """Build embedding properties for a claim edge, if an embedder is wired."""
+    if embedder is None:
+        return {}
+    card = build_retrieval_card(
+        description=edge_props.get("description")
+        if isinstance(edge_props.get("description"), str)
+        else None,
+        fact=edge_props.get("fact") if isinstance(edge_props.get("fact"), str) else None,
+        subject_key=from_key,
+        predicate=predicate,
+        object_key=to_key,
+        scope=edge_props.get("code_scope") if isinstance(edge_props.get("code_scope"), dict) else None,
+    )
+    if not card:
+        return {}
+    embedding = embedder.embed(card)
+    return {
+        "fact_embedding": [float(x) for x in embedding],
+        "embedding_model": getattr(embedder, "name", "unknown"),
+        "embedding_dim": int(getattr(embedder, "dimensions", len(embedding))),
+    }
+
+
+# Temporal types the Neo4j driver maps to native temporal properties — pass
+# these through untouched rather than JSON-encoding them.
+_NEO4J_TEMPORAL_TYPES = (datetime, date, time)
+
+
+def _neo4j_safe_value(value: Any) -> Any:
+    """Coerce one property value to a Neo4j-storable type.
+
+    Neo4j node/edge properties accept only primitives (``bool``/``int``/
+    ``float``/``str``), native temporals, and *homogeneous arrays of
+    primitives* — never maps or arrays-of-maps. The V1.5 claim metadata stamps
+    structured values (``evidence`` as a list of dicts, ``created_by`` /
+    ``code_scope`` as dicts) that the in-memory/embedded backends store
+    natively; on Neo4j they are JSON-encoded so the data survives the write
+    losslessly (readers that need the structure parse the JSON back). Flat
+    arrays (``source_refs``, ``identity_key``) stay native arrays.
+    """
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, _NEO4J_TEMPORAL_TYPES):
+        return value
+    if isinstance(value, (list, tuple)):
+        if all(
+            v is None or isinstance(v, (bool, int, float, str)) for v in value
+        ):
+            return list(value)
+        return json.dumps(list(value), default=str, sort_keys=True)
+    if isinstance(value, dict):
+        return json.dumps(value, default=str, sort_keys=True)
+    # Unknown type: stringify defensively rather than letting the driver raise.
+    return str(value)
+
+
+def _coerce_props_for_neo4j(props: dict[str, Any]) -> dict[str, Any]:
+    """Make every value in a property bag Neo4j-storable (see :func:`_neo4j_safe_value`)."""
+    return {k: _neo4j_safe_value(v) for k, v in props.items()}
 
 
 def _split_edge_properties(
@@ -193,21 +268,48 @@ async def upsert_entities_async(
     async with driver.session() as session:
         for item in items:
             props = dict(item.properties)
+            # Authored display/retrieval fields overwrite; key-derived
+            # fallbacks only fill nodes that have no value yet, so a bare
+            # re-reference (key + type only) never clobbers an authored
+            # summary/description already stored on the node.
+            authored_name = _clean_entity_text(props.pop("name", None))
+            authored_summary = compact_entity_summary(
+                props.pop("summary", None),
+                props.get("description"),
+                props.get("title"),
+                authored_name,
+            )
+            authored_description = (
+                _clean_entity_text(props.pop("description", None)) or authored_summary
+            )
             props["group_id"] = pot_id
             props["provenance_source_event"] = provenance.source_event_id
             props.update(prov_props)
-            # Backwards-compat with the prior hydrator that required
-            # non-null ``name`` / ``summary`` on entity nodes.
-            props["name"] = _string_or_default(props.get("name"), item.entity_key)
-            props["summary"] = _string_or_default(props.get("summary"), "")
             await session.run(
                 "MERGE (e:Entity {group_id: $gid, entity_key: $key}) "
                 "ON CREATE SET e.uuid = randomUUID(), e.created_at = timestamp() "
-                "SET e += $props",
+                "SET e += $props "
+                "SET e.name = CASE WHEN $a_name <> '' THEN $a_name "
+                "WHEN coalesce(e.name, '') = '' THEN $key ELSE e.name END, "
+                "e.summary = CASE WHEN $a_summary <> '' THEN $a_summary "
+                "WHEN coalesce(e.summary, '') = '' THEN $key ELSE e.summary END, "
+                "e.description = CASE WHEN $a_description <> '' THEN $a_description "
+                "WHEN coalesce(e.description, '') = '' THEN $key ELSE e.description END",
                 gid=pot_id,
                 key=item.entity_key,
-                props=props,
+                props=_coerce_props_for_neo4j(props),
+                a_name=authored_name,
+                a_summary=authored_summary,
+                a_description=authored_description,
             )
+            wanted_labels = set(canonical_entity_labels(item.labels))
+            if wanted_labels:
+                for stale in sorted(set(ENTITY_TYPES) - wanted_labels):
+                    await session.run(
+                        f"MATCH (e:Entity {{group_id: $gid, entity_key: $key}}) REMOVE e:{stale}",  # pyright: ignore[reportArgumentType]
+                        gid=pot_id,
+                        key=item.entity_key,
+                    )
             for lbl in item.labels:
                 if lbl == "Entity":
                     continue
@@ -232,6 +334,8 @@ async def upsert_edges_async(
     pot_id: str,
     items: list[EdgeUpsert],
     provenance: ProvenanceRef,
+    *,
+    embedder: Any | None = None,
 ) -> int:
     """Upsert every edge as a ``:RELATES_TO {name: <predicate>, ...}`` claim.
 
@@ -250,7 +354,7 @@ async def upsert_edges_async(
       explicit), ``invalid_at`` (null until supersession).
     - **Provenance:** ``source_system``, ``evidence_strength``, ``fact``,
       ``confidence`` (optional), ``observed_at`` (write time).
-    - **Ontology extras:** whatever else the LLM agent / scanner put on
+    - **Ontology extras:** whatever else the caller put on
       ``EdgeUpsert.properties`` (e.g. ``environment``, ``code_scope``).
     """
     _require_valid_pot_id(pot_id)
@@ -291,7 +395,8 @@ async def upsert_edges_async(
                 reserved.get("source_system") or provenance.source_system or "agent"
             )
 
-            evidence_strength = reserved.get("evidence_strength") or "inferred"
+            truth = extras.get("truth") if isinstance(extras.get("truth"), str) else None
+            evidence_strength = evidence_strength_for_truth(truth)
 
             fact = _render_fact(
                 predicate=predicate,
@@ -317,6 +422,15 @@ async def upsert_edges_async(
             # Carry the ontology-specific extras alongside POC fields.
             for k, v in extras.items():
                 edge_props[k] = v
+            edge_props.update(
+                _embedding_props(
+                    embedder=embedder,
+                    predicate=predicate,
+                    from_key=item.from_entity_key,
+                    to_key=item.to_entity_key,
+                    edge_props=edge_props,
+                )
+            )
             # Stamp a compact provenance pointer; full provenance is on
             # the source event that source_ref references.
             edge_props["provenance_source_event"] = provenance.source_event_id
@@ -347,7 +461,7 @@ async def upsert_edges_async(
                 to_key=item.to_entity_key,
                 source_ref=source_ref,
                 now=now.isoformat(),
-                props=edge_props,
+                props=_coerce_props_for_neo4j(edge_props),
             )
             # F3 deterministic supersession: when a singleton-predicate
             # claim from a deterministic-strength source lands, invalidate
@@ -642,7 +756,7 @@ async def _write_supersedes_claim(
 # ----------------------------------------------------------------------
 
 
-async def ensure_canonical_indexes(driver: Any) -> None:
+async def ensure_canonical_indexes(driver: Any, *, embedding_dim: int = 1536) -> None:
     """Create the indexes the Position B traversal patterns rely on.
 
     - ``entity_group_key``: pot-scoped entity lookup by deterministic key.
@@ -685,10 +799,11 @@ async def ensure_canonical_indexes(driver: Any) -> None:
                 CREATE VECTOR INDEX claim_fact_embeddings IF NOT EXISTS
                 FOR ()-[r:RELATES_TO]-() ON (r.fact_embedding)
                 OPTIONS { indexConfig: {
-                    `vector.dimensions`: 1536,
+                    `vector.dimensions`: $embedding_dim,
                     `vector.similarity_function`: 'cosine'
                 }}
-                """
+                """,
+                embedding_dim=int(embedding_dim),
             )
         except Exception as exc:
             logger.warning(

--- a/potpie/context-engine/adapters/outbound/graph/entity_summary_repair.py
+++ b/potpie/context-engine/adapters/outbound/graph/entity_summary_repair.py
@@ -1,0 +1,59 @@
+"""Repair helpers for entity ``summary`` / ``description`` metadata."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from domain.graph_entity_summary import normalize_entity_properties
+
+ENTITY_SUMMARY_TARGET = "entity_summaries"
+ENTITY_SUMMARY_TARGETS = frozenset(
+    {ENTITY_SUMMARY_TARGET, "entity_summary", "summaries", "summary"}
+)
+
+ENTITY_SUMMARY_SCAN_CYPHER = """
+MATCH (e:Entity {group_id: $gid})
+RETURN e.entity_key AS key, properties(e) AS props
+LIMIT $limit
+"""
+
+ENTITY_SUMMARY_UPDATE_CYPHER = """
+MATCH (e:Entity {group_id: $gid, entity_key: $key})
+SET e += $props
+RETURN count(e) AS cnt
+"""
+
+ENTITY_SUMMARY_REPAIR_LIMIT = 100_000
+
+
+def wants_entity_summary_repair(targets: Sequence[str] = ()) -> bool:
+    """Return true when a repair invocation should backfill entity summaries."""
+    if not targets:
+        return True
+    return any(t.strip().lower() in ENTITY_SUMMARY_TARGETS for t in targets)
+
+
+def repaired_entity_properties(
+    entity_key: str, raw_props: Mapping[str, Any] | None
+) -> dict[str, Any] | None:
+    """Return normalized properties when an entity needs summary repair.
+
+    The repair derives only from existing node metadata and the stable
+    ``entity_key``. It does not inspect repository files or invent repo facts.
+    """
+    props = dict(raw_props or {})
+    normalized = normalize_entity_properties(props, entity_key=entity_key)
+    for key in ("name", "summary", "description"):
+        if normalized.get(key) != props.get(key):
+            return normalized
+    return None
+
+
+__all__ = [
+    "ENTITY_SUMMARY_REPAIR_LIMIT",
+    "ENTITY_SUMMARY_SCAN_CYPHER",
+    "ENTITY_SUMMARY_TARGET",
+    "ENTITY_SUMMARY_UPDATE_CYPHER",
+    "repaired_entity_properties",
+    "wants_entity_summary_repair",
+]

--- a/potpie/context-engine/adapters/outbound/graph/falkordb_inspection.py
+++ b/potpie/context-engine/adapters/outbound/graph/falkordb_inspection.py
@@ -97,6 +97,10 @@ class FalkorDBInspection:
         self._settings = settings
         self._graph = graph  # injectable for unit tests
         self._graph_provider = graph_provider  # shared handle from the container
+        # Accepted for construction parity with the other FalkorDB capability
+        # adapters (the backend hands the same embedder to all of them).
+        # Structural inspection reads embeddings already written by the writer,
+        # so it never embeds at read time — kept for that uniform wiring.
         self._embedder = embedder
 
     def _get_graph(self) -> Any:

--- a/potpie/context-engine/adapters/outbound/graph/falkordb_inspection.py
+++ b/potpie/context-engine/adapters/outbound/graph/falkordb_inspection.py
@@ -1,0 +1,262 @@
+"""FalkorDB :class:`GraphInspectionPort` — structural traversal projection.
+
+Backs ``potpie graph inspect`` and the local graph explorer UI. A rebuildable
+view over the canonical ``(:Entity {group_id})-[:RELATES_TO {name}]->(:Entity)``
+claim edges — *not* the agent read path (that is the readers over
+:class:`ClaimQueryPort`). Reuses the writer's graph handle + result-row
+normalization so it runs unchanged on both Lite (``redislite``) and server
+FalkorDB.
+
+Traversal is done as a bounded breadth-first expansion in Python rather than a
+variable-length Cypher pattern: FalkorDB requires literal hop bounds and the
+local pot graphs are small, so a handful of 1-hop edge queries is both portable
+and easy to cap.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable, Mapping
+
+from adapters.outbound.graph.falkordb_writer import (
+    _records_from_result,
+    build_falkordb_graph,
+)
+from domain.ports.claim_query import ClaimQueryFilter
+from domain.ports.graph.inspection import GraphEdge, GraphNode, GraphSlice
+from domain.ports.embedder import EmbedderPort
+from domain.ports.settings import ContextEngineSettingsPort
+
+# Hard caps so a runaway pot can never OOM the explorer / the daemon process.
+_MAX_NODES = 2000
+_MAX_EDGES = 4000
+_MAX_DEPTH = 4
+
+_NODES_CYPHER = """
+MATCH (e:Entity {group_id: $gid})
+RETURN e.entity_key AS key, labels(e) AS labels, properties(e) AS props
+LIMIT $limit
+"""
+
+_EDGES_CYPHER = """
+MATCH (a:Entity {group_id: $gid})-[r:RELATES_TO {group_id: $gid}]->(b:Entity {group_id: $gid})
+WHERE ($include_invalid OR r.invalid_at IS NULL)
+  AND ($preds IS NULL OR r.name IN $preds)
+RETURN a.entity_key AS source, b.entity_key AS target, r.name AS predicate, properties(r) AS props
+LIMIT $limit
+"""
+
+# Edges incident (either direction) to the current BFS frontier.
+_INCIDENT_CYPHER = """
+MATCH (a:Entity {group_id: $gid})-[r:RELATES_TO {group_id: $gid}]->(b:Entity {group_id: $gid})
+WHERE (a.entity_key IN $frontier OR b.entity_key IN $frontier)
+  AND ($include_invalid OR r.invalid_at IS NULL)
+RETURN a.entity_key AS source, b.entity_key AS target, r.name AS predicate, properties(r) AS props
+"""
+
+_HYDRATE_CYPHER = """
+MATCH (e:Entity {group_id: $gid})
+WHERE e.entity_key IN $keys
+RETURN e.entity_key AS key, labels(e) AS labels, properties(e) AS props
+"""
+
+
+def _is_embedding(key: str, value: Any) -> bool:
+    """Heuristic: drop large float vectors / embedding props from explorer payloads."""
+    if "embedding" in key.lower() or "vector" in key.lower():
+        return True
+    if (
+        isinstance(value, (list, tuple))
+        and len(value) > 32
+        and all(isinstance(x, (int, float)) for x in value)
+    ):
+        return True
+    return False
+
+
+def _clean_props(props: Any) -> dict[str, Any]:
+    if not isinstance(props, Mapping):
+        return {}
+    return {
+        k: v
+        for k, v in props.items()
+        if k not in ("group_id",) and not _is_embedding(str(k), v)
+    }
+
+
+class FalkorDBInspection:
+    """:class:`GraphInspectionPort` over canonical ``:RELATES_TO`` edges in FalkorDB."""
+
+    def __init__(
+        self,
+        settings: ContextEngineSettingsPort,
+        *,
+        graph: Any | None = None,
+        graph_provider: Callable[[], Any] | None = None,
+        embedder: EmbedderPort | None = None,
+    ) -> None:
+        self._settings = settings
+        self._graph = graph  # injectable for unit tests
+        self._graph_provider = graph_provider  # shared handle from the container
+        self._embedder = embedder
+
+    def _get_graph(self) -> Any:
+        if self._graph is None:
+            self._graph = (
+                self._graph_provider()
+                if self._graph_provider is not None
+                else build_falkordb_graph(self._settings)
+            )
+        return self._graph
+
+    def _query(self, cypher: str, params: Mapping[str, Any]) -> list[dict[str, Any]]:
+        return _records_from_result(
+            self._get_graph().query(cypher, params=dict(params))
+        )
+
+    def _hydrate_nodes(self, pot_id: str, keys: list[str]) -> tuple[GraphNode, ...]:
+        if not keys:
+            return ()
+        recs = self._query(_HYDRATE_CYPHER, {"gid": pot_id, "keys": keys})
+        return tuple(
+            GraphNode(
+                key=rec["key"],
+                labels=tuple(lbl for lbl in (rec.get("labels") or [])),
+                properties=_clean_props(rec.get("props")),
+            )
+            for rec in recs
+        )
+
+    def neighborhood(
+        self,
+        *,
+        pot_id: str,
+        entity_key: str,
+        depth: int = 1,
+        direction: str = "both",
+        predicates: tuple[str, ...] = (),
+        limit: int | None = None,
+    ) -> GraphSlice:
+        depth = max(1, min(int(depth), _MAX_DEPTH))
+        max_edges = (
+            min(max(0, int(limit)), _MAX_EDGES) if limit is not None else _MAX_EDGES
+        )
+        predicate_set = {p.upper() for p in predicates if p}
+        walk_out = direction in ("out", "both")
+        walk_in = direction in ("in", "both")
+        visited: set[str] = {entity_key}
+        frontier: set[str] = {entity_key}
+        edges: dict[tuple[str, str, str], GraphEdge] = {}
+        truncated = False
+        for _ in range(depth):
+            if not frontier:
+                break
+            recs = self._query(
+                _INCIDENT_CYPHER,
+                {"gid": pot_id, "frontier": list(frontier), "include_invalid": False},
+            )
+            new: set[str] = set()
+            for rec in recs:
+                src, tgt, pred = rec["source"], rec["target"], rec["predicate"]
+                if predicate_set and str(pred).upper() not in predicate_set:
+                    continue
+                follows_out = walk_out and src in frontier
+                follows_in = walk_in and tgt in frontier
+                if not (follows_out or follows_in):
+                    continue
+                edges[(src, pred, tgt)] = GraphEdge(
+                    predicate=pred,
+                    from_key=src,
+                    to_key=tgt,
+                    properties=_clean_props(rec.get("props")),
+                )
+                if follows_out and tgt not in visited:
+                    new.add(tgt)
+                if follows_in and src not in visited:
+                    new.add(src)
+                if len(edges) >= max_edges:
+                    truncated = True
+                    break
+            if truncated:
+                break
+            visited |= new
+            frontier = new
+        nodes = self._hydrate_nodes(pot_id, list(visited)[:_MAX_NODES])
+        return GraphSlice(
+            pot_id=pot_id,
+            nodes=nodes,
+            edges=tuple(edges.values()),
+            truncated=truncated or len(visited) > _MAX_NODES,
+        )
+
+    def slice(self, *, pot_id: str, filter_: ClaimQueryFilter) -> GraphSlice:
+        preds = list(filter_.predicate_in) or None
+        node_recs = self._query(_NODES_CYPHER, {"gid": pot_id, "limit": _MAX_NODES})
+        edge_recs = self._query(
+            _EDGES_CYPHER,
+            {
+                "gid": pot_id,
+                "preds": preds,
+                "include_invalid": bool(filter_.include_invalidated),
+                "limit": _MAX_EDGES,
+            },
+        )
+        nodes = tuple(
+            GraphNode(
+                key=rec["key"],
+                labels=tuple(lbl for lbl in (rec.get("labels") or [])),
+                properties=_clean_props(rec.get("props")),
+            )
+            for rec in node_recs
+        )
+        edges = tuple(
+            GraphEdge(
+                predicate=rec["predicate"],
+                from_key=rec["source"],
+                to_key=rec["target"],
+                properties=_clean_props(rec.get("props")),
+            )
+            for rec in edge_recs
+        )
+        return GraphSlice(
+            pot_id=pot_id,
+            nodes=nodes,
+            edges=edges,
+            truncated=len(node_recs) >= _MAX_NODES or len(edge_recs) >= _MAX_EDGES,
+        )
+
+    def labels(
+        self, *, pot_id: str, entity_keys: Iterable[str]
+    ) -> Mapping[str, tuple[str, ...]]:
+        keys = list(entity_keys)
+        if not keys:
+            return {}
+        recs = self._query(_HYDRATE_CYPHER, {"gid": pot_id, "keys": keys})
+        return {
+            rec["key"]: tuple(lbl for lbl in (rec.get("labels") or [])) for rec in recs
+        }
+
+    def path(
+        self, *, pot_id: str, from_key: str, to_key: str, max_depth: int = 4
+    ) -> GraphSlice:
+        max_depth = max(1, min(int(max_depth), _MAX_DEPTH))
+        cypher = (
+            "MATCH (a:Entity {group_id: $gid}), (b:Entity {group_id: $gid}), "
+            f"p = shortestPath((a)-[:RELATES_TO*1..{max_depth}]-(b)) "
+            "WHERE a.entity_key = $from AND b.entity_key = $to "
+            "RETURN [n IN nodes(p) | n.entity_key] AS keys, "
+            "[r IN relationships(p) | [startNode(r).entity_key, r.name, endNode(r).entity_key]] AS rels "
+            "LIMIT 1"
+        )
+        recs = self._query(cypher, {"gid": pot_id, "from": from_key, "to": to_key})
+        if not recs:
+            return GraphSlice(pot_id=pot_id, nodes=(), edges=())
+        rec = recs[0]
+        edges = tuple(
+            GraphEdge(predicate=r[1], from_key=r[0], to_key=r[2])
+            for r in (rec.get("rels") or [])
+        )
+        nodes = self._hydrate_nodes(pot_id, list(rec.get("keys") or []))
+        return GraphSlice(pot_id=pot_id, nodes=nodes, edges=edges)
+
+
+__all__ = ["FalkorDBInspection"]

--- a/potpie/context-engine/adapters/outbound/graph/falkordb_reader.py
+++ b/potpie/context-engine/adapters/outbound/graph/falkordb_reader.py
@@ -8,8 +8,9 @@ predicates, ``labels()`` filters) runs unchanged on FalkorDB, so this adapter
 driver call + record normalization (FalkorDB returns ``result_set`` rows, not
 Neo4j ``Record`` maps).
 
-``fact_query`` keeps the Python token-overlap scoring (the native relationship
-vector index is not on the hot path; see history-local-graph-db.md).
+``fact_query`` uses FalkorDB's native relationship vector index when an embedder
+is wired. If the vector index/procedure is unavailable, the adapter falls back
+to the labeled lexical scorer so local/dev profiles still return useful rows.
 """
 
 from __future__ import annotations
@@ -20,15 +21,59 @@ from adapters.outbound.graph.falkordb_writer import (
     _records_from_result,
     build_falkordb_graph,
 )
-from adapters.outbound.graph.neo4j_reader import (
-    _ENTITY_LABELS_CYPHER,
-    _FIND_CLAIMS_CYPHER,
-    _embedding_score,
-    _iso,
-    _row_from_record,
+from adapters.outbound.graph.canonical_claim_query import (
+    ENTITY_LABELS_CYPHER,
+    FIND_CLAIMS_CYPHER,
+    iso,
+    row_from_record,
+    stamp_scored_rows,
+    stamp_similarity,
 )
 from domain.ports.claim_query import ClaimQueryFilter, ClaimRow
+from domain.ports.embedder import EmbedderPort
 from domain.ports.settings import ContextEngineSettingsPort
+
+_VECTOR_CLAIMS_CYPHER = """
+CALL db.idx.vector.queryRelationships(
+    'RELATES_TO',
+    'fact_embedding',
+    $k,
+    vecf32($embedding)
+) YIELD relationship AS r, score
+WITH r, score
+MATCH (a:Entity {group_id: $gid})-[rel:RELATES_TO]->(b:Entity {group_id: $gid})
+WHERE id(rel) = id(r)
+  AND rel.group_id = $gid
+  AND ($preds IS NULL OR rel.name IN $preds)
+  AND ($subjects IS NULL OR rel.subject_key IN $subjects)
+  AND ($objects IS NULL OR rel.object_key IN $objects)
+  AND ($claim_keys IS NULL OR rel.claim_key IN $claim_keys)
+  AND ($subgraphs IS NULL OR rel.subgraph IN $subgraphs)
+  AND ($mutation_ids IS NULL OR rel.mutation_id IN $mutation_ids)
+  AND ($source_refs IS NULL OR rel.source_ref IN $source_refs OR any(ref IN coalesce(rel.source_refs, []) WHERE ref IN $source_refs))
+  AND ($sources IS NULL OR rel.source_system IN $sources)
+  AND ($include_invalid OR rel.invalid_at IS NULL)
+  AND ($as_of IS NULL OR rel.valid_at IS NULL OR rel.valid_at <= $as_of)
+  AND ($va_after IS NULL OR (rel.valid_at IS NOT NULL AND rel.valid_at >= $va_after))
+  AND ($va_before IS NULL OR rel.valid_at IS NULL OR rel.valid_at <= $va_before)
+  AND ($subject_label IS NULL OR $subject_label IN labels(a))
+  AND ($object_label IS NULL OR $object_label IN labels(b))
+RETURN rel{.*} AS props, score
+ORDER BY score ASC
+LIMIT $limit
+"""
+
+_ENTITY_PROPERTIES_CYPHER = """
+MATCH (e:Entity {group_id: $gid})
+WHERE e.entity_key = $key
+RETURN properties(e) AS props
+LIMIT 1
+"""
+
+
+def _distance_to_similarity(distance: float) -> float:
+    """FalkorDB vector queries return distance; readers expect similarity."""
+    return max(0.0, min(1.0, 1.0 - distance))
 
 
 class FalkorDBClaimQueryStore:
@@ -40,10 +85,16 @@ class FalkorDBClaimQueryStore:
         *,
         graph: Any | None = None,
         graph_provider: Callable[[], Any] | None = None,
+        embedder: EmbedderPort | None = None,
     ) -> None:
         self._settings = settings
         self._graph = graph  # injectable for unit tests
         self._graph_provider = graph_provider  # shared handle from the container
+        self._embedder = embedder
+
+    @property
+    def match_mode(self) -> str:
+        return "vector" if self._embedder is not None else "lexical"
 
     def _get_graph(self) -> Any:
         if self._graph is None:
@@ -63,47 +114,62 @@ class FalkorDBClaimQueryStore:
             "preds": list(filter_.predicate_in) or None,
             "subjects": list(filter_.subject_key_in) or None,
             "objects": list(filter_.object_key_in) or None,
+            "claim_keys": list(filter_.claim_key_in) or None,
+            "subgraphs": list(filter_.subgraph_in) or None,
+            "mutation_ids": list(filter_.mutation_id_in) or None,
+            "source_refs": list(filter_.source_ref_in) or None,
             "sources": list(filter_.source_system_in) or None,
             "include_invalid": bool(filter_.include_invalidated),
-            "as_of": _iso(filter_.as_of),
-            "va_after": _iso(filter_.valid_at_after),
-            "va_before": _iso(filter_.valid_at_before),
+            "as_of": iso(filter_.as_of),
+            "va_after": iso(filter_.valid_at_after),
+            "va_before": iso(filter_.valid_at_before),
             "subject_label": filter_.subject_label,
             "object_label": filter_.object_label,
         }
-        result = self._get_graph().query(_FIND_CLAIMS_CYPHER, params=params)
-        rows = [_row_from_record(rec) for rec in _records_from_result(result)]
+        if filter_.fact_query and self._embedder is not None:
+            rows = self._find_claims_vector(filter_, params)
+            if rows:
+                return rows
+
+        rows = self._find_claims_lexical(params)
 
         if filter_.fact_query:
-            scored = sorted(
-                ((_embedding_score(row.fact, filter_.fact_query), row) for row in rows),
-                key=lambda pair: pair[0],
-                reverse=True,
-            )
-            rows = []
-            for score, row in scored:
-                props = dict(row.properties)
-                props["semantic_similarity"] = score
-                rows.append(
-                    ClaimRow(
-                        pot_id=row.pot_id,
-                        predicate=row.predicate,
-                        subject_key=row.subject_key,
-                        object_key=row.object_key,
-                        valid_at=row.valid_at,
-                        invalid_at=row.invalid_at,
-                        evidence_strength=row.evidence_strength,
-                        source_system=row.source_system,
-                        source_ref=row.source_ref,
-                        fact=row.fact,
-                        properties=props,
-                        fact_embedding=row.fact_embedding,
-                    )
-                )
+            rows = stamp_similarity(rows, filter_.fact_query)
 
         if filter_.limit is not None and filter_.limit >= 0:
             rows = rows[: filter_.limit]
         return rows
+
+    def _find_claims_lexical(self, params: Mapping[str, object]) -> list[ClaimRow]:
+        result = self._get_graph().query(FIND_CLAIMS_CYPHER, params=dict(params))
+        return [row_from_record(rec) for rec in _records_from_result(result)]
+
+    def _find_claims_vector(
+        self, filter_: ClaimQueryFilter, params: Mapping[str, object]
+    ) -> list[ClaimRow]:
+        assert filter_.fact_query is not None
+        assert self._embedder is not None
+        limit = filter_.limit if filter_.limit is not None and filter_.limit > 0 else 10
+        vector_params = {
+            **dict(params),
+            "embedding": [float(x) for x in self._embedder.embed(filter_.fact_query)],
+            "k": max(limit * 5, 50),
+            "limit": limit,
+        }
+        try:
+            result = self._get_graph().query(
+                _VECTOR_CLAIMS_CYPHER, params=vector_params
+            )
+        except Exception:
+            return []
+        scored = [
+            (
+                _distance_to_similarity(float(rec.get("score", 1.0))),
+                row_from_record(rec),
+            )
+            for rec in _records_from_result(result)
+        ]
+        return stamp_scored_rows(scored)
 
     def entity_labels(
         self, *, pot_id: str, entity_keys: Iterable[str]
@@ -112,12 +178,23 @@ class FalkorDBClaimQueryStore:
         if not keys:
             return {}
         result = self._get_graph().query(
-            _ENTITY_LABELS_CYPHER, params={"gid": pot_id, "keys": keys}
+            ENTITY_LABELS_CYPHER, params={"gid": pot_id, "keys": keys}
         )
         return {
             rec["key"]: tuple(lbl for lbl in (rec["labels"] or []))
             for rec in _records_from_result(result)
         }
 
+    def entity_properties(self, *, pot_id: str, entity_key: str) -> dict[str, Any]:
+        result = self._get_graph().query(
+            _ENTITY_PROPERTIES_CYPHER,
+            params={"gid": pot_id, "key": entity_key},
+        )
+        records = _records_from_result(result)
+        if not records:
+            return {}
+        props = records[0].get("props")
+        return dict(props) if isinstance(props, Mapping) else {}
 
-__all__ = ["FalkorDBClaimQueryStore"]
+
+__all__ = ["FalkorDBClaimQueryStore", "_VECTOR_CLAIMS_CYPHER"]

--- a/potpie/context-engine/adapters/outbound/graph/falkordb_writer.py
+++ b/potpie/context-engine/adapters/outbound/graph/falkordb_writer.py
@@ -377,8 +377,10 @@ class FalkorDBGraphWriter(GraphWriterPort):
             )
             if not card:
                 continue
-            embedding = [float(x) for x in self._embedder.embed(card)]
             try:
+                # Keep embedding inside the try: a model error must degrade to
+                # "no vector enrichment", not abort the already-written edge.
+                embedding = [float(x) for x in self._embedder.embed(card)]
                 graph.query(
                     """
                     MATCH (:Entity {group_id: $gid, entity_key: $from_key})

--- a/potpie/context-engine/adapters/outbound/graph/falkordb_writer.py
+++ b/potpie/context-engine/adapters/outbound/graph/falkordb_writer.py
@@ -29,13 +29,15 @@ import os
 from typing import Any, Callable, Coroutine, TypeVar
 
 from adapters.outbound.graph.cypher import (
+    _render_fact,
     _require_valid_pot_id,
+    _stable_source_ref,
     apply_invalidations_async,
     delete_edges_async,
     upsert_edges_async,
     upsert_entities_async,
 )
-from adapters.outbound.graph.neo4j_writer import GraphWriterPort
+from adapters.outbound.graph.writer_port import GraphWriterPort
 from domain.graph_mutations import (
     EdgeDelete,
     EdgeUpsert,
@@ -43,6 +45,7 @@ from domain.graph_mutations import (
     InvalidationOp,
     ProvenanceRef,
 )
+from domain.retrieval_card import build_retrieval_card
 from domain.ports.settings import ContextEngineSettingsPort
 
 logger = logging.getLogger(__name__)
@@ -50,9 +53,7 @@ logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
 
 # Unnamed index DDL (FalkorDB rejects named indexes + IF NOT EXISTS). Mirrors
-# the canonical indexes the Position-B traversal patterns rely on; the vector
-# index is intentionally omitted (Neo4j syntax is rejected and reads use the
-# Python token-overlap fallback).
+# the canonical indexes the Position-B traversal patterns rely on.
 _INDEX_STATEMENTS = (
     "CREATE INDEX FOR (n:Entity) ON (n.group_id, n.entity_key)",
     "CREATE INDEX FOR ()-[r:RELATES_TO]-() ON (r.group_id, r.name)",
@@ -62,6 +63,14 @@ _INDEX_STATEMENTS = (
 
 # reset_pot batch size for the client-side delete loop.
 _RESET_BATCH = 500
+
+
+def _index_statements(embedding_dim: int) -> tuple[str, ...]:
+    return (
+        *_INDEX_STATEMENTS,
+        "CREATE VECTOR INDEX FOR ()-[r:RELATES_TO]->() ON (r.fact_embedding) "
+        f"OPTIONS {{dimension:{int(embedding_dim)}, similarityFunction:'cosine'}}",
+    )
 
 
 def _records_from_result(result: Any) -> list[dict[str, Any]]:
@@ -182,11 +191,13 @@ class FalkorDBGraphWriter(GraphWriterPort):
         *,
         graph: Any | None = None,
         graph_provider: Callable[[], Any] | None = None,
+        embedder: Any | None = None,
     ) -> None:
         self._settings = settings
         self._enabled = settings.is_enabled()
         self._graph = graph  # injectable for unit tests
         self._graph_provider = graph_provider  # shared handle from the container
+        self._embedder = embedder
 
     @property
     def enabled(self) -> bool:
@@ -219,12 +230,13 @@ class FalkorDBGraphWriter(GraphWriterPort):
         if not self.enabled:
             return False
         graph = self._get_graph()
-        await asyncio.to_thread(self._ensure_indexes_sync, graph)
+        embedding_dim = int(getattr(self._embedder, "dimensions", 1536))
+        await asyncio.to_thread(self._ensure_indexes_sync, graph, embedding_dim)
         return True
 
     @staticmethod
-    def _ensure_indexes_sync(graph: Any) -> None:
-        for stmt in _INDEX_STATEMENTS:
+    def _ensure_indexes_sync(graph: Any, embedding_dim: int = 1536) -> None:
+        for stmt in _index_statements(embedding_dim):
             try:
                 graph.query(stmt)
             except Exception as exc:  # noqa: BLE001
@@ -245,9 +257,18 @@ class FalkorDBGraphWriter(GraphWriterPort):
     ) -> int:
         if not items:
             return 0
-        return await self._with_driver(
+        written = await self._with_driver(
             lambda d: upsert_edges_async(d, pot_id, items, provenance)
         )
+        if self._embedder is not None and written:
+            await asyncio.to_thread(
+                self._write_edge_vectors_sync,
+                self._get_graph(),
+                pot_id,
+                items,
+                provenance,
+            )
+        return written
 
     async def delete_edges(
         self, pot_id: str, items: list[EdgeDelete], provenance: ProvenanceRef
@@ -316,6 +337,84 @@ class FalkorDBGraphWriter(GraphWriterPort):
         )
         rows = getattr(result, "result_set", None) or []
         return int(rows[0][0]) if rows and rows[0] else 0
+
+    def _write_edge_vectors_sync(
+        self,
+        graph: Any,
+        pot_id: str,
+        items: list[EdgeUpsert],
+        provenance: ProvenanceRef,
+    ) -> None:
+        if self._embedder is None:
+            return
+        for item in items:
+            raw_props = dict(item.properties)
+            source_ref = _stable_source_ref(
+                predicate=item.edge_type,
+                from_key=item.from_entity_key,
+                to_key=item.to_entity_key,
+                provenance=provenance,
+            )
+            if isinstance(raw_props.get("source_ref"), str) and raw_props["source_ref"]:
+                source_ref = raw_props["source_ref"]
+            fact = _render_fact(
+                predicate=item.edge_type,
+                from_key=item.from_entity_key,
+                to_key=item.to_entity_key,
+                extra=raw_props,
+            )
+            card = build_retrieval_card(
+                description=raw_props.get("description")
+                if isinstance(raw_props.get("description"), str)
+                else None,
+                fact=fact,
+                subject_key=item.from_entity_key,
+                predicate=item.edge_type,
+                object_key=item.to_entity_key,
+                scope=raw_props.get("code_scope")
+                if isinstance(raw_props.get("code_scope"), dict)
+                else None,
+            )
+            if not card:
+                continue
+            embedding = [float(x) for x in self._embedder.embed(card)]
+            try:
+                graph.query(
+                    """
+                    MATCH (:Entity {group_id: $gid, entity_key: $from_key})
+                          -[r:RELATES_TO {
+                              group_id: $gid,
+                              name: $predicate,
+                              subject_key: $from_key,
+                              object_key: $to_key,
+                              source_ref: $source_ref
+                          }]->
+                          (:Entity {group_id: $gid, entity_key: $to_key})
+                    SET r.fact_embedding = vecf32($embedding),
+                        r.embedding_model = $embedding_model,
+                        r.embedding_dim = $embedding_dim
+                    """,
+                    params={
+                        "gid": pot_id,
+                        "predicate": item.edge_type,
+                        "from_key": item.from_entity_key,
+                        "to_key": item.to_entity_key,
+                        "source_ref": source_ref,
+                        "embedding": embedding,
+                        "embedding_model": getattr(self._embedder, "name", "unknown"),
+                        "embedding_dim": int(
+                            getattr(self._embedder, "dimensions", len(embedding))
+                        ),
+                    },
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "falkordb vector write skipped for %s:%s->%s: %s",
+                    item.edge_type,
+                    item.from_entity_key,
+                    item.to_entity_key,
+                    exc,
+                )
 
 
 __all__ = ["FalkorDBGraphProvider", "FalkorDBGraphWriter", "build_falkordb_graph"]

--- a/potpie/context-engine/adapters/outbound/graph/in_memory_reader.py
+++ b/potpie/context-engine/adapters/outbound/graph/in_memory_reader.py
@@ -1,18 +1,28 @@
 """In-memory :class:`ClaimQueryPort` for tests + offline benches.
 
-Production uses the Neo4j adapter against the canonical edge store.
-This implementation is *not* a substitute for that — it covers the
-filter semantics defined on :class:`ClaimQueryFilter` so reader tests
-can drive every code path without a live graph.
+Production uses the Neo4j adapter against the canonical edge store. This
+implementation is *not* a substitute for that — it covers the filter semantics
+defined on :class:`ClaimQueryFilter` so reader tests can drive every code path
+without a live graph.
+
+Semantic match (R1): when an :class:`EmbedderPort` is wired, ``fact_query`` runs
+a real cosine-similarity ranking over the persisted ``fact_embedding`` (embedding
+the retrieval card on the fly for rows that lack one). With no embedder it falls
+back to the canonical lexical token-overlap scorer
+(``match_mode == "lexical"``), so an empty result is debuggable rather than a
+silent stub.
 """
 
 from __future__ import annotations
 
-import math
+import dataclasses
 from dataclasses import dataclass, field
-from typing import Iterable, Mapping
+from typing import Any, Iterable, Mapping
 
+from adapters.outbound.graph.canonical_claim_query import embedding_score
 from domain.ports.claim_query import ClaimQueryFilter, ClaimRow
+from domain.ports.embedder import EmbedderPort
+from domain.retrieval_card import build_retrieval_card, cosine_similarity
 
 
 @dataclass(slots=True)
@@ -21,6 +31,15 @@ class InMemoryClaimQueryStore:
     entity_label_index: dict[tuple[str, str], tuple[str, ...]] = field(
         default_factory=dict
     )
+    entity_property_index: dict[tuple[str, str], dict[str, Any]] = field(
+        default_factory=dict
+    )
+    embedder: EmbedderPort | None = None
+
+    @property
+    def match_mode(self) -> str:
+        """Active semantic-match mode: ``vector`` (embedder) or ``lexical``."""
+        return "vector" if self.embedder is not None else "lexical"
 
     # ------------------------------------------------------------------
     # Loading helpers (used by tests + benches to populate the store)
@@ -36,6 +55,18 @@ class InMemoryClaimQueryStore:
     ) -> None:
         self.entity_label_index[(pot_id, entity_key)] = tuple(labels)
 
+    def set_entity_properties(
+        self, *, pot_id: str, entity_key: str, properties: Mapping[str, Any]
+    ) -> None:
+        """Merge entity properties (name / description / …) for richer reads."""
+        if not properties:
+            return
+        bucket = self.entity_property_index.setdefault((pot_id, entity_key), {})
+        bucket.update({k: v for k, v in properties.items()})
+
+    def entity_properties(self, *, pot_id: str, entity_key: str) -> dict[str, Any]:
+        return dict(self.entity_property_index.get((pot_id, entity_key), {}))
+
     # ------------------------------------------------------------------
     # ClaimQueryPort
     # ------------------------------------------------------------------
@@ -44,31 +75,7 @@ class InMemoryClaimQueryStore:
         candidates = [row for row in candidates if _matches_filter(row, filter_, self)]
 
         if filter_.fact_query:
-            scored = [
-                (row, _embedding_score(row, filter_.fact_query)) for row in candidates
-            ]
-            scored.sort(key=lambda pair: pair[1], reverse=True)
-            stamped: list[ClaimRow] = []
-            for row, score in scored:
-                props = dict(row.properties)
-                props["semantic_similarity"] = score
-                stamped.append(
-                    ClaimRow(
-                        pot_id=row.pot_id,
-                        predicate=row.predicate,
-                        subject_key=row.subject_key,
-                        object_key=row.object_key,
-                        valid_at=row.valid_at,
-                        invalid_at=row.invalid_at,
-                        evidence_strength=row.evidence_strength,
-                        source_system=row.source_system,
-                        source_ref=row.source_ref,
-                        fact=row.fact,
-                        properties=props,
-                        fact_embedding=row.fact_embedding,
-                    )
-                )
-            candidates = stamped
+            candidates = self._semantic_rank(candidates, filter_.fact_query)
 
         if filter_.limit is not None and filter_.limit >= 0:
             candidates = candidates[: filter_.limit]
@@ -84,6 +91,50 @@ class InMemoryClaimQueryStore:
                 out[key] = labels
         return out
 
+    # ------------------------------------------------------------------
+    # Semantic ranking
+    # ------------------------------------------------------------------
+    def _semantic_rank(self, candidates: list[ClaimRow], query: str) -> list[ClaimRow]:
+        if self.embedder is not None:
+            qvec = self.embedder.embed(query)
+            scored = [
+                (row, cosine_similarity(qvec, self._row_vector(row)))
+                for row in candidates
+            ]
+        else:
+            scored = [(row, embedding_score(row.fact, query)) for row in candidates]
+        scored.sort(key=lambda pair: pair[1], reverse=True)
+        return [_stamp_similarity(row, score) for row, score in scored]
+
+    def _row_vector(self, row: ClaimRow) -> tuple[float, ...]:
+        if row.fact_embedding:
+            return row.fact_embedding
+        # No persisted embedding (old data / hand-built test row): embed the
+        # card on the fly so the row still participates in vector ranking.
+        assert self.embedder is not None
+        return self.embedder.embed(card_for_row(row))
+
+
+def card_for_row(row: ClaimRow) -> str:
+    """Build the retrieval card for a stored claim row (read-side / on-the-fly embed)."""
+    props = row.properties or {}
+    return build_retrieval_card(
+        description=row.description or props.get("description"),
+        fact=row.fact,
+        subject_key=row.subject_key,
+        predicate=row.predicate,
+        object_key=row.object_key,
+        scope=props.get("code_scope")
+        if isinstance(props.get("code_scope"), Mapping)
+        else None,
+    )
+
+
+def _stamp_similarity(row: ClaimRow, score: float) -> ClaimRow:
+    props = dict(row.properties)
+    props["semantic_similarity"] = score
+    return dataclasses.replace(row, properties=props)
+
 
 def _matches_filter(
     row: ClaimRow, filter_: ClaimQueryFilter, store: InMemoryClaimQueryStore
@@ -93,6 +144,16 @@ def _matches_filter(
     if filter_.subject_key_in and row.subject_key not in filter_.subject_key_in:
         return False
     if filter_.object_key_in and row.object_key not in filter_.object_key_in:
+        return False
+    if filter_.claim_key_in and row.claim_key not in filter_.claim_key_in:
+        return False
+    if filter_.subgraph_in and row.subgraph not in filter_.subgraph_in:
+        return False
+    if filter_.mutation_id_in and row.mutation_id not in filter_.mutation_id_in:
+        return False
+    if filter_.source_ref_in and not _row_matches_source_refs(
+        row, filter_.source_ref_in
+    ):
         return False
     if filter_.source_system_in and row.source_system not in filter_.source_system_in:
         return False
@@ -119,21 +180,19 @@ def _matches_filter(
     return True
 
 
-def _embedding_score(row: ClaimRow, query: str) -> float:
-    """Stand-in similarity: token-overlap Jaccard on lowercased fact + query."""
-    if not row.fact:
-        return 0.0
-    a = set(query.lower().split())
-    b = set(row.fact.lower().split())
-    if not a or not b:
-        return 0.0
-    intersection = a & b
-    union = a | b
-    base = len(intersection) / len(union)
-    # Slight boost so close-but-not-identical phrases still score above 0
-    if intersection:
-        base = math.sqrt(base)
-    return max(0.0, min(1.0, base))
+def _row_matches_source_refs(row: ClaimRow, wanted: Iterable[str]) -> bool:
+    wanted_set = {str(ref).strip().lower() for ref in wanted if str(ref).strip()}
+    if not wanted_set:
+        return True
+    refs = []
+    if row.source_ref:
+        refs.append(row.source_ref)
+    refs.extend(row.source_refs)
+    for item in row.evidence:
+        ref = item.get("source_ref") if isinstance(item, Mapping) else None
+        if isinstance(ref, str):
+            refs.append(ref)
+    return any(ref.strip().lower() in wanted_set for ref in refs if ref)
 
 
-__all__ = ["InMemoryClaimQueryStore"]
+__all__ = ["InMemoryClaimQueryStore", "card_for_row"]

--- a/potpie/context-engine/adapters/outbound/graph/in_memory_reader.py
+++ b/potpie/context-engine/adapters/outbound/graph/in_memory_reader.py
@@ -189,7 +189,11 @@ def _row_matches_source_refs(row: ClaimRow, wanted: Iterable[str]) -> bool:
         refs.append(row.source_ref)
     refs.extend(row.source_refs)
     for item in row.evidence:
-        ref = item.get("source_ref") if isinstance(item, Mapping) else None
+        if not isinstance(item, Mapping):
+            continue
+        # The evidence DTO serializes the pointer as ``ref``; accept both that
+        # and the canonical ``source_ref`` so DTO-shaped evidence still matches.
+        ref = item.get("source_ref") or item.get("ref")
         if isinstance(ref, str):
             refs.append(ref)
     return any(ref.strip().lower() in wanted_set for ref in refs if ref)

--- a/potpie/context-engine/adapters/outbound/graph/neo4j_reader.py
+++ b/potpie/context-engine/adapters/outbound/graph/neo4j_reader.py
@@ -10,107 +10,42 @@ The driver is the plain *synchronous* Neo4j driver (``ClaimQueryPort`` is a
 sync surface; the readers call it inline). It is built lazily from settings
 and cached for reuse.
 
-``fact_query`` (semantic) currently uses the same token-overlap scoring as the
-in-memory store rather than the native relationship vector index — the
-embed-on-write/embed-query path isn't wired yet. When an embedder lands, swap
-the Python scoring here for ``db.index.vector.queryRelationships`` over
-``r.fact_embedding`` (the index name is ``claim_fact_embeddings``); the row
-shape and the ``properties['semantic_similarity']`` stamp stay identical.
+``fact_query`` uses Neo4j's native relationship vector index when an embedder is
+wired. If the vector procedure is unavailable, the adapter falls back to the
+labeled lexical scorer so old deployments degrade instead of dropping results.
 """
 
 from __future__ import annotations
 
-import math
-from datetime import datetime
 from typing import Any, Iterable, Mapping
 
+from adapters.outbound.graph.canonical_claim_query import (
+    ENTITY_LABELS_CYPHER as _ENTITY_LABELS_CYPHER,
+    FIND_CLAIMS_CYPHER as _FIND_CLAIMS_CYPHER,
+    embedding_score as _embedding_score,
+    iso as _iso,
+    row_from_record as _row_from_record,
+    stamp_scored_rows,
+    stamp_similarity,
+)
 from domain.ports.claim_query import ClaimQueryFilter, ClaimRow
+from domain.ports.embedder import EmbedderPort
 from domain.ports.settings import ContextEngineSettingsPort
 
-# Edge properties that are part of the canonical identity/bitemporal frame and
-# are surfaced as first-class ClaimRow fields; everything else on the edge is
-# passed through in ``ClaimRow.properties`` for the readers (code_scope,
-# policy_kind, environment, corroboration_count, …).
-_RESERVED_EDGE_KEYS = frozenset(
-    {
-        "group_id",
-        "name",
-        "subject_key",
-        "object_key",
-        "valid_at",
-        "invalid_at",
-        "evidence_strength",
-        "source_system",
-        "source_ref",
-        "fact",
-        "fact_embedding",
-    }
-)
+_VECTOR_INDEX_NAME = "claim_fact_embeddings"
 
-
-def _parse_dt(value: Any) -> datetime | None:
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return value
-    if isinstance(value, str):
-        try:
-            return datetime.fromisoformat(value)
-        except ValueError:
-            return None
-    # neo4j.time.DateTime → native
-    to_native = getattr(value, "to_native", None)
-    if callable(to_native):
-        try:
-            native = to_native()
-        except Exception:  # noqa: BLE001
-            return None
-        return native if isinstance(native, datetime) else None
-    return None
-
-
-def _iso(value: datetime | None) -> str | None:
-    return value.isoformat() if value is not None else None
-
-
-def _row_from_record(rec: Mapping[str, Any]) -> ClaimRow:
-    """Build a :class:`ClaimRow` from one Cypher record (``r{.*}`` props map)."""
-    props = dict(rec.get("props") or {})
-    extras = {k: v for k, v in props.items() if k not in _RESERVED_EDGE_KEYS}
-    return ClaimRow(
-        pot_id=str(props.get("group_id") or rec.get("gid") or ""),
-        predicate=str(props.get("name") or ""),
-        subject_key=str(props.get("subject_key") or ""),
-        object_key=str(props.get("object_key") or ""),
-        valid_at=_parse_dt(props.get("valid_at")),
-        invalid_at=_parse_dt(props.get("invalid_at")),
-        evidence_strength=str(props.get("evidence_strength") or "stated"),
-        source_system=props.get("source_system"),
-        source_ref=props.get("source_ref"),
-        fact=props.get("fact"),
-        properties=extras,
-    )
-
-
-def _embedding_score(fact: str | None, query: str) -> float:
-    """Token-overlap stand-in for native vector similarity (mirrors in-memory)."""
-    if not fact:
-        return 0.0
-    a = set(query.lower().split())
-    b = set(fact.lower().split())
-    if not a or not b:
-        return 0.0
-    base = len(a & b) / len(a | b)
-    if a & b:
-        base = math.sqrt(base)
-    return max(0.0, min(1.0, base))
-
-
-_FIND_CLAIMS_CYPHER = """
-MATCH (a:Entity {group_id: $gid})-[r:RELATES_TO {group_id: $gid}]->(b:Entity {group_id: $gid})
-WHERE ($preds IS NULL OR r.name IN $preds)
+_VECTOR_CLAIMS_CYPHER = """
+CALL db.index.vector.queryRelationships($index_name, $k, $embedding)
+YIELD relationship AS r, score
+MATCH (a:Entity {group_id: $gid})-[r:RELATES_TO]->(b:Entity {group_id: $gid})
+WHERE r.group_id = $gid
+  AND ($preds IS NULL OR r.name IN $preds)
   AND ($subjects IS NULL OR r.subject_key IN $subjects)
   AND ($objects IS NULL OR r.object_key IN $objects)
+  AND ($claim_keys IS NULL OR r.claim_key IN $claim_keys)
+  AND ($subgraphs IS NULL OR r.subgraph IN $subgraphs)
+  AND ($mutation_ids IS NULL OR r.mutation_id IN $mutation_ids)
+  AND ($source_refs IS NULL OR r.source_ref IN $source_refs OR any(ref IN coalesce(r.source_refs, []) WHERE ref IN $source_refs))
   AND ($sources IS NULL OR r.source_system IN $sources)
   AND ($include_invalid OR r.invalid_at IS NULL)
   AND ($as_of IS NULL OR r.valid_at IS NULL OR r.valid_at <= $as_of)
@@ -118,13 +53,16 @@ WHERE ($preds IS NULL OR r.name IN $preds)
   AND ($va_before IS NULL OR r.valid_at IS NULL OR r.valid_at <= $va_before)
   AND ($subject_label IS NULL OR $subject_label IN labels(a))
   AND ($object_label IS NULL OR $object_label IN labels(b))
-RETURN r{.*} AS props
+RETURN r{.*} AS props, score
+ORDER BY score DESC
+LIMIT $limit
 """
 
-_ENTITY_LABELS_CYPHER = """
+_ENTITY_PROPERTIES_CYPHER = """
 MATCH (e:Entity {group_id: $gid})
-WHERE e.entity_key IN $keys
-RETURN e.entity_key AS key, labels(e) AS labels
+WHERE e.entity_key = $key
+RETURN properties(e) AS props
+LIMIT 1
 """
 
 
@@ -132,10 +70,19 @@ class Neo4jClaimQueryStore:
     """:class:`ClaimQueryPort` over canonical ``:RELATES_TO`` edges."""
 
     def __init__(
-        self, settings: ContextEngineSettingsPort, *, driver: Any | None = None
+        self,
+        settings: ContextEngineSettingsPort,
+        *,
+        driver: Any | None = None,
+        embedder: EmbedderPort | None = None,
     ) -> None:
         self._settings = settings
         self._driver = driver
+        self._embedder = embedder
+
+    @property
+    def match_mode(self) -> str:
+        return "vector" if self._embedder is not None else "lexical"
 
     # -- driver lifecycle --------------------------------------------------
     def _get_driver(self) -> Any:
@@ -174,6 +121,10 @@ class Neo4jClaimQueryStore:
             "preds": list(filter_.predicate_in) or None,
             "subjects": list(filter_.subject_key_in) or None,
             "objects": list(filter_.object_key_in) or None,
+            "claim_keys": list(filter_.claim_key_in) or None,
+            "subgraphs": list(filter_.subgraph_in) or None,
+            "mutation_ids": list(filter_.mutation_id_in) or None,
+            "source_refs": list(filter_.source_ref_in) or None,
             "sources": list(filter_.source_system_in) or None,
             "include_invalid": bool(filter_.include_invalidated),
             "as_of": _iso(filter_.as_of),
@@ -182,41 +133,51 @@ class Neo4jClaimQueryStore:
             "subject_label": filter_.subject_label,
             "object_label": filter_.object_label,
         }
-        driver = self._get_driver()
-        with driver.session() as session:
-            records = list(session.run(_FIND_CLAIMS_CYPHER, **params))
-        rows = [_row_from_record(rec) for rec in records]
+        if filter_.fact_query and self._embedder is not None:
+            rows = self._find_claims_vector(filter_, params)
+            if rows:
+                return rows
 
-        if filter_.fact_query:
-            scored = sorted(
-                ((_embedding_score(row.fact, filter_.fact_query), row) for row in rows),
-                key=lambda pair: pair[0],
-                reverse=True,
-            )
-            rows = []
-            for score, row in scored:
-                props = dict(row.properties)
-                props["semantic_similarity"] = score
-                rows.append(
-                    ClaimRow(
-                        pot_id=row.pot_id,
-                        predicate=row.predicate,
-                        subject_key=row.subject_key,
-                        object_key=row.object_key,
-                        valid_at=row.valid_at,
-                        invalid_at=row.invalid_at,
-                        evidence_strength=row.evidence_strength,
-                        source_system=row.source_system,
-                        source_ref=row.source_ref,
-                        fact=row.fact,
-                        properties=props,
-                        fact_embedding=row.fact_embedding,
-                    )
-                )
+        rows = self._find_claims_lexical(filter_, params)
 
         if filter_.limit is not None and filter_.limit >= 0:
             rows = rows[: filter_.limit]
         return rows
+
+    def _find_claims_lexical(
+        self, filter_: ClaimQueryFilter, params: Mapping[str, object]
+    ) -> list[ClaimRow]:
+        driver = self._get_driver()
+        with driver.session() as session:
+            records = list(session.run(_FIND_CLAIMS_CYPHER, **params))
+        rows = [_row_from_record(rec) for rec in records]
+        if filter_.fact_query:
+            rows = stamp_similarity(rows, filter_.fact_query)
+        return rows
+
+    def _find_claims_vector(
+        self, filter_: ClaimQueryFilter, params: Mapping[str, object]
+    ) -> list[ClaimRow]:
+        assert filter_.fact_query is not None
+        assert self._embedder is not None
+        limit = filter_.limit if filter_.limit is not None and filter_.limit > 0 else 10
+        vector_params = {
+            **dict(params),
+            "index_name": _VECTOR_INDEX_NAME,
+            "embedding": [float(x) for x in self._embedder.embed(filter_.fact_query)],
+            "k": max(limit * 5, 50),
+            "limit": limit,
+        }
+        try:
+            driver = self._get_driver()
+            with driver.session() as session:
+                records = list(session.run(_VECTOR_CLAIMS_CYPHER, **vector_params))
+        except Exception:
+            return []
+        rows = [
+            (float(rec.get("score", 0.0)), _row_from_record(rec)) for rec in records
+        ]
+        return stamp_scored_rows(rows)
 
     def entity_labels(
         self, *, pot_id: str, entity_keys: Iterable[str]
@@ -231,5 +192,29 @@ class Neo4jClaimQueryStore:
             rec["key"]: tuple(lbl for lbl in (rec["labels"] or [])) for rec in records
         }
 
+    def entity_properties(self, *, pot_id: str, entity_key: str) -> dict[str, Any]:
+        driver = self._get_driver()
+        with driver.session() as session:
+            records = list(
+                session.run(
+                    _ENTITY_PROPERTIES_CYPHER,
+                    gid=pot_id,
+                    key=entity_key,
+                )
+            )
+        if not records:
+            return {}
+        props = records[0].get("props")
+        return dict(props) if isinstance(props, Mapping) else {}
 
-__all__ = ["Neo4jClaimQueryStore"]
+
+__all__ = [
+    "Neo4jClaimQueryStore",
+    "_ENTITY_LABELS_CYPHER",
+    "_ENTITY_PROPERTIES_CYPHER",
+    "_FIND_CLAIMS_CYPHER",
+    "_VECTOR_CLAIMS_CYPHER",
+    "_embedding_score",
+    "_iso",
+    "_row_from_record",
+]

--- a/potpie/context-engine/adapters/outbound/graph/neo4j_reader.py
+++ b/potpie/context-engine/adapters/outbound/graph/neo4j_reader.py
@@ -104,6 +104,10 @@ class Neo4jClaimQueryStore:
 
     # -- ClaimQueryPort ----------------------------------------------------
     def find_claims(self, filter_: ClaimQueryFilter) -> list[ClaimRow]:
+        # An explicit zero-row request must win before the vector path (which
+        # coerces limit=0 → 10) or the lexical slice can return anything.
+        if filter_.limit == 0:
+            return []
         # Short-circuit the one hopeless filter the port documents.
         if (
             not filter_.predicate_in

--- a/potpie/context-engine/adapters/outbound/graph/neo4j_writer.py
+++ b/potpie/context-engine/adapters/outbound/graph/neo4j_writer.py
@@ -1,4 +1,4 @@
-"""Graph writer port + Neo4j adapter.
+"""Neo4j graph writer adapter.
 
 One writer, one substrate: the reconciliation agent emits a typed
 :class:`ReconciliationPlan` and ``apply_reconciliation_plan`` calls these
@@ -10,7 +10,7 @@ the deterministic plan.
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, Coroutine, Protocol, TypeVar
+from typing import Any, Callable, Coroutine, TypeVar
 
 from adapters.outbound.graph.cypher import (
     _require_valid_pot_id,
@@ -20,6 +20,7 @@ from adapters.outbound.graph.cypher import (
     upsert_edges_async,
     upsert_entities_async,
 )
+from adapters.outbound.graph.writer_port import GraphWriterPort
 from domain.graph_mutations import (
     EdgeDelete,
     EdgeUpsert,
@@ -34,46 +35,15 @@ logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
 
 
-class GraphWriterPort(Protocol):
-    """The single graph mutation surface.
-
-    Every write to the project context graph goes through these five
-    verbs. Mutations are deterministic, idempotent on stable entity_keys,
-    and stamped with the provenance ref the caller threads in.
-    """
-
-    @property
-    def enabled(self) -> bool: ...
-
-    async def ensure_indexes(self) -> bool:
-        """Idempotently create entity / claim / vector indexes."""
-        ...
-
-    async def upsert_entities(
-        self, pot_id: str, items: list[EntityUpsert], provenance: ProvenanceRef
-    ) -> int: ...
-
-    async def upsert_edges(
-        self, pot_id: str, items: list[EdgeUpsert], provenance: ProvenanceRef
-    ) -> int: ...
-
-    async def delete_edges(
-        self, pot_id: str, items: list[EdgeDelete], provenance: ProvenanceRef
-    ) -> int: ...
-
-    async def invalidate(
-        self, pot_id: str, items: list[InvalidationOp], provenance: ProvenanceRef
-    ) -> int: ...
-
-    async def reset_pot(self, pot_id: str) -> dict[str, Any]: ...
-
-
 class Neo4jGraphWriter(GraphWriterPort):
     """Production writer: applies typed mutations as Position-B :RELATES_TO edges."""
 
-    def __init__(self, settings: ContextEngineSettingsPort) -> None:
+    def __init__(
+        self, settings: ContextEngineSettingsPort, *, embedder: Any | None = None
+    ) -> None:
         self._settings = settings
         self._enabled = settings.is_enabled()
+        self._embedder = embedder
 
     @property
     def enabled(self) -> bool:
@@ -107,7 +77,10 @@ class Neo4jGraphWriter(GraphWriterPort):
     async def ensure_indexes(self) -> bool:
         if not self.enabled:
             return False
-        await self._with_driver(lambda d: ensure_canonical_indexes(d))
+        embedding_dim = int(getattr(self._embedder, "dimensions", 1536))
+        await self._with_driver(
+            lambda d: ensure_canonical_indexes(d, embedding_dim=embedding_dim)
+        )
         return True
 
     async def upsert_entities(
@@ -125,7 +98,9 @@ class Neo4jGraphWriter(GraphWriterPort):
         if not items:
             return 0
         return await self._with_driver(
-            lambda d: upsert_edges_async(d, pot_id, items, provenance)
+            lambda d: upsert_edges_async(
+                d, pot_id, items, provenance, embedder=self._embedder
+            )
         )
 
     async def delete_edges(

--- a/potpie/context-engine/adapters/outbound/graph/writer_port.py
+++ b/potpie/context-engine/adapters/outbound/graph/writer_port.py
@@ -1,0 +1,50 @@
+"""Shared graph writer port.
+
+Concrete graph stores implement this narrow async mutation adapter. It is
+intentionally storage-adapter internal: application services depend on
+``GraphBackend`` / ``GraphMutationPort`` instead.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from domain.graph_mutations import (
+    EdgeDelete,
+    EdgeUpsert,
+    EntityUpsert,
+    InvalidationOp,
+    ProvenanceRef,
+)
+
+
+class GraphWriterPort(Protocol):
+    """The deterministic graph mutation surface used by backend adapters."""
+
+    @property
+    def enabled(self) -> bool: ...
+
+    async def ensure_indexes(self) -> bool:
+        """Idempotently create entity / claim / vector indexes."""
+        ...
+
+    async def upsert_entities(
+        self, pot_id: str, items: list[EntityUpsert], provenance: ProvenanceRef
+    ) -> int: ...
+
+    async def upsert_edges(
+        self, pot_id: str, items: list[EdgeUpsert], provenance: ProvenanceRef
+    ) -> int: ...
+
+    async def delete_edges(
+        self, pot_id: str, items: list[EdgeDelete], provenance: ProvenanceRef
+    ) -> int: ...
+
+    async def invalidate(
+        self, pot_id: str, items: list[InvalidationOp], provenance: ProvenanceRef
+    ) -> int: ...
+
+    async def reset_pot(self, pot_id: str) -> dict[str, Any]: ...
+
+
+__all__ = ["GraphWriterPort"]

--- a/potpie/context-engine/adapters/outbound/intelligence/__init__.py
+++ b/potpie/context-engine/adapters/outbound/intelligence/__init__.py
@@ -1,0 +1,1 @@
+"""Outbound intelligence adapters (embedders, etc.)."""

--- a/potpie/context-engine/adapters/outbound/intelligence/local_embedder.py
+++ b/potpie/context-engine/adapters/outbound/intelligence/local_embedder.py
@@ -48,6 +48,13 @@ class HashingEmbedder:
     dimensions: int = _DEFAULT_DIMENSIONS
     name: str = "local-hashing-v1"
 
+    def __post_init__(self) -> None:
+        # A non-positive dimension would crash at runtime (modulo-by-zero in
+        # ``_bucket`` for 0, negative indexing for <0); reject it up front.
+        self.dimensions = int(self.dimensions)
+        if self.dimensions <= 0:
+            raise ValueError("HashingEmbedder.dimensions must be a positive integer")
+
     def embed(self, text: str) -> tuple[float, ...]:
         vec = [0.0] * self.dimensions
         for token, weight in _features(text):

--- a/potpie/context-engine/adapters/outbound/intelligence/local_embedder.py
+++ b/potpie/context-engine/adapters/outbound/intelligence/local_embedder.py
@@ -1,0 +1,173 @@
+"""Context-graph embedders.
+
+The Trigger Model non-negotiable: retrieval must work with **no API key and no
+external embeddings service**, on the user's machine. This is the default OSS
+embedder. It is a real local embedding model in the feature-hashing family: text
+is tokenized into words *and* character n-grams, each feature is hashed (via a
+stable digest, so embeddings are identical across processes — required for the
+JSON-persisted embedded backend) into a fixed-dimension accumulator with a signed
+contribution, then L2-normalized.
+
+Why this beats the old Jaccard stub for V1.5 recall:
+
+- It scores in continuous vector space, so near-misses rank above noise instead
+  of collapsing to 0.
+- Character n-grams catch morphological variants (``retry`` / ``retries`` /
+  ``retrying`` share trigrams) and typos — the paraphrase failure mode Jaccard
+  misses entirely.
+
+It is intentionally swappable: ``build_embedder`` reads ``CONTEXT_ENGINE_EMBEDDER``.
+The default remains the dependency-free hashing embedder; setting
+``CONTEXT_ENGINE_EMBEDDER=legacy`` (or ``sentence-transformers``) uses the same
+SentenceTransformer family legacy Potpie uses for code-graph semantic search.
+``CONTEXT_ENGINE_EMBEDDER=none`` disables embeddings and the store falls back to
+a *labeled* lexical match.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import os
+import re
+from dataclasses import dataclass
+from typing import Sequence
+
+from domain.ports.embedder import EmbedderPort
+
+_DEFAULT_DIMENSIONS = 256
+_WORD_RE = re.compile(r"[a-z0-9]+")
+_CHAR_NGRAM_MIN = 3
+_CHAR_NGRAM_MAX = 4
+
+
+@dataclass(slots=True)
+class HashingEmbedder:
+    """Deterministic feature-hashing embedder (the bundled local default)."""
+
+    dimensions: int = _DEFAULT_DIMENSIONS
+    name: str = "local-hashing-v1"
+
+    def embed(self, text: str) -> tuple[float, ...]:
+        vec = [0.0] * self.dimensions
+        for token, weight in _features(text):
+            idx, sign = _bucket(token, self.dimensions)
+            vec[idx] += sign * weight
+        return _l2_normalize(vec)
+
+    def embed_many(self, texts: Sequence[str]) -> list[tuple[float, ...]]:
+        return [self.embed(t) for t in texts]
+
+
+@dataclass(slots=True)
+class SentenceTransformerEmbedder:
+    """Legacy-compatible local embedder backed by ``sentence-transformers``."""
+
+    model_name: str = "all-MiniLM-L6-v2"
+    device: str = "cpu"
+    _model: object | None = None
+
+    @property
+    def name(self) -> str:
+        return f"sentence-transformers/{self.model_name}"
+
+    @property
+    def dimensions(self) -> int:
+        model = self._get_model()
+        dim = getattr(model, "get_sentence_embedding_dimension", lambda: None)()
+        return int(dim or 384)
+
+    def embed(self, text: str) -> tuple[float, ...]:
+        embedding = self._get_model().encode(text or "")
+        return tuple(float(x) for x in embedding.tolist())
+
+    def embed_many(self, texts: Sequence[str]) -> list[tuple[float, ...]]:
+        if not texts:
+            return []
+        embeddings = self._get_model().encode(list(texts))
+        return [tuple(float(x) for x in emb.tolist()) for emb in embeddings]
+
+    def _get_model(self):
+        if self._model is None:
+            try:
+                from sentence_transformers import SentenceTransformer
+            except Exception as exc:  # noqa: BLE001
+                raise RuntimeError(
+                    "CONTEXT_ENGINE_EMBEDDER=legacy requires sentence-transformers. "
+                    "Install the legacy Potpie dependencies or add an embeddings extra."
+                ) from exc
+            self._model = SentenceTransformer(self.model_name, device=self.device)
+        return self._model
+
+
+def _features(text: str):
+    """Yield (token, weight) features: whole words plus char n-grams.
+
+    Words carry full weight; subword n-grams carry a smaller weight so exact
+    word matches dominate but morphological variants still contribute.
+    """
+    if not text:
+        return
+    words = _WORD_RE.findall(text.lower())
+    for word in words:
+        yield (f"w:{word}", 1.0)
+        # Bound the n-gram cost on very long tokens.
+        padded = f"^{word}$"
+        for n in range(_CHAR_NGRAM_MIN, _CHAR_NGRAM_MAX + 1):
+            if len(padded) < n:
+                continue
+            for i in range(len(padded) - n + 1):
+                yield (f"c{n}:{padded[i : i + n]}", 0.45)
+
+
+def _bucket(token: str, dimensions: int) -> tuple[int, float]:
+    """Stable bucket index + sign for a feature (process-independent hash)."""
+    digest = hashlib.blake2b(token.encode("utf-8"), digest_size=8).digest()
+    value = int.from_bytes(digest, "big")
+    idx = value % dimensions
+    sign = 1.0 if (value >> 63) & 1 else -1.0
+    return idx, sign
+
+
+def _l2_normalize(vec: list[float]) -> tuple[float, ...]:
+    norm = math.sqrt(sum(x * x for x in vec))
+    if norm <= 0.0:
+        return tuple(vec)
+    return tuple(x / norm for x in vec)
+
+
+def build_embedder() -> EmbedderPort | None:
+    """Build the configured embedder (bundled local default, or None to disable).
+
+    ``CONTEXT_ENGINE_EMBEDDER``:
+      - unset / ``local`` / ``hashing`` → :class:`HashingEmbedder` (default)
+      - ``legacy`` / ``sentence-transformers`` → all-MiniLM-L6-v2 by default
+      - ``none`` / ``off`` / ``lexical`` → ``None`` (labeled lexical fallback)
+
+    ``CONTEXT_ENGINE_EMBEDDING_MODEL`` overrides the SentenceTransformer model
+    name when the legacy embedder is selected.
+    """
+    choice = (os.getenv("CONTEXT_ENGINE_EMBEDDER") or "local").strip().lower()
+    if choice in ("none", "off", "lexical", "disabled", "0", "false"):
+        return None
+    if choice in ("", "local", "hashing", "default", "on", "1", "true"):
+        return HashingEmbedder()
+    if choice in (
+        "legacy",
+        "sentence-transformers",
+        "sentence_transformers",
+        "sbert",
+        "minilm",
+        "all-minilm-l6-v2",
+    ):
+        return SentenceTransformerEmbedder(
+            model_name=(
+                os.getenv("CONTEXT_ENGINE_EMBEDDING_MODEL") or "all-MiniLM-L6-v2"
+            ).strip()
+            or "all-MiniLM-L6-v2"
+        )
+    # Unknown value: default to the bundled local embedder rather than crashing.
+    return HashingEmbedder()
+
+
+__all__ = ["HashingEmbedder", "SentenceTransformerEmbedder", "build_embedder"]

--- a/potpie/context-engine/adapters/outbound/settings_env.py
+++ b/potpie/context-engine/adapters/outbound/settings_env.py
@@ -1,6 +1,7 @@
 """Environment-backed ContextEngineSettingsPort."""
 
 import os
+from pathlib import Path
 
 from domain.ports.settings import ContextEngineSettingsPort
 
@@ -64,7 +65,14 @@ def context_engine_falkordb_lite_path() -> str:
         or os.getenv("FALKORDB_LITE_PATH")
         or ""
     ).strip()
-    return v or ".potpie/context_graph/falkordb.db"
+    if v:
+        return v
+    # Home-rooted absolute default (same resolution as the pot store): a
+    # relative default lands wherever the daemon's cwd happens to be — e.g.
+    # inside site-packages for an installed CLI, wiped on reinstall.
+    home = (os.getenv("CONTEXT_ENGINE_HOME") or "").strip()
+    base = Path(home).expanduser() if home else Path.home() / ".potpie"
+    return str(base / "context_graph" / "falkordb.db")
 
 
 class EnvContextEngineSettings(ContextEngineSettingsPort):

--- a/potpie/context-engine/application/services/record_to_semantic.py
+++ b/potpie/context-engine/application/services/record_to_semantic.py
@@ -1,0 +1,418 @@
+"""Convert a V1 ``context_record`` into a V1.5 semantic mutation (Step 8).
+
+The V1 compatibility write (``context_record``) must use the *same* path as
+``graph mutate`` — no private direct-lowering. This module is the bridge: it maps
+each ``record_type`` onto a single semantic operation (op + predicate + truth +
+subgraph) per the Step 8 table. ``DefaultGraphService.record`` calls this and
+then ``self.mutate`` so the record flows through validation, risk classification,
+and the one lowerer.
+
+Compatibility: unknown ``record_type`` values still fall back to a free-form
+claim. Known structured record types are always validated, so CLI/MCP writes
+reject the same malformed payloads as the managed HTTP path instead of silently
+downgrading into generic summary-derived claims.
+
+Because a ``context_record`` *is* a deliberate write action by the agent, the
+request is marked approved so medium-risk record types (decisions) auto-apply
+rather than dead-ending on the approval gate. Review-required *ops* (supersede /
+merge) are never produced here.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from domain.context_records import (
+    validate_record_payload,
+)
+from domain.identity import _slugify  # deterministic slug; reused for keys
+from domain.ontology import ENTITY_TYPES, record_type_spec
+from domain.ports.agent_context import RecordRequest
+from domain.semantic_mutations import (
+    MutationActor,
+    SemanticMutation,
+    SemanticMutationRequest,
+)
+
+_APPROVED_BY = "context_record"
+_PREFIX_TO_LABEL: dict[str, str] = {
+    spec.key_prefix: label for label, spec in ENTITY_TYPES.items()
+}
+
+
+def record_to_semantic_request(
+    request: RecordRequest, *, record_type: str, source_id: str
+) -> SemanticMutationRequest:
+    """Build the semantic mutation request for a durable record."""
+    details = dict(request.details)
+    validate_record_payload(
+        record_type=record_type, summary=request.summary, details=details
+    )
+
+    raw_ops = _build_operation(
+        record_type=record_type,
+        request=request,
+        details=details,
+        source_id=source_id,
+    )
+    op_payloads = raw_ops if isinstance(raw_ops, list) else [raw_ops]
+    actor = MutationActor(
+        surface=str(request.metadata.get("surface") or "agent"),
+        harness=_opt(request.metadata.get("harness")),
+        user=_opt(request.metadata.get("user")),
+    )
+    return SemanticMutationRequest(
+        pot_id=request.pot_id,
+        operations=tuple(SemanticMutation.parse(op) for op in op_payloads),
+        idempotency_key=request.idempotency_key or source_id,
+        created_by=actor,
+        allow_review_required=True,
+        approved_by=_APPROVED_BY,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-record-type mapping (Step 8 table) — details-driven with safe defaults
+# ---------------------------------------------------------------------------
+
+
+def _build_operation(
+    *,
+    record_type: str,
+    request: RecordRequest,
+    details: Mapping[str, Any],
+    source_id: str,
+) -> dict:
+    scope = dict(request.scope)
+    summary = request.summary or ""
+    evidence_payload = [{"source_ref": ref} for ref in request.source_refs]
+    target = _scope_target(scope, request.pot_id)
+    code_scope = _code_scope(scope)
+    spec = record_type_spec(record_type)
+    anchor = spec.anchor_label if spec else None
+
+    base = {
+        "evidence": evidence_payload,
+        "extra": code_scope,
+    }
+
+    if record_type in ("preference", "policy"):
+        prefix = (
+            "policy"
+            if (anchor == "Policy" or record_type == "policy")
+            else "preference"
+        )
+        prescription = _str(details.get("prescription")) or summary
+        return {
+            **base,
+            "op": "assert_claim",
+            "subgraph": "decisions",
+            "predicate": "POLICY_APPLIES_TO",
+            "truth": "preference",
+            "subject": {
+                "key": f"{prefix}:{_slug(prescription or summary or source_id)}",
+                "type": anchor or "Preference",
+                "description": summary,
+                "properties": _drop_empty(
+                    {
+                        "policy_kind": _str(details.get("policy_kind")) or "general",
+                        "prescription": prescription,
+                        "strength": _str(details.get("strength")) or "soft",
+                        "audience": _str(details.get("audience")) or "team",
+                        **code_scope,
+                        **_as_str_map(details.get("code_scope")),
+                    }
+                ),
+            },
+            "object": target,
+            "description": summary or prescription,
+        }
+
+    if record_type == "bug_pattern":
+        symptom = _str(details.get("symptom_signature")) or summary
+        return {
+            **base,
+            "op": "assert_claim",
+            "subgraph": "debugging",
+            "predicate": "REPRODUCES",
+            "truth": "agent_claim",
+            "subject": {
+                "key": f"bug_pattern:{_slug(symptom or source_id)}",
+                "type": "BugPattern",
+                "description": summary,
+                "properties": _drop_empty(
+                    {
+                        "symptom_signature": symptom,
+                        "kind": _str(details.get("kind")),
+                        **code_scope,
+                    }
+                ),
+            },
+            "object": target,
+            "description": " • ".join(p for p in (summary, symptom) if p),
+        }
+
+    if record_type == "fix":
+        symptom = _str(details.get("symptom_signature")) or summary
+        bug = {
+            "key": f"bug_pattern:{_slug(symptom or source_id)}",
+            "type": "BugPattern",
+            "description": symptom,
+        }
+        verification_status = _str(details.get("verification_status")) or "unverified"
+        main_predicate = (
+            "ATTEMPTED_FIX_FAILED"
+            if verification_status.lower()
+            in {"failed", "didnt_work", "did_not_work", "didn't_work"}
+            else "RESOLVED"
+        )
+        ops = [
+            {
+                **base,
+                "op": "assert_claim",
+                "subgraph": "debugging",
+                "predicate": "REPRODUCES",
+                "truth": "agent_claim",
+                "subject": bug,
+                "object": target,
+                "description": " • ".join(p for p in (summary, symptom) if p),
+            },
+            {
+                **base,
+                "op": "assert_claim",
+                "subgraph": "debugging",
+                "predicate": main_predicate,
+                "truth": "agent_claim",
+                "subject": {
+                    "key": f"fix:{_slug(summary or source_id)}",
+                    "type": "Fix",
+                    "description": summary,
+                    "properties": _drop_empty(
+                        {
+                            "fix_steps": _as_list(details.get("fix_steps")),
+                            "verification_status": verification_status,
+                            "root_cause": _str(details.get("root_cause")),
+                            **code_scope,
+                        }
+                    ),
+                },
+                # RESOLVED / ATTEMPTED_FIX_FAILED are Fix -> BugPattern; derive
+                # the bug from the symptom.
+                "object": bug,
+                "description": " • ".join(p for p in (summary, symptom) if p),
+            }
+        ]
+        for attempt in _as_list(details.get("attempted_failed_fixes")):
+            ops.append(
+                {
+                    **base,
+                    "op": "assert_claim",
+                    "subgraph": "debugging",
+                    "predicate": "ATTEMPTED_FIX_FAILED",
+                    "truth": "agent_claim",
+                    "subject": {
+                        "key": f"fix:{_slug(attempt)}",
+                        "type": "Fix",
+                        "description": attempt,
+                        "properties": _drop_empty(
+                            {
+                                "fix_steps": [attempt],
+                                "verification_status": "failed",
+                                "resolution_status": "failed",
+                                **code_scope,
+                            }
+                        ),
+                    },
+                    "object": bug,
+                    "description": " • ".join(
+                        p for p in (attempt, f"failed attempt for {symptom}") if p
+                    ),
+                }
+            )
+        return ops
+
+    if record_type == "verification":
+        target_ref = _str(details.get("target_ref")) or source_id
+        return {
+            **base,
+            "op": "assert_claim",
+            "subgraph": "debugging",
+            "predicate": "VERIFIED",
+            "truth": "timeline_event",
+            "subject": {
+                "key": f"activity:verification:{_slug(target_ref)}",
+                "type": "Activity",
+                "description": summary,
+                "properties": _drop_empty(
+                    {
+                        "verb_class": "verified",
+                        "outcome": _str(details.get("outcome")),
+                    }
+                ),
+            },
+            "object": {"key": _fix_ref(target_ref), "type": "Fix"},
+            "description": summary or f"verification: {details.get('outcome')}",
+        }
+
+    if record_type == "decision":
+        title = _str(details.get("title")) or summary
+        decision = {
+            "key": f"decision:{_slug(title or source_id)}",
+            "type": "Decision",
+            "description": summary,
+            "properties": _drop_empty(
+                {
+                    "title": title,
+                    "rationale": _str(details.get("rationale")),
+                    "alternatives_rejected": _as_list(
+                        details.get("alternatives_rejected")
+                    ),
+                }
+            ),
+        }
+        ops = [
+            {
+                **base,
+                "op": "assert_claim",
+                "subgraph": "decisions",
+                "predicate": "DECIDED",
+                "truth": "user_decision",
+                "subject": decision,
+                "object": target,
+                "description": " • ".join(p for p in (summary, title) if p),
+            }
+        ]
+        for affected in _as_list(details.get("affects_refs")):
+            ops.append(
+                {
+                    **base,
+                    "op": "assert_claim",
+                    "subgraph": "decisions",
+                    "predicate": "AFFECTS",
+                    "truth": "user_decision",
+                    "subject": decision,
+                    "object": _entity_ref_for_key(affected),
+                    "description": " • ".join(
+                        p for p in (summary, f"affects {affected}") if p
+                    ),
+                }
+            )
+        return ops
+
+    # Free-form record (no structured schema): a generic association from a
+    # Document/Observation anchor to the scope target. RELATED_TO accepts any
+    # endpoints, so it always lands and surfaces via raw_graph.
+    anchor_label = anchor or "Document"
+    prefix = "observation" if anchor_label == "Observation" else "document"
+    return {
+        **base,
+        "op": "assert_claim",
+        "subgraph": "admin",
+        "predicate": "RELATED_TO",
+        "truth": "agent_claim",
+        "subject": {
+            "key": f"{prefix}:{_slug(summary or source_id)}",
+            "type": anchor_label,
+            "description": summary,
+            "properties": {"record_type": record_type},
+        },
+        "object": target,
+        "description": summary,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _scope_target(scope: dict, pot_id: str) -> dict:
+    service = scope.get("service")
+    if isinstance(service, str) and service.strip():
+        return {"key": f"service:{_slug(service)}", "type": "Service"}
+    repo = scope.get("repo") or scope.get("repo_name")
+    if isinstance(repo, str) and repo.strip():
+        return {"key": f"repo:{_slug(repo)}", "type": "Repository"}
+    return {"key": f"repo:{_slug(pot_id)}", "type": "Repository"}
+
+
+def _code_scope(scope: dict) -> dict[str, str]:
+    keys = (
+        "language",
+        "framework",
+        "repo",
+        "service",
+        "file_path",
+        "audience",
+        "environment",
+    )
+    out: dict[str, str] = {}
+    for key in keys:
+        val = scope.get(key)
+        if isinstance(val, str) and val.strip():
+            out[key] = val.strip()
+    return out
+
+
+def _slug(text: str) -> str:
+    try:
+        return _slugify(text or "untitled")
+    except Exception:
+        import re
+
+        s = re.sub(r"[^a-z0-9]+", "-", (text or "untitled").lower()).strip("-")
+        return s or "untitled"
+
+
+def _fix_ref(target_ref: str) -> str:
+    ref = (target_ref or "").strip()
+    return ref if ref.startswith("fix:") else f"fix:{_slug(ref)}"
+
+
+def _entity_ref_for_key(raw: str) -> dict[str, str]:
+    value = raw.strip()
+    if ":" in value:
+        prefix = value.partition(":")[0]
+        label = _PREFIX_TO_LABEL.get(prefix)
+        if label:
+            return {"key": value, "type": label}
+    return {"key": f"observation:{_slug(value)}", "type": "Observation"}
+
+
+def _str(value: Any) -> str | None:
+    if value is None:
+        return None
+    s = str(value).strip()
+    return s or None
+
+
+def _as_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    if isinstance(value, (list, tuple)):
+        return [str(v) for v in value if str(v).strip()]
+    return []
+
+
+def _as_str_map(value: Any) -> dict[str, str]:
+    if isinstance(value, Mapping):
+        return {
+            str(k): str(v) for k, v in value.items() if isinstance(v, str) and v.strip()
+        }
+    return {}
+
+
+def _drop_empty(d: dict[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in d.items() if v not in (None, "", [], {})}
+
+
+def _opt(value) -> str | None:
+    if value is None:
+        return None
+    s = str(value).strip()
+    return s or None
+
+
+__all__ = ["record_to_semantic_request"]

--- a/potpie/context-engine/application/services/semantic_mutation_lowering.py
+++ b/potpie/context-engine/application/services/semantic_mutation_lowering.py
@@ -1,0 +1,857 @@
+"""Lower semantic mutations into the structural :class:`MutationBatch` (Step 5).
+
+The public ``SemanticMutation*`` tier never names ``EntityUpsert`` / ``EdgeUpsert``
+/ Cypher; this lowerer is the one place that bridges the agent-facing semantic
+ops to the backend-bound mutation batch, stamping the full V1.5 claim metadata
+(truth, confidence, evidence, retrieval-card description, environment, validity,
+provenance, contract/ontology version, deterministic ``claim_key``) on every
+edge so a claim is future-readable without a migration.
+
+It produces no ``EventRef`` for non-event writes — provenance flows through
+:class:`ProvenanceContext`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import replace
+from datetime import datetime, timezone
+
+from domain.graph_contract import (
+    DEFAULT_TRUTH_CLASS,
+    GRAPH_CONTRACT_VERSION,
+    ONTOLOGY_VERSION,
+    SemanticMutationOp,
+    edge_identity_key,
+    evidence_strength_for_truth,
+    make_claim_key,
+    normalize_entity_key,
+)
+from domain.graph_entity_summary import compact_entity_summary
+from domain.graph_mutations import (
+    EdgeUpsert,
+    EntityUpsert,
+    InvalidationOp,
+    ProvenanceContext,
+)
+from domain.ontology import ENTITY_TYPES, edge_spec
+from domain.reconciliation import MutationBatch
+from domain.semantic_mutations import (
+    GraphEntityRef,
+    LoweredOperation,
+    SemanticMutation,
+    SemanticMutationPlan,
+    SemanticMutationRequest,
+)
+
+# Reverse map: canonical key prefix → entity label, for inferring a label when
+# an entity ref omits ``type`` but its key carries a known prefix.
+_PREFIX_TO_LABEL: dict[str, str] = {
+    spec.key_prefix: label for label, spec in ENTITY_TYPES.items()
+}
+
+# Default truth class per event/claim op when the caller omits one.
+_EVENT_TRUTH = "timeline_event"
+
+
+def lower_semantic_request(
+    request: SemanticMutationRequest, plan: SemanticMutationPlan
+) -> SemanticMutationPlan:
+    """Lower the plan's accepted ops into ``plan.batch`` + ``plan.provenance``.
+
+    Mutates and returns ``plan``. Only ``accepted_ops`` are lowered (review /
+    deferred / rejected ops never reach the write tier). Each accepted op's
+    ``claim_keys`` are filled in so the receipt can report them.
+    """
+    batch = MutationBatch()
+    provenance = _provenance_from_request(request)
+
+    # Dedup entity upserts by key (a later op may re-reference the same entity).
+    entity_by_key: dict[str, EntityUpsert] = {}
+    new_accepted: list[LoweredOperation] = []
+
+    for outcome in plan.accepted_ops:
+        op = request.operations[outcome.op_index]
+        claim_keys = _lower_op(
+            op,
+            request=request,
+            batch=batch,
+            entity_by_key=entity_by_key,
+        )
+        new_accepted.append(
+            LoweredOperation(
+                op_index=outcome.op_index,
+                op=outcome.op,
+                risk=outcome.risk,
+                status=outcome.status,
+                subgraph=outcome.subgraph,
+                truth=outcome.truth,
+                claim_keys=tuple(claim_keys),
+            )
+        )
+
+    batch.entity_upserts = list(entity_by_key.values())
+    plan.batch = batch
+    plan.provenance = provenance
+    plan.accepted_ops = tuple(new_accepted)
+    return plan
+
+
+# ---------------------------------------------------------------------------
+# Per-op lowering
+# ---------------------------------------------------------------------------
+
+
+def _lower_op(
+    op: SemanticMutation,
+    *,
+    request: SemanticMutationRequest,
+    batch: MutationBatch,
+    entity_by_key: dict[str, EntityUpsert],
+) -> list[str]:
+    name = op.op
+    if name == SemanticMutationOp.upsert_entity.value:
+        _ensure_entity(op.subject, entity_by_key, default_label="Observation")
+        return []
+    if name in (
+        SemanticMutationOp.link_entities.value,
+        SemanticMutationOp.assert_claim.value,
+    ):
+        return _lower_claim(op, request=request, batch=batch, entity_by_key=entity_by_key)
+    if name == SemanticMutationOp.append_event.value:
+        return _lower_event(op, request=request, batch=batch, entity_by_key=entity_by_key)
+    if name in (
+        SemanticMutationOp.end_relation_validity.value,
+        SemanticMutationOp.retract_claim.value,
+    ):
+        _lower_retract(op, batch=batch)
+        return []
+    if name == SemanticMutationOp.supersede_claim.value:
+        return _lower_supersede_claim(
+            op,
+            request=request,
+            batch=batch,
+            entity_by_key=entity_by_key,
+        )
+    if name == SemanticMutationOp.merge_duplicate_entities.value:
+        return _lower_merge_duplicate_entities(
+            op,
+            request=request,
+            batch=batch,
+            entity_by_key=entity_by_key,
+        )
+    if name == SemanticMutationOp.patch_entity.value:
+        _lower_patch_entity(op, entity_by_key=entity_by_key)
+        return []
+    if name == SemanticMutationOp.transition_state.value:
+        return _lower_transition_state(
+            op,
+            request=request,
+            batch=batch,
+            entity_by_key=entity_by_key,
+        )
+    return []
+
+
+def _lower_claim(
+    op: SemanticMutation,
+    *,
+    request: SemanticMutationRequest,
+    batch: MutationBatch,
+    entity_by_key: dict[str, EntityUpsert],
+) -> list[str]:
+    subject = _ensure_entity(op.subject, entity_by_key, default_label="Observation")
+    predicate = (op.predicate or "RELATED_TO").strip().upper()
+    subgraph = op.subgraph or _subgraph_for_predicate(predicate)
+
+    # Object is an entity ref or a literal value (→ Observation entity).
+    if op.object is not None:
+        obj = _ensure_entity(op.object, entity_by_key, default_label="Observation")
+        object_key = obj.entity_key
+        object_component = object_key
+    else:
+        # assert_claim with a value object: mint an Observation carrying the
+        # value, never an authoritative fact from raw text.
+        value = "" if op.value is None else str(op.value)
+        obj_key = normalize_entity_key(f"observation:{_short(value)}")
+        _ensure_entity(
+            GraphEntityRef(
+                key=obj_key,
+                type="Observation",
+                properties={"value": value},
+                description=op.description,
+            ),
+            entity_by_key,
+            default_label="Observation",
+        )
+        object_key = obj_key
+        object_component = value or obj_key
+
+    claim_key = make_claim_key(
+        pot_id=request.pot_id,
+        subgraph=subgraph,
+        subject_key=subject.entity_key,
+        predicate=predicate,
+        object_component=object_component,
+        discriminator=_discriminator(op, request),
+        environment=op.environment,
+    )
+    props = _claim_properties(
+        op,
+        request=request,
+        subgraph=subgraph,
+        claim_key=claim_key,
+        subject_key=subject.entity_key,
+        object_key=object_key,
+        predicate=predicate,
+    )
+    batch.edge_upserts.append(
+        EdgeUpsert(
+            edge_type=predicate,
+            from_entity_key=subject.entity_key,
+            to_entity_key=object_key,
+            properties=props,
+        )
+    )
+    return [claim_key]
+
+
+def _lower_event(
+    op: SemanticMutation,
+    *,
+    request: SemanticMutationRequest,
+    batch: MutationBatch,
+    entity_by_key: dict[str, EntityUpsert],
+) -> list[str]:
+    # Anchor an Activity entity (the caller's subject, or one minted from the
+    # verb + occurred_at so re-submits are idempotent).
+    if op.subject is not None:
+        activity = _ensure_entity(op.subject, entity_by_key, default_label="Activity")
+    else:
+        anchor = f"{op.verb}:{op.occurred_at or ''}:{op.description or ''}"
+        activity = _ensure_entity(
+            GraphEntityRef(
+                key=normalize_entity_key(f"activity:{_short(anchor)}"),
+                type="Activity",
+                properties={"verb_class": op.verb, "occurred_at": op.occurred_at},
+                description=op.description,
+            ),
+            entity_by_key,
+            default_label="Activity",
+        )
+    # Stamp verb/occurred_at on the activity.
+    if op.verb:
+        activity.properties.setdefault("verb_class", op.verb)
+    if op.occurred_at:
+        activity.properties.setdefault("occurred_at", op.occurred_at)
+
+    subgraph = op.subgraph or "recent_changes"
+    claim_keys: list[str] = []
+
+    def edge(from_key: str, predicate: str, to_key: str) -> None:
+        ck = make_claim_key(
+            pot_id=request.pot_id,
+            subgraph=subgraph,
+            subject_key=from_key,
+            predicate=predicate,
+            object_component=to_key,
+            discriminator=_discriminator(op, request),
+            environment=op.environment,
+        )
+        props = _claim_properties(
+            op,
+            request=request,
+            subgraph=subgraph,
+            claim_key=ck,
+            subject_key=from_key,
+            object_key=to_key,
+            predicate=predicate,
+            truth_override=op.truth or _EVENT_TRUTH,
+        )
+        batch.edge_upserts.append(
+            EdgeUpsert(
+                edge_type=predicate,
+                from_entity_key=from_key,
+                to_entity_key=to_key,
+                properties=props,
+            )
+        )
+        claim_keys.append(ck)
+
+    if op.actor is not None:
+        actor = _ensure_entity(op.actor, entity_by_key, default_label="Person")
+        edge(actor.entity_key, "PERFORMED", activity.entity_key)
+    for target in op.targets:
+        t = _ensure_entity(target, entity_by_key, default_label="Observation")
+        edge(activity.entity_key, "TOUCHED", t.entity_key)
+    for mention in op.mentions:
+        m = _ensure_entity(mention, entity_by_key, default_label="Observation")
+        edge(activity.entity_key, "MENTIONS", m.entity_key)
+
+    return claim_keys
+
+
+def _lower_retract(op: SemanticMutation, *, batch: MutationBatch) -> None:
+    reason = op.reason or "retracted via semantic mutation"
+    valid_to = op.valid_until or _now_iso()
+    if (
+        op.op == SemanticMutationOp.end_relation_validity.value
+        and not (op.subject is not None and op.predicate and op.object is not None)
+    ):
+        return
+    if op.subject is not None and op.predicate and op.object is not None:
+        target_edge = (
+            op.predicate.strip().upper(),
+            normalize_entity_key(op.subject.key),
+            normalize_entity_key(op.object.key),
+        )
+        batch.invalidations.append(
+            InvalidationOp(
+                target_entity_key=None,
+                target_edge=target_edge,
+                reason=reason,
+                valid_to=valid_to,
+            )
+        )
+    elif op.subject is not None:
+        batch.invalidations.append(
+            InvalidationOp(
+                target_entity_key=normalize_entity_key(op.subject.key),
+                target_edge=None,
+                reason=reason,
+                valid_to=valid_to,
+            )
+        )
+
+
+def _lower_supersede_claim(
+    op: SemanticMutation,
+    *,
+    request: SemanticMutationRequest,
+    batch: MutationBatch,
+    entity_by_key: dict[str, EntityUpsert],
+) -> list[str]:
+    if op.subject is None or op.object is None or op.superseded_by is None or not op.predicate:
+        return []
+
+    predicate = op.predicate.strip().upper()
+    replacement_op = replace(
+        op,
+        op=SemanticMutationOp.assert_claim.value,
+        object=op.superseded_by,
+        superseded_by=None,
+    )
+    claim_keys = _lower_claim(
+        replacement_op,
+        request=request,
+        batch=batch,
+        entity_by_key=entity_by_key,
+    )
+    reason = op.reason or "claim superseded via semantic mutation"
+    old_subject_key = normalize_entity_key(op.subject.key)
+    old_object_key = normalize_entity_key(op.object.key)
+    replacement_key = normalize_entity_key(op.superseded_by.key)
+    for edge in batch.edge_upserts:
+        if edge.properties.get("claim_key") in claim_keys:
+            edge.properties.update(
+                {
+                    "last_semantic_op": SemanticMutationOp.supersede_claim.value,
+                    "correction_reason": reason,
+                    "supersedes_predicate": predicate,
+                    "supersedes_subject_key": old_subject_key,
+                    "supersedes_object_key": old_object_key,
+                }
+            )
+    batch.invalidations.append(
+        InvalidationOp(
+            target_entity_key=None,
+            target_edge=(predicate, old_subject_key, old_object_key),
+            reason=reason,
+            superseded_by_key=replacement_key,
+            valid_to=op.valid_until or _now_iso(),
+        )
+    )
+    return claim_keys
+
+
+def _lower_merge_duplicate_entities(
+    op: SemanticMutation,
+    *,
+    request: SemanticMutationRequest,
+    batch: MutationBatch,
+    entity_by_key: dict[str, EntityUpsert],
+) -> list[str]:
+    if op.subject is None or op.object is None:
+        return []
+
+    winning_key = normalize_entity_key(op.object.key)
+    reason = op.reason or "duplicate entity merge"
+    occurred_at = op.observed_at or _now_iso()
+    external_ids = _merge_external_ids(op)
+    losing = _ensure_entity(
+        GraphEntityRef(
+            key=op.subject.key,
+            type=op.subject.type,
+            properties={
+                "merged_into": winning_key,
+                "merge_status": "merged_duplicate",
+                "merge_reason": reason,
+                "merge_recorded_at": occurred_at,
+                "merge_external_ids": external_ids,
+                "last_semantic_op": SemanticMutationOp.merge_duplicate_entities.value,
+            },
+        ),
+        entity_by_key,
+        default_label=op.subject.type or "Observation",
+    )
+    winning = _ensure_entity(
+        op.object,
+        entity_by_key,
+        default_label=op.object.type or "Observation",
+    )
+
+    predicate = "RELATED_TO"
+    subgraph = op.subgraph or _subgraph_for_entity(op.subject)
+    description = (
+        op.description
+        or f"{losing.entity_key} was merged into {winning.entity_key}: {reason}"
+    )
+    claim_key = make_claim_key(
+        pot_id=request.pot_id,
+        subgraph=subgraph,
+        subject_key=losing.entity_key,
+        predicate=predicate,
+        object_component=winning.entity_key,
+        discriminator=_discriminator(op, request) or reason,
+        environment=op.environment,
+    )
+    props = _claim_properties(
+        op,
+        request=request,
+        subgraph=subgraph,
+        claim_key=claim_key,
+        subject_key=losing.entity_key,
+        object_key=winning.entity_key,
+        predicate=predicate,
+    )
+    props.update(
+        {
+            "fact": description,
+            "description": description,
+            "last_semantic_op": SemanticMutationOp.merge_duplicate_entities.value,
+            "merge_record": True,
+            "merge_loser_key": losing.entity_key,
+            "merge_winner_key": winning.entity_key,
+            "merge_external_ids": external_ids,
+            "correction_reason": reason,
+            "occurred_at": occurred_at,
+        }
+    )
+    batch.edge_upserts.append(
+        EdgeUpsert(
+            edge_type=predicate,
+            from_entity_key=losing.entity_key,
+            to_entity_key=winning.entity_key,
+            properties=props,
+        )
+    )
+    return [claim_key]
+
+
+def _lower_patch_entity(
+    op: SemanticMutation,
+    *,
+    entity_by_key: dict[str, EntityUpsert],
+) -> None:
+    if op.subject is None:
+        return
+    props = dict(op.patch)
+    if op.reason:
+        props["last_patch_reason"] = op.reason
+    if op.expected_entity_version:
+        props["expected_entity_version"] = op.expected_entity_version
+    props["last_semantic_op"] = SemanticMutationOp.patch_entity.value
+    _ensure_entity(
+        GraphEntityRef(
+            key=op.subject.key,
+            type=op.subject.type,
+            properties=props,
+        ),
+        entity_by_key,
+        default_label=op.subject.type or "Observation",
+    )
+
+
+def _lower_transition_state(
+    op: SemanticMutation,
+    *,
+    request: SemanticMutationRequest,
+    batch: MutationBatch,
+    entity_by_key: dict[str, EntityUpsert],
+) -> list[str]:
+    if op.subject is None or not (op.from_state and op.to_state):
+        return []
+
+    occurred_at = op.observed_at or _now_iso()
+    transition_props = {
+        "lifecycle_state": op.to_state,
+        "previous_lifecycle_state": op.from_state,
+        "state_transition_reason": op.reason or "",
+        "state_transition_at": occurred_at,
+        "last_semantic_op": SemanticMutationOp.transition_state.value,
+    }
+    if op.expected_entity_version:
+        transition_props["expected_entity_version"] = op.expected_entity_version
+    target = _ensure_entity(
+        GraphEntityRef(
+            key=op.subject.key,
+            type=op.subject.type,
+            properties=transition_props,
+        ),
+        entity_by_key,
+        default_label=op.subject.type or "Observation",
+    )
+    description = (
+        op.description
+        or f"{target.entity_key} transitioned from {op.from_state} to {op.to_state}: "
+        f"{op.reason or 'state transition'}"
+    )
+    activity_key = normalize_entity_key(
+        "activity:"
+        + _short(
+            "transition_state:"
+            f"{target.entity_key}:{op.from_state}:{op.to_state}:"
+            f"{request.idempotency_key or op.reason or description}"
+        )
+    )
+    activity = _ensure_entity(
+        GraphEntityRef(
+            key=activity_key,
+            type="Activity",
+            properties={
+                "verb_class": SemanticMutationOp.transition_state.value,
+                "occurred_at": occurred_at,
+            },
+            description=description,
+        ),
+        entity_by_key,
+        default_label="Activity",
+    )
+
+    predicate = "MENTIONS"
+    subgraph = op.subgraph or "recent_changes"
+    claim_key = make_claim_key(
+        pot_id=request.pot_id,
+        subgraph=subgraph,
+        subject_key=activity.entity_key,
+        predicate=predicate,
+        object_component=target.entity_key,
+        discriminator=_discriminator(op, request),
+        environment=op.environment,
+    )
+    props = _claim_properties(
+        op,
+        request=request,
+        subgraph=subgraph,
+        claim_key=claim_key,
+        subject_key=activity.entity_key,
+        object_key=target.entity_key,
+        predicate=predicate,
+        truth_override=_EVENT_TRUTH,
+    )
+    props.update(
+        {
+            "fact": description,
+            "description": description,
+            "verb_class": SemanticMutationOp.transition_state.value,
+            "occurred_at": occurred_at,
+            "state_transition_from": op.from_state,
+            "state_transition_to": op.to_state,
+            "state_transition_reason": op.reason or "",
+        }
+    )
+    batch.edge_upserts.append(
+        EdgeUpsert(
+            edge_type=predicate,
+            from_entity_key=activity.entity_key,
+            to_entity_key=target.entity_key,
+            properties=props,
+        )
+    )
+    return [claim_key]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ensure_entity(
+    ref: GraphEntityRef | None,
+    entity_by_key: dict[str, EntityUpsert],
+    *,
+    default_label: str,
+) -> EntityUpsert:
+    """Upsert (and dedup) an entity for a ref, returning the EntityUpsert."""
+    # Should not happen for validated ops; mint a placeholder Observation.
+    resolved: GraphEntityRef = ref or GraphEntityRef(
+        key=normalize_entity_key("observation:_missing"), type=default_label
+    )
+    key = normalize_entity_key(resolved.key)
+    label = _label_for(resolved, default_label)
+    existing = entity_by_key.get(key)
+    if existing is not None and label == default_label and existing.labels:
+        label = existing.labels[0]
+    props = dict(existing.properties) if existing else {}
+    props.update({k: v for k, v in resolved.properties.items()})
+    if resolved.name:
+        props.setdefault("name", resolved.name)
+    if resolved.summary:
+        props["summary"] = resolved.summary
+    if resolved.description:
+        # The agent-authored retrieval card on the entity.
+        props["description"] = resolved.description
+    # Derive a compact summary only from authored material — never from the
+    # entity key. A bare re-reference (key + type only) must not carry a
+    # key-derived summary downstream, where it would overwrite an authored
+    # summary already stored on the node. Writers fill key-derived fallbacks
+    # for genuinely-new nodes without clobbering existing values.
+    summary = compact_entity_summary(
+        props.get("summary"),
+        props.get("description"),
+        props.get("title"),
+        props.get("name"),
+    )
+    if summary:
+        props["summary"] = summary
+    else:
+        props.pop("summary", None)
+    upsert = EntityUpsert(entity_key=key, labels=(label,), properties=props)
+    entity_by_key[key] = upsert
+    return upsert
+
+
+def _label_for(ref: GraphEntityRef, default_label: str) -> str:
+    prefix = normalize_entity_key(ref.key).partition(":")[0]
+    prefix_label = _PREFIX_TO_LABEL.get(prefix)
+    if prefix_label:
+        return prefix_label
+    if ref.type and ref.type in ENTITY_TYPES:
+        return ref.type
+    return default_label
+
+
+def _claim_properties(
+    op: SemanticMutation,
+    *,
+    request: SemanticMutationRequest,
+    subgraph: str,
+    claim_key: str,
+    subject_key: str,
+    object_key: str,
+    predicate: str,
+    truth_override: str | None = None,
+) -> dict[str, object]:
+    truth = truth_override or op.truth or DEFAULT_TRUTH_CLASS
+    evidence_strength = evidence_strength_for_truth(truth)
+    fact = op.description or _synthesize_fact(subject_key, predicate, object_key)
+    source_refs = [ev.source_ref for ev in op.evidence]
+    evidence_dicts = [
+        {"source_ref": ev.source_ref, "authority": ev.authority, **dict(ev.metadata)}
+        for ev in op.evidence
+    ]
+    valid_at = _valid_at_for_claim(op, truth=truth)
+    props: dict[str, object] = {
+        "claim_key": claim_key,
+        "subgraph": subgraph,
+        "truth": truth,
+        "evidence_strength": evidence_strength,
+        "confidence": op.confidence if op.confidence is not None else 1.0,
+        "fact": fact,
+        "description": op.description,
+        "source_refs": source_refs,
+        "evidence": evidence_dicts,
+        "source_system": request.created_by.surface or "agent",
+        "source_ref": source_refs[0] if source_refs else (request.idempotency_key or claim_key),
+        "valid_at": valid_at,
+        "valid_from": valid_at,
+        "observed_at": op.observed_at or _now_iso(),
+        "created_by": _actor_dict(request),
+        "graph_contract_version": request.graph_contract_version or GRAPH_CONTRACT_VERSION,
+        "ontology_version": ONTOLOGY_VERSION,
+        "idempotency_key": request.idempotency_key,
+        "identity_key": list(
+            edge_identity_key(subject_key, predicate, object_key, environment=op.environment)
+        ),
+    }
+    if op.environment:
+        props["environment"] = op.environment.strip().lower()
+    if op.verb:
+        props["verb_class"] = op.verb
+    if op.occurred_at:
+        props["occurred_at"] = op.occurred_at
+    if op.valid_until:
+        props["valid_until"] = op.valid_until
+    props.update(_structured_claim_fields_for(op))
+    # Carry the scope hierarchy for the readers (R4) when the subject/object
+    # properties or op extras name a code scope.
+    code_scope = _code_scope_for(op)
+    if code_scope:
+        props["code_scope"] = code_scope
+    return props
+
+
+def _valid_at_for_claim(op: SemanticMutation, *, truth: str) -> str:
+    if op.valid_from:
+        return op.valid_from
+    if (
+        (truth == _EVENT_TRUTH or op.op == SemanticMutationOp.append_event.value)
+        and op.occurred_at
+    ):
+        return op.occurred_at
+    return _now_iso()
+
+
+def _structured_claim_fields_for(op: SemanticMutation) -> dict[str, object]:
+    """Copy use-case fields readers need from semantic op metadata.
+
+    Entity properties describe the anchor node, while claim properties describe
+    why that anchor applies to this target. Readers rank and display the claim,
+    so fields like preference prescription or fix status must ride the edge too.
+    """
+    keys = (
+        "policy_kind",
+        "prescription",
+        "strength",
+        "audience",
+        "symptom_signature",
+        "fix_steps",
+        "verification_status",
+        "resolution_status",
+        "change_kind",
+        "ticket_key",
+        "pr_number",
+    )
+    out: dict[str, object] = {}
+    sources: list[dict[str, object]] = [dict(op.extra)]
+    if op.subject is not None:
+        sources.append(dict(op.subject.properties))
+    if op.object is not None:
+        sources.append(dict(op.object.properties))
+    for src in sources:
+        for key in keys:
+            value = src.get(key)
+            if value is None:
+                continue
+            if isinstance(value, str) and not value.strip():
+                continue
+            out.setdefault(key, value)
+    return out
+
+
+def _code_scope_for(op: SemanticMutation) -> dict[str, str]:
+    """Collect scope hints (repo/service/file_path/...) from op + subject props."""
+    keys = ("language", "framework", "repo", "service", "file_path", "audience", "environment")
+    out: dict[str, str] = {}
+    sources = [dict(op.extra)]
+    if op.subject is not None:
+        sources.append(dict(op.subject.properties))
+    for src in sources:
+        for key in keys:
+            val = src.get(key)
+            if isinstance(val, str) and val.strip():
+                out.setdefault(key, val.strip())
+    if op.environment:
+        out.setdefault("environment", op.environment.strip().lower())
+    return out
+
+
+def _provenance_from_request(request: SemanticMutationRequest) -> ProvenanceContext:
+    return ProvenanceContext(
+        source_ref=request.idempotency_key,
+        created_by_agent=request.created_by.harness,
+        actor_user_id=request.created_by.user or request.approved_by,
+        actor_surface=request.created_by.surface,
+        actor_client_name=request.created_by.harness,
+    )
+
+
+def _actor_dict(request: SemanticMutationRequest) -> dict[str, str]:
+    out: dict[str, str] = {}
+    if request.created_by.surface:
+        out["surface"] = request.created_by.surface
+    if request.created_by.harness:
+        out["harness"] = request.created_by.harness
+    if request.created_by.user:
+        out["user"] = request.created_by.user
+    if request.approved_by:
+        out["approved_by"] = request.approved_by
+    return out
+
+
+def _discriminator(op: SemanticMutation, request: SemanticMutationRequest) -> str | None:
+    if op.evidence:
+        return op.evidence[0].source_ref
+    return request.idempotency_key
+
+
+def _synthesize_fact(subject_key: str, predicate: str, object_key: str) -> str:
+    return f"{subject_key} {predicate.lower().replace('_', ' ')} {object_key}"
+
+
+_MEMORY_PREDICATE_SUBGRAPH = {
+    "PROVIDES": "features",
+    "IMPLEMENTED_IN": "features",
+    "POLICY_APPLIES_TO": "decisions",
+    "REPRODUCES": "debugging",
+    "RESOLVED": "debugging",
+    "ATTEMPTED_FIX_FAILED": "debugging",
+    "VERIFIED": "debugging",
+    "DECIDED": "decisions",
+    "AFFECTS": "decisions",
+}
+_CATEGORY_SUBGRAPH = {
+    "topology": "infra_topology",
+    "ownership": "code_topology",
+    "people": "code_topology",
+    "timeline": "recent_changes",
+    "generic": "admin",
+}
+
+
+def _subgraph_for_predicate(predicate: str) -> str:
+    pred = (predicate or "").strip().upper()
+    if pred in _MEMORY_PREDICATE_SUBGRAPH:
+        return _MEMORY_PREDICATE_SUBGRAPH[pred]
+    spec = edge_spec(pred)
+    if spec is not None:
+        return _CATEGORY_SUBGRAPH.get(spec.category, "memory")
+    return "memory"
+
+
+def _subgraph_for_entity(ref: GraphEntityRef | None) -> str:
+    label = _label_for(ref, "Observation") if ref is not None else "Observation"
+    spec = ENTITY_TYPES.get(label)
+    if spec is None:
+        return "admin"
+    return _CATEGORY_SUBGRAPH.get(spec.category, "memory")
+
+
+def _merge_external_ids(op: SemanticMutation) -> dict[str, object]:
+    if op.external_ids:
+        return dict(op.external_ids)
+    raw = op.extra.get("external_ids") if isinstance(op.extra, Mapping) else None
+    return dict(raw) if isinstance(raw, Mapping) else {}
+
+
+def _short(text: str, *, length: int = 12) -> str:
+    import hashlib
+
+    return hashlib.sha256((text or "").encode("utf-8")).hexdigest()[:length]
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+__all__ = ["lower_semantic_request"]

--- a/potpie/context-engine/application/services/semantic_mutation_validator.py
+++ b/potpie/context-engine/application/services/semantic_mutation_validator.py
@@ -270,9 +270,16 @@ def _validate_entity_ref(ref, role, *, required, err, warn) -> None:
 def _validate_claim_op(op, *, err, warn) -> None:
     _validate_entity_ref(op.subject, "subject", required=True, err=err, warn=warn)
 
-    # Object is either an entity ref or a literal value.
+    # Object is either an entity ref or a literal value — never both. A value is
+    # silently ignored by the lowerer when an object is also present, so reject
+    # the ambiguity instead of accepting a misleading op.
     if op.object is None and op.value is None:
         err("missing_object", "claim op requires an 'object' entity or a 'value'")
+    elif op.object is not None and op.value is not None:
+        err(
+            "ambiguous_object",
+            "claim op accepts either an 'object' entity or a 'value', not both",
+        )
     elif op.object is not None:
         _validate_entity_ref(op.object, "object", required=False, err=err, warn=warn)
 
@@ -291,6 +298,11 @@ def _validate_claim_op(op, *, err, warn) -> None:
                 "invalid_endpoints",
                 f"{op.predicate} does not allow {s_type} -> {o_type}; allowed: {allowed}",
             )
+    # NOTE (CodeRabbit value-only endpoint suggestion, intentionally skipped):
+    # a ``value`` claim lowers to a synthetic Observation object on purpose and
+    # is exempt from endpoint-type rules (e.g. BugPattern -REPRODUCES-> value).
+    # Enforcing subject -> Observation here would reject those valid claims, so
+    # endpoint validation stays scoped to explicit ``object`` entities.
 
     # Durable writes need evidence OR an explicit low-authority truth class.
     _check_evidence_or_low_authority(op, err)
@@ -372,6 +384,19 @@ def _validate_retract_op(op, *, err, warn) -> None:
         err(
             "missing_object",
             "end_relation_validity requires an 'object' entity to target an exact relation",
+        )
+    if (
+        op.op == SemanticMutationOp.retract_claim.value
+        and op.predicate
+        and op.object is None
+    ):
+        # The lowerer has no predicate-scoped invalidation shape: subject +
+        # predicate without an object would silently fall through to whole-entity
+        # invalidation. Require an object until predicate-scoped retraction exists.
+        err(
+            "missing_object",
+            "retract_claim with a predicate requires an 'object' entity until "
+            "predicate-scoped invalidation is supported",
         )
     if op.predicate:
         _validate_predicate_and_endpoints(op, err=err)

--- a/potpie/context-engine/application/services/semantic_mutation_validator.py
+++ b/potpie/context-engine/application/services/semantic_mutation_validator.py
@@ -1,0 +1,783 @@
+"""Semantic-mutation validation + risk policy (Graph V1.5 Step 4).
+
+Reject unsafe or ungrounded semantic mutations *before* they become a
+structural :class:`~domain.reconciliation.MutationBatch`. Validation is purely a
+domain concern — it reads the ontology and the contract constants, never a
+backend — so a payload can be checked without touching a store.
+
+Two outputs per request:
+
+1. **Structured issues** — per-op ``error`` / ``warning`` findings.
+2. **Risk classification + decision** — each op gets a :class:`MutationRisk`
+   and a status (``accepted`` / ``review_required`` / ``deferred`` /
+   ``rejected``); the batch's overall ``decision`` (``apply`` /
+   ``review_required`` / ``rejected``) follows the risk policy and the caller's
+   approval flags. A batch applies atomically: if any op cannot be auto-applied
+   under the current flags, the whole batch returns ``review_required`` and
+   nothing is written.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Mapping
+
+from domain.graph_contract import (
+    DEFERRED_OPS,
+    EVIDENCE_REQUIRED_TRUTH_CLASSES,
+    REVIEW_REQUIRED_OPS,
+    MutationRisk,
+    SemanticMutationOp,
+    SourceAuthority,
+    entity_key_matches_type,
+    entity_key_prefix,
+    is_known_op,
+    is_source_authority,
+    is_supported_contract_version,
+    is_truth_class,
+    normalize_entity_key,
+)
+from domain.ontology import EDGE_TYPES, ENTITY_TYPES, edge_spec
+from domain.semantic_mutations import (
+    GraphEntityRef,
+    LoweredOperation,
+    SemanticMutation,
+    SemanticMutationPlan,
+    SemanticMutationRequest,
+    SemanticMutationValidationIssue,
+)
+
+# Ops that establish a durable typed claim (subject-predicate-object). These
+# carry the "evidence-or-low-authority" and endpoint rules.
+_CLAIM_OPS = frozenset(
+    {SemanticMutationOp.link_entities.value, SemanticMutationOp.assert_claim.value}
+)
+# Ops that end / retract validity — state changes, classified medium.
+_RETRACT_OPS = frozenset(
+    {
+        SemanticMutationOp.end_relation_validity.value,
+        SemanticMutationOp.retract_claim.value,
+    }
+)
+_PREFIX_TO_ENTITY_TYPE: dict[str, str] = {
+    spec.key_prefix: label for label, spec in ENTITY_TYPES.items()
+}
+_STATE_PATCH_FIELDS = frozenset({"lifecycle_state", "status", "state"})
+
+
+def validate_semantic_request(request: SemanticMutationRequest) -> SemanticMutationPlan:
+    """Validate + risk-classify a parsed semantic mutation request.
+
+    Returns a :class:`SemanticMutationPlan` with ``batch=None`` (lowering is a
+    separate step) carrying issues, per-op classification, the overall risk and
+    the batch decision.
+    """
+    issues: list[SemanticMutationValidationIssue] = []
+
+    if not is_supported_contract_version(request.graph_contract_version):
+        issues.append(
+            SemanticMutationValidationIssue(
+                code="unsupported_contract_version",
+                message=(
+                    f"graph_contract_version {request.graph_contract_version!r} "
+                    f"is not supported by this build"
+                ),
+            )
+        )
+    if not request.pot_id.strip():
+        issues.append(
+            SemanticMutationValidationIssue(code="missing_pot_id", message="pot_id is required")
+        )
+
+    accepted: list[LoweredOperation] = []
+    review: list[LoweredOperation] = []
+    deferred: list[LoweredOperation] = []
+
+    for index, op in enumerate(request.operations):
+        op_issues, outcome = _validate_op(op, index)
+        issues.extend(op_issues)
+        if outcome.status == "deferred":
+            deferred.append(outcome)
+        elif outcome.status == "review_required":
+            review.append(outcome)
+        elif outcome.status == "accepted":
+            accepted.append(outcome)
+        # "rejected" ops contribute their errors but no applicable op.
+
+    has_errors = any(i.is_error for i in issues)
+    overall_risk = _overall_risk(accepted, review)
+    decision = _decide(
+        has_errors=has_errors,
+        accepted=accepted,
+        review=review,
+        allow_review_required=request.allow_review_required,
+        approved_by=request.approved_by,
+    )
+
+    # If the decision is review_required because of an unapproved medium op,
+    # surface a non-blocking warning so the harness knows how to proceed.
+    if decision == "review_required" and not has_errors and not review:
+        issues.append(
+            SemanticMutationValidationIssue(
+                code="approval_required",
+                message=(
+                    "batch contains medium- or high-risk operations; re-submit with "
+                    "--allow-review-required --approved-by <user-ref> to apply"
+                ),
+                severity="warning",
+            )
+        )
+
+    return SemanticMutationPlan(
+        pot_id=request.pot_id,
+        ok=not has_errors,
+        risk=overall_risk.value,
+        decision=decision,
+        issues=tuple(issues),
+        accepted_ops=tuple(accepted),
+        review_required_ops=tuple(review),
+        deferred_ops=tuple(deferred),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-op validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_op(
+    op: SemanticMutation, index: int
+) -> tuple[list[SemanticMutationValidationIssue], LoweredOperation]:
+    issues: list[SemanticMutationValidationIssue] = []
+
+    def err(code: str, message: str) -> None:
+        issues.append(
+            SemanticMutationValidationIssue(
+                code=code, message=message, severity="error", op_index=index
+            )
+        )
+
+    def warn(code: str, message: str) -> None:
+        issues.append(
+            SemanticMutationValidationIssue(
+                code=code, message=message, severity="warning", op_index=index
+            )
+        )
+
+    name = op.op
+    subgraph = op.subgraph or _subgraph_for(op)
+
+    # 1. op known
+    if not is_known_op(name):
+        err("unknown_op", f"unknown mutation op {name!r}")
+        return issues, LoweredOperation(
+            op_index=index, op=name, risk=MutationRisk.high.value, status="rejected"
+        )
+
+    # 2. deferred ops — honest dead end, not silent
+    if name in DEFERRED_OPS:
+        err(
+            "op_deferred",
+            f"op {name!r} is deferred to V2 — model the change as a new claim "
+            f"(assert_claim) or append_event in V1.5",
+        )
+        return issues, LoweredOperation(
+            op_index=index, op=name, risk=MutationRisk.high.value, status="deferred"
+        )
+
+    # 3. truth class (default applied downstream; only validate when present)
+    if op.truth is not None and not is_truth_class(op.truth):
+        err("bad_truth_class", f"unknown truth class {op.truth!r}")
+
+    # 4. confidence range
+    if op.confidence is not None and not (0.0 <= op.confidence <= 1.0):
+        err("bad_confidence", "confidence must be between 0.0 and 1.0")
+
+    # 5. timestamps parse ISO 8601
+    for field_name, raw in (
+        ("valid_from", op.valid_from),
+        ("valid_until", op.valid_until),
+        ("observed_at", op.observed_at),
+        ("occurred_at", op.occurred_at),
+    ):
+        if raw and not _parses_iso(raw):
+            err("bad_timestamp", f"{field_name} {raw!r} is not a valid ISO 8601 timestamp")
+
+    # 6. evidence authorities (when present) must be known
+    for ev in op.evidence:
+        if ev.authority is not None and not is_source_authority(ev.authority):
+            err(
+                "bad_authority",
+                f"evidence authority {ev.authority!r} is not a known source authority "
+                f"({', '.join(sorted(a.value for a in SourceAuthority))})",
+            )
+
+    # 7. per-op structural rules
+    if name == SemanticMutationOp.upsert_entity.value:
+        _validate_entity_ref(op.subject, "subject", required=True, err=err, warn=warn)
+    elif name in _CLAIM_OPS:
+        _validate_claim_op(op, err=err, warn=warn)
+    elif name == SemanticMutationOp.append_event.value:
+        _validate_event_op(op, err=err, warn=warn)
+    elif name in _RETRACT_OPS:
+        _validate_retract_op(op, err=err, warn=warn)
+    elif name == SemanticMutationOp.patch_entity.value:
+        _validate_patch_entity_op(op, err=err, warn=warn)
+    elif name == SemanticMutationOp.transition_state.value:
+        _validate_transition_state_op(op, err=err, warn=warn)
+    elif name == SemanticMutationOp.supersede_claim.value:
+        _validate_supersede_claim_op(op, err=err, warn=warn)
+    elif name == SemanticMutationOp.merge_duplicate_entities.value:
+        _validate_merge_duplicate_entities_op(op, err=err, warn=warn)
+
+    has_errors = any(i.is_error and i.op_index == index for i in issues)
+    if has_errors:
+        return issues, LoweredOperation(
+            op_index=index, op=name, risk=_op_risk(op).value, status="rejected",
+            subgraph=subgraph, truth=op.truth,
+        )
+
+    # 8. review-required ops (always)
+    if name in REVIEW_REQUIRED_OPS:
+        return issues, LoweredOperation(
+            op_index=index, op=name, risk=MutationRisk.high.value,
+            status="review_required", subgraph=subgraph, truth=op.truth,
+        )
+
+    return issues, LoweredOperation(
+        op_index=index, op=name, risk=_op_risk(op).value, status="accepted",
+        subgraph=subgraph, truth=op.truth,
+    )
+
+
+def _validate_entity_ref(ref, role, *, required, err, warn) -> None:
+    del warn
+    if ref is None:
+        if required:
+            err("missing_entity", f"{role} entity is required for this op")
+        return
+    if ref.type is not None and ref.type not in ENTITY_TYPES:
+        err("unknown_entity_type", f"{role} type {ref.type!r} is not a known entity type")
+        return
+    if ref.type is not None and not entity_key_matches_type(ref.key, ref.type):
+        err(
+            "key_prefix_mismatch",
+            f"{role} key {ref.key!r} does not match the canonical key prefix for "
+            f"{ref.type!r}",
+        )
+
+
+def _validate_claim_op(op, *, err, warn) -> None:
+    _validate_entity_ref(op.subject, "subject", required=True, err=err, warn=warn)
+
+    # Object is either an entity ref or a literal value.
+    if op.object is None and op.value is None:
+        err("missing_object", "claim op requires an 'object' entity or a 'value'")
+    elif op.object is not None:
+        _validate_entity_ref(op.object, "object", required=False, err=err, warn=warn)
+
+    # Predicate must be a known canonical edge type.
+    if not op.predicate:
+        err("missing_predicate", "claim op requires a 'predicate'")
+    elif op.predicate not in EDGE_TYPES:
+        err("unknown_predicate", f"predicate {op.predicate!r} is not a known edge type")
+    elif op.object is not None and op.subject is not None:
+        # Endpoint rules: when both endpoint types are declared, enforce them.
+        spec = edge_spec(op.predicate)
+        s_type, o_type = op.subject.type, op.object.type
+        if spec and s_type and o_type and not spec.allows([s_type], [o_type]):
+            allowed = ", ".join(f"{a}->{b}" for a, b in spec.allowed_pairs)
+            err(
+                "invalid_endpoints",
+                f"{op.predicate} does not allow {s_type} -> {o_type}; allowed: {allowed}",
+            )
+
+    # Durable writes need evidence OR an explicit low-authority truth class.
+    _check_evidence_or_low_authority(op, err)
+
+    # Recall depends on the agent-authored description; warn (don't reject).
+    if not (op.description and op.description.strip()):
+        warn(
+            "missing_description",
+            "claim has no agent-authored description; retrieval recall depends on a "
+            "description written for search (symptoms, synonyms, scope)",
+        )
+
+
+def _validate_event_op(op, *, err, warn) -> None:
+    _validate_entity_ref(op.subject, "subject", required=False, err=err, warn=warn)
+    _validate_entity_ref(op.actor, "actor", required=False, err=err, warn=warn)
+    for index, target in enumerate(op.targets):
+        _validate_entity_ref(target, f"targets[{index}]", required=False, err=err, warn=warn)
+    for index, mention in enumerate(op.mentions):
+        _validate_entity_ref(mention, f"mentions[{index}]", required=False, err=err, warn=warn)
+
+    if op.subject is not None:
+        _validate_activity_anchor(op.subject, "subject", err=err)
+    if op.actor is not None:
+        _validate_edge_endpoints(
+            "PERFORMED",
+            op.actor,
+            op.subject,
+            from_role="actor",
+            to_role="subject",
+            from_default="Person",
+            to_default="Activity",
+            err=err,
+        )
+    for index, target in enumerate(op.targets):
+        _validate_edge_endpoints(
+            "TOUCHED",
+            op.subject,
+            target,
+            from_role="subject",
+            to_role=f"targets[{index}]",
+            from_default="Activity",
+            to_default="Observation",
+            err=err,
+        )
+    for index, mention in enumerate(op.mentions):
+        _validate_edge_endpoints(
+            "MENTIONS",
+            op.subject,
+            mention,
+            from_role="subject",
+            to_role=f"mentions[{index}]",
+            from_default="Activity",
+            to_default="Observation",
+            err=err,
+        )
+
+    if not (op.verb and op.verb.strip()):
+        err("missing_verb", "append_event requires a 'verb' (verb_class)")
+    if op.occurred_at and not _parses_iso(op.occurred_at):
+        err("bad_timestamp", f"occurred_at {op.occurred_at!r} is not valid ISO 8601")
+    # An event with no target / actor / mention is allowed (it can still anchor
+    # a timeline entry), but description aids recall.
+    if not (op.description and op.description.strip()):
+        warn(
+            "missing_description",
+            "event has no description; timeline recall improves with one",
+        )
+
+
+def _validate_retract_op(op, *, err, warn) -> None:
+    # Target identity: subject+predicate(+object) or an explicit subject key.
+    _validate_entity_ref(op.subject, "subject", required=True, err=err, warn=warn)
+    if op.object is not None:
+        _validate_entity_ref(op.object, "object", required=False, err=err, warn=warn)
+    if op.op == SemanticMutationOp.end_relation_validity.value and not op.predicate:
+        err("missing_predicate", "end_relation_validity requires a 'predicate'")
+    if op.op == SemanticMutationOp.end_relation_validity.value and op.object is None:
+        err(
+            "missing_object",
+            "end_relation_validity requires an 'object' entity to target an exact relation",
+        )
+    if op.predicate:
+        _validate_predicate_and_endpoints(op, err=err)
+    if not (op.reason and op.reason.strip()):
+        warn("missing_reason", "retraction has no 'reason'; recording one aids audit")
+
+
+def _validate_supersede_claim_op(op, *, err, warn) -> None:
+    _validate_relation_target_op(
+        op,
+        op_name=SemanticMutationOp.supersede_claim.value,
+        require_object=True,
+        err=err,
+        warn=warn,
+    )
+    _validate_entity_ref(
+        op.superseded_by, "superseded_by", required=True, err=err, warn=warn
+    )
+    if op.predicate and op.subject is not None and op.superseded_by is not None:
+        _validate_edge_endpoints(
+            op.predicate,
+            op.subject,
+            op.superseded_by,
+            from_role="subject",
+            to_role="superseded_by",
+            from_default=None,
+            to_default=None,
+            err=err,
+        )
+    if not (op.reason and op.reason.strip()):
+        err("missing_reason", "supersede_claim requires a reason for audit history")
+    _check_evidence_or_low_authority(op, err)
+    if not (op.description and op.description.strip()):
+        warn(
+            "missing_description",
+            "supersede_claim writes a replacement claim; retrieval recall improves with a description",
+        )
+
+
+def _validate_merge_duplicate_entities_op(op, *, err, warn) -> None:
+    _validate_entity_ref(op.subject, "subject", required=True, err=err, warn=warn)
+    _validate_entity_ref(op.object, "object", required=True, err=err, warn=warn)
+    if op.subject is not None and op.object is not None:
+        if normalize_entity_key(op.subject.key) == normalize_entity_key(op.object.key):
+            err("self_merge", "merge_duplicate_entities requires two distinct entity keys")
+        subject_type = _effective_entity_type(op.subject, None)
+        object_type = _effective_entity_type(op.object, None)
+        if subject_type and object_type and subject_type != object_type:
+            err(
+                "merge_type_mismatch",
+                "merge_duplicate_entities requires subject and object to have the same entity type",
+            )
+    if not _merge_external_ids(op):
+        err(
+            "missing_external_ids",
+            "merge_duplicate_entities requires external_ids or extra.external_ids for audit",
+        )
+    if not (op.reason and op.reason.strip()):
+        err("missing_reason", "merge_duplicate_entities requires a reason for audit history")
+    if not (op.description and op.description.strip()):
+        warn(
+            "missing_description",
+            "merge_duplicate_entities writes a merge record; retrieval recall improves with a description",
+        )
+
+
+def _validate_patch_entity_op(op, *, err, warn) -> None:
+    _validate_entity_ref(op.subject, "subject", required=True, err=err, warn=warn)
+    entity_type = _effective_entity_type(op.subject, None)
+    if entity_type not in ENTITY_TYPES:
+        err("missing_entity_type", "patch_entity requires a known subject entity type")
+        return
+
+    if not op.patch:
+        err("missing_patch", "patch_entity requires a non-empty 'patch' object")
+        return
+
+    allowed = ENTITY_TYPES[entity_type].patchable_properties
+    for field, value in op.patch.items():
+        if field not in allowed:
+            err(
+                "patch_field_not_allowed",
+                f"{entity_type} does not allow patching field {field!r}; "
+                f"allowed: {', '.join(sorted(allowed))}",
+            )
+            continue
+        if field in _STATE_PATCH_FIELDS:
+            err(
+                "state_patch_not_allowed",
+                "state fields must use transition_state so lifecycle history is preserved",
+            )
+        if field == "description" and not _retrieval_description_strong(value):
+            err(
+                "weak_description",
+                "patch_entity description must be retrieval-grade and cannot be a weak overwrite",
+            )
+
+    if not op.expected_entity_version:
+        warn(
+            "missing_expected_entity_version",
+            "patch_entity has no expected_entity_version; commit still checks subgraph versions",
+        )
+
+
+def _validate_transition_state_op(op, *, err, warn) -> None:
+    _validate_entity_ref(op.subject, "subject", required=True, err=err, warn=warn)
+    entity_type = _effective_entity_type(op.subject, None)
+    if entity_type not in ENTITY_TYPES:
+        err("missing_entity_type", "transition_state requires a known subject entity type")
+        return
+
+    spec = ENTITY_TYPES[entity_type]
+    if not spec.lifecycle_states:
+        err(
+            "lifecycle_not_declared",
+            f"{entity_type} does not declare lifecycle states",
+        )
+        return
+
+    if not op.from_state:
+        err("missing_from_state", "transition_state requires 'from_state'")
+    elif op.from_state not in spec.lifecycle_states:
+        err(
+            "invalid_from_state",
+            f"{entity_type} state {op.from_state!r} is not declared; "
+            f"allowed: {', '.join(sorted(spec.lifecycle_states))}",
+        )
+
+    if not op.to_state:
+        err("missing_to_state", "transition_state requires 'to_state'")
+    elif op.to_state not in spec.lifecycle_states:
+        err(
+            "invalid_to_state",
+            f"{entity_type} state {op.to_state!r} is not declared; "
+            f"allowed: {', '.join(sorted(spec.lifecycle_states))}",
+        )
+
+    if op.from_state and op.to_state:
+        allowed_targets = spec.lifecycle_transitions.get(op.from_state, frozenset())
+        if op.from_state == op.to_state or op.to_state not in allowed_targets:
+            allowed = ", ".join(sorted(allowed_targets)) or "(none)"
+            err(
+                "invalid_state_transition",
+                f"{entity_type} cannot transition {op.from_state!r} -> "
+                f"{op.to_state!r}; allowed from {op.from_state!r}: {allowed}",
+            )
+
+    if not (op.reason and op.reason.strip()):
+        err("missing_reason", "transition_state requires a reason for audit history")
+    if not op.expected_entity_version:
+        warn(
+            "missing_expected_entity_version",
+            "transition_state has no expected_entity_version; commit still checks subgraph versions",
+        )
+
+
+def _validate_relation_target_op(
+    op,
+    *,
+    op_name: str,
+    require_object: bool,
+    err,
+    warn,
+) -> None:
+    _validate_entity_ref(op.subject, "subject", required=True, err=err, warn=warn)
+    if require_object:
+        _validate_entity_ref(op.object, "object", required=True, err=err, warn=warn)
+    elif op.object is not None:
+        _validate_entity_ref(op.object, "object", required=False, err=err, warn=warn)
+    if not op.predicate:
+        err("missing_predicate", f"{op_name} requires a 'predicate'")
+    else:
+        _validate_predicate_and_endpoints(op, err=err)
+
+
+def _validate_predicate_and_endpoints(op, *, err) -> None:
+    predicate = op.predicate
+    if not predicate:
+        return
+    if predicate not in EDGE_TYPES:
+        err("unknown_predicate", f"predicate {predicate!r} is not a known edge type")
+        return
+    if op.subject is not None and op.object is not None:
+        _validate_edge_endpoints(
+            predicate,
+            op.subject,
+            op.object,
+            from_role="subject",
+            to_role="object",
+            from_default=None,
+            to_default=None,
+            err=err,
+        )
+
+
+def _validate_activity_anchor(ref: GraphEntityRef, role: str, *, err) -> None:
+    spec = edge_spec("MENTIONS")
+    ref_type = _effective_entity_type(ref, "Activity")
+    if spec and ref_type and not spec.allows([ref_type], ["Observation"]):
+        err(
+            "invalid_endpoints",
+            f"append_event {role} must be Activity-like; got {ref_type}",
+        )
+
+
+def _validate_edge_endpoints(
+    predicate: str,
+    from_ref: GraphEntityRef | None,
+    to_ref: GraphEntityRef | None,
+    *,
+    from_role: str,
+    to_role: str,
+    from_default: str | None,
+    to_default: str | None,
+    err,
+) -> None:
+    spec = edge_spec(predicate)
+    from_type = _effective_entity_type(from_ref, from_default)
+    to_type = _effective_entity_type(to_ref, to_default)
+    if not (spec and from_type and to_type):
+        return
+    if spec.allows([from_type], [to_type]):
+        return
+    allowed = ", ".join(f"{a}->{b}" for a, b in spec.allowed_pairs)
+    err(
+        "invalid_endpoints",
+        f"{predicate} does not allow {from_role} {from_type} -> "
+        f"{to_role} {to_type}; allowed: {allowed}",
+    )
+
+
+def _effective_entity_type(ref: GraphEntityRef | None, default: str | None) -> str | None:
+    if ref is None:
+        return default
+    if ref.type in ENTITY_TYPES:
+        return ref.type
+    prefix = entity_key_prefix(ref.key)
+    if prefix is None:
+        return default
+    return _PREFIX_TO_ENTITY_TYPE.get(prefix, default)
+
+
+def _check_evidence_or_low_authority(op, err) -> None:
+    truth = op.truth or ""
+    # Only fact-asserting truth classes (authoritative_fact / source_observation)
+    # must be grounded in evidence. Subjective/attributed classes (preference,
+    # user_decision, timeline_event, agent_claim, …) carry their own authority.
+    if truth not in EVIDENCE_REQUIRED_TRUTH_CLASSES:
+        return
+    if not op.evidence:
+        err(
+            "missing_evidence",
+            f"a {truth!r} claim asserts an objective fact and must carry evidence; "
+            f"use a low-authority truth class (agent_claim) for an ungrounded claim",
+        )
+
+
+def _retrieval_description_strong(value) -> bool:
+    if not isinstance(value, str):
+        return False
+    text = " ".join(value.strip().split())
+    if len(text) < 40:
+        return False
+    return len([token for token in text.split(" ") if token]) >= 6
+
+
+# ---------------------------------------------------------------------------
+# Risk policy
+# ---------------------------------------------------------------------------
+
+
+def _op_risk(op: SemanticMutation) -> MutationRisk:
+    name = op.op
+    if name in REVIEW_REQUIRED_OPS:
+        return MutationRisk.high
+    if name in (
+        SemanticMutationOp.supersede_claim.value,
+        SemanticMutationOp.merge_duplicate_entities.value,
+    ):
+        return MutationRisk.high
+    if name in _RETRACT_OPS:
+        return MutationRisk.medium
+    if name in (
+        SemanticMutationOp.patch_entity.value,
+        SemanticMutationOp.transition_state.value,
+    ):
+        return MutationRisk.medium
+    if name in _CLAIM_OPS:
+        if op.truth == "user_decision":
+            return MutationRisk.medium
+        return MutationRisk.low
+    if name in (
+        SemanticMutationOp.append_event.value,
+        SemanticMutationOp.upsert_entity.value,
+    ):
+        return MutationRisk.low
+    return MutationRisk.high
+
+
+def _overall_risk(
+    accepted: list[LoweredOperation], review: list[LoweredOperation]
+) -> MutationRisk:
+    order = {MutationRisk.low.value: 0, MutationRisk.medium.value: 1, MutationRisk.high.value: 2}
+    worst = MutationRisk.low
+    for outcome in (*accepted, *review):
+        if order[outcome.risk] > order[worst.value]:
+            worst = MutationRisk(outcome.risk)
+    return worst
+
+
+def _decide(
+    *,
+    has_errors: bool,
+    accepted: list[LoweredOperation],
+    review: list[LoweredOperation],
+    allow_review_required: bool,
+    approved_by: str | None,
+) -> str:
+    if has_errors:
+        return "rejected"
+    if review:
+        return "review_required"
+    if not accepted:
+        # Nothing applicable and no errors (e.g. an empty-after-filter batch).
+        return "rejected"
+    # Any medium/high-risk op requires explicit approval; otherwise auto-apply.
+    needs_approval = any(
+        o.risk in {MutationRisk.medium.value, MutationRisk.high.value}
+        for o in accepted
+    )
+    if needs_approval and not (allow_review_required and approved_by):
+        return "review_required"
+    return "apply"
+
+
+def _subgraph_for(op: SemanticMutation) -> str:
+    """Best-effort subgraph for an op when not explicitly provided."""
+    if op.predicate:
+        return subgraph_for_predicate(op.predicate)
+    if op.op == SemanticMutationOp.append_event.value:
+        return "recent_changes"
+    if op.op in (
+        SemanticMutationOp.patch_entity.value,
+        SemanticMutationOp.transition_state.value,
+        SemanticMutationOp.merge_duplicate_entities.value,
+    ):
+        entity_type = _effective_entity_type(op.subject, None)
+        if entity_type in _ENTITY_TYPE_SUBGRAPH:
+            return _ENTITY_TYPE_SUBGRAPH[entity_type]
+        if entity_type in ENTITY_TYPES:
+            return _CATEGORY_SUBGRAPH.get(ENTITY_TYPES[entity_type].category, "memory")
+    return "memory"
+
+
+def _merge_external_ids(op: SemanticMutation) -> Mapping[str, object]:
+    if op.external_ids:
+        return op.external_ids
+    raw = op.extra.get("external_ids") if isinstance(op.extra, Mapping) else None
+    return raw if isinstance(raw, Mapping) else {}
+
+
+# Predicate → subgraph (the named slice a claim belongs to).
+_MEMORY_PREDICATE_SUBGRAPH = {
+    "PROVIDES": "features",
+    "IMPLEMENTED_IN": "features",
+    "POLICY_APPLIES_TO": "decisions",
+    "REPRODUCES": "debugging",
+    "RESOLVED": "debugging",
+    "ATTEMPTED_FIX_FAILED": "debugging",
+    "VERIFIED": "debugging",
+    "DECIDED": "decisions",
+    "AFFECTS": "decisions",
+}
+_CATEGORY_SUBGRAPH = {
+    "topology": "infra_topology",
+    "ownership": "code_topology",
+    "people": "code_topology",
+    "timeline": "recent_changes",
+    "generic": "admin",
+}
+_ENTITY_TYPE_SUBGRAPH = {
+    "Preference": "decisions",
+    "Policy": "decisions",
+    "Decision": "decisions",
+    "BugPattern": "debugging",
+    "Fix": "debugging",
+    "Activity": "recent_changes",
+}
+
+
+def subgraph_for_predicate(predicate: str) -> str:
+    pred = (predicate or "").strip().upper()
+    if pred in _MEMORY_PREDICATE_SUBGRAPH:
+        return _MEMORY_PREDICATE_SUBGRAPH[pred]
+    spec = edge_spec(pred)
+    if spec is not None:
+        return _CATEGORY_SUBGRAPH.get(spec.category, "memory")
+    return "memory"
+
+
+def _parses_iso(value: str) -> bool:
+    try:
+        datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        return True
+    except (ValueError, AttributeError):
+        return False
+
+
+__all__ = ["subgraph_for_predicate", "validate_semantic_request"]

--- a/potpie/context-engine/domain/context_records.py
+++ b/potpie/context-engine/domain/context_records.py
@@ -16,7 +16,7 @@ downstream consumers can read it without re-parsing free text.
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 from typing import Any, Iterable, Mapping
 
 
@@ -144,9 +144,30 @@ _RECORD_TYPE_TO_BUILDER: dict[str, str] = {
     "verification": "_build_verification",
 }
 
+_RECORD_TYPE_TO_CLASS: dict[str, type[Any]] = {
+    "fix": FixRecord,
+    "bug_pattern": BugPatternRecord,
+    "preference": PreferenceRecord,
+    "policy": PreferenceRecord,
+    "decision": DecisionRecord,
+    "verification": VerificationRecord,
+}
+
 
 def has_structured_schema(record_type: str) -> bool:
     return record_type in _RECORD_TYPE_TO_BUILDER
+
+
+def structured_detail_keys(record_type: str) -> frozenset[str]:
+    record_cls = _RECORD_TYPE_TO_CLASS.get(record_type)
+    if record_cls is None:
+        return frozenset()
+    return frozenset(f.name for f in fields(record_cls) if f.name != "summary")
+
+
+def has_structured_details(record_type: str, details: Mapping[str, Any]) -> bool:
+    keys = structured_detail_keys(record_type)
+    return bool(keys and any(key in keys for key in details))
 
 
 def validate_record_payload(
@@ -382,6 +403,8 @@ __all__ = [
     "VERIFICATION_OUTCOMES",
     "VerificationRecord",
     "has_structured_schema",
+    "has_structured_details",
     "record_to_dict",
+    "structured_detail_keys",
     "validate_record_payload",
 ]

--- a/potpie/context-engine/domain/graph_history.py
+++ b/potpie/context-engine/domain/graph_history.py
@@ -1,0 +1,131 @@
+"""Graph V2 history DTOs.
+
+History is a read-only workbench view over mutation plans and committed claim
+metadata. It deliberately reuses the plan store and ``ClaimQueryPort`` instead
+of introducing a second mutation ledger in the first V2 cut.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Mapping
+
+from domain.graph_workbench import GRAPH_WORKBENCH_CONTRACT_VERSION
+from domain.graph_workbench import GRAPH_WORKBENCH_ONTOLOGY_VERSION
+
+
+@dataclass(frozen=True, slots=True)
+class GraphHistoryRequest:
+    pot_id: str
+    entity_key: str | None = None
+    claim_key: str | None = None
+    subgraph: str | None = None
+    plan_id: str | None = None
+    mutation_id: str | None = None
+    since: datetime | None = None
+    until: datetime | None = None
+    limit: int = 50
+
+    def filters(self) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        for key, value in (
+            ("entity", self.entity_key),
+            ("claim", self.claim_key),
+            ("subgraph", self.subgraph),
+            ("plan", self.plan_id),
+            ("mutation", self.mutation_id),
+        ):
+            if value:
+                out[key] = value
+        if self.since:
+            out["since"] = self.since.isoformat()
+        if self.until:
+            out["until"] = self.until.isoformat()
+        out["limit"] = self.limit
+        return out
+
+
+@dataclass(frozen=True, slots=True)
+class GraphHistoryEntry:
+    kind: str
+    id: str
+    status: str | None = None
+    occurred_at: datetime | None = None
+    plan_id: str | None = None
+    mutation_id: str | None = None
+    claim_key: str | None = None
+    entity_keys: tuple[str, ...] = ()
+    subgraph: str | None = None
+    truth: str | None = None
+    source_refs: tuple[str, ...] = ()
+    evidence: tuple[Mapping[str, Any], ...] = ()
+    summary: str | None = None
+    detail: str | None = None
+    payload: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "kind": self.kind,
+            "id": self.id,
+            "entity_keys": list(self.entity_keys),
+            "source_refs": list(self.source_refs),
+            "evidence": [dict(item) for item in self.evidence],
+            "payload": dict(self.payload),
+        }
+        values = (
+            ("status", self.status),
+            ("occurred_at", self.occurred_at.isoformat() if self.occurred_at else None),
+            ("plan_id", self.plan_id),
+            ("mutation_id", self.mutation_id),
+            ("claim_key", self.claim_key),
+            ("subgraph", self.subgraph),
+            ("truth", self.truth),
+            ("summary", self.summary),
+            ("detail", self.detail),
+        )
+        for key, value in values:
+            if value is not None:
+                out[key] = value
+        return out
+
+
+@dataclass(frozen=True, slots=True)
+class GraphHistoryResult:
+    ok: bool
+    pot_id: str
+    filters: Mapping[str, Any]
+    entries: tuple[GraphHistoryEntry, ...] = ()
+    warnings: tuple[str, ...] = ()
+    unsupported: tuple[Mapping[str, Any], ...] = ()
+    detail: str | None = None
+    recommended_next_action: str | None = None
+    subgraph_versions: Mapping[str, int] = field(default_factory=dict)
+    graph_contract_version: str = GRAPH_WORKBENCH_CONTRACT_VERSION
+    ontology_version: str = GRAPH_WORKBENCH_ONTOLOGY_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "ok": self.ok,
+            "pot_id": self.pot_id,
+            "filters": dict(self.filters),
+            "entries": [entry.to_dict() for entry in self.entries],
+            "entry_count": len(self.entries),
+            "warnings": list(self.warnings),
+            "unsupported": [dict(item) for item in self.unsupported],
+            "subgraph_versions": dict(self.subgraph_versions),
+            "graph_contract_version": self.graph_contract_version,
+            "ontology_version": self.ontology_version,
+        }
+        if self.detail:
+            out["detail"] = self.detail
+        if self.recommended_next_action:
+            out["recommended_next_action"] = self.recommended_next_action
+        return out
+
+
+__all__ = [
+    "GraphHistoryEntry",
+    "GraphHistoryRequest",
+    "GraphHistoryResult",
+]

--- a/potpie/context-engine/domain/graph_inbox.py
+++ b/potpie/context-engine/domain/graph_inbox.py
@@ -1,0 +1,191 @@
+"""Graph V2 inbox DTOs.
+
+Inbox items are pending graph work. They intentionally do not become graph
+facts until a harness processes them through read/search, propose, and commit.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import StrEnum
+from typing import Any, Mapping
+
+from domain.graph_workbench import GRAPH_WORKBENCH_CONTRACT_VERSION
+from domain.graph_workbench import GRAPH_WORKBENCH_ONTOLOGY_VERSION
+
+
+class GraphInboxStatus(StrEnum):
+    pending = "pending"
+    claimed = "claimed"
+    applied = "applied"
+    rejected = "rejected"
+    closed = "closed"
+
+
+TERMINAL_INBOX_STATUSES: frozenset[str] = frozenset(
+    {
+        GraphInboxStatus.applied.value,
+        GraphInboxStatus.rejected.value,
+        GraphInboxStatus.closed.value,
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class GraphInboxItem:
+    item_id: str
+    pot_id: str
+    status: str
+    summary: str
+    details: str | None = None
+    evidence: tuple[str, ...] = ()
+    source_refs: tuple[str, ...] = ()
+    suspected_subgraphs: tuple[str, ...] = ()
+    created_by: Mapping[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    claimed_by: str | None = None
+    claimed_at: datetime | None = None
+    closed_by: str | None = None
+    closed_at: datetime | None = None
+    linked_plan_id: str | None = None
+    linked_mutation_id: str | None = None
+    rejection_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "item_id": self.item_id,
+            "inbox_id": self.item_id,
+            "pot_id": self.pot_id,
+            "status": self.status,
+            "summary": self.summary,
+            "evidence": list(self.evidence),
+            "source_refs": list(self.source_refs),
+            "suspected_subgraphs": list(self.suspected_subgraphs),
+            "suggested_subgraphs": list(self.suspected_subgraphs),
+            "created_by": _json_safe_mapping(self.created_by),
+            "created_at": self.created_at.isoformat(),
+            "claimed_by": self.claimed_by,
+            "claimed_at": self.claimed_at.isoformat() if self.claimed_at else None,
+            "closed_by": self.closed_by,
+            "closed_at": self.closed_at.isoformat() if self.closed_at else None,
+            "linked_plan_id": self.linked_plan_id,
+            "linked_mutation_id": self.linked_mutation_id,
+            "rejection_reason": self.rejection_reason,
+        }
+        if self.details:
+            out["details"] = self.details
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "GraphInboxItem":
+        item_id = str(raw.get("item_id") or raw.get("inbox_id") or "")
+        return cls(
+            item_id=item_id,
+            pot_id=str(raw.get("pot_id") or ""),
+            status=str(raw.get("status") or GraphInboxStatus.pending.value),
+            summary=str(raw.get("summary") or ""),
+            details=str(raw.get("details") or "") or None,
+            evidence=_string_tuple(raw.get("evidence")),
+            source_refs=_string_tuple(raw.get("source_refs")),
+            suspected_subgraphs=_string_tuple(
+                raw.get("suspected_subgraphs") or raw.get("suggested_subgraphs")
+            ),
+            created_by=_mapping(raw.get("created_by")),
+            created_at=_parse_datetime(raw.get("created_at"))
+            or datetime.now(timezone.utc),
+            claimed_by=str(raw.get("claimed_by") or "") or None,
+            claimed_at=_parse_datetime(raw.get("claimed_at")),
+            closed_by=str(raw.get("closed_by") or "") or None,
+            closed_at=_parse_datetime(raw.get("closed_at")),
+            linked_plan_id=str(raw.get("linked_plan_id") or "") or None,
+            linked_mutation_id=str(raw.get("linked_mutation_id") or "") or None,
+            rejection_reason=str(raw.get("rejection_reason") or "") or None,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class GraphInboxResult:
+    ok: bool
+    pot_id: str
+    action: str
+    item: GraphInboxItem | None = None
+    items: tuple[GraphInboxItem, ...] = ()
+    filters: Mapping[str, Any] = field(default_factory=dict)
+    warnings: tuple[str, ...] = ()
+    detail: str | None = None
+    recommended_next_action: str | None = None
+    graph_contract_version: str = GRAPH_WORKBENCH_CONTRACT_VERSION
+    ontology_version: str = GRAPH_WORKBENCH_ONTOLOGY_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "ok": self.ok,
+            "pot_id": self.pot_id,
+            "action": self.action,
+            "filters": dict(self.filters),
+            "items": [item.to_dict() for item in self.items],
+            "item_count": len(self.items),
+            "warnings": list(self.warnings),
+            "graph_contract_version": self.graph_contract_version,
+            "ontology_version": self.ontology_version,
+        }
+        if self.item is not None:
+            out["item"] = self.item.to_dict()
+        if self.detail:
+            out["detail"] = self.detail
+        if self.recommended_next_action:
+            out["recommended_next_action"] = self.recommended_next_action
+        return out
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,) if value else ()
+    if isinstance(value, (list, tuple)):
+        return tuple(str(item) for item in value if item)
+    return (str(value),)
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    return {}
+
+
+def _json_safe_mapping(value: Mapping[str, Any]) -> dict[str, Any]:
+    return {str(key): _json_safe(item) for key, item in value.items()}
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [_json_safe(item) for item in value]
+    return value
+
+
+__all__ = [
+    "GraphInboxItem",
+    "GraphInboxResult",
+    "GraphInboxStatus",
+    "TERMINAL_INBOX_STATUSES",
+]

--- a/potpie/context-engine/domain/graph_plans.py
+++ b/potpie/context-engine/domain/graph_plans.py
@@ -214,6 +214,9 @@ class GraphMutationPlanRecord:
             ),
             current_subgraph_versions=_int_mapping(
                 raw.get("current_subgraph_versions")
+                # ``to_dict`` also emits the ``subgraph_versions`` alias; honor it
+                # so alias-only persisted payloads don't deserialize to empty.
+                or raw.get("subgraph_versions")
             ),
             diff=GraphMutationDiff.from_dict(raw.get("diff")),
             warnings=tuple(str(w) for w in raw.get("warnings") or ()),

--- a/potpie/context-engine/domain/graph_plans.py
+++ b/potpie/context-engine/domain/graph_plans.py
@@ -1,0 +1,647 @@
+"""Graph V2 mutation-plan DTOs and serializers.
+
+The plan store persists a server-created, validated mutation plan so
+``graph commit`` can apply exactly that lowered batch by id. The agent never
+resends the mutation payload at commit time.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import StrEnum
+from typing import Any, Mapping
+
+from domain.context_events import EventRef
+from domain.graph_contract import GRAPH_CONTRACT_VERSION, ONTOLOGY_VERSION
+from domain.graph_mutations import (
+    EdgeDelete,
+    EdgeUpsert,
+    EntityUpsert,
+    InvalidationOp,
+    ProvenanceContext,
+)
+from domain.llm_reconciliation import EvidenceRef
+from domain.reconciliation import MutationBatch
+
+
+class GraphMutationPlanStatus(StrEnum):
+    validated = "validated"
+    invalid = "invalid"
+    conflict = "conflict"
+    review_required = "review_required"
+    approved = "approved"
+    committed = "committed"
+    expired = "expired"
+    abandoned = "abandoned"
+    error = "error"
+
+
+TERMINAL_PLAN_STATUSES: frozenset[str] = frozenset(
+    {
+        GraphMutationPlanStatus.invalid.value,
+        GraphMutationPlanStatus.conflict.value,
+        GraphMutationPlanStatus.committed.value,
+        GraphMutationPlanStatus.expired.value,
+        GraphMutationPlanStatus.abandoned.value,
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class GraphMutationDiff:
+    entity_upserts: int = 0
+    edge_upserts: int = 0
+    edge_deletes: int = 0
+    invalidations: int = 0
+    claim_keys: tuple[str, ...] = ()
+
+    @classmethod
+    def from_batch(
+        cls, batch: MutationBatch | None, *, claim_keys: tuple[str, ...] = ()
+    ) -> "GraphMutationDiff":
+        if batch is None:
+            return cls(claim_keys=claim_keys)
+        return cls(
+            entity_upserts=len(batch.entity_upserts),
+            edge_upserts=len(batch.edge_upserts),
+            edge_deletes=len(batch.edge_deletes),
+            invalidations=len(batch.invalidations),
+            claim_keys=claim_keys,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "entity_upserts": self.entity_upserts,
+            "edge_upserts": self.edge_upserts,
+            "edge_deletes": self.edge_deletes,
+            "invalidations": self.invalidations,
+            "claims_asserted": len(self.claim_keys),
+            "claims_retracted": self.invalidations,
+            "claim_keys": list(self.claim_keys),
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any] | None) -> "GraphMutationDiff":
+        data = raw or {}
+        return cls(
+            entity_upserts=_int(data.get("entity_upserts")),
+            edge_upserts=_int(data.get("edge_upserts")),
+            edge_deletes=_int(data.get("edge_deletes")),
+            invalidations=_int(data.get("invalidations")),
+            claim_keys=tuple(str(k) for k in data.get("claim_keys") or ()),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class GraphMutationApproval:
+    approved_by: str
+    approved_at: datetime
+    reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "approved_by": self.approved_by,
+            "approved_at": self.approved_at.isoformat(),
+        }
+        if self.reason:
+            out["reason"] = self.reason
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any] | None) -> "GraphMutationApproval | None":
+        if not raw:
+            return None
+        approved_by = str(raw.get("approved_by") or "").strip()
+        approved_at = _parse_datetime(raw.get("approved_at"))
+        if not approved_by or approved_at is None:
+            return None
+        reason = raw.get("reason")
+        return cls(
+            approved_by=approved_by,
+            approved_at=approved_at,
+            reason=str(reason) if reason else None,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class GraphMutationPlanRecord:
+    plan_id: str
+    pot_id: str
+    status: str
+    risk: str
+    created_at: datetime
+    expires_at: datetime
+    original_payload: Mapping[str, Any] = field(default_factory=dict)
+    validation_issues: tuple[Mapping[str, Any], ...] = ()
+    accepted_ops: tuple[Mapping[str, Any], ...] = ()
+    review_required_ops: tuple[Mapping[str, Any], ...] = ()
+    rejected_ops: tuple[Mapping[str, Any], ...] = ()
+    lowered_batch: MutationBatch | None = None
+    provenance: ProvenanceContext | None = None
+    expected_subgraph_versions: Mapping[str, int] = field(default_factory=dict)
+    current_subgraph_versions: Mapping[str, int] = field(default_factory=dict)
+    diff: GraphMutationDiff = field(default_factory=GraphMutationDiff)
+    warnings: tuple[str, ...] = ()
+    approval: GraphMutationApproval | None = None
+    mutation_id: str | None = None
+    committed_at: datetime | None = None
+    final_subgraph_versions: Mapping[str, int] = field(default_factory=dict)
+    detail: str | None = None
+    graph_contract_version: str = GRAPH_CONTRACT_VERSION
+    ontology_version: str = ONTOLOGY_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "plan_id": self.plan_id,
+            "pot_id": self.pot_id,
+            "status": self.status,
+            "risk": self.risk,
+            "created_at": self.created_at.isoformat(),
+            "expires_at": self.expires_at.isoformat(),
+            "original_payload": _json_safe(self.original_payload),
+            "validation_issues": [_json_safe(i) for i in self.validation_issues],
+            "accepted_ops": [_json_safe(op) for op in self.accepted_ops],
+            "review_required_ops": [_json_safe(op) for op in self.review_required_ops],
+            "rejected_ops": [_json_safe(op) for op in self.rejected_ops],
+            "lowered_batch": mutation_batch_to_dict(self.lowered_batch)
+            if self.lowered_batch is not None
+            else None,
+            "provenance": provenance_context_to_dict(self.provenance)
+            if self.provenance is not None
+            else None,
+            "expected_subgraph_versions": dict(self.expected_subgraph_versions),
+            "current_subgraph_versions": dict(self.current_subgraph_versions),
+            "subgraph_versions": dict(self.current_subgraph_versions),
+            "diff": self.diff.to_dict(),
+            "warnings": list(self.warnings),
+            "approval": self.approval.to_dict() if self.approval else None,
+            "mutation_id": self.mutation_id,
+            "committed_at": self.committed_at.isoformat()
+            if self.committed_at is not None
+            else None,
+            "final_subgraph_versions": dict(self.final_subgraph_versions),
+            "detail": self.detail,
+            "graph_contract_version": self.graph_contract_version,
+            "ontology_version": self.ontology_version,
+        }
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "GraphMutationPlanRecord":
+        return cls(
+            plan_id=str(raw.get("plan_id") or ""),
+            pot_id=str(raw.get("pot_id") or ""),
+            status=str(raw.get("status") or GraphMutationPlanStatus.invalid.value),
+            risk=str(raw.get("risk") or "low"),
+            created_at=_parse_datetime(raw.get("created_at"))
+            or datetime.now(timezone.utc),
+            expires_at=_parse_datetime(raw.get("expires_at"))
+            or datetime.now(timezone.utc),
+            original_payload=dict(raw.get("original_payload") or {}),
+            validation_issues=tuple(
+                dict(i) for i in raw.get("validation_issues") or ()
+            ),
+            accepted_ops=tuple(dict(i) for i in raw.get("accepted_ops") or ()),
+            review_required_ops=tuple(
+                dict(i) for i in raw.get("review_required_ops") or ()
+            ),
+            rejected_ops=tuple(dict(i) for i in raw.get("rejected_ops") or ()),
+            lowered_batch=mutation_batch_from_dict(raw.get("lowered_batch")),
+            provenance=provenance_context_from_dict(raw.get("provenance")),
+            expected_subgraph_versions=_int_mapping(
+                raw.get("expected_subgraph_versions")
+            ),
+            current_subgraph_versions=_int_mapping(
+                raw.get("current_subgraph_versions")
+            ),
+            diff=GraphMutationDiff.from_dict(raw.get("diff")),
+            warnings=tuple(str(w) for w in raw.get("warnings") or ()),
+            approval=GraphMutationApproval.from_dict(raw.get("approval")),
+            mutation_id=str(raw.get("mutation_id") or "") or None,
+            committed_at=_parse_datetime(raw.get("committed_at")),
+            final_subgraph_versions=_int_mapping(raw.get("final_subgraph_versions")),
+            detail=str(raw.get("detail") or "") or None,
+            graph_contract_version=str(
+                raw.get("graph_contract_version") or GRAPH_CONTRACT_VERSION
+            ),
+            ontology_version=str(raw.get("ontology_version") or ONTOLOGY_VERSION),
+        )
+
+    def is_expired(self, *, now: datetime | None = None) -> bool:
+        probe = now or datetime.now(timezone.utc)
+        return probe >= self.expires_at
+
+
+@dataclass(frozen=True, slots=True)
+class GraphMutationProposal:
+    ok: bool
+    plan_id: str
+    status: str
+    risk: str
+    pot_id: str
+    auto_applicable: bool
+    expires_at: datetime
+    expected_subgraph_versions: Mapping[str, int]
+    current_subgraph_versions: Mapping[str, int]
+    diff: GraphMutationDiff
+    warnings: tuple[str, ...] = ()
+    issues: tuple[Mapping[str, Any], ...] = ()
+    rejected_operations: tuple[Mapping[str, Any], ...] = ()
+    review_required_operations: tuple[Mapping[str, Any], ...] = ()
+    claim_keys: tuple[str, ...] = ()
+    recommended_next_action: str | None = None
+    detail: str | None = None
+    graph_contract_version: str = GRAPH_CONTRACT_VERSION
+    ontology_version: str = ONTOLOGY_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "ok": self.ok,
+            "plan_id": self.plan_id,
+            "status": self.status,
+            "risk": self.risk,
+            "pot_id": self.pot_id,
+            "auto_applicable": self.auto_applicable,
+            "expires_at": self.expires_at.isoformat(),
+            "expected_subgraph_versions": dict(self.expected_subgraph_versions),
+            "current_subgraph_versions": dict(self.current_subgraph_versions),
+            "diff": self.diff.to_dict(),
+            "warnings": list(self.warnings),
+            "issues": [_json_safe(i) for i in self.issues],
+            "rejected_operations": [_json_safe(op) for op in self.rejected_operations],
+            "review_required_operations": [
+                _json_safe(op) for op in self.review_required_operations
+            ],
+            "claim_keys": list(self.claim_keys),
+            "graph_contract_version": self.graph_contract_version,
+            "ontology_version": self.ontology_version,
+        }
+        if self.recommended_next_action:
+            out["recommended_next_action"] = self.recommended_next_action
+        if self.detail:
+            out["detail"] = self.detail
+        return out
+
+
+@dataclass(frozen=True, slots=True)
+class GraphIngestionVerificationResult:
+    """Post-commit verification for source-backed graph ingestion."""
+
+    ok: bool
+    status: str
+    plan_id: str
+    pot_id: str
+    claim_keys: tuple[str, ...] = ()
+    readback_claim_keys: tuple[str, ...] = ()
+    missing_claim_keys: tuple[str, ...] = ()
+    readback_count: int = 0
+    quality_status: str | None = None
+    quality_counts: Mapping[str, int] = field(default_factory=dict)
+    quality_delta: Mapping[str, int] = field(default_factory=dict)
+    quality_regressions: Mapping[str, Mapping[str, int]] = field(default_factory=dict)
+    checked_reports: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+    unsupported: tuple[Mapping[str, Any], ...] = ()
+    detail: str | None = None
+    recommended_next_action: str | None = None
+    subgraph_versions: Mapping[str, int] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "ok": self.ok,
+            "status": self.status,
+            "plan_id": self.plan_id,
+            "pot_id": self.pot_id,
+            "claim_keys": list(self.claim_keys),
+            "readback_claim_keys": list(self.readback_claim_keys),
+            "missing_claim_keys": list(self.missing_claim_keys),
+            "readback_count": self.readback_count,
+            "quality_status": self.quality_status,
+            "quality_counts": dict(self.quality_counts),
+            "quality_delta": dict(self.quality_delta),
+            "quality_regressions": {
+                key: dict(value) for key, value in self.quality_regressions.items()
+            },
+            "checked_reports": list(self.checked_reports),
+            "warnings": list(self.warnings),
+            "unsupported": [dict(item) for item in self.unsupported],
+            "subgraph_versions": dict(self.subgraph_versions),
+        }
+        if self.detail:
+            out["detail"] = self.detail
+        if self.recommended_next_action:
+            out["recommended_next_action"] = self.recommended_next_action
+        return out
+
+
+@dataclass(frozen=True, slots=True)
+class GraphMutationCommitResult:
+    ok: bool
+    plan_id: str
+    status: str
+    risk: str
+    pot_id: str
+    mutation_id: str | None = None
+    applied_at: datetime | None = None
+    expected_subgraph_versions: Mapping[str, int] = field(default_factory=dict)
+    current_subgraph_versions: Mapping[str, int] = field(default_factory=dict)
+    new_subgraph_versions: Mapping[str, int] = field(default_factory=dict)
+    diff: GraphMutationDiff = field(default_factory=GraphMutationDiff)
+    claim_keys: tuple[str, ...] = ()
+    approval: GraphMutationApproval | None = None
+    verification: GraphIngestionVerificationResult | None = None
+    detail: str | None = None
+    recommended_next_action: str | None = None
+    graph_contract_version: str = GRAPH_CONTRACT_VERSION
+    ontology_version: str = ONTOLOGY_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "ok": self.ok,
+            "plan_id": self.plan_id,
+            "status": self.status,
+            "risk": self.risk,
+            "pot_id": self.pot_id,
+            "mutation_id": self.mutation_id,
+            "applied_at": self.applied_at.isoformat()
+            if self.applied_at is not None
+            else None,
+            "expected_subgraph_versions": dict(self.expected_subgraph_versions),
+            "current_subgraph_versions": dict(self.current_subgraph_versions),
+            "new_subgraph_versions": dict(self.new_subgraph_versions),
+            "subgraph_versions": dict(
+                self.new_subgraph_versions or self.current_subgraph_versions
+            ),
+            "diff": self.diff.to_dict(),
+            "claim_keys": list(self.claim_keys),
+            "approval": self.approval.to_dict() if self.approval else None,
+            "verification": self.verification.to_dict()
+            if self.verification is not None
+            else None,
+            "graph_contract_version": self.graph_contract_version,
+            "ontology_version": self.ontology_version,
+        }
+        if self.mutation_id:
+            out["history_pointer"] = {"mutation_id": self.mutation_id}
+            out["audit_ref"] = f"audit:mutation:{self.mutation_id}"
+        if self.detail:
+            out["detail"] = self.detail
+        if self.recommended_next_action:
+            out["recommended_next_action"] = self.recommended_next_action
+        return out
+
+
+def mutation_batch_to_dict(batch: MutationBatch) -> dict[str, Any]:
+    return {
+        "event_ref": event_ref_to_dict(batch.event_ref),
+        "summary": batch.summary,
+        "entity_upserts": [
+            {
+                "entity_key": item.entity_key,
+                "labels": list(item.labels),
+                "properties": _json_safe(item.properties),
+            }
+            for item in batch.entity_upserts
+        ],
+        "edge_upserts": [
+            {
+                "edge_type": item.edge_type,
+                "from_entity_key": item.from_entity_key,
+                "to_entity_key": item.to_entity_key,
+                "properties": _json_safe(item.properties),
+            }
+            for item in batch.edge_upserts
+        ],
+        "edge_deletes": [
+            {
+                "edge_type": item.edge_type,
+                "from_entity_key": item.from_entity_key,
+                "to_entity_key": item.to_entity_key,
+            }
+            for item in batch.edge_deletes
+        ],
+        "invalidations": [
+            {
+                "target_entity_key": item.target_entity_key,
+                "target_edge": list(item.target_edge) if item.target_edge else None,
+                "reason": item.reason,
+                "superseded_by_key": item.superseded_by_key,
+                "valid_to": item.valid_to,
+            }
+            for item in batch.invalidations
+        ],
+        "evidence": [
+            {"kind": item.kind, "ref": item.ref, "metadata": _json_safe(item.metadata)}
+            for item in batch.evidence
+        ],
+        "confidence": batch.confidence,
+        "warnings": list(batch.warnings),
+        "ontology_downgrades": [_json_safe(item) for item in batch.ontology_downgrades],
+    }
+
+
+def mutation_batch_from_dict(raw: Mapping[str, Any] | None) -> MutationBatch | None:
+    if not raw:
+        return None
+    return MutationBatch(
+        event_ref=event_ref_from_dict(raw.get("event_ref")),
+        summary=str(raw.get("summary") or ""),
+        entity_upserts=[
+            EntityUpsert(
+                entity_key=str(item.get("entity_key") or ""),
+                labels=tuple(str(label) for label in item.get("labels") or ()),
+                properties=dict(item.get("properties") or {}),
+            )
+            for item in raw.get("entity_upserts") or ()
+            if isinstance(item, Mapping)
+        ],
+        edge_upserts=[
+            EdgeUpsert(
+                edge_type=str(item.get("edge_type") or ""),
+                from_entity_key=str(item.get("from_entity_key") or ""),
+                to_entity_key=str(item.get("to_entity_key") or ""),
+                properties=dict(item.get("properties") or {}),
+            )
+            for item in raw.get("edge_upserts") or ()
+            if isinstance(item, Mapping)
+        ],
+        edge_deletes=[
+            EdgeDelete(
+                edge_type=str(item.get("edge_type") or ""),
+                from_entity_key=str(item.get("from_entity_key") or ""),
+                to_entity_key=str(item.get("to_entity_key") or ""),
+            )
+            for item in raw.get("edge_deletes") or ()
+            if isinstance(item, Mapping)
+        ],
+        invalidations=[
+            InvalidationOp(
+                target_entity_key=str(item.get("target_entity_key") or "") or None,
+                target_edge=tuple(item.get("target_edge"))
+                if item.get("target_edge")
+                else None,
+                reason=str(item.get("reason") or ""),
+                superseded_by_key=str(item.get("superseded_by_key") or "") or None,
+                valid_to=str(item.get("valid_to") or "") or None,
+            )
+            for item in raw.get("invalidations") or ()
+            if isinstance(item, Mapping)
+        ],
+        evidence=[
+            EvidenceRef(
+                kind=str(item.get("kind") or ""),
+                ref=str(item.get("ref") or ""),
+                metadata=dict(item.get("metadata") or {}),
+            )
+            for item in raw.get("evidence") or ()
+            if isinstance(item, Mapping)
+        ],
+        confidence=_float_or_none(raw.get("confidence")),
+        warnings=[str(item) for item in raw.get("warnings") or ()],
+        ontology_downgrades=[
+            dict(item)
+            for item in raw.get("ontology_downgrades") or ()
+            if isinstance(item, Mapping)
+        ],
+    )
+
+
+def provenance_context_to_dict(ctx: ProvenanceContext) -> dict[str, Any]:
+    return {
+        "source_event_id": ctx.source_event_id,
+        "source_system": ctx.source_system,
+        "source_kind": ctx.source_kind,
+        "source_ref": ctx.source_ref,
+        "event_occurred_at": ctx.event_occurred_at.isoformat()
+        if ctx.event_occurred_at
+        else None,
+        "event_received_at": ctx.event_received_at.isoformat()
+        if ctx.event_received_at
+        else None,
+        "created_by_agent": ctx.created_by_agent,
+        "reconciliation_run_id": ctx.reconciliation_run_id,
+        "actor_user_id": ctx.actor_user_id,
+        "actor_surface": ctx.actor_surface,
+        "actor_client_name": ctx.actor_client_name,
+        "actor_auth_method": ctx.actor_auth_method,
+    }
+
+
+def provenance_context_from_dict(
+    raw: Mapping[str, Any] | None,
+) -> ProvenanceContext | None:
+    if not raw:
+        return None
+    return ProvenanceContext(
+        source_event_id=str(raw.get("source_event_id") or "") or None,
+        source_system=str(raw.get("source_system") or "") or None,
+        source_kind=str(raw.get("source_kind") or "") or None,
+        source_ref=str(raw.get("source_ref") or "") or None,
+        event_occurred_at=_parse_datetime(raw.get("event_occurred_at")),
+        event_received_at=_parse_datetime(raw.get("event_received_at")),
+        created_by_agent=str(raw.get("created_by_agent") or "") or None,
+        reconciliation_run_id=str(raw.get("reconciliation_run_id") or "") or None,
+        actor_user_id=str(raw.get("actor_user_id") or "") or None,
+        actor_surface=str(raw.get("actor_surface") or "") or None,
+        actor_client_name=str(raw.get("actor_client_name") or "") or None,
+        actor_auth_method=str(raw.get("actor_auth_method") or "") or None,
+    )
+
+
+def event_ref_to_dict(event_ref: EventRef | None) -> dict[str, Any] | None:
+    if event_ref is None:
+        return None
+    return {
+        "event_id": event_ref.event_id,
+        "source_system": event_ref.source_system,
+        "pot_id": event_ref.pot_id,
+    }
+
+
+def event_ref_from_dict(raw: Mapping[str, Any] | None) -> EventRef | None:
+    if not raw:
+        return None
+    event_id = str(raw.get("event_id") or "")
+    source_system = str(raw.get("source_system") or "")
+    pot_id = str(raw.get("pot_id") or "")
+    if not event_id or not source_system or not pot_id:
+        return None
+    return EventRef(event_id=event_id, source_system=source_system, pot_id=pot_id)
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Mapping):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, tuple):
+        return [_json_safe(v) for v in value]
+    if isinstance(value, list):
+        return [_json_safe(v) for v in value]
+    return value
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip()
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _int_mapping(value: Any) -> dict[str, int]:
+    if not isinstance(value, Mapping):
+        return {}
+    out: dict[str, int] = {}
+    for key, raw in value.items():
+        try:
+            out[str(key)] = int(raw)
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+__all__ = [
+    "GraphIngestionVerificationResult",
+    "GraphMutationApproval",
+    "GraphMutationCommitResult",
+    "GraphMutationDiff",
+    "GraphMutationPlanRecord",
+    "GraphMutationPlanStatus",
+    "GraphMutationProposal",
+    "TERMINAL_PLAN_STATUSES",
+    "event_ref_from_dict",
+    "event_ref_to_dict",
+    "mutation_batch_from_dict",
+    "mutation_batch_to_dict",
+    "provenance_context_from_dict",
+    "provenance_context_to_dict",
+]

--- a/potpie/context-engine/domain/graph_quality.py
+++ b/potpie/context-engine/domain/graph_quality.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping
 
 from domain.ontology import (
     FACT_FAMILY_FRESHNESS_TTL_HOURS,
@@ -14,6 +14,8 @@ from domain.ontology import (
     predicate_family_for_episodic_supersede,
     temporal_subject_key_for_edge,
 )
+from domain.graph_workbench import GRAPH_WORKBENCH_CONTRACT_VERSION
+from domain.graph_workbench import GRAPH_WORKBENCH_ONTOLOGY_VERSION
 from domain.source_references import SourceFallback, SourceReferenceRecord
 
 
@@ -65,6 +67,87 @@ class GraphQualityReport:
     conflicts: list[dict[str, Any]] = field(default_factory=list)
     # Auto-supersession or other automatic resolutions (informational).
     resolved_conflicts: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class GraphQualityFinding:
+    """One read-only quality finding surfaced by the V2 workbench."""
+
+    finding_id: str
+    kind: str
+    severity: str
+    summary: str
+    entity_keys: tuple[str, ...] = ()
+    claim_keys: tuple[str, ...] = ()
+    predicates: tuple[str, ...] = ()
+    subgraph: str | None = None
+    source_refs: tuple[str, ...] = ()
+    evidence: tuple[Mapping[str, Any], ...] = ()
+    detail: str | None = None
+    suggested_action: Mapping[str, Any] = field(default_factory=dict)
+    payload: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "finding_id": self.finding_id,
+            "kind": self.kind,
+            "severity": self.severity,
+            "summary": self.summary,
+            "entity_keys": list(self.entity_keys),
+            "claim_keys": list(self.claim_keys),
+            "predicates": list(self.predicates),
+            "source_refs": list(self.source_refs),
+            "evidence": [dict(item) for item in self.evidence],
+            "suggested_action": dict(self.suggested_action),
+            "payload": dict(self.payload),
+        }
+        if self.subgraph:
+            out["subgraph"] = self.subgraph
+        if self.detail:
+            out["detail"] = self.detail
+        return out
+
+
+@dataclass(frozen=True, slots=True)
+class GraphQualityResult:
+    """V2 workbench result body for ``graph quality`` reports."""
+
+    ok: bool
+    pot_id: str
+    report: str
+    status: str
+    findings: tuple[GraphQualityFinding, ...] = ()
+    metrics: Mapping[str, Any] = field(default_factory=dict)
+    filters: Mapping[str, Any] = field(default_factory=dict)
+    warnings: tuple[str, ...] = ()
+    unsupported: tuple[Mapping[str, Any], ...] = ()
+    detail: str | None = None
+    recommended_next_action: str | None = None
+    subgraph_versions: Mapping[str, int] = field(default_factory=dict)
+    graph_contract_version: str = GRAPH_WORKBENCH_CONTRACT_VERSION
+    ontology_version: str = GRAPH_WORKBENCH_ONTOLOGY_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "ok": self.ok,
+            "pot_id": self.pot_id,
+            "report": self.report,
+            "status": self.status,
+            "findings": [finding.to_dict() for finding in self.findings],
+            "finding_count": len(self.findings),
+            "metrics": dict(self.metrics),
+            "filters": dict(self.filters),
+            "warnings": list(self.warnings),
+            "unsupported": [dict(item) for item in self.unsupported],
+            "subgraph_versions": dict(self.subgraph_versions),
+            "graph_contract_version": self.graph_contract_version,
+            "ontology_version": self.ontology_version,
+        }
+        if self.detail:
+            out["detail"] = self.detail
+        if self.recommended_next_action:
+            out["recommended_next_action"] = self.recommended_next_action
+        return out
 
 
 # Aliases from external ``source_type`` strings (e.g. "PullRequest", "PR")

--- a/potpie/context-engine/domain/ports/graph/inbox_store.py
+++ b/potpie/context-engine/domain/ports/graph/inbox_store.py
@@ -1,0 +1,38 @@
+"""Graph inbox persistence port."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Protocol
+
+from domain.graph_inbox import GraphInboxItem
+
+
+class GraphInboxStorePort(Protocol):
+    """Persist pending graph work that is not yet a canonical fact."""
+
+    def save(self, item: GraphInboxItem) -> None:
+        """Insert or replace an inbox item."""
+        ...
+
+    def get(self, *, pot_id: str, item_id: str) -> GraphInboxItem | None:
+        """Return one inbox item for a pot, if present."""
+        ...
+
+    def list(
+        self,
+        *,
+        pot_id: str,
+        status: tuple[str, ...] = (),
+        claimed_by: str | None = None,
+        suspected_subgraph: str | None = None,
+        source_ref: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        limit: int | None = None,
+    ) -> tuple[GraphInboxItem, ...]:
+        """Return inbox items for worklists and operator inspection."""
+        ...
+
+
+__all__ = ["GraphInboxStorePort"]

--- a/potpie/context-engine/domain/ports/graph/inspection.py
+++ b/potpie/context-engine/domain/ports/graph/inspection.py
@@ -47,7 +47,14 @@ class GraphInspectionPort(Protocol):
     """Structural traversal over the canonical graph."""
 
     def neighborhood(
-        self, *, pot_id: str, entity_key: str, depth: int = 1
+        self,
+        *,
+        pot_id: str,
+        entity_key: str,
+        depth: int = 1,
+        direction: str = "both",
+        predicates: tuple[str, ...] = (),
+        limit: int | None = None,
     ) -> GraphSlice:
         """Return the subgraph within ``depth`` hops of ``entity_key``."""
         ...

--- a/potpie/context-engine/domain/ports/graph/plan_store.py
+++ b/potpie/context-engine/domain/ports/graph/plan_store.py
@@ -1,0 +1,36 @@
+"""Graph mutation-plan persistence port."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Protocol
+
+from domain.graph_plans import GraphMutationPlanRecord
+
+
+class GraphPlanStorePort(Protocol):
+    """Persist server-created mutation plans until commit, expiry, or close."""
+
+    def save(self, record: GraphMutationPlanRecord) -> None:
+        """Insert or replace a plan record."""
+        ...
+
+    def get(self, *, pot_id: str, plan_id: str) -> GraphMutationPlanRecord | None:
+        """Return one plan for a pot, if present."""
+        ...
+
+    def list(
+        self,
+        *,
+        pot_id: str,
+        plan_id: str | None = None,
+        mutation_id: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        limit: int | None = None,
+    ) -> tuple[GraphMutationPlanRecord, ...]:
+        """Return plan records for history and operator inspection."""
+        ...
+
+
+__all__ = ["GraphPlanStorePort"]

--- a/potpie/context-engine/pyproject.toml
+++ b/potpie/context-engine/pyproject.toml
@@ -17,7 +17,13 @@ dependencies = [
     "typer>=0.15.0",
     "uvicorn[standard]>=0.32.0",
     "pydantic>=2.0",
+    "potpie-observability[sentry]>=0.1.0,<0.2.0",
     "sentry-sdk>=2.61.1",
+    # Default CLI backend is FalkorDBLite on Python 3.12+.
+    "falkordblite>=0.10.0; python_version >= '3.12'",
+    # redis 8 enables maintenance notifications that break FalkorDBLite's
+    # hostless embedded connection; keep the bound wherever falkordblite ships.
+    "redis>=7.1,<8; python_version >= '3.12'",
 ]
 
 [project.optional-dependencies]
@@ -33,10 +39,14 @@ graph = [
     "neo4j>=5.28.0",
 ]
 falkordb = [
+    "falkordb>=1.6.1",
     # FalkorDBLite (embedded) requires Python >= 3.12; marker keeps resolution
     # valid across the project's wider requires-python range.
     "falkordblite>=0.10.0; python_version >= '3.12'",
     "redis>=7.1,<8",
+]
+embeddings = [
+    "sentence-transformers>=5.1.2",
 ]
 github = [
     "pygithub>=2.8.0",
@@ -56,6 +66,10 @@ all = [
     "sqlalchemy>=2.0",
     "psycopg[binary]>=3.2",
     "neo4j>=5.28.0",
+    "falkordb>=1.6.1",
+    "falkordblite>=0.10.0; python_version >= '3.12'",
+    "redis>=7.1,<8",
+    "sentence-transformers>=5.1.2",
     "pygithub>=2.8.0",
     "pydantic-deep>=0.3.0",
     "hatchet-sdk>=1.29.0",
@@ -72,6 +86,7 @@ dev = [
 [project.scripts]
 potpie = "adapters.inbound.cli.host_cli:main"
 potpie-mcp = "adapters.inbound.mcp.server:main"
+potpie-daemon = "host.daemon_main:main"
 
 [tool.hatch.build.force-include]
 "adapters/inbound/cli/ui/assets/potpie-logo-static.json" = "adapters/inbound/cli/ui/assets/potpie-logo-static.json"

--- a/potpie/context-engine/tests/conformance/test_graph_backend_conformance.py
+++ b/potpie/context-engine/tests/conformance/test_graph_backend_conformance.py
@@ -13,6 +13,8 @@ hook points at; new backends drop into ``FULL_PROFILES`` / ``PARTIAL_PROFILES``.
 
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 from adapters.outbound.graph.backends import build_backend
@@ -27,6 +29,10 @@ POT = "conformance-pot"
 
 # Profiles that implement all six capabilities end to end.
 FULL_PROFILES = ["in_memory", "embedded"]
+
+# Profiles with the canonical source-of-truth ports wired and projections
+# deliberately fail-closed until implemented.
+PARTIAL_PROFILES = ["neo4j", "falkordb", "falkordb_lite"]
 
 
 def _build(profile, tmp_path):
@@ -159,3 +165,34 @@ def test_embedded_unbuilt_profile_fails_closed():
         stub.search(pot_id=POT, query="x")
     assert exc.value.capability == "graph.neo4j.semantic.search"
     assert exc.value.recommended_next_action
+
+
+@pytest.mark.parametrize("profile", PARTIAL_PROFILES)
+def test_partial_backend_profiles_fail_closed_for_unbuilt_projections(profile, tmp_path):
+    if profile in ("falkordb", "falkordb_lite") and sys.version_info < (3, 12):
+        # FalkorDBLite (embedded, via redislite) ships only on Python >= 3.12
+        # (see the pyproject marker); on 3.11 the backend can't be built.
+        pytest.skip("FalkorDBLite (redislite) requires Python >= 3.12")
+    backend = _build(profile, tmp_path)
+    assert isinstance(backend, GraphBackend)
+    expected = {
+        "neo4j": {"mutation", "claim_query", "semantic", "analytics"},
+        # FalkorDB profiles implement structural inspection (graph explorer /
+        # ``potpie graph inspect``) over the canonical RELATES_TO edges.
+        "falkordb": {"mutation", "claim_query", "semantic", "analytics", "inspection"},
+        "falkordb_lite": {
+            "mutation",
+            "claim_query",
+            "semantic",
+            "analytics",
+            "inspection",
+        },
+    }[profile]
+    assert set(backend.capabilities().implemented()) == expected
+    if "inspection" in expected:
+        # Implemented: answers without raising (empty pot → empty slice).
+        sl = backend.inspection.neighborhood(pot_id=POT, entity_key="pref:logging")
+        assert sl.pot_id == POT
+    else:
+        with pytest.raises(CapabilityNotImplemented):
+            backend.inspection.neighborhood(pot_id=POT, entity_key="pref:logging")

--- a/potpie/context-engine/tests/integration/test_falkordb_roundtrip.py
+++ b/potpie/context-engine/tests/integration/test_falkordb_roundtrip.py
@@ -44,6 +44,20 @@ class _Settings:
         return "context_graph"
 
 
+class _FakeEmbedder:
+    name = "fake-integration-embedder"
+    dimensions = 3
+
+    def embed(self, text: str) -> tuple[float, ...]:
+        t = text.lower()
+        if "auth" in t or "login" in t:
+            return (1.0, 0.0, 0.0)
+        return (0.0, 1.0, 0.0)
+
+    def embed_many(self, texts):
+        return [self.embed(t) for t in texts]
+
+
 @pytest.fixture()
 def shared_graph():
     tmp = tempfile.mkdtemp(prefix="falkordblite_test_")
@@ -144,3 +158,52 @@ def test_write_read_reset_roundtrip(shared_graph) -> None:
     final = asyncio.run(writer.reset_pot(pot))
     assert final["ok"] is True
     assert final["group_id_nodes_remaining"] == 0
+
+
+def test_vector_search_orders_by_cosine_distance(shared_graph) -> None:
+    settings = _Settings()
+    embedder = _FakeEmbedder()
+    writer = FalkorDBGraphWriter(settings, graph=shared_graph, embedder=embedder)
+    reader = FalkorDBClaimQueryStore(settings, graph=shared_graph, embedder=embedder)
+    pot = "potV"
+    prov = ProvenanceRef(pot_id=pot, source_event_id="e1", source_system="agent")
+
+    async def _seed() -> None:
+        assert await writer.ensure_indexes() is True
+        await writer.upsert_entities(
+            pot,
+            [
+                EntityUpsert("service:web", ("Entity", "Service"), {}),
+                EntityUpsert("service:auth", ("Entity", "Service"), {}),
+                EntityUpsert("service:db", ("Entity", "Service"), {}),
+            ],
+            prov,
+        )
+        await writer.upsert_edges(
+            pot,
+            [
+                EdgeUpsert(
+                    "DEPENDS_ON",
+                    "service:web",
+                    "service:auth",
+                    {"fact": "web depends on auth login"},
+                ),
+                EdgeUpsert(
+                    "DEPENDS_ON",
+                    "service:web",
+                    "service:db",
+                    {"fact": "web stores data in database"},
+                ),
+            ],
+            prov,
+        )
+
+    asyncio.run(_seed())
+
+    rows = reader.find_claims(
+        ClaimQueryFilter(pot_id=pot, fact_query="login auth", limit=2)
+    )
+
+    assert [r.object_key for r in rows] == ["service:auth", "service:db"]
+    assert rows[0].properties["semantic_similarity"] == pytest.approx(1.0)
+    assert rows[1].properties["semantic_similarity"] == pytest.approx(0.0)

--- a/potpie/context-engine/tests/unit/test_context_graph_writer.py
+++ b/potpie/context-engine/tests/unit/test_context_graph_writer.py
@@ -119,6 +119,7 @@ def test_canonical_entity_upsert_sets_non_null_string_defaults() -> None:
     )
 
     assert count == 1
-    props = driver.session_obj.calls[0][1]["props"]
-    assert props["name"] == "123"
-    assert props["summary"] == ""
+    kwargs = driver.session_obj.calls[0][1]
+    assert kwargs["a_name"] == "123"
+    assert kwargs["a_summary"] == "123"
+    assert kwargs["a_description"] == "123"

--- a/potpie/context-engine/tests/unit/test_context_records.py
+++ b/potpie/context-engine/tests/unit/test_context_records.py
@@ -13,7 +13,9 @@ from domain.context_records import (
     PreferenceRecord,
     VerificationRecord,
     has_structured_schema,
+    has_structured_details,
     record_to_dict,
+    structured_detail_keys,
     validate_record_payload,
 )
 
@@ -193,6 +195,22 @@ class TestUnknownTypesFallback:
         assert has_structured_schema("fix")
         assert has_structured_schema("preference")
         assert not has_structured_schema("workflow")
+
+
+class TestStructuredDetailDetection:
+    def test_schema_keys_detect_structured_details(self) -> None:
+        assert "kind" in structured_detail_keys("bug_pattern")
+        assert has_structured_details("bug_pattern", {"kind": 123})
+
+    def test_generic_metadata_is_not_structured_details(self) -> None:
+        assert not has_structured_details(
+            "preference",
+            {"confidence": 0.7, "visibility": "project", "text": "use ruff"},
+        )
+
+    def test_unknown_record_type_has_no_structured_details(self) -> None:
+        assert structured_detail_keys("workflow") == frozenset()
+        assert not has_structured_details("workflow", {"kind": 123})
 
 
 class TestSerialisation:

--- a/potpie/context-engine/tests/unit/test_falkordb_backend.py
+++ b/potpie/context-engine/tests/unit/test_falkordb_backend.py
@@ -1,0 +1,186 @@
+"""FalkorDB GraphBackend wiring tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from adapters.outbound.graph.backends import KNOWN_PROFILES, build_backend
+from adapters.outbound.graph.backends.falkordb_backend import FalkorDBGraphBackend
+from bootstrap.host_wiring import build_host_shell
+from domain.context_events import EventRef
+from domain.graph_mutations import EdgeUpsert, EntityUpsert, ProvenanceRef
+from domain.ports.graph.backend import GraphBackend
+from domain.reconciliation import ReconciliationPlan
+
+pytestmark = pytest.mark.unit
+
+
+class _Settings:
+    def __init__(self, *, backend: str = "falkordb", mode: str = "lite") -> None:
+        self._backend = backend
+        self._mode = mode
+
+    def is_enabled(self) -> bool:
+        return True
+
+    def graph_db_backend(self) -> str:
+        return self._backend
+
+    def falkordb_url(self) -> str | None:
+        return None
+
+    def falkordb_graph_name(self) -> str:
+        return "context_graph"
+
+    def falkordb_mode(self) -> str:
+        return self._mode
+
+    def falkordb_lite_path(self) -> str:
+        return ".potpie/test/falkordb.db"
+
+
+class _Writer:
+    enabled = True
+
+    def __init__(self) -> None:
+        self.entities = []
+        self.edges = []
+
+    async def ensure_indexes(self) -> bool:
+        return True
+
+    async def upsert_entities(self, pot_id, items, provenance: ProvenanceRef) -> int:
+        self.entities.extend(items)
+        return len(items)
+
+    async def upsert_edges(self, pot_id, items, provenance: ProvenanceRef) -> int:
+        self.edges.extend(items)
+        return len(items)
+
+    async def delete_edges(self, pot_id, items, provenance: ProvenanceRef) -> int:
+        return len(items)
+
+    async def invalidate(self, pot_id, items, provenance: ProvenanceRef) -> int:
+        return len(items)
+
+    async def reset_pot(self, pot_id: str) -> dict:
+        return {"ok": True, "group_id_nodes_before": 0, "group_id_nodes_remaining": 0}
+
+
+class _FakeResult:
+    def __init__(self, names, rows):
+        self.header = [[1, name] for name in names]
+        self.result_set = rows
+
+
+class _RepairGraph:
+    def __init__(self) -> None:
+        self.updates: list[dict] = []
+
+    def query(self, cypher: str, params: dict | None = None) -> _FakeResult:
+        params = params or {}
+        if "RETURN e.entity_key AS key" in cypher:
+            return _FakeResult(
+                ["key", "props"],
+                [
+                    ["service:web", {"description": "Web frontend service."}],
+                    ["service:auth", {"name": "auth", "summary": ""}],
+                ],
+            )
+        if "SET e += $props" in cypher:
+            self.updates.append(params)
+            return _FakeResult(["cnt"], [[1]])
+        return _FakeResult([], [])
+
+
+def test_build_backend_registers_falkordb_without_connecting() -> None:
+    assert "falkordb" in KNOWN_PROFILES
+    backend = build_backend("falkordb", settings=_Settings(mode="server"))
+    assert isinstance(backend, GraphBackend)
+    assert backend.profile == "falkordb"
+    assert backend.capabilities().implemented() == (
+        "mutation",
+        "claim_query",
+        "semantic",
+        "inspection",
+        "analytics",
+    )
+
+
+@pytest.mark.parametrize("profile", ["falkordb_lite", "falkordblite", "falkordb-lite"])
+def test_build_backend_registers_falkordb_lite_without_connecting(profile) -> None:
+    assert "falkordb_lite" in KNOWN_PROFILES
+    # Mode is intentionally set to server here; the explicit Lite profile pins
+    # the runtime to embedded Lite and therefore needs no server URL.
+    backend = build_backend(profile, settings=_Settings(mode="server"))
+    assert isinstance(backend, GraphBackend)
+    assert backend.profile == "falkordb_lite"
+    assert backend.graph_writer.enabled is True
+    assert backend.capabilities().implemented() == (
+        "mutation",
+        "claim_query",
+        "semantic",
+        "inspection",
+        "analytics",
+    )
+
+
+async def test_falkordb_backend_apply_uses_writer() -> None:
+    writer = _Writer()
+    backend = FalkorDBGraphBackend(_Settings(), writer=writer)
+    plan = ReconciliationPlan(
+        event_ref=EventRef(event_id="e1", source_system="agent", pot_id="p1"),
+        entity_upserts=[
+            EntityUpsert(entity_key="service:web", labels=("Entity", "Service"))
+        ],
+        edge_upserts=[
+            EdgeUpsert(
+                edge_type="DEPENDS_ON",
+                from_entity_key="service:web",
+                to_entity_key="service:auth",
+                properties={"fact": "web depends on auth"},
+            )
+        ],
+    )
+
+    result = await backend.mutation.apply_async(plan, expected_pot_id="p1")
+
+    assert result.ok
+    assert len(writer.entities) == 1
+    assert len(writer.edges) == 1
+
+
+def test_host_shell_accepts_falkordb_env(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("CONTEXT_ENGINE_HOME", str(tmp_path))
+    monkeypatch.setenv("CONTEXT_ENGINE_BACKEND", "falkordb")
+
+    host = build_host_shell()
+
+    assert host.backend.profile == "falkordb"
+
+
+def test_host_shell_accepts_falkordb_lite_env(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("CONTEXT_ENGINE_HOME", str(tmp_path))
+    monkeypatch.setenv("CONTEXT_ENGINE_BACKEND", "falkordb_lite")
+    monkeypatch.setenv("FALKORDB_MODE", "server")
+
+    host = build_host_shell()
+
+    assert host.backend.profile == "falkordb_lite"
+
+
+def test_falkordb_repair_backfills_entity_summaries() -> None:
+    graph = _RepairGraph()
+    backend = FalkorDBGraphBackend(
+        _Settings(),
+        graph_provider=lambda: graph,
+    )
+
+    report = backend.analytics.repair("p1", targets=["entity_summaries"])
+
+    assert report.repaired == {"entity_summaries": 2}
+    assert [u["key"] for u in graph.updates] == ["service:web", "service:auth"]
+    assert graph.updates[0]["props"]["summary"] == "Web frontend service."
+    assert graph.updates[0]["props"]["description"] == "Web frontend service."
+    assert graph.updates[1]["props"]["summary"] == "auth"
+    assert graph.updates[1]["props"]["description"] == "auth"

--- a/potpie/context-engine/tests/unit/test_falkordb_inspection.py
+++ b/potpie/context-engine/tests/unit/test_falkordb_inspection.py
@@ -1,0 +1,94 @@
+"""Unit tests for the FalkorDB graph-inspection adapter.
+
+A fake graph handle returns canned ``result_set`` rows (the FalkorDB row shape
+``_records_from_result`` normalizes), so these run without redislite.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from adapters.outbound.graph.falkordb_inspection import FalkorDBInspection
+from domain.ports.claim_query import ClaimQueryFilter
+
+POT = "pot_test"
+
+
+class _FakeResult:
+    def __init__(self, names: list[str], rows: list[list[Any]]) -> None:
+        self.header = [[1, n] for n in names]
+        self.result_set = rows
+
+
+class _FakeGraph:
+    """Routes the inspection cyphers to canned results by content."""
+
+    def __init__(self) -> None:
+        self.queries: list[str] = []
+
+    def query(self, cypher: str, params: dict[str, Any] | None = None) -> _FakeResult:
+        self.queries.append(cypher)
+        if "$frontier" in cypher:  # neighborhood incident edges
+            return _FakeResult(
+                ["source", "target", "predicate"],
+                [["person:y", "repo:x", "PERFORMED"]],
+            )
+        if "$keys" in cypher:  # hydrate nodes
+            return _FakeResult(
+                ["key", "labels", "props"],
+                [
+                    ["repo:x", ["Entity", "Repository"], {"name": "x"}],
+                    ["person:y", ["Entity", "Person"], {"name": "y"}],
+                ],
+            )
+        if "a.entity_key AS source" in cypher:  # slice edges
+            return _FakeResult(
+                ["source", "target", "predicate"],
+                [["person:y", "repo:x", "PERFORMED"]],
+            )
+        # slice nodes
+        return _FakeResult(
+            ["key", "labels", "props"],
+            [
+                [
+                    "repo:x",
+                    ["Entity", "Repository"],
+                    {"name": "x", "fact_embedding": [0.1] * 64, "group_id": POT},
+                ],
+                ["person:y", ["Entity", "Person"], {"name": "y"}],
+            ],
+        )
+
+
+def test_slice_returns_nodes_and_edges_and_strips_embeddings() -> None:
+    insp = FalkorDBInspection(settings=object(), graph=_FakeGraph())
+    sl = insp.slice(pot_id=POT, filter_=ClaimQueryFilter(pot_id=POT))
+    assert sl.pot_id == POT
+    assert {n.key for n in sl.nodes} == {"repo:x", "person:y"}
+    repo = next(n for n in sl.nodes if n.key == "repo:x")
+    assert ("Entity", "Repository") == repo.labels
+    # embedding + group_id are dropped from the explorer payload
+    assert "fact_embedding" not in repo.properties
+    assert "group_id" not in repo.properties
+    assert repo.properties["name"] == "x"
+    assert len(sl.edges) == 1
+    e = sl.edges[0]
+    assert (e.from_key, e.predicate, e.to_key) == ("person:y", "PERFORMED", "repo:x")
+
+
+def test_neighborhood_bfs_collects_incident_edges_and_hydrates() -> None:
+    insp = FalkorDBInspection(settings=object(), graph=_FakeGraph())
+    sl = insp.neighborhood(pot_id=POT, entity_key="repo:x", depth=1)
+    assert {n.key for n in sl.nodes} == {"repo:x", "person:y"}
+    assert len(sl.edges) == 1
+    assert sl.edges[0].predicate == "PERFORMED"
+
+
+def test_neighborhood_clamps_depth() -> None:
+    g = _FakeGraph()
+    insp = FalkorDBInspection(settings=object(), graph=g)
+    # depth far over the cap must not loop unbounded (one frontier round here
+    # since the fake always returns the same edge → BFS converges immediately).
+    insp.neighborhood(pot_id=POT, entity_key="repo:x", depth=99)
+    incident_rounds = sum(1 for q in g.queries if "$frontier" in q)
+    assert 1 <= incident_rounds <= 4

--- a/potpie/context-engine/tests/unit/test_falkordb_reader.py
+++ b/potpie/context-engine/tests/unit/test_falkordb_reader.py
@@ -39,6 +39,17 @@ def _props_graph(*prop_dicts):
     return _FakeGraph(header=[[1, "props"]], result_set=[[p] for p in prop_dicts])
 
 
+class _FakeEmbedder:
+    name = "fake-embedder"
+    dimensions = 3
+
+    def embed(self, text: str) -> tuple[float, ...]:
+        return (0.1, 0.2, 0.3)
+
+    def embed_many(self, texts):
+        return [self.embed(t) for t in texts]
+
+
 def test_find_claims_builds_params_and_parses_rows() -> None:
     graph = _props_graph(
         {
@@ -69,6 +80,58 @@ def test_find_claims_builds_params_and_parses_rows() -> None:
     assert params["as_of"] == "2026-03-01T00:00:00+00:00"
 
 
+def test_find_claims_hydrates_v15_metadata_from_rows() -> None:
+    graph = _props_graph(
+        {
+            "group_id": "p1",
+            "name": "DEPLOYED_TO",
+            "subject_key": "service:web",
+            "object_key": "environment:prod",
+            "valid_at": "2026-02-01T00:00:00+00:00",
+            "valid_until": "2026-05-01T00:00:00+00:00",
+            "claim_key": "claim:p1:deploy:web:prod",
+            "subgraph": "infra_topology",
+            "truth": "source_observation",
+            "confidence": 1.0,
+            "description": "web is deployed to prod",
+            "environment": "prod",
+            "observed_at": "2026-02-02T00:00:00+00:00",
+            "mutation_id": "mut-2",
+            "source_refs": ["repo:x:k8s.yaml"],
+            "evidence": [
+                {"source_ref": "repo:x:k8s.yaml", "authority": "repository_metadata"}
+            ],
+            "graph_contract_version": "1.5",
+            "ontology_version": "2026-06-01",
+            "source_system": "kubernetes",
+            "source_ref": "repo:x:k8s.yaml",
+            "fact": "web is deployed to prod",
+            "code_scope": {"service": "web"},
+        }
+    )
+    store = FalkorDBClaimQueryStore(settings=object(), graph=graph)  # type: ignore[arg-type]
+
+    row = store.find_claims(
+        ClaimQueryFilter(pot_id="p1", predicate_in=("DEPLOYED_TO",), limit=1)
+    )[0]
+
+    assert row.claim_key == "claim:p1:deploy:web:prod"
+    assert row.subgraph == "infra_topology"
+    assert row.truth == "source_observation"
+    assert row.evidence_strength == "deterministic"
+    assert row.environment == "prod"
+    assert row.valid_until == datetime(2026, 5, 1, tzinfo=timezone.utc)
+    assert row.source_refs == ("repo:x:k8s.yaml",)
+    assert row.evidence == (
+        {"source_ref": "repo:x:k8s.yaml", "authority": "repository_metadata"},
+    )
+    assert row.graph_contract_version == "1.5"
+    assert row.ontology_version == "2026-06-01"
+    assert "truth" not in row.properties
+    assert "environment" not in row.properties
+    assert row.properties["code_scope"] == {"service": "web"}
+
+
 def test_fact_query_stamps_similarity_and_orders() -> None:
     graph = _props_graph(
         {
@@ -95,6 +158,43 @@ def test_fact_query_stamps_similarity_and_orders() -> None:
         rows[0].properties["semantic_similarity"]
         > rows[1].properties["semantic_similarity"]
     )
+
+
+def test_fact_query_uses_native_relationship_vector_index_when_embedder_present() -> (
+    None
+):
+    graph = _FakeGraph(
+        header=[[1, "props"], [1, "score"]],
+        result_set=[
+            [
+                {
+                    "group_id": "p1",
+                    "name": "X",
+                    "subject_key": "a",
+                    "object_key": "b",
+                    "fact": "connection pool exhausted in checkout",
+                },
+                0.12,
+            ]
+        ],
+    )
+    store = FalkorDBClaimQueryStore(
+        settings=object(), graph=graph, embedder=_FakeEmbedder()
+    )  # type: ignore[arg-type]
+
+    rows = store.find_claims(
+        ClaimQueryFilter(pot_id="p1", fact_query="connection pool exhausted", limit=3)
+    )
+
+    cypher, params = graph.captured[0]
+    assert "db.idx.vector.queryRelationships" in cypher
+    assert "vecf32($embedding)" in cypher
+    assert "id(rel) = id(r)" in cypher
+    assert "ORDER BY score ASC" in cypher
+    assert params["embedding"] == [0.1, 0.2, 0.3]
+    assert params["k"] == 50
+    assert rows[0].subject_key == "a"
+    assert rows[0].properties["semantic_similarity"] == pytest.approx(0.88)
 
 
 def test_limit_truncates() -> None:
@@ -130,3 +230,28 @@ def test_entity_labels_empty_keys_short_circuits() -> None:
     store = FalkorDBClaimQueryStore(settings=object(), graph=graph)  # type: ignore[arg-type]
     assert store.entity_labels(pot_id="p1", entity_keys=[]) == {}
     assert graph.captured == []
+
+
+def test_entity_properties_returns_node_props() -> None:
+    graph = _FakeGraph(
+        header=[[1, "props"]],
+        result_set=[
+            [
+                {
+                    "entity_key": "service:web",
+                    "name": "web",
+                    "summary": "Web frontend service.",
+                    "description": "Web frontend service for browser clients.",
+                }
+            ]
+        ],
+    )
+    store = FalkorDBClaimQueryStore(settings=object(), graph=graph)  # type: ignore[arg-type]
+
+    props = store.entity_properties(pot_id="p1", entity_key="service:web")
+
+    assert props["summary"] == "Web frontend service."
+    assert props["description"] == "Web frontend service for browser clients."
+    cypher, params = graph.captured[0]
+    assert "RETURN properties(e) AS props" in cypher
+    assert params == {"gid": "p1", "key": "service:web"}

--- a/potpie/context-engine/tests/unit/test_falkordb_writer.py
+++ b/potpie/context-engine/tests/unit/test_falkordb_writer.py
@@ -16,7 +16,7 @@ from adapters.outbound.graph.falkordb_writer import (
     _records_from_result,
     build_falkordb_graph,
 )
-from domain.graph_mutations import EntityUpsert, ProvenanceRef
+from domain.graph_mutations import EdgeUpsert, EntityUpsert, ProvenanceRef
 
 pytestmark = pytest.mark.unit
 
@@ -72,6 +72,17 @@ class _FakeSettings:
 
     def falkordb_lite_path(self) -> str:
         return ".potpie/test/falkordb.db"
+
+
+class _FakeEmbedder:
+    name = "fake-embedder"
+    dimensions = 3
+
+    def embed(self, text: str) -> tuple[float, ...]:
+        return (0.1, 0.2, 0.3)
+
+    def embed_many(self, texts):
+        return [self.embed(t) for t in texts]
 
 
 def test_records_from_result_maps_columns() -> None:
@@ -157,6 +168,20 @@ async def test_ensure_indexes_uses_unnamed_form() -> None:
         assert q.startswith("CREATE INDEX FOR")
 
 
+async def test_ensure_indexes_creates_falkordb_vector_index_with_embedder_dim() -> None:
+    graph = _FakeGraph()
+    w = FalkorDBGraphWriter(
+        _FakeSettings(), graph=graph, embedder=_FakeEmbedder()
+    )
+    await w.ensure_indexes()
+    vector_qs = [q for q, _ in graph.queries if "CREATE VECTOR INDEX" in q]
+    assert len(vector_qs) == 1
+    assert "RELATES_TO" in vector_qs[0]
+    assert "fact_embedding" in vector_qs[0]
+    assert "dimension:3" in vector_qs[0]
+    assert "similarityFunction:'cosine'" in vector_qs[0]
+
+
 async def test_upsert_entities_issues_merge_via_shim() -> None:
     graph = _FakeGraph()
     w = FalkorDBGraphWriter(_FakeSettings(), graph=graph)
@@ -178,6 +203,34 @@ async def test_upsert_entities_empty_is_noop() -> None:
     )
     assert n == 0
     assert graph.queries == []
+
+
+async def test_upsert_edges_writes_falkordb_vecf32_embedding() -> None:
+    graph = _FakeGraph()
+    w = FalkorDBGraphWriter(
+        _FakeSettings(), graph=graph, embedder=_FakeEmbedder()
+    )
+    prov = ProvenanceRef(pot_id="p1", source_event_id="e1")
+    n = await w.upsert_edges(
+        "p1",
+        [
+            EdgeUpsert(
+                edge_type="DEPENDS_ON",
+                from_entity_key="service:web",
+                to_entity_key="service:auth",
+                properties={"fact": "web depends on auth"},
+            )
+        ],
+        prov,
+    )
+
+    assert n == 1
+    vector_writes = [item for item in graph.queries if "vecf32($embedding)" in item[0]]
+    assert len(vector_writes) == 1
+    _, params = vector_writes[0]
+    assert params["embedding"] == [0.1, 0.2, 0.3]
+    assert params["embedding_model"] == "fake-embedder"
+    assert params["embedding_dim"] == 3
 
 
 def test_build_falkordb_graph_server_mode_requires_url() -> None:

--- a/potpie/context-engine/tests/unit/test_neo4j_claim_query.py
+++ b/potpie/context-engine/tests/unit/test_neo4j_claim_query.py
@@ -7,6 +7,7 @@ fact_query token-overlap stamping + ordering, and limit truncation.
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 
 import pytest
@@ -50,6 +51,17 @@ def _rec(**props):
     return {"props": props}
 
 
+class _FakeEmbedder:
+    name = "fake-embedder"
+    dimensions = 3
+
+    def embed(self, text: str) -> tuple[float, ...]:
+        return (0.1, 0.2, 0.3)
+
+    def embed_many(self, texts):
+        return [self.embed(t) for t in texts]
+
+
 def test_row_parsing_maps_reserved_and_extras() -> None:
     row = _row_from_record(
         _rec(
@@ -58,12 +70,32 @@ def test_row_parsing_maps_reserved_and_extras() -> None:
             subject_key="service:web",
             object_key="team:platform",
             valid_at="2026-01-01T00:00:00+00:00",
+            valid_until="2026-06-01T00:00:00+00:00",
             invalid_at=None,
-            evidence_strength="deterministic",
+            evidence_strength="hypothesized",
+            claim_key="claim:p1:owned-by:web",
+            subgraph="infra_topology",
+            truth="source_observation",
+            confidence="0.97",
+            description="web ownership comes from CODEOWNERS",
+            environment="prod",
+            observed_at="2026-01-02T00:00:00+00:00",
+            mutation_id="mut-1",
+            source_refs=["repo:x:CODEOWNERS", "repo:x:owners.yaml"],
+            evidence=json.dumps(
+                [
+                    {
+                        "source_ref": "repo:x:CODEOWNERS",
+                        "authority": "repository_metadata",
+                    }
+                ]
+            ),
+            graph_contract_version="1.5",
+            ontology_version="2026-06-01",
             source_system="codeowners",
             source_ref="repo:x:CODEOWNERS",
             fact="web is owned by platform",
-            code_scope={"language": "py"},
+            code_scope=json.dumps({"language": "py"}),
             policy_kind="ownership",
         )
     )
@@ -71,9 +103,29 @@ def test_row_parsing_maps_reserved_and_extras() -> None:
     assert row.subject_key == "service:web"
     assert row.object_key == "team:platform"
     assert row.valid_at == datetime(2026, 1, 1, tzinfo=timezone.utc)
+    assert row.valid_until == datetime(2026, 6, 1, tzinfo=timezone.utc)
+    assert row.observed_at == datetime(2026, 1, 2, tzinfo=timezone.utc)
+    assert row.claim_key == "claim:p1:owned-by:web"
+    assert row.subgraph == "infra_topology"
+    assert row.truth == "source_observation"
+    assert row.confidence == pytest.approx(0.97)
+    assert row.description == "web ownership comes from CODEOWNERS"
+    assert row.environment == "prod"
+    assert row.mutation_id == "mut-1"
+    assert row.source_refs == ("repo:x:CODEOWNERS", "repo:x:owners.yaml")
+    assert row.evidence == (
+        {"source_ref": "repo:x:CODEOWNERS", "authority": "repository_metadata"},
+    )
+    assert row.graph_contract_version == "1.5"
+    assert row.ontology_version == "2026-06-01"
+    # Derived from V1.5 truth; the legacy edge value is ignored.
     assert row.evidence_strength == "deterministic"
-    # Reserved keys are lifted out; extras stay in properties.
+    # Contract keys are lifted out; extras stay in properties and JSON extras
+    # stored by Neo4j are decoded.
     assert "name" not in row.properties
+    assert "truth" not in row.properties
+    assert "environment" not in row.properties
+    assert "claim_key" not in row.properties
     assert row.properties["code_scope"] == {"language": "py"}
     assert row.properties["policy_kind"] == "ownership"
 
@@ -109,6 +161,30 @@ def test_find_claims_builds_params_and_parses_rows() -> None:
     assert params["as_of"] == "2026-03-01T00:00:00+00:00"
 
 
+def test_entity_properties_returns_node_props() -> None:
+    driver = _FakeDriver(
+        [
+            {
+                "props": {
+                    "entity_key": "service:web",
+                    "name": "web",
+                    "summary": "Web frontend service.",
+                    "description": "Web frontend service for browser clients.",
+                }
+            }
+        ]
+    )
+    store = Neo4jClaimQueryStore(settings=object(), driver=driver)  # type: ignore[arg-type]
+
+    props = store.entity_properties(pot_id="p1", entity_key="service:web")
+
+    assert props["summary"] == "Web frontend service."
+    assert props["description"] == "Web frontend service for browser clients."
+    cypher, params = driver.captured[0]
+    assert "RETURN properties(e) AS props" in cypher
+    assert params == {"gid": "p1", "key": "service:web"}
+
+
 def test_fact_query_stamps_similarity_and_orders() -> None:
     driver = _FakeDriver(
         [
@@ -138,6 +214,39 @@ def test_fact_query_stamps_similarity_and_orders() -> None:
         rows[0].properties["semantic_similarity"]
         > rows[1].properties["semantic_similarity"]
     )
+
+
+def test_fact_query_uses_native_relationship_vector_index_when_embedder_present() -> (
+    None
+):
+    driver = _FakeDriver(
+        [
+            {
+                "props": {
+                    "group_id": "p1",
+                    "name": "X",
+                    "subject_key": "a",
+                    "object_key": "b",
+                    "fact": "connection pool exhausted in checkout",
+                },
+                "score": 0.91,
+            }
+        ]
+    )
+    store = Neo4jClaimQueryStore(
+        settings=object(), driver=driver, embedder=_FakeEmbedder()
+    )  # type: ignore[arg-type]
+
+    rows = store.find_claims(
+        ClaimQueryFilter(pot_id="p1", fact_query="connection pool exhausted", limit=3)
+    )
+
+    cypher, params = driver.captured[0]
+    assert "db.index.vector.queryRelationships" in cypher
+    assert params["embedding"] == [0.1, 0.2, 0.3]
+    assert params["k"] == 50
+    assert rows[0].subject_key == "a"
+    assert rows[0].properties["semantic_similarity"] == pytest.approx(0.91)
 
 
 def test_limit_truncates() -> None:

--- a/potpie/context-engine/tests/unit/test_semantic_mutation_validation.py
+++ b/potpie/context-engine/tests/unit/test_semantic_mutation_validation.py
@@ -1,0 +1,707 @@
+"""Tests for the semantic validator + risk policy + lowerer (V1.5 Steps 4, 5)."""
+
+from __future__ import annotations
+
+import pytest
+
+from application.services.semantic_mutation_lowering import lower_semantic_request
+from application.services.semantic_mutation_validator import (
+    subgraph_for_predicate,
+    validate_semantic_request,
+)
+from domain.graph_contract import GRAPH_CONTRACT_VERSION, ONTOLOGY_VERSION
+from domain.semantic_mutations import SemanticMutationRequest
+
+pytestmark = pytest.mark.unit
+
+
+def _req(op: dict, **kw) -> SemanticMutationRequest:
+    return SemanticMutationRequest.parse({"pot_id": "p", "operations": [op]}, **kw)
+
+
+def _link(**over) -> dict:
+    base = {
+        "op": "link_entities",
+        "subgraph": "infra_topology",
+        "subject": {"key": "service:payments-api", "type": "Service"},
+        "predicate": "DEPENDS_ON",
+        "object": {"key": "service:ledger-api", "type": "Service"},
+        "truth": "source_observation",
+        "evidence": [{"source_ref": "repo:manifest", "authority": "repository_metadata"}],
+        "description": "payments calls ledger to post entries",
+    }
+    base.update(over)
+    return base
+
+
+# --- validation -------------------------------------------------------------
+
+
+def test_valid_low_risk_link_is_accepted_and_apply() -> None:
+    plan = validate_semantic_request(_req(_link()))
+    assert plan.ok
+    assert plan.decision == "apply"
+    assert plan.risk == "low"
+    assert len(plan.accepted_ops) == 1
+
+
+def test_unsupported_contract_version_rejected() -> None:
+    req = SemanticMutationRequest.parse(
+        {"pot_id": "p", "graph_contract_version": "v9", "operations": [_link()]}
+    )
+    plan = validate_semantic_request(req)
+    assert not plan.ok
+    assert plan.decision == "rejected"
+    assert any(i.code == "unsupported_contract_version" for i in plan.errors)
+
+
+def test_unknown_predicate_rejected() -> None:
+    plan = validate_semantic_request(_req(_link(predicate="FROBNICATES")))
+    assert not plan.ok
+    assert any(i.code == "unknown_predicate" for i in plan.errors)
+
+
+def test_invalid_endpoints_rejected() -> None:
+    # DEPENDS_ON is Service->Service; Service->Repository is invalid.
+    plan = validate_semantic_request(
+        _req(_link(object={"key": "repo:foo", "type": "Repository"}))
+    )
+    assert not plan.ok
+    assert any(i.code == "invalid_endpoints" for i in plan.errors)
+
+
+def test_key_prefix_mismatch_rejected() -> None:
+    plan = validate_semantic_request(
+        _req(_link(subject={"key": "repo:wrong", "type": "Service"}))
+    )
+    assert any(i.code == "key_prefix_mismatch" for i in plan.errors)
+
+
+def test_durable_claim_without_evidence_rejected() -> None:
+    # authoritative_fact is not low-authority → must carry evidence.
+    plan = validate_semantic_request(
+        _req(_link(truth="authoritative_fact", evidence=[]))
+    )
+    assert any(i.code == "missing_evidence" for i in plan.errors)
+
+
+def test_agent_claim_without_evidence_allowed() -> None:
+    # A low-authority agent_claim needs no evidence.
+    plan = validate_semantic_request(_req(_link(truth="agent_claim", evidence=[])))
+    assert plan.ok
+    assert plan.decision == "apply"
+
+
+def test_code_asset_endpoint_is_valid_for_preferences() -> None:
+    op = {
+        "op": "assert_claim",
+        "subgraph": "decisions",
+        "subject": {
+            "key": "preference:cli-errors",
+            "type": "Preference",
+            "properties": {
+                "policy_kind": "error_handling",
+                "prescription": "CLI commands should surface validation errors with next actions.",
+                "strength": "strong",
+            },
+        },
+        "predicate": "POLICY_APPLIES_TO",
+        "object": {
+            "key": "code:potpie-context-engine:adapters/inbound/cli",
+            "type": "CodeAsset",
+        },
+        "truth": "preference",
+        "description": "CLI graph commands should return structured errors with next actions.",
+        "extra": {"file_path": "adapters/inbound/cli", "language": "python"},
+    }
+
+    plan = validate_semantic_request(_req(op))
+
+    assert plan.ok
+    assert plan.decision == "apply"
+
+
+def test_missing_description_warns_not_rejects() -> None:
+    plan = validate_semantic_request(_req(_link(description=None)))
+    assert plan.ok  # still applies
+    assert any(i.code == "missing_description" and not i.is_error for i in plan.issues)
+
+
+def test_bad_confidence_rejected() -> None:
+    plan = validate_semantic_request(_req(_link(confidence=1.5)))
+    assert any(i.code == "bad_confidence" for i in plan.errors)
+
+
+def test_bad_timestamp_rejected() -> None:
+    plan = validate_semantic_request(_req(_link(valid_from="not-a-date")))
+    assert any(i.code == "bad_timestamp" for i in plan.errors)
+
+
+def test_patch_entity_is_medium_risk_and_needs_approval() -> None:
+    op = {
+        "op": "patch_entity",
+        "subject": {"key": "service:payments-api", "type": "Service"},
+        "patch": {"summary": "Payments API service"},
+        "expected_entity_version": "entity-version:1",
+        "reason": "tighten display metadata",
+    }
+
+    plan = validate_semantic_request(_req(op))
+    assert plan.ok
+    assert plan.risk == "medium"
+    assert plan.decision == "review_required"
+    assert plan.accepted_ops[0].op == "patch_entity"
+
+    approved = validate_semantic_request(
+        _req(op, allow_review_required=True, approved_by="user:alice")
+    )
+    assert approved.decision == "apply"
+
+
+def test_patch_entity_rejects_non_contract_field_and_weak_description() -> None:
+    plan = validate_semantic_request(
+        _req(
+            {
+                "op": "patch_entity",
+                "subject": {"key": "service:payments-api", "type": "Service"},
+                "patch": {
+                    "identity_key": "service:other",
+                    "description": "payments",
+                },
+                "expected_entity_version": "entity-version:1",
+            }
+        )
+    )
+
+    assert not plan.ok
+    assert any(i.code == "patch_field_not_allowed" for i in plan.errors)
+    assert any(i.code == "weak_description" for i in plan.errors)
+
+
+def test_transition_state_validates_lifecycle_contract() -> None:
+    op = {
+        "op": "transition_state",
+        "subject": {"key": "decision:adr-1", "type": "Decision"},
+        "from_state": "proposed",
+        "to_state": "accepted",
+        "expected_entity_version": "entity-version:2",
+        "reason": "ADR approved by maintainers",
+    }
+
+    plan = validate_semantic_request(_req(op))
+
+    assert plan.ok
+    assert plan.risk == "medium"
+    assert plan.decision == "review_required"
+    assert plan.accepted_ops[0].subgraph == "decisions"
+
+
+def test_transition_state_rejects_invalid_transition() -> None:
+    plan = validate_semantic_request(
+        _req(
+            {
+                "op": "transition_state",
+                "subject": {"key": "decision:adr-1", "type": "Decision"},
+                "from_state": "rejected",
+                "to_state": "accepted",
+                "expected_entity_version": "entity-version:2",
+                "reason": "try to reopen rejected ADR",
+            }
+        )
+    )
+
+    assert not plan.ok
+    assert any(i.code == "invalid_state_transition" for i in plan.errors)
+
+
+def test_supersede_claim_is_high_risk_and_needs_approval() -> None:
+    op = {
+        "op": "supersede_claim",
+        "subject": {"key": "service:a", "type": "Service"},
+        "predicate": "DEPENDS_ON",
+        "object": {"key": "service:b", "type": "Service"},
+        "superseded_by": {"key": "service:c", "type": "Service"},
+        "reason": "dependency target changed",
+        "description": "service:a now depends on service:c instead of service:b",
+    }
+
+    plan = validate_semantic_request(_req(op))
+    assert plan.ok
+    assert plan.risk == "high"
+    assert plan.decision == "review_required"
+    assert plan.accepted_ops[0].op == "supersede_claim"
+    assert not plan.review_required_ops
+
+    approved = validate_semantic_request(
+        _req(op, allow_review_required=True, approved_by="user:alice")
+    )
+    assert approved.decision == "apply"
+
+
+def test_supersede_claim_requires_replacement_and_reason() -> None:
+    plan = validate_semantic_request(
+        _req(
+            {
+                "op": "supersede_claim",
+                "subject": {"key": "service:a", "type": "Service"},
+                "predicate": "DEPENDS_ON",
+                "object": {"key": "service:b", "type": "Service"},
+            }
+        )
+    )
+    assert plan.decision == "rejected"
+    assert any(i.code == "missing_entity" for i in plan.errors)
+    assert any(i.code == "missing_reason" for i in plan.errors)
+
+
+def test_merge_duplicate_entities_is_high_risk_and_needs_approval() -> None:
+    op = {
+        "op": "merge_duplicate_entities",
+        "subject": {"key": "service:payments-v1", "type": "Service"},
+        "object": {"key": "service:payments", "type": "Service"},
+        "external_ids": {
+            "losing": {"source": "manifest:payments-v1.yaml"},
+            "winning": {"source": "manifest:payments.yaml"},
+        },
+        "reason": "manifests describe the same deployable service",
+        "description": "service:payments-v1 is a duplicate identity for service:payments",
+    }
+
+    plan = validate_semantic_request(_req(op))
+    assert plan.ok
+    assert plan.risk == "high"
+    assert plan.decision == "review_required"
+
+    approved = validate_semantic_request(
+        _req(op, allow_review_required=True, approved_by="user:alice")
+    )
+    assert approved.decision == "apply"
+
+
+def test_merge_duplicate_entities_validates_identity_records() -> None:
+    plan = validate_semantic_request(
+        _req(
+            {
+                "op": "merge_duplicate_entities",
+                "subject": {"key": "service:payments-v1", "type": "Service"},
+                "object": {"key": "repo:github.com/potpie-ai/potpie", "type": "Repository"},
+                "reason": "bad merge target",
+            }
+        )
+    )
+    assert not plan.ok
+    assert any(i.code == "merge_type_mismatch" for i in plan.errors)
+    assert any(i.code == "missing_external_ids" for i in plan.errors)
+
+
+def test_append_event_validates_entity_refs_and_endpoints() -> None:
+    plan = validate_semantic_request(
+        _req(
+            {
+                "op": "append_event",
+                "verb": "merged_pr",
+                "occurred_at": "2026-06-08T00:00:00Z",
+                "actor": {"key": "repo:not-person"},
+                "targets": [{"key": "service:payments-api", "type": "Nope"}],
+                "description": "merged PR #42",
+            }
+        )
+    )
+
+    assert not plan.ok
+    assert plan.decision == "rejected"
+    assert any(i.code == "invalid_endpoints" for i in plan.errors)
+    assert any(i.code == "unknown_entity_type" for i in plan.errors)
+
+
+def test_end_relation_validity_requires_exact_object() -> None:
+    plan = validate_semantic_request(
+        _req(
+            {
+                "op": "end_relation_validity",
+                "subgraph": "infra_topology",
+                "subject": {"key": "service:payments-api", "type": "Service"},
+                "predicate": "DEPENDS_ON",
+                "reason": "dependency removed",
+            },
+            allow_review_required=True,
+            approved_by="user:alice",
+        )
+    )
+
+    assert not plan.ok
+    assert plan.decision == "rejected"
+    assert any(i.code == "missing_object" for i in plan.errors)
+
+
+def test_supersede_claim_validates_refs_first() -> None:
+    plan = validate_semantic_request(
+        _req(
+            {
+                "op": "supersede_claim",
+                "subject": {"key": "repo:not-person", "type": "Person"},
+                "predicate": "DEPENDS_ON",
+                "object": {"key": "service:payments-api", "type": "Service"},
+                "superseded_by": {"key": "service:ledger-api", "type": "Service"},
+                "reason": "dependency target changed",
+            }
+        )
+    )
+
+    assert not plan.ok
+    assert plan.decision == "rejected"
+    assert any(i.code == "key_prefix_mismatch" for i in plan.errors)
+    assert any(i.code == "invalid_endpoints" for i in plan.errors)
+
+
+def test_user_decision_is_medium_and_needs_approval() -> None:
+    op = {
+        "op": "assert_claim",
+        "subgraph": "decisions",
+        "subject": {"key": "decision:use-postgres", "type": "Decision"},
+        "predicate": "DECIDED",
+        "object": {"key": "service:payments-api", "type": "Service"},
+        "truth": "user_decision",
+        "evidence": [{"source_ref": "thread:123", "authority": "user_statement"}],
+        "description": "we will use postgres for payments",
+    }
+    # Without approval → review_required.
+    plan = validate_semantic_request(_req(op))
+    assert plan.risk == "medium"
+    assert plan.decision == "review_required"
+    # With approval → apply.
+    plan2 = validate_semantic_request(
+        _req(op, allow_review_required=True, approved_by="user:alice")
+    )
+    assert plan2.decision == "apply"
+
+
+def test_subgraph_for_predicate() -> None:
+    assert subgraph_for_predicate("PROVIDES") == "features"
+    assert subgraph_for_predicate("IMPLEMENTED_IN") == "features"
+    assert subgraph_for_predicate("POLICY_APPLIES_TO") == "decisions"
+    assert subgraph_for_predicate("RESOLVED") == "debugging"
+    assert subgraph_for_predicate("DEPENDS_ON") == "infra_topology"
+    assert subgraph_for_predicate("DECIDED") == "decisions"
+
+
+# --- lowering ---------------------------------------------------------------
+
+
+def test_lowering_produces_batch_with_metadata() -> None:
+    req = _req(_link())
+    plan = validate_semantic_request(req)
+    lower_semantic_request(req, plan)
+    assert plan.batch is not None
+    # link_entities → two entity upserts + one edge upsert.
+    assert len(plan.batch.entity_upserts) == 2
+    assert len(plan.batch.edge_upserts) == 1
+    edge = plan.batch.edge_upserts[0]
+    assert edge.edge_type == "DEPENDS_ON"
+    props = edge.properties
+    # Full V1.5 claim metadata is stamped.
+    for key in (
+        "claim_key",
+        "subgraph",
+        "truth",
+        "confidence",
+        "source_refs",
+        "evidence",
+        "valid_at",
+        "observed_at",
+        "created_by",
+        "graph_contract_version",
+        "ontology_version",
+        "fact",
+    ):
+        assert key in props, key
+    assert props["truth"] == "source_observation"
+    assert props["evidence_strength"] == "deterministic"  # truth→strength map
+    assert props["graph_contract_version"] == GRAPH_CONTRACT_VERSION
+    assert props["ontology_version"] == ONTOLOGY_VERSION
+    assert props["source_refs"] == ["repo:manifest"]
+    # claim_keys surfaced on the accepted op.
+    assert plan.accepted_ops[0].claim_keys
+    # No EventRef fabricated for a non-event write.
+    assert plan.batch.event_ref is None
+
+
+def test_lowering_stamps_environment_into_identity() -> None:
+    req = _req(_link(environment="prod"))
+    plan = validate_semantic_request(req)
+    lower_semantic_request(req, plan)
+    edge = plan.batch.edge_upserts[0]
+    assert edge.properties["environment"] == "prod"
+    assert edge.properties["identity_key"][-1] == "prod"
+
+
+def test_lowering_derives_subgraph_when_omitted() -> None:
+    req = _req(
+        _link(
+            subgraph=None,
+            predicate="USES_ADAPTER",
+            object={"key": "adapter:graph-backend:embedded", "type": "Adapter"},
+            environment="local",
+        )
+    )
+    plan = validate_semantic_request(req)
+    assert plan.ok
+    lower_semantic_request(req, plan)
+
+    edge = plan.batch.edge_upserts[0]
+    assert edge.properties["subgraph"] == "infra_topology"
+    assert ":infra_topology:" in edge.properties["claim_key"]
+
+
+def test_lowering_patch_entity_updates_entity_metadata_only() -> None:
+    req = _req(
+        {
+            "op": "patch_entity",
+            "subject": {"key": "service:payments-api", "type": "Service"},
+            "patch": {"summary": "Payments API service"},
+            "expected_entity_version": "entity-version:1",
+            "reason": "tighten display metadata",
+        },
+        allow_review_required=True,
+        approved_by="user:alice",
+    )
+    plan = validate_semantic_request(req)
+    assert plan.decision == "apply"
+    lower_semantic_request(req, plan)
+
+    assert len(plan.batch.entity_upserts) == 1
+    assert plan.batch.entity_upserts[0].entity_key == "service:payments-api"
+    assert plan.batch.entity_upserts[0].properties["summary"] == "Payments API service"
+    assert plan.batch.entity_upserts[0].properties["last_semantic_op"] == "patch_entity"
+    assert plan.batch.edge_upserts == []
+
+
+def test_lowering_transition_state_updates_entity_and_writes_audit_claim() -> None:
+    req = _req(
+        {
+            "op": "transition_state",
+            "subject": {"key": "decision:adr-1", "type": "Decision"},
+            "from_state": "proposed",
+            "to_state": "accepted",
+            "expected_entity_version": "entity-version:2",
+            "reason": "ADR approved by maintainers",
+            "observed_at": "2026-06-15T10:00:00+00:00",
+        },
+        allow_review_required=True,
+        approved_by="user:alice",
+    )
+    plan = validate_semantic_request(req)
+    assert plan.decision == "apply"
+    lower_semantic_request(req, plan)
+
+    by_key = {entity.entity_key: entity for entity in plan.batch.entity_upserts}
+    decision = by_key["decision:adr-1"]
+    assert decision.properties["lifecycle_state"] == "accepted"
+    assert decision.properties["previous_lifecycle_state"] == "proposed"
+    assert decision.properties["state_transition_reason"] == "ADR approved by maintainers"
+    edge = plan.batch.edge_upserts[0]
+    assert edge.edge_type == "MENTIONS"
+    assert edge.to_entity_key == "decision:adr-1"
+    assert edge.properties["truth"] == "timeline_event"
+    assert edge.properties["state_transition_from"] == "proposed"
+    assert edge.properties["state_transition_to"] == "accepted"
+    assert plan.accepted_ops[0].claim_keys
+
+
+def test_lowering_keeps_canonical_label_for_referenced_entity() -> None:
+    req = SemanticMutationRequest.parse(
+        {
+            "pot_id": "p",
+            "operations": [
+                {
+                    "op": "upsert_entity",
+                    "subject": {
+                        "key": "repo:github.com/potpie-ai/potpie",
+                        "type": "Repository",
+                        "summary": "Potpie repo",
+                    },
+                },
+                {
+                    "op": "assert_claim",
+                    "subject": {
+                        "key": "feature:context-graph",
+                        "type": "Feature",
+                    },
+                    "predicate": "IMPLEMENTED_IN",
+                    "object": {"key": "repo:github.com/potpie-ai/potpie"},
+                    "truth": "source_observation",
+                    "description": "context graph is implemented in potpie",
+                    "evidence": [{"source_ref": "repo:README"}],
+                },
+            ],
+        }
+    )
+    plan = validate_semantic_request(req)
+    assert plan.ok
+    lower_semantic_request(req, plan)
+
+    labels = {e.entity_key: e.labels for e in plan.batch.entity_upserts}
+    assert labels["repo:github.com/potpie-ai/potpie"] == ("Repository",)
+
+
+def test_lowering_carries_preference_fields_on_claim() -> None:
+    op = {
+        "op": "assert_claim",
+        "subgraph": "decisions",
+        "subject": {
+            "key": "preference:cli-errors",
+            "type": "Preference",
+            "properties": {
+                "policy_kind": "error_handling",
+                "prescription": "Emit structured CLI errors with recommended next actions.",
+                "strength": "strong",
+                "audience": "path",
+            },
+        },
+        "predicate": "POLICY_APPLIES_TO",
+        "object": {"key": "repo:github.com/potpie-ai/potpie", "type": "Repository"},
+        "truth": "preference",
+        "description": "CLI graph commands should return structured errors with next actions.",
+        "extra": {
+            "repo": "github.com/potpie-ai/potpie",
+            "file_path": "potpie/context-engine/adapters/inbound/cli",
+            "language": "python",
+        },
+    }
+    req = _req(op)
+    plan = validate_semantic_request(req)
+    assert plan.ok
+    lower_semantic_request(req, plan)
+
+    props = plan.batch.edge_upserts[0].properties
+    assert props["policy_kind"] == "error_handling"
+    assert props["prescription"].startswith("Emit structured CLI errors")
+    assert props["strength"] == "strong"
+    assert props["code_scope"]["file_path"] == "potpie/context-engine/adapters/inbound/cli"
+
+
+def test_lowering_value_object_creates_observation() -> None:
+    op = {
+        "op": "assert_claim",
+        "subgraph": "debugging",
+        "subject": {"key": "bug_pattern:refund-race", "type": "BugPattern"},
+        "predicate": "REPRODUCES",
+        "value": "fails under concurrent settle calls",
+        "truth": "agent_claim",
+        "description": "refund race: deadlock on concurrent settle",
+    }
+    req = _req(op)
+    plan = validate_semantic_request(req)
+    assert plan.ok
+    lower_semantic_request(req, plan)
+    labels = {lbl for e in plan.batch.entity_upserts for lbl in e.labels}
+    assert "Observation" in labels
+
+
+def test_lowering_append_event_creates_activity_and_edges() -> None:
+    op = {
+        "op": "append_event",
+        "subgraph": "recent_changes",
+        "verb": "merged_pr",
+        "occurred_at": "2026-06-08T00:00:00Z",
+        "actor": {"key": "person:alice", "type": "Person"},
+        "targets": [{"key": "service:payments-api", "type": "Service"}],
+        "description": "merged PR #42",
+    }
+    req = _req(op)
+    plan = validate_semantic_request(req)
+    assert plan.ok
+    lower_semantic_request(req, plan)
+    edge_types = {e.edge_type for e in plan.batch.edge_upserts}
+    assert "PERFORMED" in edge_types
+    assert "TOUCHED" in edge_types
+    for edge in plan.batch.edge_upserts:
+        assert edge.properties["valid_at"] == "2026-06-08T00:00:00Z"
+    labels = {lbl for e in plan.batch.entity_upserts for lbl in e.labels}
+    assert "Activity" in labels
+
+
+def test_lowering_retract_produces_invalidation() -> None:
+    op = {
+        "op": "retract_claim",
+        "subgraph": "infra_topology",
+        "subject": {"key": "service:payments-api", "type": "Service"},
+        "predicate": "DEPENDS_ON",
+        "object": {"key": "service:ledger-api", "type": "Service"},
+        "reason": "dependency removed",
+    }
+    req = _req(op, allow_review_required=True, approved_by="user:alice")
+    plan = validate_semantic_request(req)
+    assert plan.decision == "apply"  # medium + approved
+    lower_semantic_request(req, plan)
+    assert len(plan.batch.invalidations) == 1
+    assert plan.batch.invalidations[0].target_edge[0] == "DEPENDS_ON"
+
+
+def test_lowering_supersede_claim_replaces_claim_and_invalidates_old_relation() -> None:
+    req = _req(
+        {
+            "op": "supersede_claim",
+            "subgraph": "infra_topology",
+            "subject": {"key": "service:payments-api", "type": "Service"},
+            "predicate": "DEPENDS_ON",
+            "object": {"key": "service:ledger-old", "type": "Service"},
+            "superseded_by": {"key": "service:ledger-new", "type": "Service"},
+            "reason": "ledger dependency moved",
+            "description": "payments now depends on the new ledger service",
+        },
+        allow_review_required=True,
+        approved_by="user:alice",
+    )
+    plan = validate_semantic_request(req)
+    assert plan.decision == "apply"
+    lower_semantic_request(req, plan)
+
+    assert len(plan.batch.edge_upserts) == 1
+    edge = plan.batch.edge_upserts[0]
+    assert edge.edge_type == "DEPENDS_ON"
+    assert edge.to_entity_key == "service:ledger-new"
+    assert edge.properties["last_semantic_op"] == "supersede_claim"
+    assert len(plan.batch.invalidations) == 1
+    invalidation = plan.batch.invalidations[0]
+    assert invalidation.target_edge == (
+        "DEPENDS_ON",
+        "service:payments-api",
+        "service:ledger-old",
+    )
+    assert invalidation.superseded_by_key == "service:ledger-new"
+    assert plan.accepted_ops[0].claim_keys
+
+
+def test_lowering_merge_duplicate_entities_writes_merge_record() -> None:
+    req = _req(
+        {
+            "op": "merge_duplicate_entities",
+            "subject": {"key": "service:payments-v1", "type": "Service"},
+            "object": {"key": "service:payments", "type": "Service"},
+            "external_ids": {
+                "losing": {"source": "manifest:payments-v1.yaml"},
+                "winning": {"source": "manifest:payments.yaml"},
+            },
+            "reason": "same service in source manifests",
+            "description": "payments-v1 is a duplicate identity for payments service",
+        },
+        allow_review_required=True,
+        approved_by="user:alice",
+    )
+    plan = validate_semantic_request(req)
+    assert plan.decision == "apply"
+    lower_semantic_request(req, plan)
+
+    by_key = {entity.entity_key: entity for entity in plan.batch.entity_upserts}
+    losing = by_key["service:payments-v1"]
+    assert losing.properties["merged_into"] == "service:payments"
+    assert losing.properties["merge_status"] == "merged_duplicate"
+    edge = plan.batch.edge_upserts[0]
+    assert edge.edge_type == "RELATED_TO"
+    assert edge.from_entity_key == "service:payments-v1"
+    assert edge.to_entity_key == "service:payments"
+    assert edge.properties["merge_record"] is True
+    assert edge.properties["merge_external_ids"]["losing"]["source"].endswith("v1.yaml")
+    assert plan.batch.invalidations == []
+    assert plan.accepted_ops[0].claim_keys

--- a/potpie/context-engine/tests/unit/test_settings_graph_backend.py
+++ b/potpie/context-engine/tests/unit/test_settings_graph_backend.py
@@ -6,6 +6,8 @@ Covers default (neo4j), backend selection, and the
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from adapters.outbound.settings_env import EnvContextEngineSettings
@@ -75,9 +77,15 @@ def test_mode_default_lite_and_override(monkeypatch: pytest.MonkeyPatch) -> None
 
 def test_lite_path_default_and_override(monkeypatch: pytest.MonkeyPatch) -> None:
     _clear(monkeypatch)
+    monkeypatch.delenv("CONTEXT_ENGINE_HOME", raising=False)
+    # Default is home-rooted and absolute: a relative path would resolve
+    # against the daemon's cwd (e.g. site-packages for an installed CLI).
+    default = EnvContextEngineSettings().falkordb_lite_path()
+    assert default == str(Path.home() / ".potpie" / "context_graph" / "falkordb.db")
+    monkeypatch.setenv("CONTEXT_ENGINE_HOME", "/srv/potpie-home")
     assert (
         EnvContextEngineSettings().falkordb_lite_path()
-        == ".potpie/context_graph/falkordb.db"
+        == "/srv/potpie-home/context_graph/falkordb.db"
     )
     monkeypatch.setenv("FALKORDB_LITE_PATH", "/tmp/cg.db")
     assert EnvContextEngineSettings().falkordb_lite_path() == "/tmp/cg.db"

--- a/uv.lock
+++ b/uv.lock
@@ -665,6 +665,70 @@ wheels = [
 ]
 
 [[package]]
+name = "cuda-bindings"
+version = "13.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/6b/457ca12dad3ee9bfcc9a545cfd6b64b359ba49de40f776f6e028e678f262/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5879712accf6e14bb01aa5e67440eb84998b8d104b509cc7a6dc0b8f656a474", size = 6053539, upload-time = "2026-05-29T23:11:43.19Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7a/c5e3c34a409b148f5c0f5a4ea374158f95d488862c1dffedf9aa5c639df9/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04436a9364059c84b8f9636f359eccda1cf814341f5b670c71d80d2f79dbc708", size = 6674166, upload-time = "2026-05-29T23:11:45.478Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e32d08f71ebcdf00f0f41eab2eb37e8da94c8ed411cc9f7f7a019ce6b34abe3a", size = 6657965, upload-time = "2026-05-29T23:11:52.227Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c2/ef9b6a63f7dc432712a462c816662e662e00d38caa9b861c8c2588195d03/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2732904099e0a4d4db774a5fc6d91ee95fae065b4d2ecabb4968c5fe2406c9d7", size = 6476660, upload-time = "2026-05-29T23:11:59.188Z" },
+]
+
+[[package]]
+name = "cuda-pathfinder"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/c8/26f2e4aae92f11522a96043892ba39a90eac610d5242523aa863212bc1c7/cuda_pathfinder-1.5.5-py3-none-any.whl", hash = "sha256:0228c023f95d1480f143ef5c8922d27a2ab052087a942e81dc289c9eb8f91689", size = 51671, upload-time = "2026-05-27T01:21:25.413Z" },
+]
+
+[[package]]
+name = "cuda-toolkit"
+version = "13.0.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b2/453099f5f3b698d7d0eab38916aac44c7f76229f451709e2eb9db6615dcd/cuda_toolkit-13.0.2-py2.py3-none-any.whl", hash = "sha256:b198824cf2f54003f50d64ada3a0f184b42ca0846c1c94192fa269ecd97a66eb", size = 2364, upload-time = "2025-12-19T23:24:07.328Z" },
+]
+
+[package.optional-dependencies]
+cudart = [
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cufft = [
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cufile = [
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+]
+cupti = [
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+curand = [
+    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cusolver = [
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cusparse = [
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+nvjitlink = [
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+nvrtc = [
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+nvtx = [
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+
+[[package]]
 name = "daytona"
 version = "0.184.0"
 source = { registry = "https://pypi.org/simple" }
@@ -810,8 +874,8 @@ name = "falkordb"
 version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "python-dateutil", marker = "python_full_version >= '3.12'" },
-    { name = "redis", marker = "python_full_version >= '3.12'" },
+    { name = "python-dateutil" },
+    { name = "redis" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c8/3a/58da510e5800a5cdbf9591111e4287cbf68b475bf074db12a94e5db8bcea/falkordb-1.6.1.tar.gz", hash = "sha256:bbef448a0b43e00ff3062bd6201368618d7b36e969d16ba71e8b8e3fa90873d4", size = 103185, upload-time = "2026-04-28T13:24:44.524Z" }
 wheels = [
@@ -937,6 +1001,15 @@ wheels = [
 ]
 
 [[package]]
+name = "fsspec"
+version = "2026.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
+]
+
+[[package]]
 name = "genai-prices"
 version = "0.0.62"
 source = { registry = "https://pypi.org/simple" }
@@ -970,7 +1043,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/42/3c/ff890b466eaba2b0f5e6bdfff025f8c75f41b8ffdc3dbc3d24ad261e764a/greenlet-3.5.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:73f78f9b9f0a5c06e5c946ba1e8e36f5114923b6be109ee618c54f079c3ea14f", size = 284764, upload-time = "2026-05-20T13:09:10.204Z" },
     { url = "https://files.pythonhosted.org/packages/81/0e/5e5457be3d256918f6a4756f073548a3f0190836e2cc94aa6d0d617a940b/greenlet-3.5.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a0cbed8bb44e23c5b199f888f4e4ce096b45ad9f25ff74a7ad0213875e936bb2", size = 603479, upload-time = "2026-05-20T14:00:04.757Z" },
     { url = "https://files.pythonhosted.org/packages/6d/e1/f89a21d58d308298e6f275f13a1b472ed96c680b601a371b08be6a725989/greenlet-3.5.1-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a203a8bd0acb0701653d3bbb26e404854a68674139ed5cbb778830f42b09bb33", size = 615495, upload-time = "2026-05-20T14:05:40.87Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/8fd452fd81adb9ec79c8275c1375702ab0fd6bee4952da12eaa09b9508d8/greenlet-3.5.1-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ebeb75c81211f5c702576cf81f315e77e23cfdb2c7c6fcb9dd143e6de35c360", size = 623515, upload-time = "2026-05-20T14:09:07.853Z" },
     { url = "https://files.pythonhosted.org/packages/75/de/af6cef182862d2ccd6975440d21c9058a77c3f9b469abf94e322dfd2e0e3/greenlet-3.5.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a271fcd66c74615cda6a964fda3f304267a12e50a084472218a39bb0376f563", size = 614754, upload-time = "2026-05-20T13:14:24.947Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bc/c318aa9f3ffc77320fddcee3d892be957b42e2ff947198d9450b004f3a38/greenlet-3.5.1-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:017a544f0385d441e88714160d089d6900ef46c9eff9d99b6715a5ef2d127747", size = 418439, upload-time = "2026-05-20T14:01:38.446Z" },
     { url = "https://files.pythonhosted.org/packages/1a/c6/50e520283a9f19388a7326b05f9e8637e566003475eacaadad04f558c68d/greenlet-3.5.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ded7b068c7c31c1a8657d4fd42d886b3e051ae29f88b80c5ff9d502257b0f071", size = 1574097, upload-time = "2026-05-20T14:02:24.003Z" },
     { url = "https://files.pythonhosted.org/packages/21/1c/13abd1f4860d987fa5e1170a01930d6e6cd40d328de487a3c9fdaff0ffd0/greenlet-3.5.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d0932b81d72f552ded9d810d00021b64d89f2195a91ce115b893f943b7a4ab3c", size = 1641058, upload-time = "2026-05-20T13:14:31.83Z" },
     { url = "https://files.pythonhosted.org/packages/f5/56/5f332b7705545eac2dc01b4e9254d24a793f2656d55d5cc6b94ee59d22ae/greenlet-3.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:88e300d136eac057b2397aa1cfd7328b4c87c7eb66a09c7bc6a1292234db474e", size = 238089, upload-time = "2026-05-20T13:14:03.229Z" },
@@ -978,7 +1053,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/37/4549f149c9797c21b32c2683c33522af22522099de128b2406672526d005/greenlet-3.5.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:fa4f98af3a528f0c3fd592a26df7f376f93329c8f4d987f6bb979057af8bf5e2", size = 286220, upload-time = "2026-05-20T13:07:28.463Z" },
     { url = "https://files.pythonhosted.org/packages/38/ff/a4f436709716965eaab9f36ea7b906c8a927fbe32fb1372a2071d964f6b1/greenlet-3.5.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffea73584b216150eab159b6d12348fb253e68757974de1e2c40d8a318ac89ed", size = 601585, upload-time = "2026-05-20T14:00:06.141Z" },
     { url = "https://files.pythonhosted.org/packages/65/ad/54bc3fcee3ad368a61b19b67d88117f7a8c29727bf71fffdeda81fbd946e/greenlet-3.5.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1072b4f9edcc1e192d9283a66a3e68d6b84c561de33a83d7858beb9ba1effe10", size = 614215, upload-time = "2026-05-20T14:05:42.675Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/6c/de5b1b388cd2d9fbdfeab324863daba37d54e6e233ddbefd70b385a8c591/greenlet-3.5.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:89101bfd5011e069be974903cb3a4e4523845e4ece2d62dcd8d358933c0ef249", size = 620094, upload-time = "2026-05-20T14:09:09.18Z" },
     { url = "https://files.pythonhosted.org/packages/40/69/b91cda0647df839483201545913514c2827ebea5e5ccdf931842763bc127/greenlet-3.5.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:add5217d68b31130f0beca584d7fef4878327d2e31642b66618a14eef312b63b", size = 611358, upload-time = "2026-05-20T13:14:26.37Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/43/1204baffab8a6476464795a7ccf394a3248d4f22c9f87173a15b36b6d971/greenlet-3.5.1-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:e6cd99ea59dd5d89f0c956606571d79bfe6f68c9eb7f4a4083a41a7f1587edee", size = 422782, upload-time = "2026-05-20T14:01:39.597Z" },
     { url = "https://files.pythonhosted.org/packages/59/90/3cf77e080350cd02fa307bb2abf05df48f4482c240275bbd2c203ba8bb1c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a5ea42a752d47a145eae922b605cd1634665ac3d5ec1e72402d5048e8d60d207", size = 1570475, upload-time = "2026-05-20T14:02:25.29Z" },
     { url = "https://files.pythonhosted.org/packages/65/2c/18cece62045e74598c3c393f70dce4a63f56222015ba29a5d4eeb04f764c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c5551170cf4f5ff5623e9af81323751979fee2c731e2287b61f73cd27257b823", size = 1635625, upload-time = "2026-05-20T13:14:34.027Z" },
     { url = "https://files.pythonhosted.org/packages/30/f5/310d104ddf41eb5a70f4c268d22508dfb0c3c8e86fec152be34d0d2ed819/greenlet-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3c8bb982ad117d29478ef8f5533e97df21f1e2befd17a299257b0c96d1371c0b", size = 238791, upload-time = "2026-05-20T13:10:39.018Z" },
@@ -986,7 +1063,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/27/69/7f7e5372d998b81001899b1c0823c957aa413ba0f2662e65821611cc31e4/greenlet-3.5.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:51518ff74664078fc51bffcc6fc529b0df5ae58da192691cee765d45ce944a2b", size = 285060, upload-time = "2026-05-20T13:08:51.899Z" },
     { url = "https://files.pythonhosted.org/packages/b1/bf/387f9b6b865fd2ae0d0be09e0004827295a01b71be76ed350dd1e28a91a4/greenlet-3.5.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ffdb3c0bb002c99cd8f298957e046c3dbf6006b5b7cdf11a4e19194624a0a0a", size = 604370, upload-time = "2026-05-20T14:00:07.492Z" },
     { url = "https://files.pythonhosted.org/packages/32/f5/169ce3d4e4c67291bd18f8cbe0299c9f3e45102c7f1fb3c14780c93e4532/greenlet-3.5.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7715a5a2c3378ba602c3a440558261e13a820bb53a82693aacd7b7f6d964e283", size = 616987, upload-time = "2026-05-20T14:05:44.237Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ba/c24110c55dffa55aa6e1d98b45310da33801aeba7686ff0190fe5d46fd32/greenlet-3.5.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d40a890035c0058cadbdc4af7569800fd28a0e527a0fdbb7b5f9418f176846ce", size = 622911, upload-time = "2026-05-20T14:09:10.598Z" },
     { url = "https://files.pythonhosted.org/packages/ee/e5/7f2e41d5273be07e77560d61ea4e56485b4d6c316d2a84518c62d1364061/greenlet-3.5.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc71ff466927a201b08305acac451ebe1aedfcea002f62f1f2f2ac2ac1e6a135", size = 613911, upload-time = "2026-05-20T13:14:27.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/7b/d20db2e8a5ad6c038702f3179b136f93f0a3d1a21a0c0777f3e470cdf4b2/greenlet-3.5.1-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:67821bb03e4e98664490edb787ff6af501194c29bbee0f5c1dfdcf1dc3d9d436", size = 425228, upload-time = "2026-05-20T14:01:40.837Z" },
     { url = "https://files.pythonhosted.org/packages/c5/a4/fbdc67579b73615a1f91615e814303cc71e06128f7baaba87be79b8fb90c/greenlet-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cd443683db272ebaaca03af98c0b063ab30db70ea8a31a1559f35e3f7b744ccd", size = 1570689, upload-time = "2026-05-20T14:02:27.225Z" },
     { url = "https://files.pythonhosted.org/packages/e6/b4/77abbe35078be39718a46cd49caf16bceb35662f97a34101dca28aa98e47/greenlet-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:089fff7a6ce8d9316d1f65ebc00273a56be258c1725b32b94de90a3a979557e1", size = 1635602, upload-time = "2026-05-20T13:14:36.344Z" },
     { url = "https://files.pythonhosted.org/packages/37/f7/129f27ca700845b8ee8ca88ce7f43435a1239c2eddb7677fc938822762cf/greenlet-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:110a1ca7b49b014b097f6078272c3f4ed31af45b254de5228b79adba879f6af9", size = 238683, upload-time = "2026-05-20T13:11:50.57Z" },
@@ -1131,6 +1210,30 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/2d/57fd21d84d93efb4bd0b962383790e19dd1bc053501b4264c97903b4e83e/hf_xet-1.5.1.tar.gz", hash = "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6", size = 876636, upload-time = "2026-06-08T23:02:53.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/ee/dd9ba7beae1005e54131b7d45263cc74c8a066d47d354e6d58ae9445a388/hf_xet-1.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:dbf48c0d02cf0b2e568944330c60d9120c272dabe013bd892d48e25bc6797577", size = 4069485, upload-time = "2026-06-08T23:02:13.193Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/bc/9cae6cfeb4e03070874e73e5c97c66eb90369d3206b6a2b1ef5f96520888/hf_xet-1.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78e4e5192ad2b674c2e1160b651cb9134db974f8ae1835bdfbfb0166b894a43", size = 3838493, upload-time = "2026-06-08T23:02:15.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b4/d5c01e0eb6d9f2ca2dacd84d0d1b71e6cfbb2ef3208c968528e010e9b3d7/hf_xet-1.5.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6f7a04a8ad962422e225bc49fbbac99dc1806764b1f3e54dbd154bffa7593947", size = 4505658, upload-time = "2026-06-08T23:02:17.196Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c5/29a7598c0c6383c523dc22186d577f4e04267a626cd95ae60f67c00bfe66/hf_xet-1.5.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d48199c2bf4f8df0adc55d31d1368b6ec0e4d4f45bc86b08038089c23db0bed8", size = 4292822, upload-time = "2026-06-08T23:02:18.608Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9a/dceaf6ca69390126b86ea825fb354b93d01163199070b7bd849225de9468/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:97f212a88d14bbf573619a74b7fecb238de77d08fc702e54dec6f78276ca3283", size = 4491255, upload-time = "2026-06-08T23:02:20.124Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/e5a7afaacf6c1791fdbeeac42951fb81c3d2bc482992b115dedcc86d963e/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f61e3665892a6c8c5e765395838b8ddf36185da835253d4bc4509a81e49fb342", size = 4711062, upload-time = "2026-06-08T23:02:21.863Z" },
+    { url = "https://files.pythonhosted.org/packages/53/49/2802f8433c9742ce281bddc1e65c02c32268ca3098d66828b05e12e45ee2/hf_xet-1.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f4ad3ebd4c32dd2b27099d69dc7b2df821e30767e46fb6ee6a0713778243b8ff", size = 4017205, upload-time = "2026-06-08T23:02:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5a/50c71195b9fb883659f596e7252faf4c18c58e753a9013bdbf9bac5d2250/hf_xet-1.5.1-cp313-cp313t-win_arm64.whl", hash = "sha256:8298485c1e36e7e67cbd01eeb1376619b7af43d4f1ec245caae306f890a8a32d", size = 3845426, upload-time = "2026-06-08T23:02:25.124Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d8/5e54cf37434759d1f4f2ba9b66077ff9d4c4e1f37b6bd7975da5c40d94ab/hf_xet-1.5.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6abd35c3221eff63836618ddfb954dcf84798603f71d8e33e3ed7b04acfdbe6e", size = 4077794, upload-time = "2026-06-08T23:02:40.656Z" },
+    { url = "https://files.pythonhosted.org/packages/35/94/4b2ecfbad8f8b04701a23aefb62f540b9137d058b7e1dbef16a32676f0e9/hf_xet-1.5.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:94e761bbd266bf4c03cee73753916062665ce8365aa40ed321f45afcb934b41e", size = 3845354, upload-time = "2026-06-08T23:02:42.702Z" },
+    { url = "https://files.pythonhosted.org/packages/de/cc/f99f4bc7295023d7bd9ebbfd51f75cc530ca262c1227666268b8208f4b77/hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350", size = 4514864, upload-time = "2026-06-08T23:02:44.497Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6e/21f7e5a2381278bd3b7b7a5a4d90038518bb6308a0c1daf5d9f8268bb178/hf_xet-1.5.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4", size = 4303784, upload-time = "2026-06-08T23:02:46.203Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0e/f992bb6927ac1cb30ef74e62268f551f338bc32b2191f7c96a44c6f7283e/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6", size = 4500703, upload-time = "2026-06-08T23:02:47.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b6/20f99cfe97cc663a711f7b33cc21d4793e51968e9a26125b4afcd77315ba/hf_xet-1.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5", size = 4026419, upload-time = "2026-06-08T23:02:50.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fa/77453694888f03e5a8c8852d1514a0894d8e81c622d39edbaf308ea0dcf4/hf_xet-1.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e", size = 3855178, upload-time = "2026-06-08T23:02:52.452Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1240,6 +1343,26 @@ wheels = [
 ]
 
 [[package]]
+name = "huggingface-hub"
+version = "1.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/79/621a7dbb80c70974f73a597275351ebe03ce5bc65cb5f8f4acb5859252bc/huggingface_hub-1.16.1-py3-none-any.whl", hash = "sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22", size = 668176, upload-time = "2026-05-21T18:39:58.596Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.19"
 source = { registry = "https://pypi.org/simple" }
@@ -1333,6 +1456,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "jiter"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1390,6 +1525,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
     { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
     { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
+]
+
+[[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
 ]
 
 [[package]]
@@ -1518,6 +1662,58 @@ wheels = [
 ]
 
 [[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+]
+
+[[package]]
 name = "mccabe"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1567,6 +1763,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
 ]
 
 [[package]]
@@ -1660,6 +1865,15 @@ wheels = [
 ]
 
 [[package]]
+name = "narwhals"
+version = "2.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/3c/c4ef2164a71c1a63d7f1ae411c4082c5fa872405106db60a4b7114989ad7/narwhals-2.22.1.tar.gz", hash = "sha256:d62920805a0a43b7ff8b54b0c0d3142d796f8a9301836ada37e573d6a33cbcd9", size = 647493, upload-time = "2026-06-05T12:34:34.051Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/ca/36339329c4604adbcc99c899b7eb1ce1a555c499b6a6860757dc9bfed36d/narwhals-2.22.1-py3-none-any.whl", hash = "sha256:60567d774edf77db53906f89d9fbd164e66e56d66d388e1e6990f17ac33cfb53", size = 454815, upload-time = "2026-06-05T12:34:32.289Z" },
+]
+
+[[package]]
 name = "neo4j"
 version = "6.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1687,6 +1901,216 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/49/ec46835a70be8fa6446c495126ac84fdb28cb2558e1620ffb87a10c8b64c/numpy-2.4.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0280e0356c0829a18d9de1cb7eee50ec22ca639878d7240307ca0943d73cd2c4", size = 16969194, upload-time = "2026-05-18T23:33:13.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0d/f5957185c0ee2f3e12f78715aa9e3b353fd83633316c8532b38faa37e3f6/numpy-2.4.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:110f8b71aacb688ec69062bb7f6938a0f8acb01b7c1c4beb453c65b6d234584d", size = 14964111, upload-time = "2026-05-18T23:33:17.795Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/40/40a40ee0ddf7ceb782c49af278894b686e586d65d8c1889c8b5da01a3d7d/numpy-2.4.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4cfe66903cc32a9921a6733d96b19bb6abf310397581bbad89c228f5abaf0ee8", size = 5469159, upload-time = "2026-05-18T23:33:20.654Z" },
+    { url = "https://files.pythonhosted.org/packages/63/13/f9a8046535cb21deae82f8d03de9617e08882d274fad2539630761888228/numpy-2.4.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8155154c7c691289fe18f510b5d4657c68c67989f293f0535a91360392ff6538", size = 6798936, upload-time = "2026-05-18T23:33:22.987Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a8/6fa8c1a345a8c85dbb21932c447bee07c30a2c2a3f31e369c0a84b300147/numpy-2.4.6-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ab0a9c4ffb1a6d95ef519fe4247dba8eb6b18ad93999f76b7f657039acabd47", size = 15966692, upload-time = "2026-05-18T23:33:26.62Z" },
+    { url = "https://files.pythonhosted.org/packages/02/03/74fe2a4cb3817d94d86402f2506554130a2f01414e299b5a843e5a8a957f/numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89cd468399cfd2504718f0ba50e410dca55a170b61a02ad92bb18c8a65186e93", size = 16918164, upload-time = "2026-05-18T23:33:29.955Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/80/3615be3313f7e7696609bc194b9f0101da809df79e859bdb84e0cd043f46/numpy-2.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c2d37ab77531417474168eb79d6d80b14f821a966818505d03013d0833edb7a8", size = 17322877, upload-time = "2026-05-18T23:33:34.724Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ac/a691e0fe2675e370d0e08ff905adc49a1c8830e8cae03efe4477e92cd55d/numpy-2.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f407cb6b8e9d6d8c626bc73c945db1706035af8fd632295547bf1c9e46d092d6", size = 18651487, upload-time = "2026-05-18T23:33:38.217Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a7/9bc1cd626d7bf6869bfedf27b91b6ab5dd607758bf8e959d6fa80c6a59cb/numpy-2.4.6-cp311-cp311-win32.whl", hash = "sha256:ddea102b48f9e339f3948bf22040944184627a30fdf7f858667673b9c5f033c8", size = 6233945, upload-time = "2026-05-18T23:33:41.331Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/7fc6239c12bce7e931463251cca4426c465e1876ba3cc785402ef4dd8f4e/numpy-2.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:1e254a00cdf42b1e4d5b3d68d33af63268d41340d8885df2ab6470f2e1500147", size = 12608406, upload-time = "2026-05-18T23:33:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/27/83/140f85a466595a16382996a1bf06b2b54bcd597488921b0c9daaeeda72af/numpy-2.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:ed9749eef4cbd126da3dc1d6bcb3a57f5eb7ac6a6484146bdbf743f552dfc577", size = 10479528, upload-time = "2026-05-18T23:33:50.725Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/de/12/b422cc84439adc0d00de605bf4a308890ae5c26f2c71fbd73e5d08fbb0dd/numpy-2.4.6-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:55cced7c52e981362f708ad635198e97a752dfba412cc03c23bbf3bd8d5cd662", size = 16847511, upload-time = "2026-05-18T23:36:50.673Z" },
+    { url = "https://files.pythonhosted.org/packages/44/53/f481bef68011740f8849418d82db07230e825013f31f4eef5ba5b805316a/numpy-2.4.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d6da64deb6b8ed903e7560180a92f2d804ee1ba5eeb849ac2748b8c1aba1f6d7", size = 14889064, upload-time = "2026-05-18T23:36:53.879Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/57/42ed575c10ced8af951d426bc4e1f8aff16fd851db33f067036215a7f860/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:68a5124b13fa6cc2086764a20005d30bc0548146f7f5322f02fce212ca14317f", size = 5394157, upload-time = "2026-05-18T23:36:57.194Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ef/f66cc724fcc36c1e364c67f51ae9146090b8b584f27d58b97fdae3edd737/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:948424b06129ce883307e8cff868c31396d8dc7630a59c61d70d98dbe70f222c", size = 6708728, upload-time = "2026-05-18T23:36:59.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/9c/c531f2293b91265d8b48e9b329f54fdd7ffae73cb4134ea10cca4237e9cc/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0", size = 15798374, upload-time = "2026-05-18T23:37:02.674Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b0/413077f6b1153ed3cba361401c6783bbad6114804a000cc22eb71c13e190/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02", size = 16747286, upload-time = "2026-05-18T23:37:06.327Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ce/e5ec180bc41812edcd8daeb8639d205622c0e8c02259d8ab25a0201b3c2a/numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73", size = 12504263, upload-time = "2026-05-18T23:37:09.715Z" },
+]
+
+[[package]]
+name = "nvidia-cublas"
+version = "13.1.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-nvrtc" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime"
+version = "13.0.96"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu13"
+version = "9.20.0.48"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
+]
+
+[[package]]
+name = "nvidia-cufft"
+version = "12.0.0.61"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+]
+
+[[package]]
+name = "nvidia-cufile"
+version = "1.15.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44", size = 1223672, upload-time = "2025-09-04T08:32:22.779Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/73/cc4a14c9813a8a0d509417cf5f4bdaba76e924d58beb9864f5a7baceefbf/nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1", size = 1136992, upload-time = "2025-09-04T08:32:14.119Z" },
+]
+
+[[package]]
+name = "nvidia-curand"
+version = "10.4.0.35"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver"
+version = "12.0.4.66"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse"
+version = "12.6.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu13"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu13"
+version = "2.29.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/0d/daf50d44177ee0cbc7ff0a0c91eb5ff676c82be42f9a970bc7597f440c3a/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:674a12383e3c38a1bcccae7d4f3633b37852230b6047883cb2f4c2d1b36d9bf5", size = 206014712, upload-time = "2026-03-03T05:34:20.843Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f4/58e4e91b6919367c7aafb8e36fce9aad1a3047e536bf7e2fd560927d3a4c/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:edd81538446786ec3b73972543e53bb43bcaf0bfc8ef76cb679fcc390ffe136d", size = 205976000, upload-time = "2026-03-03T05:36:24.472Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/7a/123e033aaff487c77107195fa5a2b8686795ca537935a24efae476c41f05/nvidia_nvjitlink-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:13a74f429e23b921c1109976abefacc69835f2f433ebd323d3946e11d804e47b", size = 40713933, upload-time = "2025-09-04T08:35:43.553Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2c/93c5250e64df4f894f1cbb397c6fd71f79813f9fd79d7cd61de3f97b3c2d/nvidia_nvjitlink-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e931536ccc7d467a98ba1d8b89ff7fa7f1fa3b13f2b0069118cd7f47bff07d0c", size = 38768748, upload-time = "2025-09-04T08:35:20.008Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu13"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947, upload-time = "2025-09-06T00:32:20.022Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546, upload-time = "2025-09-06T00:32:41.564Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
 ]
 
 [[package]]
@@ -2086,12 +2510,15 @@ name = "potpie-context-engine"
 version = "0.1.0"
 source = { editable = "potpie/context-engine" }
 dependencies = [
+    { name = "falkordblite", marker = "python_full_version >= '3.12'" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "keyring" },
     { name = "mcp" },
     { name = "pillow" },
+    { name = "potpie-observability", extra = ["sentry"] },
     { name = "pydantic" },
+    { name = "redis", marker = "python_full_version >= '3.12'" },
     { name = "rich" },
     { name = "sentry-sdk" },
     { name = "typer" },
@@ -2100,6 +2527,8 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
+    { name = "falkordb" },
+    { name = "falkordblite", marker = "python_full_version >= '3.12'" },
     { name = "hatchet-sdk" },
     { name = "neo4j" },
     { name = "opentelemetry-exporter-otlp" },
@@ -2108,6 +2537,8 @@ all = [
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic-deep" },
     { name = "pygithub" },
+    { name = "redis" },
+    { name = "sentence-transformers" },
     { name = "sqlalchemy" },
 ]
 benchmarks = [
@@ -2119,7 +2550,11 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
+embeddings = [
+    { name = "sentence-transformers" },
+]
 falkordb = [
+    { name = "falkordb" },
     { name = "falkordblite", marker = "python_full_version >= '3.12'" },
     { name = "redis" },
 ]
@@ -2152,6 +2587,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "falkordb", marker = "extra == 'all'", specifier = ">=1.6.1" },
+    { name = "falkordb", marker = "extra == 'falkordb'", specifier = ">=1.6.1" },
+    { name = "falkordblite", marker = "python_full_version >= '3.12'", specifier = ">=0.10.0" },
+    { name = "falkordblite", marker = "python_full_version >= '3.12' and extra == 'all'", specifier = ">=0.10.0" },
     { name = "falkordblite", marker = "python_full_version >= '3.12' and extra == 'falkordb'", specifier = ">=0.10.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "hatchet-sdk", marker = "extra == 'all'", specifier = ">=1.29.0" },
@@ -2169,6 +2608,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", marker = "extra == 'all'", specifier = ">=1.27.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'observability'", specifier = ">=1.27.0" },
     { name = "pillow", specifier = ">=10.0.0" },
+    { name = "potpie-observability", extras = ["sentry"], editable = "potpie/observability" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'all'", specifier = ">=3.2" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.2" },
     { name = "pydantic", specifier = ">=2.0" },
@@ -2179,16 +2619,20 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pyyaml", marker = "extra == 'benchmarks'", specifier = ">=6.0" },
+    { name = "redis", marker = "python_full_version >= '3.12'", specifier = ">=7.1,<8" },
+    { name = "redis", marker = "extra == 'all'", specifier = ">=7.1,<8" },
     { name = "redis", marker = "extra == 'falkordb'", specifier = ">=7.1,<8" },
     { name = "rich", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
+    { name = "sentence-transformers", marker = "extra == 'all'", specifier = ">=5.1.2" },
+    { name = "sentence-transformers", marker = "extra == 'embeddings'", specifier = ">=5.1.2" },
     { name = "sentry-sdk", specifier = ">=2.61.1" },
     { name = "sqlalchemy", marker = "extra == 'all'", specifier = ">=2.0" },
     { name = "sqlalchemy", marker = "extra == 'postgres'", specifier = ">=2.0" },
     { name = "typer", specifier = ">=0.15.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
 ]
-provides-extras = ["postgres", "benchmarks", "graph", "falkordb", "github", "reconciliation-agent", "hatchet", "observability", "all", "dev"]
+provides-extras = ["postgres", "benchmarks", "graph", "falkordb", "embeddings", "github", "reconciliation-agent", "hatchet", "observability", "all", "dev"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest-cov", specifier = ">=7.1.0" }]
@@ -3022,6 +3466,78 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.5.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/dc/c1f2df4027e82fc54b5a473e4b250f5139faca49a0fbe29a48668d228f34/regex-2026.5.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ccf5249114cc3e772ecdd88a98a86eca0fd74c61ce32a94743758c083fc05d48", size = 489445, upload-time = "2026-05-09T23:12:06.111Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d2/59f01110660081cce9c0bc30ebd0b5ee250dacf658e3248ed92f01e0e8ee/regex-2026.5.9-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:46f1326ca6e65b0879d23ca302c0f2415aad42ff0309b9c818e7949fe19a41d8", size = 291271, upload-time = "2026-05-09T23:12:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/58/b6/14b2c84ff90ddb370c81d27503f4a0fcf071496416f4855f6cc8c5d81c35/regex-2026.5.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ef31cbfe458e21c6122ba8150ff060e0c7789ed0d26eb423f25472584920b555", size = 289212, upload-time = "2026-05-09T23:12:09.266Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d0/4db86529117320de0c84afd90e70bb47434625875e34fcef9d8c127c5b16/regex-2026.5.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:992604d02e6d9c6d786c24a706a71ecffe1020fc1ef264044474cd81fa2c3919", size = 792310, upload-time = "2026-05-09T23:12:11.416Z" },
+    { url = "https://files.pythonhosted.org/packages/07/78/fe4800cd322f862ecffd2d553409b20d80650e5ed71b9d178f853d020b82/regex-2026.5.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9411dd64ca95477225734a93dfc8583b51916b8d5942f99d6cac21e09965451", size = 861721, upload-time = "2026-05-09T23:12:13.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d0/b3618a895dd8feb897c61bb2954edd265e1767d82a01d53065d5871127a3/regex-2026.5.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3dd4a3ff360dfb836fecdb93a4598f9d6e2ac81e3e397125145c6221bf58cf4c", size = 906460, upload-time = "2026-05-09T23:12:15.443Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6f/1481597e859ef19508b345eec4afd1416ed6e6b459c75a64026ef193aecf/regex-2026.5.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a661a7d270a61f7cf460caee8b9fa2d5ef9e5c681234bcb9e0fe14f488e7dfc", size = 799843, upload-time = "2026-05-09T23:12:16.892Z" },
+    { url = "https://files.pythonhosted.org/packages/73/59/955734c803f59108deccba3597ae440c76b62a652733c0006e6243758420/regex-2026.5.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f079e50a0d3cc3cd5091fa9ff45869a2e6b2cd35895731edafb0327901a8d86d", size = 773610, upload-time = "2026-05-09T23:12:19.127Z" },
+    { url = "https://files.pythonhosted.org/packages/68/8f/70c04a236d651c81881dac42ef8538bddda6121434509d0a22d9e601503b/regex-2026.5.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4ebe8f0b5ec5a5024dc4a4c59f444c4e9afc5f2abdbb8962065b75d27fb971f9", size = 781645, upload-time = "2026-05-09T23:12:20.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/96/05c7434d88185e5d27fe54aeb74df86bd77cd79f52f0b4eae54faa8fea70/regex-2026.5.9-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:97cf3bc1b7d7d2306772ec07366c80d9df00ff79e79cea32898883a646d2fae2", size = 854473, upload-time = "2026-05-09T23:12:22.465Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c1/6e3d8202d981f3117004bf341ee74893ba4ba8a9fbaf4b94615846550a08/regex-2026.5.9-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:0f9eede6a5cbdc02d4978090186390936e1776a7d1359b21e41014c609880bcf", size = 763311, upload-time = "2026-05-09T23:12:24.351Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c7/e7737f1526b3fb32bd4c337fd6c71c3ebb5c8296fc34d11197e0955d2e35/regex-2026.5.9-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:01f0f5f55f4b64dacec85dc116d3c05fd23ad3ff037bbc73a2085775953c2611", size = 844593, upload-time = "2026-05-09T23:12:26.341Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/27/0daffb1a535bb39f422c3d200f4ab023c71110ad66a32b366bee708baba0/regex-2026.5.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1268eddd8486dc561d08eee1156e40aa3a8fe10f4bdec8fa653b455fcbffd12c", size = 789167, upload-time = "2026-05-09T23:12:27.975Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fc/294fe4fac4f2ed67207b17471815870c1c45b3a489e08e0ac96daea16ef6/regex-2026.5.9-cp311-cp311-win32.whl", hash = "sha256:8676474c07469d6f33dd1085ca2cd45f65785f32518f2b20e36d9953ca07f994", size = 266249, upload-time = "2026-05-09T23:12:30.141Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b0/8dce459f6245bcf8f6e9f23ac9569f1a0f15c131cc0745e82b43226204cf/regex-2026.5.9-cp311-cp311-win_amd64.whl", hash = "sha256:246de9d60aa3f8538b519834dd95cbf276ea263d6a7bd5a3666dc3fa0230505b", size = 278423, upload-time = "2026-05-09T23:12:31.676Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8d/f9aeff6ad63a3ef720386f2907e6d34a35a510a6e498ebad28b0fb3f6ab6/regex-2026.5.9-cp311-cp311-win_arm64.whl", hash = "sha256:d726ca3f0d76969bf1e8e477d160d3d666bbf999f6860bd314889e5345782046", size = 270420, upload-time = "2026-05-09T23:12:33.194Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9b/6550044bc44e17c84d312c031c2ec42fbdb6a4ec4e29093be3a172d08772/regex-2026.5.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57eeeb05db7979413dec5438f2db21d7ecbba787cde7a711df1a6f6df672aa06", size = 490451, upload-time = "2026-05-09T23:12:34.72Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/95/fc7ba4303b5a0f92446a12ee6778ef2c6c799233f5060042a31bf390cfe9/regex-2026.5.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:398c521292f4c7fb807001dcd54694d3a1fcafc179a36ad9cc56f98df85930b6", size = 292112, upload-time = "2026-05-09T23:12:36.285Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4b/ee27938d1b2c443e89a9a10e00d2d19aa5ee300cd3d61140644e93bb083e/regex-2026.5.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f7a7c26137296beba7784de6eba69c6a93a63ccebc385e4962fe67e267a91225", size = 289599, upload-time = "2026-05-09T23:12:38.089Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/dd/ba103dc19614e25f3880800ca67ce093d6e21b325d72b8383c7bf906e9fa/regex-2026.5.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6441cc660d76107934a09c22167200839a0e89604a6297f78a974e66e931d2c0", size = 796732, upload-time = "2026-05-09T23:12:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e7/f035b4fd858b050b0080bf302968dc0f59ba34e391872d54936758e6844e/regex-2026.5.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:91328f1c23d47595ca3ef0a7557fa129c5a23404b775c770697d2f35b33e0107", size = 865440, upload-time = "2026-05-09T23:12:42.059Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/51/8cd301ecc899aea28124357f729f4272f44de7806fc7ca02490bfbe253e8/regex-2026.5.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:93a7860539414dddaefba2b40f8771765ae17949d4c7182b876ce429e11a8309", size = 912329, upload-time = "2026-05-09T23:12:44.373Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1e/3fbe2fa1e8cebd62f3bb7d3321cff1640aca2e240b51d9bd624aad949260/regex-2026.5.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd2810d22146b6d838acc5ec15602cb6b47920aa4e33015df3868eedfd20bab8", size = 801239, upload-time = "2026-05-09T23:12:46.268Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2f/6f6008682bf2cf98040a0d3153a8e557b6ab728d7713d045cee4ce544ab8/regex-2026.5.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daff2bdbaf1d23e52fdff7c0b7bc2048b68f978df6a4d107ac981f94caef2e66", size = 777054, upload-time = "2026-05-09T23:12:48.051Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2b/eee0d20a6842ba04df4b8847a920b57ef56853f14ef85405473e586b605a/regex-2026.5.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4eeb011098fcb77af513dcef521a3dbecbf8849b1e38940759d293b7a93f5026", size = 785098, upload-time = "2026-05-09T23:12:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/98/6fc1e6410feefb92159edaed5041992bfe390e8d26c721865434acbca558/regex-2026.5.9-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:ea9c8ecfa1b73c73b626534d6626e5340d429630943672b8480724f44e84b962", size = 860095, upload-time = "2026-05-09T23:12:51.666Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a3/bd855e0f2cb1a978ecf6fa6bb69632dd9c3f6ea3b81cde62fde14c9daec7/regex-2026.5.9-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cd2846168eb9ee3c513902bc8225409cb1caab31d04728b145171fa1625d9621", size = 765762, upload-time = "2026-05-09T23:12:53.413Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/66/0ae8c092e60b14c79d24f8e0b7f0aea5bfbffdcab00b5483d13404d3c3a5/regex-2026.5.9-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:39617fb0cde9c0e6306dc70e3bfc096f3da793219879f7ae7aa341a69fbdcf6d", size = 852100, upload-time = "2026-05-09T23:12:55.256Z" },
+    { url = "https://files.pythonhosted.org/packages/21/de/8dfde60fc1b21c946a893ba273403b72617edb261370cb1087099a83f088/regex-2026.5.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd03c4f0e33280d15cae17159b899245d6b7c53d21def19b263b39655061f5ce", size = 789479, upload-time = "2026-05-09T23:12:57.573Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1c/bdcc98f9a4af4fdd166c74941174619ccff4726d3ce32faa8e9a2ecd38dd/regex-2026.5.9-cp312-cp312-win32.whl", hash = "sha256:164eba9b755ea6f244b0d881196fbc1fac09714e9782c9e2732b813142033c8e", size = 266699, upload-time = "2026-05-09T23:12:59.14Z" },
+    { url = "https://files.pythonhosted.org/packages/78/87/240d36864f9e48ace85f72e79ced97ceb7f27ce87739a947dcb834b4e6bc/regex-2026.5.9-cp312-cp312-win_amd64.whl", hash = "sha256:86f40a5d6444db30a125c9c9177e6b25dad981cbc37451fd838f145e6edac92e", size = 277783, upload-time = "2026-05-09T23:13:00.789Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b5/7b30f312b0669dff5beebe5b0989dc2d1a312b1a44fab852199c387a5b96/regex-2026.5.9-cp312-cp312-win_arm64.whl", hash = "sha256:96f5f58b54a063d7ea9dca08e1cf57bfe10499c4d579ee672da284f57f5f0070", size = 270513, upload-time = "2026-05-09T23:13:02.426Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/da/797e91ecec6f84135da778ddce78c20e0af5d2a15c26f87a81bc3eadb6db/regex-2026.5.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d626b84406444b165fc0ba981604edea39f0588ff1f92baa23fe50799ea9afdb", size = 490303, upload-time = "2026-05-09T23:13:04.382Z" },
+    { url = "https://files.pythonhosted.org/packages/44/da/bf30abaaa737b58f4a4b8c4a03659e02fd92092c822e0197ed9e0daab917/regex-2026.5.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d7bdc0ab8f3dd7e1b4f9ab88634e13374669db86bb3c72e8292f07ae313f539f", size = 292019, upload-time = "2026-05-09T23:13:06.022Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e7/d0eaf5713828417b9e5648cf81fa9bacd4961f6ab98c380c2034f8716e35/regex-2026.5.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a8820737949116ffff55fe18f9fc644530063ba6ebfcb8314239416e78f1347c", size = 289468, upload-time = "2026-05-09T23:13:08.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9b/b3fdd62b003baa1a9b593cd8c8699c9651c2e80cc21a5c715707983c42d7/regex-2026.5.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0fbdbac82cb3e4450d0ccde7d7a35607f4cb2dd9fba4b8b69bfaf8c9fa6aed", size = 796749, upload-time = "2026-05-09T23:13:10.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/30/66ab84588765f5b4b271a9ca09ef7ce2b87caa95176ec3d2ad65d7bc4902/regex-2026.5.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:57e8915c7986aa33d25e4d3629cef711cd2863f2961b10409f0c04cb8b7d9020", size = 865445, upload-time = "2026-05-09T23:13:12.523Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/f05169e8588aac365f35ffc7f3bc3184f095ef4cfded7cfaa3c7fd5dbd89/regex-2026.5.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508f56a89ba9cb26e4168cbc37dbd60a28d82430a9e18ad1d25fe0883c314ca2", size = 912322, upload-time = "2026-05-09T23:13:14.281Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/c93444052cf41581f3c884ab3fb5823daf0992f11cd4388d4275ca610558/regex-2026.5.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6d189041f15691cfa2b6c4290448ec221244d225b3f5fe9e7771b34ffcdf6e2", size = 801269, upload-time = "2026-05-09T23:13:16.569Z" },
+    { url = "https://files.pythonhosted.org/packages/50/fe/0cf96b882f540e62e8b9956599798203d599c44cf4c77917ca27400ff69b/regex-2026.5.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e82db382b44d0111b22601c509c89f64434816c9e0eef9d1989cda8cc6ff1c04", size = 777085, upload-time = "2026-05-09T23:13:18.675Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/d78d4924e7fc875557b9e9b768423925fdfaac5549d06da7810019a9bd26/regex-2026.5.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2acfb48634f64996b57f90f39afa692ff362162722581921fe92239a59960f3c", size = 785153, upload-time = "2026-05-09T23:13:20.525Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e0/5214774090e7b4524dcea3e3c4aa74141d43043f8beb49c1599db1c8b53a/regex-2026.5.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d29eebfc9525db68cad3c97eedd7f754fa265aa5cd0cf4f863b2421e1b48fc9f", size = 860164, upload-time = "2026-05-09T23:13:22.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/e1/4a57a83350319b1271f0d7a249b8672513ed928b237a741631270de6caea/regex-2026.5.9-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:debb893095e944091c16e641a6e33c1b0f4cb61ab945ec5afbf53ce7068834d8", size = 765731, upload-time = "2026-05-09T23:13:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f4/499e74a20c156fc75836ee04a72a38d1a063978f600937f9760467beb1b0/regex-2026.5.9-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d659eee77986549c9ea45b861c7567e44d6287c3dc9a4565478853f7b9fe2ff6", size = 852062, upload-time = "2026-05-09T23:13:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/92/7eebc0d0a01e78629695f342ba17e0deaff8fb45e79cc0d7b98287da6e3e/regex-2026.5.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2efa205e6d98b24d1f3ab395c11aa15cdf10935bca283d0285e0499c284fba21", size = 789577, upload-time = "2026-05-09T23:13:27.814Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a4/018e71f7d2ad48c1ebe6d3ae0026f9b7cb4802fd15c7cc02fdf724355102/regex-2026.5.9-cp313-cp313-win32.whl", hash = "sha256:f3844f134e834076677dd369976e9f5068679fcb8e50102fdf6b7ac96a3ec127", size = 266691, upload-time = "2026-05-09T23:13:29.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1d/861a93719fb9ee7dbfc3761b3797b7a3e112a5d42c6129459d2d741be9b5/regex-2026.5.9-cp313-cp313-win_amd64.whl", hash = "sha256:3527bb4942d2c14552155406cdedd906567456821848aed1cb4933a391bf5eca", size = 277747, upload-time = "2026-05-09T23:13:31.859Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c6/0a2436ae4da1ba76e51cb98943c6838a9a721faa40ebe2dce07694ae34e3/regex-2026.5.9-cp313-cp313-win_arm64.whl", hash = "sha256:56a33f191f17d8c417f99945ebdc1e691d3af9605d86ec68c7e54a57e3e17af6", size = 270500, upload-time = "2026-05-09T23:13:33.525Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e9/d21346f7b60ed58789371358ed66b09d00f832e1bd7c06e55d9da5679882/regex-2026.5.9-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:01f28d868834624c934b8d2e0aa1c8341337e37831f4a012f18a5afcba4cbaf3", size = 494172, upload-time = "2026-05-09T23:13:35.935Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/43/fd1177a2032037c681baecdb3422ee4e1424aec4e4f470ef47793d325274/regex-2026.5.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:48036f6374aaa79eb3b754ec29c61d1c6b1606749d705a13f8854fa2539671f6", size = 293952, upload-time = "2026-05-09T23:13:38.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7d/9fbf919768368d3f8a4f6c692cf2aa61e482b2b81ec6a298ace4cbf02480/regex-2026.5.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b96350aa424e79d4fd6b567b344dcbe2b2d6bfc48dfe7717587e1fa6d43da6ff", size = 292314, upload-time = "2026-05-09T23:13:40.353Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6c/e41bfeecb589716843e7c4df09ba46ff2a42961457afece19059d85caeef/regex-2026.5.9-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f3af7a4903c5c04a11a196a5aa75cdd7dd3f8508132f9fb3259d9f5908e3b88", size = 811681, upload-time = "2026-05-09T23:13:42.543Z" },
+    { url = "https://files.pythonhosted.org/packages/87/83/a5c1c525fba0aa656e88ad0face0b1829788ef4c2fb6b26df58aa1151b84/regex-2026.5.9-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7e87577720152d2caae19fe2baaf1f8d5ca12091e9e229f03915c37d1e4b9178", size = 871135, upload-time = "2026-05-09T23:13:44.326Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/80882e799e440dd878b0979cbebf8fa4d54624a332c83037c7a701649e3f/regex-2026.5.9-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c8b9b9d294cfea3cd19c718ade7cc93492b2c4991abd9a68d0b3477ae6d8e100", size = 917265, upload-time = "2026-05-09T23:13:47.295Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ff/8db60211e2286e396aad7dc7725356c502bff0901ea05bd6cdc2e1a042b9/regex-2026.5.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:728d8bfd28a8845c8b6bc5dc7ce010453d206396786c0765c2740cb65f37791e", size = 816311, upload-time = "2026-05-09T23:13:49.885Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/47/742ef579c61730f8d268e5cf1f9ce0e37e2ea041ad0f5644724f2378e463/regex-2026.5.9-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7e30b874d341fac767d7df5a0870540541c2c054b80cfaac116e8d367a8a7ff2", size = 785498, upload-time = "2026-05-09T23:13:52.25Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ab/cb0999802dcb0fb95b1ab005e8d4163d8afdd67efc2cb6b6630ac13f8cb1/regex-2026.5.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fd190e88a895a8901325fad284a3f74ea52b1da8525b76cc811fa9b1edf0ce2b", size = 801348, upload-time = "2026-05-09T23:13:54.127Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/8ca59a24c55bc34d166eefaf3717bd77772f329fdbf984d86581e0a3571c/regex-2026.5.9-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:8e76e8161ad00694cfce6767d5dea860c6391ac5b83e5c3a39661e696f11fc7e", size = 866493, upload-time = "2026-05-09T23:13:56.067Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/3d/30f2ae62cef3278bb5bb821f467277a55fb73f01032cf85997e15e8289a8/regex-2026.5.9-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ddda5340e6c01a293027dd46232fa79eaff1b48058ce7a98f572b6445b088041", size = 772811, upload-time = "2026-05-09T23:13:57.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ae/7d2089bcd78ad0c0161bc684339df50032acb438a7bd3305e7ddb1193cec/regex-2026.5.9-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:205109e96b3cf5adf8f4cd62bedde9487feb282b9497a3535451e5a24cd706a0", size = 856584, upload-time = "2026-05-09T23:13:59.679Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/29/92ff47f75990131ea4f24ba17819e5a9d141e10819807e09addd73409af6/regex-2026.5.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dfbe4579b9f08036aa7d101d1835437a20783574ac66327e6b29b4018a138081", size = 803453, upload-time = "2026-05-09T23:14:01.978Z" },
+    { url = "https://files.pythonhosted.org/packages/04/99/eff29f1037dcab36702c9ee5d6858cf1ce2336ea8ea2987f64245b99ea5e/regex-2026.5.9-cp313-cp313t-win32.whl", hash = "sha256:ed2c9e8068b614c574d8d30e543d617cf5379b0535d46f97ef00e904745a08b5", size = 269951, upload-time = "2026-05-09T23:14:03.661Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/9d/8870b8981d27b22cda77bb26a5ac7ebfa9c7d9e0dea195a834a82380e748/regex-2026.5.9-cp313-cp313t-win_amd64.whl", hash = "sha256:b46b0f094dc1d3b90356c85a0bd2c9bafc4a6a190b9d6f8ddd5a033b6e088ed4", size = 281240, upload-time = "2026-05-09T23:14:05.56Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b1/3379415e8f135c13ac551353397cc4fe97b4978f3cac73c5fcbcded548b8/regex-2026.5.9-cp313-cp313t-win_arm64.whl", hash = "sha256:872acc074bd29ffc9913ecdfedf6ea77502312ca44a4aa0d3779089c6069d8de", size = 272383, upload-time = "2026-05-09T23:14:07.843Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3154,6 +3670,112 @@ wheels = [
 ]
 
 [[package]]
+name = "safetensors"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/9c/6e74567782559a63bd040a236edca26fd71bc7ba88de2ef35d75df3bca5e/safetensors-0.7.0.tar.gz", hash = "sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0", size = 200878, upload-time = "2025-11-19T15:18:43.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/47/aef6c06649039accf914afef490268e1067ed82be62bcfa5b7e886ad15e8/safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517", size = 467781, upload-time = "2025-11-19T15:18:35.84Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/00/374c0c068e30cd31f1e1b46b4b5738168ec79e7689ca82ee93ddfea05109/safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57", size = 447058, upload-time = "2025-11-19T15:18:34.416Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07d91d0c92a31200f25351f4acb2bc6aff7f48094e13ebb1d0fb995b54b6542", size = 491748, upload-time = "2025-11-19T15:18:09.79Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/33/1debbbb70e4791dde185edb9413d1fe01619255abb64b300157d7f15dddd/safetensors-0.7.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8469155f4cb518bafb4acf4865e8bb9d6804110d2d9bdcaa78564b9fd841e104", size = 503881, upload-time = "2025-11-19T15:18:16.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1c/40c2ca924d60792c3be509833df711b553c60effbd91da6f5284a83f7122/safetensors-0.7.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54bef08bf00a2bff599982f6b08e8770e09cc012d7bba00783fc7ea38f1fb37d", size = 623463, upload-time = "2025-11-19T15:18:21.11Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3a/13784a9364bd43b0d61eef4bea2845039bc2030458b16594a1bd787ae26e/safetensors-0.7.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:42cb091236206bb2016d245c377ed383aa7f78691748f3bb6ee1bfa51ae2ce6a", size = 532855, upload-time = "2025-11-19T15:18:25.719Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac7252938f0696ddea46f5e855dd3138444e82236e3be475f54929f0c510d48", size = 507152, upload-time = "2025-11-19T15:18:33.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a8/4b45e4e059270d17af60359713ffd83f97900d45a6afa73aaa0d737d48b6/safetensors-0.7.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1d060c70284127fa805085d8f10fbd0962792aed71879d00864acda69dbab981", size = 541856, upload-time = "2025-11-19T15:18:31.075Z" },
+    { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060, upload-time = "2025-11-19T15:18:37.211Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f5/57644a2ff08dc6325816ba7217e5095f17269dada2554b658442c66aed51/safetensors-0.7.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:672132907fcad9f2aedcb705b2d7b3b93354a2aec1b2f706c4db852abe338f85", size = 771715, upload-time = "2025-11-19T15:18:38.689Z" },
+    { url = "https://files.pythonhosted.org/packages/86/31/17883e13a814bd278ae6e266b13282a01049b0c81341da7fd0e3e71a80a3/safetensors-0.7.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:5d72abdb8a4d56d4020713724ba81dac065fedb7f3667151c4a637f1d3fb26c0", size = 714377, upload-time = "2025-11-19T15:18:40.162Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368, upload-time = "2025-11-19T15:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/05/e5/cb4b713c8a93469e3c5be7c3f8d77d307e65fe89673e731f5c2bfd0a9237/safetensors-0.7.0-cp38-abi3-win32.whl", hash = "sha256:c74af94bf3ac15ac4d0f2a7c7b4663a15f8c2ab15ed0fc7531ca61d0835eccba", size = 326423, upload-time = "2025-11-19T15:18:45.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e6/ec8471c8072382cb91233ba7267fd931219753bb43814cbc71757bfd4dab/safetensors-0.7.0-cp38-abi3-win_amd64.whl", hash = "sha256:d1239932053f56f3456f32eb9625590cc7582e905021f94636202a864d470755", size = 341380, upload-time = "2025-11-19T15:18:44.427Z" },
+]
+
+[[package]]
+name = "scikit-learn"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "narwhals" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/be/e844fd9586e66540a15b71924d17a6cbc1bb749e81ddd0a796bcdba4c055/scikit_learn-1.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9db6f4d34e68c8899e4cab27fdf8eafe6ed21f2ba52ceb25ea250cd237f8e47b", size = 8789686, upload-time = "2026-06-02T11:53:05.439Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e2/ff880f62677a17d035817d543cb0fc8727d01eccbee81c5f7fc733a9d856/scikit_learn-1.9.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:f401448645a3e7bc115aa3c094097865155b34bff1cba8101857d9104e99074c", size = 8256782, upload-time = "2026-06-02T11:53:08.904Z" },
+    { url = "https://files.pythonhosted.org/packages/25/64/eb40435e1a508ab1b4e284ce43ae80f6a162e5be5e38ed5a6fab467a9ea4/scikit_learn-1.9.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fd3a8ef0c758555a3b23c03adaa858af32f7736785ded50ad5991f59c4ed03fa", size = 8992419, upload-time = "2026-06-02T11:53:11.551Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/4810a28e473185429e45a57eebcc91fc991b33d889cc0676063e671db03d/scikit_learn-1.9.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7e254636164090da847715a27f8e5478feb98c40a9e0ee90cbd277de9e5ceb8", size = 9281411, upload-time = "2026-06-02T11:53:15.063Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/67/be3d369f40d8178ba3bd86635d132e08cb5329b023e4669d9426d84bc007/scikit_learn-1.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:5dc1818c77575d149e25fce9ef82dd7b7263ae372f03494158668ad632a69759", size = 8272736, upload-time = "2026-06-02T11:53:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/37/79/a733f02dc2118da7e77a134b34f39f40201a353311b011d20859d2db3556/scikit_learn-1.9.0-cp311-cp311-win_arm64.whl", hash = "sha256:366652351f092b219c248f1e72821e841960a63d8f358f1dcfd54dc1cbdbbc28", size = 7919564, upload-time = "2026-06-02T11:53:21.2Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/20/75f915ff375d6249e6550ac740fdbbd66159a068fd3af1400ff62036b07a/scikit_learn-1.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2bd41b0d201bc81575531b96b713d3eb5e5f50fb0b82101ff0f92294fdc236ac", size = 8741122, upload-time = "2026-06-02T11:53:24.08Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d5/2b5148f2279196775e1db2aeb85d14b70ac80e7e32b3b28e7ebeafb0901d/scikit_learn-1.9.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5be45aa4a42a68a533913a6ed736cf309de2226411c79ef8d609a5456f1939b1", size = 8261512, upload-time = "2026-06-02T11:53:27.183Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ee/5adbc77656b71f9456a2f5a7a9fdb4bcf9207a6b962889f1c2f9323afa4e/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e50ed4da51974e86e940690e9a3d82e729b62b5a49f7c9bac534d515d39d86f", size = 8837603, upload-time = "2026-06-02T11:53:30.328Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c2/63fdda36c56437eeb44aaf9493c8bcd62ce230ab1598924fc626ffbfa943/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:056c92bb67ad4c28463c2f2653d9701449201e7e7a9e94e321be0f71c4fef2b8", size = 9132097, upload-time = "2026-06-02T11:53:33.456Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a4/c8e67227c680e2259c8864ae72ff48b06e16a6f51253a22167aa02a8aa4e/scikit_learn-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:4306775fad04cc4b472a1b15af1ae9cede1540fbfcc17fbce3767cd8dc7ae283", size = 8211173, upload-time = "2026-06-02T11:53:36.602Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/fd/3c0863792e98e67e9184aa4029288a175935eb65443afcd30d4f143450cf/scikit_learn-1.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:26e22435f63bcdcf396b574273f29f13dd531f5ea035801f5be10ba1540a4e60", size = 7867451, upload-time = "2026-06-02T11:53:39.075Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/cf3310626b6d48d3e9be69a1223f9180360b5e6edb045f50fade723ce494/scikit_learn-1.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:80746d63bd4b6eaca54d36fe5feaf4d28bb38dc6f9470f81c7cad7c40155f119", size = 8705188, upload-time = "2026-06-02T11:53:41.964Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/04/5acd7ae280c5f93b6ac5ef6cdec14eef4c8d1cd91d85b3292989c94d96b1/scikit_learn-1.9.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5b934c45c252844a91d69fda3a34cff5e7307e1db10d77cb10a3980312c74713", size = 8228299, upload-time = "2026-06-02T11:53:44.817Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/39/ffe829a5b8ecb40a518724a997794657fdc354ada5e8fe8e64d998c0bac9/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:38c3dcb9a1ffb85505ec53d54c7b4aea0cff70050425a7760c2af661ac85df05", size = 8789690, upload-time = "2026-06-02T11:53:47.461Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/88/8dab5de10c638c083772a6be83a3d8106ced492f74a928c8693638e5bb50/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da76d09304a4706db7cc1e3ebaa3b6b98a67365cc11d2996c4f1e58ba47df714", size = 9087723, upload-time = "2026-06-02T11:53:50.702Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3f/7917ca72464038f6240ec70c29f94862d08a34a74291ae4d4ec5eb8186a0/scikit_learn-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:5808d98f15c6bf6d9d96d2348c1997392a5888ce7097e664105f930c4bca1277", size = 8184330, upload-time = "2026-06-02T11:53:53.396Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c7/15739eb2f61fda3c54639e9942414e5a19ad8a8d1f5a3266afad7cb7df80/scikit_learn-1.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:d77f54c017633791bc0225a43e2f8d03745fdcfe4880268fcc4df15f505dec2e", size = 7840653, upload-time = "2026-06-02T11:53:56.035Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/75/b4ce781849931fef6fd529afa6b63711d5a733065722d0c3e2724af9e40a/scipy-1.17.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:1f95b894f13729334fb990162e911c9e5dc1ab390c58aa6cbecb389c5b5e28ec", size = 31613675, upload-time = "2026-02-23T00:16:00.13Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/58/bccc2861b305abdd1b8663d6130c0b3d7cc22e8d86663edbc8401bfd40d4/scipy-1.17.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:e18f12c6b0bc5a592ed23d3f7b891f68fd7f8241d69b7883769eb5d5dfb52696", size = 28162057, upload-time = "2026-02-23T00:16:09.456Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ee/18146b7757ed4976276b9c9819108adbc73c5aad636e5353e20746b73069/scipy-1.17.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:a3472cfbca0a54177d0faa68f697d8ba4c80bbdc19908c3465556d9f7efce9ee", size = 20334032, upload-time = "2026-02-23T00:16:17.358Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e6/cef1cf3557f0c54954198554a10016b6a03b2ec9e22a4e1df734936bd99c/scipy-1.17.1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:766e0dc5a616d026a3a1cffa379af959671729083882f50307e18175797b3dfd", size = 22709533, upload-time = "2026-02-23T00:16:25.791Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/60/8804678875fc59362b0fb759ab3ecce1f09c10a735680318ac30da8cd76b/scipy-1.17.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:744b2bf3640d907b79f3fd7874efe432d1cf171ee721243e350f55234b4cec4c", size = 33062057, upload-time = "2026-02-23T00:16:36.931Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/af933f0f6e0767995b4e2d705a0665e454d1c19402aa7e895de3951ebb04/scipy-1.17.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43af8d1f3bea642559019edfe64e9b11192a8978efbd1539d7bc2aaa23d92de4", size = 35349300, upload-time = "2026-02-23T00:16:49.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/3d/7ccbbdcbb54c8fdc20d3b6930137c782a163fa626f0aef920349873421ba/scipy-1.17.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd96a1898c0a47be4520327e01f874acfd61fb48a9420f8aa9f6483412ffa444", size = 35127333, upload-time = "2026-02-23T00:17:01.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/19/f926cb11c42b15ba08e3a71e376d816ac08614f769b4f47e06c3580c836a/scipy-1.17.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4eb6c25dd62ee8d5edf68a8e1c171dd71c292fdae95d8aeb3dd7d7de4c364082", size = 37741314, upload-time = "2026-02-23T00:17:12.576Z" },
+    { url = "https://files.pythonhosted.org/packages/95/da/0d1df507cf574b3f224ccc3d45244c9a1d732c81dcb26b1e8a766ae271a8/scipy-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:d30e57c72013c2a4fe441c2fcb8e77b14e152ad48b5464858e07e2ad9fbfceff", size = 36607512, upload-time = "2026-02-23T00:17:23.424Z" },
+    { url = "https://files.pythonhosted.org/packages/68/7f/bdd79ceaad24b671543ffe0ef61ed8e659440eb683b66f033454dcee90eb/scipy-1.17.1-cp311-cp311-win_arm64.whl", hash = "sha256:9ecb4efb1cd6e8c4afea0daa91a87fbddbce1b99d2895d151596716c0b2e859d", size = 24599248, upload-time = "2026-02-23T00:17:34.561Z" },
+    { url = "https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8", size = 31610954, upload-time = "2026-02-23T00:17:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662, upload-time = "2026-02-23T00:18:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366, upload-time = "2026-02-23T00:18:12.015Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f5/906eda513271c8deb5af284e5ef0206d17a96239af79f9fa0aebfe0e36b4/scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b", size = 22704017, upload-time = "2026-02-23T00:18:21.502Z" },
+    { url = "https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21", size = 32927842, upload-time = "2026-02-23T00:18:35.367Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890, upload-time = "2026-02-23T00:18:49.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/9d7f4c88bea6e0d5a4f1bc0506a53a00e9fcb198de372bfe4d3652cef482/scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb", size = 35003557, upload-time = "2026-02-23T00:18:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856, upload-time = "2026-02-23T00:19:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682, upload-time = "2026-02-23T00:19:07.67Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340, upload-time = "2026-02-23T00:19:12.024Z" },
+    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199, upload-time = "2026-02-23T00:19:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001, upload-time = "2026-02-23T00:19:22.241Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719, upload-time = "2026-02-23T00:19:26.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595, upload-time = "2026-02-23T00:19:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429, upload-time = "2026-02-23T00:19:35.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952, upload-time = "2026-02-23T00:19:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063, upload-time = "2026-02-23T00:19:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449, upload-time = "2026-02-23T00:19:53.238Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943, upload-time = "2026-02-23T00:20:50.89Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621, upload-time = "2026-02-23T00:20:55.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708, upload-time = "2026-02-23T00:19:58.694Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135, upload-time = "2026-02-23T00:20:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977, upload-time = "2026-02-23T00:20:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601, upload-time = "2026-02-23T00:20:12.161Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667, upload-time = "2026-02-23T00:20:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159, upload-time = "2026-02-23T00:20:23.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771, upload-time = "2026-02-23T00:20:28.636Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
+]
+
+[[package]]
 name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3164,6 +3786,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
+name = "sentence-transformers"
+version = "5.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/d4/7ef93157485e978c016f49da05363c1e4e7237beb5343b64b5631101f0f1/sentence_transformers-5.5.1.tar.gz", hash = "sha256:02b7740dfc60bdbbcb6061625f5d97a5c1a4e2d3baac5f9391b912bb5eae2290", size = 445161, upload-time = "2026-05-20T07:37:44.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/03/ee99a6b030e7a2e056547729f8a4709dd93e13d9c6f07590f74c395c4017/sentence_transformers-5.5.1-py3-none-any.whl", hash = "sha256:4fe11d433badc5282d32f7fc08bc714216b7a5aca426f9df77a45a554756deb7", size = 588887, upload-time = "2026-05-20T07:37:43.004Z" },
 ]
 
 [[package]]
@@ -3310,12 +3951,59 @@ wheels = [
 ]
 
 [[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
 ]
 
 [[package]]
@@ -3373,6 +4061,46 @@ wheels = [
 ]
 
 [[package]]
+name = "torch"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/62/131124fb95df03811b8260d1d43dcc5ee85ea1a344b964613d7efe77fb08/torch-2.12.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:10802fd383bbfed646212e765a72c37d2185205d4f26eb197a254e8ac7ddcb25", size = 87990344, upload-time = "2026-05-13T14:55:42.154Z" },
+    { url = "https://files.pythonhosted.org/packages/12/9c/dda0dbd547dc549839824135f223792fd0e725f28ed0715dda366b7acaa2/torch-2.12.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:c12592630aef72feaf18bd3f197ef587bbfa21131b31c38b23ab2e55fce92e36", size = 426362932, upload-time = "2026-05-13T14:54:15.295Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/d2/a7dd5a3f9bdaa7842124e8e2359202b317c48d47d2fc5816fafdf2049adb/torch-2.12.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:415c1b8d0412f67551c8e89a2daca0fb3e56694af0281ba155eaa9da481f58b4", size = 532170085, upload-time = "2026-05-13T14:55:20.788Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1b/a61ce2004f9ab0ea8964a6e6168133a127795667639e2ff4f8f2bdb16a65/torch-2.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:dd37188ea325042cb1f6cafa56822b11ada2520c04791a52629b0af25bdfbfd9", size = 122953128, upload-time = "2026-05-13T14:54:52.744Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/bb/285d643f254731294c9b595a007eac39db4600a98682d7bca688f42ca164/torch-2.12.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:b41339df93d491435e790ff8bcbae1c0ce777175889bfd1281d119862793e6a2", size = 88010197, upload-time = "2026-05-13T14:55:35.414Z" },
+    { url = "https://files.pythonhosted.org/packages/79/81/76debf1db1343bd929bbb5d74c89fb437c2ed88eb144712557e7bd3eea45/torch-2.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:8fbef9f108a863e7722a73740998967e3b074742a834fc5be3a535a2befa7057", size = 426376751, upload-time = "2026-05-13T14:55:03.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f0/80026028b603c4650ff270fc3785bdef4bd6738765a9cc5a0f5a637d65a2/torch-2.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4b4f64c2c2b11f7510d93dd6412b87025ff6eddd6bb61c3b5a3d892ea20c4756", size = 532261691, upload-time = "2026-05-13T14:52:54.453Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c2/64b06cbb7830fb3cd9be13e1158b31a3f36b68e6a209105ee3c9d9480be0/torch-2.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:8b958caff4a14d3a3b0b2dfc6a378f64dda9728a9dad28c08a0db9ce4dafb549", size = 122988114, upload-time = "2026-05-13T14:54:42.153Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ca/01896c80ba921676aa45886b2c5b8d774912de2a1f719de48169c6f755cd/torch-2.12.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:90dd587a5f61bfe1307148b581e2084fc5bc4a06e2b90a20e9a36b81087ff16b", size = 88009511, upload-time = "2026-05-13T14:54:47.411Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/04/52bdaf4787eab6ac7d7f5851dff934e4def0bc8ead9c8fd2b69b3e529699/torch-2.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:864392c73b7654f4d2b3ae712f607937d0dbb1101c4555fbb41848106b297f39", size = 426383231, upload-time = "2026-05-13T14:53:32.129Z" },
+    { url = "https://files.pythonhosted.org/packages/49/8a/94bdecd13f5aaa90d45920b89789d9fe7c6f4af8c3cdd7ce01fcb59908fc/torch-2.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5d6b560dfa7d56291c07d615c3bb73e8d9943d9b6d87f76cd0d9d570c4797fa6", size = 532269288, upload-time = "2026-05-13T14:53:49.423Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2f/bdbaaa267de519ef1b73054bf590d8c93c37a266c9a4e24a01bd38b6918f/torch-2.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:3fee918902090ade827643e758e98363278815de583c75d111fdd665ebffde9f", size = 122987706, upload-time = "2026-05-13T14:54:00.335Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ad/e95e822f3538171e22640a7fbe839a1fdb666600bf6487025de2ff03b11a/torch-2.12.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:10ee1448a9f304d3b987eb4656f664ba6e4d7b410ca7a5a7c642199777a2cf88", size = 88319556, upload-time = "2026-05-13T14:54:05.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/07/055d06d985b445d67422d25b033c11cf55bbb81785d4c4e68e28bca5820e/torch-2.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:af68dbf403439cae9ceaeaaf92f8352b460787dcd27b92aa05c40dd4a19c0f1e", size = 426397656, upload-time = "2026-05-13T14:52:38.84Z" },
+    { url = "https://files.pythonhosted.org/packages/43/94/b0b4fdc3014122e0a7302fb90086d352aa48f2576f0b252561ebb38c01a8/torch-2.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:a6a2eebb237d3b1d9ad3b378e86d9b9e0782afdea8b1e0eba6a13646b9b49c07", size = 532183124, upload-time = "2026-05-13T14:53:16.178Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/c8/052405e6ad05d3237bfe5a4df78f917773956f8e17813a2d44c059068b74/torch-2.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2140e373e9a51a3e22ef62e8d14366d0b470d18f0adf19fdc757368077133a34", size = 123232462, upload-time = "2026-05-13T14:52:27.26Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3382,6 +4110,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "transformers"
+version = "5.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/38/d5f978bd5091019e89aef29b9a831f5cd70f2598963a3ead8b9570cab592/transformers-5.10.2.tar.gz", hash = "sha256:f9a44b9c8ca9ab1156b467f574d832ea066284299c2fd0ed84641ccb592751fc", size = 8799687, upload-time = "2026-06-04T18:43:49.119Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/6f/e1564b0cc182afa05e219a8e09a8e770ffaab879b6b824b56c819bd221da/transformers-5.10.2-py3-none-any.whl", hash = "sha256:8a669db546f82c7c3618cb46ceb0f0afd89292bc70f319c058f8332ec63e268d", size = 11003830, upload-time = "2026-06-04T18:43:45.303Z" },
 ]
 
 [[package]]
@@ -3425,6 +4173,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/c4/fc366dbf351a60c0be82040ac1d21c1c2c4dc0e9ee3890b1b67d9e8504c4/tree_sitter_language_pack-1.6.0-cp310-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:adf0a7529ce6aed91d05f89f38cd25ac605189500ad63d488bb1c88fddc26a02", size = 2425750, upload-time = "2026-04-14T09:25:55.373Z" },
     { url = "https://files.pythonhosted.org/packages/e1/38/e8d0acfff2bbc912ecdf24ae01985a2ec45e92685e72e4983ea52f2325e4/tree_sitter_language_pack-1.6.0-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:e05b73032e671465e8946b459eec3407fbacd59e214a643636f5919761eee417", size = 2561118, upload-time = "2026-04-14T09:25:57.455Z" },
     { url = "https://files.pythonhosted.org/packages/4d/18/9a8a24f54e472b21ab7a3f207b58569b8a7c83fdb24e7ce67c4914d5eac2/tree_sitter_language_pack-1.6.0-cp310-abi3-win_amd64.whl", hash = "sha256:a1222defc8ba8558f221e3d8319b5e1f97bd1b7f8320b6b1bbaf3d5591649af7", size = 2357768, upload-time = "2026-04-14T09:26:00.257Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.7.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/c1/5d842314bb6c78442cc60437928781701c6050b8d479bc2a1aed691d37ca/triton-3.7.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a9e71fc392675fac364e0ecf4ef3f76f85b7f5433a16f4c3c5fe5f05a52c85fe", size = 188480277, upload-time = "2026-05-07T19:05:03.231Z" },
+    { url = "https://files.pythonhosted.org/packages/13/31/8315ea5f8dd18e60970b3022e3a8b93fd37e0b784fbbef86e10c8e6e5ca1/triton-3.7.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22bacffce443f54593dd20f05294d5a40622e0ea9ab632816f87154504356221", size = 201415942, upload-time = "2026-05-07T18:46:06.479Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/13/ec05adfcd87311d532ba61e3af143e8be59fcd26675884c4682841406a20/triton-3.7.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4bf49b00a7a377a68a6da603a876e797614e6455a80e9021669c476a953ad9a", size = 188505104, upload-time = "2026-05-07T19:05:09.843Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7b/468a576e35beef1426e0828e28e9ba9e65f5474d496f16ee126c15646324/triton-3.7.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f111161d49bf903c0eaedde3962353a3d841c08a836839b7cc1025b8426efcf", size = 201457567, upload-time = "2026-05-07T18:46:13.505Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e1/a59a583de59b8f62c495d67c80ee3ea97d09e91ac80c4c6e76456ed8d8ac/triton-3.7.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abdf6beaa89b1bcfb9a43cd990536ce66091a997841a4814b260b7bee4c88c3c", size = 188503209, upload-time = "2026-05-07T19:05:17.935Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b1/b7507bb9815d403927c8dd51d4158ed2e11751a92dbc118a044f247b6848/triton-3.7.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a35d7afe3f3f058e7ec49fcce09794049e0ffc5c59019ac25ec3413741b8c4e7", size = 201453566, upload-time = "2026-05-07T18:46:20.427Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/8f/0bea7a6a0c989315c9135a1d7fb37e41905cfb3a17cbc1f10044ebd4cc3a/triton-3.7.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc1d61c172d257db80ddf42595131fb196ad2e9bdd751e90fe2ef13531734e8b", size = 188612899, upload-time = "2026-05-07T19:05:24.955Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/02/d96f57828d0912aec733b9bc7e0e7dbfd2c6f079a8fa433ac25cb93d1a30/triton-3.7.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70fb9bbdc9f400afc54bbf6eb2670af28829a6ae3996863317964783141daf56", size = 201553816, upload-time = "2026-05-07T18:46:27.49Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

CE **backends layer** — the outbound-adapter + write-DTO tier the CE application services sit on. Follows #905 (cg-04) in the Context Engine rollout; base `main`.

Lands:
- **Deps:** `falkordblite` + `redis<8` promoted to default CLI deps on Python 3.12+, plus `falkordb`/`embeddings`/`all` extras and a `potpie-daemon` script entry; `uv.lock` regenerated.
- **Local embedder:** dependency-free 256-dim feature-hashing `HashingEmbedder`, deterministic across processes (the JSON-persisted embedded backend is process-per-call).
- **FalkorDB backend** profile + inspection + writer-port abstraction + `apply_plan` rename.
- **Embedding-aware claim query** across in-memory / embedded / Neo4j / FalkorDB.
- **Write-workbench DTOs + ports** (`graph_plans` / `graph_inbox` / `graph_history`, `plan_store` / `inbox_store`).
- **Semantic mutation pipeline:** validator → risk policy, lowerer → structural `MutationBatch` with V1.5 claim metadata, `record_to_semantic` V1 `context_record` bridge.

47 files, +7.7k/−0.4k.

## Follow-ups (not blocking this PR)

- #909 — reconcile embedder vector dimensionality (`HashingEmbedder` 256 vs the writers' `1536` index default; risk of an index/data width mismatch when no embedder is wired).

## Review note

Some FalkorDB **integration** tests (ingestion-server wiring, host default-backend selection) exercise behavior that lands in later rollout layers and are run there; the backend **unit** tests run here. The writer canonical-entity test is updated in place to match this PR's `cypher` upsert contract.
