### PR TITLE
feat(cli): CE graph workbench command surface

### DIFF
--- a/potpie/context-engine/adapters/inbound/cli/commands/_common.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/_common.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import json
 import os
-import subprocess
 import time
 from contextlib import contextmanager
 from pathlib import Path
@@ -25,7 +24,11 @@ from typing import Any, Callable, Final, Iterator, NoReturn
 import click
 import typer
 
-from adapters.inbound.cli.repo_location import repo_identity_key
+from adapters.inbound.cli.repo_location import (
+    current_git_remote as shared_current_git_remote,
+    normalize_repo_ref as shared_normalize_repo_ref,
+    repo_identity_key,
+)
 from domain.errors import (
     CapabilityNotImplemented,
     ContextEngineDisabled,
@@ -601,39 +604,11 @@ def _repo_source_matches_cwd(
 
 
 def _current_git_remote(cwd: Path) -> str | None:
-    try:
-        proc = subprocess.run(
-            ["git", "config", "--get", "remote.origin.url"],
-            cwd=str(cwd),
-            capture_output=True,
-            text=True,
-            timeout=1,
-            check=False,
-        )
-    except Exception:  # noqa: BLE001
-        return None
-    if proc.returncode != 0:
-        return None
-    return _normalize_repo_ref(proc.stdout.strip())
+    return shared_current_git_remote(cwd)
 
 
 def _normalize_repo_ref(value: str) -> str | None:
-    text = value.strip()
-    if not text:
-        return None
-    if text.endswith(".git"):
-        text = text[:-4]
-    if text.startswith("git@"):
-        # git@github.com:owner/repo
-        text = text[4:].replace(":", "/", 1)
-    elif "://" in text:
-        from urllib.parse import urlparse
-
-        parsed = urlparse(text)
-        path = parsed.path.strip("/")
-        if parsed.netloc and path:
-            text = f"{parsed.netloc}/{path}"
-    return text.strip("/").lower().replace(" ", "-") or None
+    return shared_normalize_repo_ref(value)
 
 
 __all__ = [

--- a/potpie/context-engine/adapters/inbound/cli/commands/_common.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/_common.py
@@ -15,13 +15,17 @@ This module owns the cross-cutting concerns so the command bodies stay thin:
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 import time
 from contextlib import contextmanager
-from typing import Any, Final, Iterator, NoReturn
+from pathlib import Path
+from typing import Any, Callable, Final, Iterator, NoReturn
 
 import click
 import typer
 
+from adapters.inbound.cli.repo_location import repo_identity_key
 from domain.errors import (
     CapabilityNotImplemented,
     ContextEngineDisabled,
@@ -36,7 +40,13 @@ EXIT_UNAVAILABLE = 2
 EXIT_DEGRADED = 3
 EXIT_AUTH = 4
 
-_state: dict[str, Any] = {"json": False, "verbose": False, "host": None, "store": None}
+_state: dict[str, Any] = {
+    "json": False,
+    "verbose": False,
+    "host": None,
+    "store": None,
+    "json_error_formatter": None,
+}
 _CLI_METRIC_ATTRIBUTE_KEYS: Final[frozenset[str]] = frozenset(
     {
         "arch",
@@ -70,6 +80,17 @@ def is_verbose() -> bool:
 def get_host():
     """Return the process-wide ``HostShell`` (built lazily)."""
     if _state["host"] is None:
+        mode = os.getenv("CONTEXT_ENGINE_HOST_MODE", "").strip().lower()
+        if mode != "in_process":
+            try:
+                from host.daemon_client import RemoteHostShell
+            except ModuleNotFoundError as exc:
+                if exc.name != "host.daemon_client":
+                    raise
+            else:
+                _state["host"] = RemoteHostShell()
+                return _state["host"]
+
         from bootstrap.host_wiring import build_host_shell
 
         _state["host"] = build_host_shell()
@@ -101,6 +122,24 @@ def set_store(store: CredentialStore) -> None:
     _state["store"] = store
 
 
+@contextmanager
+def json_error_formatter(
+    formatter: Callable[[dict[str, Any]], dict[str, Any]] | None,
+) -> Iterator[None]:
+    """Temporarily wrap JSON errors emitted by ``fail``.
+
+    This lets command groups with stricter envelopes, such as ``potpie graph``,
+    reuse the shared error boundary without changing every other CLI command's
+    documented error contract.
+    """
+    old = _state.get("json_error_formatter")
+    _state["json_error_formatter"] = formatter
+    try:
+        yield
+    finally:
+        _state["json_error_formatter"] = old
+
+
 def emit(payload: dict[str, Any], *, human: str) -> None:
     """Emit a success result: JSON when ``--json``, else a human line."""
     if is_json():
@@ -121,14 +160,18 @@ def fail(
 ) -> NoReturn:
     """Emit the structured error contract and exit with the given code."""
     if is_json():
+        payload = {
+            "code": code,
+            "message": message,
+            "detail": detail,
+            "recommended_next_action": next_action,
+        }
+        formatter = _state.get("json_error_formatter")
+        if callable(formatter):
+            payload = formatter(payload)
         typer.echo(
             json.dumps(
-                {
-                    "code": code,
-                    "message": message,
-                    "detail": detail,
-                    "recommended_next_action": next_action,
-                },
+                payload,
                 default=str,
             )
         )
@@ -271,8 +314,17 @@ def _cli_metric_attributes(
     return attributes
 
 
-def resolve_pot_id(host: Any, explicit: str | None = None) -> str:
-    """Resolve ``--pot`` ref → id, else the active pot. Fails (exit 1) if none."""
+def resolve_pot_id(
+    host: Any, explicit: str | None = None, *, infer_from_repo: bool = True
+) -> str:
+    """Resolve ``--pot`` ref → id, else current-repo pot, else active pot.
+
+    ``infer_from_repo=False`` skips current-repo inference and goes straight to
+    the active pot. Source registration uses this: ``source add repo .`` is the
+    command that *establishes* the repo→pot mapping, so inferring its target
+    from existing registrations would route the new source to the wrong pot
+    (or fail as ambiguous when other pots already track the same repo).
+    """
     pots = host.pots
     if explicit:
         for pot in pots.list_pots():
@@ -283,14 +335,305 @@ def resolve_pot_id(host: Any, explicit: str | None = None) -> str:
             message=f"No pot matching '{explicit}'.",
             next_action="run 'potpie pot list'",
         )
+    repo_identity = _current_repo_identity() if infer_from_repo else None
+    default_pot = _repo_default_pot_id(host, repo_identity)
+    if default_pot:
+        return default_pot
+    matches = _pots_matching_current_repo(host) if infer_from_repo else []
     active = pots.active_pot()
+    if len(matches) == 1:
+        return matches[0][0]
+    if len(matches) > 1:
+        if active is not None and any(active.pot_id == pid for pid, _ in matches):
+            return active.pot_id
+        names = ", ".join(f"{name} ({pid})" for pid, name in matches)
+        fail(
+            code="ambiguous_pot",
+            message=f"Current repo is registered in multiple pots: {names}.",
+            next_action="pick one with '--pot <id-or-name>' or set it active with 'potpie pot use <id-or-name>'",
+        )
     if active is None:
         fail(
             code="no_active_pot",
-            message="No active pot.",
-            next_action="run 'potpie setup' to create and activate a pot",
+            message="No active pot, and the current repo is not registered as a source in any pot.",
+            next_action="run 'potpie setup', or create a pot with 'potpie pot create <name> --use' and register this repo with 'potpie source add repo .'",
         )
     return active.pot_id
+
+
+def current_repo_identity_for_cli() -> str | None:
+    return _current_repo_identity()
+
+
+def repo_pot_candidates(host: Any, repo: str | None = None) -> dict[str, Any]:
+    repo_identity = (
+        _current_repo_identity()
+        if repo in (None, "", ".", "current")
+        else repo_identity_key(repo or "")
+    )
+    matches = (
+        _pots_matching_current_repo(host)
+        if repo in (None, "", ".", "current")
+        else _pots_matching_repo_identity(host, repo_identity)
+    )
+    default_pot_id = _repo_default_pot_id(host, repo_identity)
+    active = _safe_call(lambda: host.pots.active_pot(), None)
+    rows: list[dict[str, Any]] = []
+    for pot_id, name in matches:
+        counts = pot_graph_counts(host, pot_id)
+        rows.append(
+            {
+                "pot_id": pot_id,
+                "name": name,
+                "active": bool(
+                    active is not None and getattr(active, "pot_id", None) == pot_id
+                ),
+                "default": bool(default_pot_id == pot_id),
+                "source_count": pot_source_count(host, pot_id),
+                "counts": counts,
+            }
+        )
+    return {
+        "repo": repo_identity,
+        "default_pot_id": default_pot_id,
+        "candidates": rows,
+    }
+
+
+def pot_scope_info(host: Any, pot_id: str) -> dict[str, Any]:
+    pot = _pot_for_id(host, pot_id)
+    return {
+        "id": pot_id,
+        "name": getattr(pot, "name", pot_id) if pot is not None else pot_id,
+        "active": bool(getattr(pot, "active", False)) if pot is not None else False,
+        "source_count": pot_source_count(host, pot_id),
+        "counts": pot_graph_counts(host, pot_id),
+    }
+
+
+def pot_scope_human(host: Any, pot_id: str) -> str:
+    info = pot_scope_info(host, pot_id)
+    counts = info.get("counts") or {}
+    claims = counts.get("claims", 0)
+    entities = counts.get("entities", 0)
+    return (
+        f"pot={info.get('name')} ({pot_id}) "
+        f"sources={info.get('source_count', 0)} claims={claims} entities={entities}"
+    )
+
+
+def empty_pot_warnings(host: Any, pot_id: str) -> tuple[str, ...]:
+    counts = pot_graph_counts(host, pot_id)
+    if int(counts.get("claims", 0) or 0) != 0:
+        return ()
+    linked = repo_pot_candidates(host)
+    alternatives = [
+        row
+        for row in linked.get("candidates", ())
+        if row.get("pot_id") != pot_id
+        and int((row.get("counts") or {}).get("claims", 0) or 0) > 0
+    ]
+    if not alternatives:
+        return ()
+    best = sorted(
+        alternatives,
+        key=lambda row: int((row.get("counts") or {}).get("claims", 0) or 0),
+        reverse=True,
+    )[0]
+    claims = int((best.get("counts") or {}).get("claims", 0) or 0)
+    return (
+        (
+            f"current pot has 0 claims; repo {linked.get('repo')} also links to "
+            f"{best.get('name')} ({best.get('pot_id')}) with {claims} claims. "
+            f"Retry with --pot {best.get('pot_id')} or run "
+            f"`potpie pot default set --repo current {best.get('pot_id')}`."
+        ),
+    )
+
+
+def pot_graph_counts(host: Any, pot_id: str) -> dict[str, int]:
+    graph = getattr(host, "graph", None)
+    if graph is None:
+        return {}
+    status = _safe_call(lambda: graph.data_plane_status(pot_id), None)
+    if status is None:
+        return {}
+    counts = getattr(status, "counts", {}) or {}
+    out: dict[str, int] = {}
+    for key, value in dict(counts).items():
+        try:
+            out[str(key)] = int(value)
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def pot_source_count(host: Any, pot_id: str) -> int:
+    return len(_safe_call(lambda: host.pots.list_sources(pot_id=pot_id), []) or [])
+
+
+def _pots_matching_current_repo(host: Any) -> list[tuple[str, str]]:
+    """Return ``(pot_id, name)`` for every pot whose repo source matches cwd.
+
+    A pot is the project boundary, not a single repository. This helper only
+    chooses the pot from the current working tree; it does not inject a repo
+    scope into reads. Timeline queries therefore default to the whole project
+    across all repositories attached to the pot. The caller decides how to
+    disambiguate multiple matches (active pot wins; otherwise a structured
+    ``ambiguous_pot`` error).
+    """
+
+    try:
+        cwd = Path.cwd().resolve()
+    except OSError:
+        return []
+    remote = _current_git_remote(cwd)
+    matches: list[tuple[str, str]] = []
+    try:
+        pots = list(host.pots.list_pots())
+    except Exception:  # noqa: BLE001 - pot resolution should not mask commands
+        return []
+    for pot in pots:
+        try:
+            sources = host.pots.list_sources(pot_id=pot.pot_id)
+        except Exception:  # noqa: BLE001
+            continue
+        for source in sources:
+            if getattr(source, "kind", None) != "repo":
+                continue
+            refs = {
+                str(getattr(source, "name", "") or "").strip(),
+                str(getattr(source, "location", "") or "").strip(),
+            }
+            if any(
+                _repo_source_matches_cwd(ref, cwd=cwd, remote=remote)
+                for ref in refs
+                if ref
+            ):
+                matches.append((pot.pot_id, pot.name))
+                break
+    return matches
+
+
+def _pots_matching_repo_identity(
+    host: Any, repo_identity: str | None
+) -> list[tuple[str, str]]:
+    if not repo_identity:
+        return []
+    matches: list[tuple[str, str]] = []
+    try:
+        pots = list(host.pots.list_pots())
+    except Exception:  # noqa: BLE001
+        return []
+    for pot in pots:
+        try:
+            sources = host.pots.list_sources(pot_id=pot.pot_id)
+        except Exception:  # noqa: BLE001
+            continue
+        for source in sources:
+            if getattr(source, "kind", None) != "repo":
+                continue
+            refs = (
+                str(getattr(source, "name", "") or "").strip(),
+                str(getattr(source, "location", "") or "").strip(),
+            )
+            if any(repo_identity_key(ref) == repo_identity for ref in refs if ref):
+                matches.append((pot.pot_id, pot.name))
+                break
+    return matches
+
+
+def _current_repo_identity() -> str | None:
+    try:
+        cwd = Path.cwd().resolve()
+    except OSError:
+        return None
+    return _current_git_remote(cwd) or str(cwd)
+
+
+def _repo_default_pot_id(host: Any, repo_identity: str | None) -> str | None:
+    if not repo_identity:
+        return None
+    getter = getattr(host.pots, "repo_default", None)
+    if not callable(getter):
+        return None
+    pot_id = _safe_call(lambda: getter(repo=repo_identity), None)
+    if not pot_id:
+        return None
+    pot_id = str(pot_id)
+    return pot_id if _pot_for_id(host, pot_id) is not None else None
+
+
+def _pot_for_id(host: Any, pot_id: str):
+    for pot in _safe_call(lambda: host.pots.list_pots(), []) or []:
+        if getattr(pot, "pot_id", None) == pot_id:
+            return pot
+    return None
+
+
+def _safe_call(fn, default):
+    try:
+        return fn()
+    except Exception:  # noqa: BLE001
+        return default
+
+
+def _repo_source_matches_cwd(
+    source_name: str, *, cwd: Path, remote: str | None
+) -> bool:
+    if not source_name:
+        return False
+    source_path = Path(source_name).expanduser()
+    if source_path.is_absolute() or source_name.startswith((".", "~")):
+        try:
+            resolved = source_path.resolve(strict=False)
+        except OSError:
+            resolved = source_path.absolute()
+        if (
+            cwd == resolved
+            or cwd.is_relative_to(resolved)
+            or resolved.is_relative_to(cwd)
+        ):
+            return True
+
+    normalized_source = _normalize_repo_ref(source_name)
+    return bool(remote and normalized_source and normalized_source == remote)
+
+
+def _current_git_remote(cwd: Path) -> str | None:
+    try:
+        proc = subprocess.run(
+            ["git", "config", "--get", "remote.origin.url"],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=1,
+            check=False,
+        )
+    except Exception:  # noqa: BLE001
+        return None
+    if proc.returncode != 0:
+        return None
+    return _normalize_repo_ref(proc.stdout.strip())
+
+
+def _normalize_repo_ref(value: str) -> str | None:
+    text = value.strip()
+    if not text:
+        return None
+    if text.endswith(".git"):
+        text = text[:-4]
+    if text.startswith("git@"):
+        # git@github.com:owner/repo
+        text = text[4:].replace(":", "/", 1)
+    elif "://" in text:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(text)
+        path = parsed.path.strip("/")
+        if parsed.netloc and path:
+            text = f"{parsed.netloc}/{path}"
+    return text.strip("/").lower().replace(" ", "-") or None
 
 
 __all__ = [
@@ -304,8 +647,15 @@ __all__ = [
     "fail",
     "get_host",
     "get_store",
+    "current_repo_identity_for_cli",
+    "empty_pot_warnings",
     "is_json",
     "is_verbose",
+    "pot_graph_counts",
+    "pot_scope_human",
+    "pot_scope_info",
+    "pot_source_count",
+    "repo_pot_candidates",
     "resolve_pot_id",
     "set_host",
     "set_store",

--- a/potpie/context-engine/adapters/inbound/cli/commands/graph.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/graph.py
@@ -7,50 +7,1946 @@ that lack them) surface as the structured not-implemented contract.
 
 from __future__ import annotations
 
+import json
+import re
+import sys
+import time
+from contextlib import contextmanager
+from collections.abc import Mapping
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
 import typer
 
+from bootstrap.observability_runtime import get_observability
+from application.services.graph_workbench import (
+    graph_error_envelope,
+    graph_not_implemented_envelope,
+    graph_success_envelope,
+    new_graph_request_id,
+    normalize_catalog_result,
+    normalize_workbench_result,
+)
 from adapters.inbound.cli.commands._common import (
+    EXIT_UNAVAILABLE,
+    EXIT_VALIDATION,
     contract,
+    empty_pot_warnings,
     emit,
+    fail,
     get_host,
+    is_json,
+    json_error_formatter,
+    pot_scope_human,
+    pot_scope_info,
     resolve_pot_id,
 )
+from domain.errors import CapabilityNotImplemented
+from domain.graph_contract import GRAPH_CONTRACT_VERSION as DATA_PLANE_CONTRACT_VERSION
+from domain.graph_contract import ONTOLOGY_VERSION
+from domain.graph_workbench import (
+    GRAPH_WORKBENCH_COMMANDS,
+    GraphUnsupported,
+    GraphWorkbenchStatus,
+)
+from domain.ports.observability import SPAN_KIND_INTERNAL
+from domain.graph_workbench_ontology import describe_contract
+from domain.nudge import NUDGE_EVENT_HELP
 
 graph_app = typer.Typer(help="Graph reads/admin via capability ports.")
+inbox_app = typer.Typer(help="Pending graph-work inbox.")
+quality_app = typer.Typer(help="Read-only graph quality reports.")
+bulk_app = typer.Typer(help="Chunked semantic graph mutation application.")
 backend_app = typer.Typer(help="GraphBackend profile selection + health.")
+timeline_app = typer.Typer(help="Timeline reads over the active project pot.")
+
+graph_app.add_typer(inbox_app, name="inbox")
+graph_app.add_typer(quality_app, name="quality")
+graph_app.add_typer(bulk_app, name="bulk")
+
+
+class _GraphCliCommandContext:
+    def __init__(self, command: str) -> None:
+        self.command = command
+        self.request_id = new_graph_request_id()
+        self.pot_id: str | None = None
+        self.subgraph_versions: dict[str, int] = {}
+        self.telemetry_result = "ok"
+        self.telemetry_error_code = "none"
+        self.telemetry_attributes: dict[str, str] = {}
+
+    def set_pot_id(self, pot_id: str | None) -> None:
+        self.pot_id = pot_id
+
+    def set_subgraph_versions(self, versions: Mapping[str, Any] | None) -> None:
+        if not versions:
+            return
+        clean: dict[str, int] = {}
+        for key, value in versions.items():
+            try:
+                clean[str(key)] = int(value)
+            except (TypeError, ValueError):
+                continue
+        self.subgraph_versions = clean
+
+    def format_error(self, payload: dict[str, Any]) -> dict[str, Any]:
+        code = str(payload.get("code") or "error")
+        self.mark_result(result=code, error_code=code)
+        return graph_error_envelope(
+            command=self.command,
+            request_id=self.request_id,
+            pot_id=self.pot_id,
+            code=code,
+            message=str(payload.get("message") or "Graph command failed."),
+            detail=payload.get("detail"),
+            subgraph_versions=self.subgraph_versions,
+            recommended_next_action=payload.get("recommended_next_action"),
+        ).to_dict()
+
+    def mark_result(
+        self,
+        *,
+        result: str,
+        error_code: str = "none",
+        attributes: Mapping[str, Any] | None = None,
+    ) -> None:
+        self.telemetry_result = result
+        self.telemetry_error_code = error_code
+        if attributes:
+            for key, value in attributes.items():
+                if value is None:
+                    continue
+                self.telemetry_attributes[str(key)] = str(value)
+
+
+@contextmanager
+def _graph_command(command: str):
+    ctx = _GraphCliCommandContext(command)
+    obs = get_observability()
+    span_name, base_attrs = _graph_telemetry_shape(command)
+    started_at = time.perf_counter()
+    with obs.span(
+        span_name,
+        kind=SPAN_KIND_INTERNAL,
+        attributes={
+            **base_attrs,
+            "command": command,
+            "request_id": ctx.request_id,
+        },
+    ) as span:
+        try:
+            with json_error_formatter(ctx.format_error):
+                with contract():
+                    yield ctx
+        except BaseException as exc:
+            if ctx.telemetry_error_code == "none":
+                if isinstance(exc, typer.Exit):
+                    result = "ok" if (exc.exit_code in (None, 0)) else "exit"
+                    ctx.mark_result(result=result, error_code="exit")
+                else:
+                    ctx.mark_result(
+                        result="unexpected",
+                        error_code=exc.__class__.__name__,
+                    )
+                    span.record_exception(exc)
+                    span.set_error(repr(exc))
+            raise
+        finally:
+            duration_ms = max((time.perf_counter() - started_at) * 1000.0, 0.0)
+            attrs = {
+                **base_attrs,
+                **ctx.telemetry_attributes,
+                "command": command,
+                "request_id": ctx.request_id,
+                "result": ctx.telemetry_result,
+                "error_code": ctx.telemetry_error_code,
+            }
+            if ctx.pot_id:
+                attrs["pot_id"] = ctx.pot_id
+            span.set_attributes(attrs)
+            if ctx.telemetry_error_code != "none":
+                span.set_error(ctx.telemetry_error_code)
+            _record_graph_command_telemetry(
+                obs,
+                command=command,
+                duration_ms=duration_ms,
+                attributes=attrs,
+            )
+
+
+def _graph_telemetry_shape(command: str) -> tuple[str, dict[str, str]]:
+    raw = command.removeprefix("graph.").replace("-", "_")
+    parts = raw.split(".")
+    if not parts:
+        return "graph.unknown", {}
+    if parts[0] == "inbox":
+        attrs = {"operation": parts[1] if len(parts) > 1 else "unknown"}
+        return "graph.inbox", attrs
+    if parts[0] == "quality":
+        attrs = {"report": parts[1] if len(parts) > 1 else "summary"}
+        return "graph.quality", attrs
+    return f"graph.{parts[0]}", {}
+
+
+def _record_graph_command_telemetry(
+    obs,
+    *,
+    command: str,
+    duration_ms: float,
+    attributes: Mapping[str, str],
+) -> None:
+    _span_name, base_attrs = _graph_telemetry_shape(command)
+    raw = command.removeprefix("graph.").replace("-", "_")
+    root = raw.split(".", 1)[0] if raw else "unknown"
+    metric_root = root
+    metric_attrs = dict(base_attrs)
+    metric_attrs.update(
+        {
+            key: value
+            for key, value in attributes.items()
+            if key
+            in {
+                "result",
+                "error_code",
+                "pot_id",
+                "subgraph",
+                "view",
+                "risk",
+                "status",
+                "operation",
+                "report",
+                "backend_profile",
+                "match_mode",
+            }
+        }
+    )
+    try:
+        obs.counter(f"ce.graph.{metric_root}_total", 1, attributes=metric_attrs)
+        obs.histogram(
+            f"ce.graph.{metric_root}_ms",
+            duration_ms,
+            attributes=metric_attrs,
+        )
+    except Exception:  # noqa: BLE001 - observability must never fail a command
+        pass
+
+
+def _graph_telemetry_attributes(result: Mapping[str, Any]) -> dict[str, str]:
+    attrs: dict[str, str] = {}
+    for key in (
+        "subgraph",
+        "view",
+        "risk",
+        "status",
+        "report",
+        "action",
+        "backend_profile",
+        "match_mode",
+    ):
+        value = result.get(key)
+        if value is not None:
+            target = "operation" if key == "action" else key
+            attrs[target] = str(value)
+    backend = result.get("backend")
+    if isinstance(backend, Mapping):
+        if backend.get("profile") is not None:
+            attrs["backend_profile"] = str(backend["profile"])
+        if backend.get("ready") is not None:
+            attrs["backend_ready"] = str(bool(backend["ready"])).lower()
+    graph_service = result.get("graph_service")
+    if (
+        isinstance(graph_service, Mapping)
+        and graph_service.get("match_mode") is not None
+    ):
+        attrs["match_mode"] = str(graph_service["match_mode"])
+    return attrs
+
+
+def _emit_graph_result(
+    ctx: _GraphCliCommandContext,
+    payload: Mapping[str, Any],
+    *,
+    human: str,
+    warnings: tuple[str, ...] = (),
+    unsupported: tuple[GraphUnsupported, ...] = (),
+    recommended_next_action: str | None = None,
+) -> None:
+    result, versions, payload_warnings, payload_unsupported = (
+        normalize_workbench_result(payload)
+    )
+    if versions:
+        ctx.set_subgraph_versions(versions)
+    merged_warnings = tuple(warnings) + payload_warnings
+    merged_unsupported = tuple(unsupported) + payload_unsupported
+    result_label = "ok"
+    error_code = "none"
+    if payload.get("ok", True) is False:
+        result_label = str(payload.get("status") or _error_code_from_result(payload))
+        error_code = _error_code_from_result(payload)
+    ctx.mark_result(
+        result=result_label,
+        error_code=error_code,
+        attributes=_graph_telemetry_attributes(result),
+    )
+
+    if payload.get("ok", True) is False:
+        env = graph_error_envelope(
+            command=ctx.command,
+            request_id=ctx.request_id,
+            pot_id=ctx.pot_id,
+            code=_error_code_from_result(payload),
+            message=_error_message_from_result(payload),
+            detail=result or None,
+            subgraph_versions=ctx.subgraph_versions,
+            warnings=merged_warnings,
+            unsupported=merged_unsupported,
+            recommended_next_action=recommended_next_action
+            or payload.get("recommended_next_action"),
+        )
+    else:
+        env = graph_success_envelope(
+            command=ctx.command,
+            request_id=ctx.request_id,
+            pot_id=ctx.pot_id,
+            result=result,
+            subgraph_versions=ctx.subgraph_versions,
+            warnings=merged_warnings,
+            unsupported=merged_unsupported,
+            recommended_next_action=recommended_next_action
+            or payload.get("recommended_next_action"),
+        )
+    emit(env.to_dict(), human=_with_graph_warnings(human, merged_warnings))
+
+
+def _with_graph_warnings(human: str, warnings: tuple[str, ...]) -> str:
+    if not warnings:
+        return human
+    return "\n".join([human, *(f"! {warning}" for warning in warnings)])
+
+
+def _emit_inbox_result(ctx: _GraphCliCommandContext, result) -> None:
+    _emit_graph_result(ctx, result.to_dict(), human=_inbox_human(result))
+    if not result.ok:
+        raise typer.Exit(code=EXIT_VALIDATION)
+
+
+def _emit_quality_result(ctx: _GraphCliCommandContext, result) -> None:
+    _emit_graph_result(ctx, result.to_dict(), human=_quality_human(result))
+    if not result.ok:
+        raise typer.Exit(code=EXIT_VALIDATION)
+
+
+def _emit_graph_not_implemented(
+    ctx: _GraphCliCommandContext,
+    *,
+    detail: str | None = None,
+    recommended_next_action: str | None = None,
+) -> None:
+    env = graph_not_implemented_envelope(
+        command=ctx.command,
+        request_id=ctx.request_id,
+        pot_id=ctx.pot_id,
+        detail=detail,
+        recommended_next_action=recommended_next_action,
+    )
+    emit(env.to_dict(), human=detail or f"{ctx.command} is not implemented yet")
+    raise typer.Exit(code=EXIT_UNAVAILABLE)
+
+
+def _error_code_from_result(payload: Mapping[str, Any]) -> str:
+    issues = payload.get("issues")
+    if isinstance(issues, list) and issues:
+        first = issues[0]
+        if isinstance(first, Mapping) and first.get("code"):
+            return str(first["code"])
+    return str(payload.get("status") or "graph_command_failed")
+
+
+def _error_message_from_result(payload: Mapping[str, Any]) -> str:
+    if payload.get("detail"):
+        return str(payload["detail"])
+    issues = payload.get("issues")
+    if isinstance(issues, list) and issues:
+        first = issues[0]
+        if isinstance(first, Mapping) and first.get("message"):
+            return str(first["message"])
+    status = payload.get("status")
+    return f"Graph command failed with status {status!r}."
+
+
+def _legacy_warning(command: str, replacement: str) -> tuple[str, ...]:
+    return (
+        f"{command} is a legacy transition command and is not part of the canonical V2 workbench command set; use {replacement}.",
+    )
+
+
+# --- Graph Surface Lite (V1.5) ----------------------------------------------
+
+
+@graph_app.command("catalog")
+def graph_catalog(
+    task: str = typer.Option(None, "--task", help="(accepted, ignored in V1.5)"),
+    subgraph: str = typer.Option(None, "--subgraph"),
+    profile: str = typer.Option(
+        "full",
+        "--profile",
+        help="full | read",
+    ),
+    format_: str = typer.Option(
+        "auto",
+        "--format",
+        help="auto | table",
+    ),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    """Discover the graph contract: versions, views, mutation ops, ontology."""
+    from domain.ports.services.graph_service import GraphCatalogRequest
+
+    with _graph_command("graph.catalog") as ctx:
+        host = get_host()
+        pot_id = resolve_pot_id(host, pot)
+        ctx.set_pot_id(pot_id)
+        result = host.graph.catalog(
+            GraphCatalogRequest(pot_id=pot_id, task=task, subgraph=subgraph)
+        )
+        payload = normalize_catalog_result(result.to_dict(), task=task)
+        payload = _catalog_payload_for_profile(payload, profile=profile)
+        human = _catalog_human(payload, format_=format_)
+        _emit_graph_result(ctx, payload, human=human)
+
+
+@graph_app.command("read")
+def graph_read(
+    subgraph: str = typer.Option(
+        None, "--subgraph", help="Canonical graph subgraph, e.g. debugging"
+    ),
+    view: str = typer.Option(
+        None, "--view", help="View name within --subgraph, e.g. prior_occurrences"
+    ),
+    query: str = typer.Option(None, "--query"),
+    scope: str = typer.Option(None, "--scope", help="key:value[,key:value]"),
+    current: bool = typer.Option(
+        False,
+        "--current",
+        help="Resolve the pot from the current repo; does not add repo scope.",
+    ),
+    repo: str = typer.Option(
+        None,
+        "--repo",
+        help="Optional repo scope (owner/repo, URL, or 'current'). Omit for project-wide timeline.",
+    ),
+    since: str = typer.Option(None, "--since", help="ISO instant lower bound."),
+    until: str = typer.Option(None, "--until", help="ISO instant upper bound."),
+    time_window: str = typer.Option(
+        None,
+        "--time-window",
+        "--window",
+        help="Relative lookback such as 24h, 7d, 2w. Ignored when --since is set.",
+    ),
+    environment: str = typer.Option(None, "--environment"),
+    source_ref: list[str] | None = typer.Option(
+        None,
+        "--source-ref",
+        help="Exact claim source ref such as github:owner/repo#issue/123.",
+    ),
+    depth: int = typer.Option(
+        None, "--depth", help="traversal depth (neighborhood views)"
+    ),
+    direction: str = typer.Option(None, "--direction", help="out | in | both"),
+    limit: int = typer.Option(12, "--limit"),
+    sort: str = typer.Option(
+        "auto",
+        "--sort",
+        help="auto | score | occurred_at (timeline defaults to occurred_at)",
+    ),
+    dedupe: str = typer.Option(
+        "auto", "--dedupe", help="auto | none | source_ref | activity"
+    ),
+    format_: str = typer.Option(
+        "auto",
+        "--format",
+        help="auto | raw | events | table | jsonl (timeline defaults to events)",
+    ),
+    detail: str = typer.Option(
+        "compact",
+        "--detail",
+        help="compact | full",
+    ),
+    relations: str = typer.Option(
+        "summary",
+        "--relations",
+        help="summary | full",
+    ),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    """V2-style read over a named view (routes through the read trunk)."""
+    from domain.ports.services.graph_service import GraphReadRequest
+
+    with _graph_command("graph.read") as ctx:
+        if not subgraph:
+            raise ValueError("--subgraph is required")
+        if not view:
+            raise ValueError("--view is required")
+        if "." in view:
+            raise ValueError(
+                "graph read now requires --subgraph <name> --view <view>; "
+                f"got fully-qualified view {view!r}"
+            )
+        host = get_host()
+        pot_id = resolve_pot_id(host, pot)
+        ctx.set_pot_id(pot_id)
+        del current  # pot resolution already considers the current working tree.
+        since_dt, until_dt = _resolve_time_bounds(
+            since=since, until=until, window=time_window
+        )
+        parsed_scope = _parse_scope(scope)
+        if repo:
+            parsed_scope["repo"] = _resolve_repo_scope(repo)
+        effective_format = _effective_requested_format(
+            subgraph=subgraph, view=view, requested=format_
+        )
+        read_limit = _service_limit_for_read(
+            subgraph=subgraph,
+            view=view,
+            format_=effective_format,
+            requested_limit=limit,
+        )
+        result = host.graph.read(
+            GraphReadRequest(
+                pot_id=pot_id,
+                subgraph=subgraph,
+                view=view,
+                query=query,
+                scope=parsed_scope,
+                environment=environment,
+                source_refs=tuple(source_ref or ()),
+                since=since_dt,
+                until=until_dt,
+                depth=depth,
+                direction=direction,
+                limit=read_limit,
+                detail=detail,
+                relations=relations,
+                freshness_preference=(
+                    "fresh"
+                    if _is_timeline_view(f"{subgraph}.{view}") and not query
+                    else "balanced"
+                ),
+            )
+        )
+        _emit_graph_read(
+            ctx,
+            result,
+            format_=format_,
+            sort=sort,
+            dedupe=dedupe,
+            event_limit=limit,
+            human_prefix=pot_scope_human(host, pot_id),
+            warnings=empty_pot_warnings(host, pot_id),
+        )
+
+
+@timeline_app.command("recent")
+def timeline_recent(
+    query: str = typer.Option(None, "--query"),
+    since: str = typer.Option(None, "--since", help="ISO instant lower bound."),
+    until: str = typer.Option(None, "--until", help="ISO instant upper bound."),
+    time_window: str = typer.Option(
+        None,
+        "--time-window",
+        "--window",
+        help="Relative lookback such as 24h, 7d, 2w. Ignored when --since is set.",
+    ),
+    service: str = typer.Option(
+        None,
+        "--service",
+        help="Optional service scope. Omit for project-wide timeline across repos.",
+    ),
+    limit: int = typer.Option(12, "--limit"),
+    format_: str = typer.Option(
+        "auto", "--format", help="auto | events | table | raw | jsonl"
+    ),
+    detail: str = typer.Option(
+        "compact",
+        "--detail",
+        help="compact | full",
+    ),
+    relations: str = typer.Option(
+        "summary",
+        "--relations",
+        help="summary | full",
+    ),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    """Recent project events from the active/current pot, across all repo sources."""
+    from domain.ports.services.graph_service import GraphReadRequest
+
+    with contract():
+        host = get_host()
+        pot_id = resolve_pot_id(host, pot)
+        since_dt, until_dt = _resolve_time_bounds(
+            since=since, until=until, window=time_window
+        )
+        scope = {"service": service} if service else {}
+        read_limit = _service_limit_for_read(
+            subgraph="recent_changes",
+            view="timeline",
+            format_="events",
+            requested_limit=limit,
+        )
+        result = host.graph.read(
+            GraphReadRequest(
+                pot_id=pot_id,
+                subgraph="recent_changes",
+                view="timeline",
+                query=query,
+                scope=scope,
+                since=since_dt,
+                until=until_dt,
+                limit=read_limit,
+                detail=detail,
+                relations=relations,
+                freshness_preference="fresh" if not query else "balanced",
+            )
+        )
+        _emit_read(
+            result,
+            format_=format_,
+            sort="occurred_at",
+            dedupe="source_ref",
+            event_limit=limit,
+            human_prefix=pot_scope_human(host, pot_id),
+            warnings=empty_pot_warnings(host, pot_id),
+        )
+
+
+@graph_app.command("search-entities")
+def graph_search_entities(
+    query_arg: str = typer.Argument(None, help="text to match entities/claims against"),
+    query: str = typer.Option(
+        None, "--query", help="text to match entities/claims against"
+    ),
+    type_: str = typer.Option(None, "--type", help="entity label filter, e.g. Service"),
+    predicate: str = typer.Option(None, "--predicate"),
+    subgraph: str = typer.Option(None, "--subgraph"),
+    scope: str = typer.Option(None, "--scope", help="key:value[,key:value]"),
+    truth: str = typer.Option(None, "--truth"),
+    source_system: str = typer.Option(None, "--source-system"),
+    source_family: str = typer.Option(None, "--source-family"),
+    since: str = typer.Option(None, "--since", help="ISO instant lower bound."),
+    until: str = typer.Option(None, "--until", help="ISO instant upper bound."),
+    environment: str = typer.Option(None, "--environment"),
+    external_id: str = typer.Option(None, "--external-id"),
+    source_ref: list[str] | None = typer.Option(
+        None,
+        "--source-ref",
+        help="Exact claim source ref such as github:owner/repo#issue/123.",
+    ),
+    limit: int = typer.Option(10, "--limit"),
+    supporting_claims: int = typer.Option(
+        0,
+        "--supporting-claims",
+        help="number of supporting claims per entity to include in JSON",
+    ),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    """Narrow entity/claim lookup for identity resolution before a write."""
+    from domain.ports.services.graph_service import GraphEntitySearchRequest
+
+    with _graph_command("graph.search-entities") as ctx:
+        effective_query = query or query_arg
+        if not effective_query:
+            raise ValueError("query is required")
+        if supporting_claims < 0:
+            raise ValueError("--supporting-claims must be >= 0")
+        host = get_host()
+        pot_id = resolve_pot_id(host, pot)
+        ctx.set_pot_id(pot_id)
+        since_dt, until_dt = _resolve_time_bounds(since=since, until=until, window=None)
+        result = host.graph.search_entities(
+            GraphEntitySearchRequest(
+                pot_id=pot_id,
+                query=effective_query,
+                type=type_,
+                predicate=predicate,
+                subgraph=subgraph,
+                scope=_parse_scope(scope),
+                truth=truth,
+                source_system=source_system,
+                source_family=source_family,
+                since=since_dt,
+                until=until_dt,
+                environment=environment,
+                external_id=external_id,
+                source_refs=tuple(source_ref or ()),
+                limit=limit,
+                supporting_claims=supporting_claims,
+            )
+        )
+        payload = result.to_dict()
+        human = (
+            "\n".join(
+                f"  • [{', '.join(e['labels']) or '?'}] {e['key']} (score={e['score']:.2f})"
+                for e in payload["entities"]
+            )
+            or "(no matching entities)"
+        )
+        warnings = empty_pot_warnings(host, pot_id)
+        _emit_graph_result(
+            ctx,
+            payload,
+            human=_with_read_context(
+                human,
+                human_prefix=pot_scope_human(host, pot_id),
+                warnings=(),
+            ),
+            warnings=warnings,
+            recommended_next_action=warnings[0] if warnings else None,
+        )
+
+
+@graph_app.command("mutate")
+def graph_mutate(
+    file: str = typer.Option(
+        None, "--file", help="mutation JSON path; omit to read stdin"
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run"),
+    allow_review_required: bool = typer.Option(False, "--allow-review-required"),
+    approved_by: str = typer.Option(
+        None, "--approved-by", help="user-ref for medium-risk approval"
+    ),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    """Legacy transition wrapper over graph propose + commit."""
+    with _graph_command("graph.mutate") as ctx:
+        host = get_host()
+        pot_id = resolve_pot_id(host, pot)
+        ctx.set_pot_id(pot_id)
+        payload = _load_json(file)
+        proposal = host.graph_workbench.propose(payload, pot_id=pot_id)
+        legacy_warning = _legacy_warning(
+            "graph.mutate", "graph.propose and graph.commit"
+        )
+        if dry_run or not proposal.ok:
+            _emit_graph_result(
+                ctx,
+                proposal.to_dict(),
+                human=_proposal_human(proposal),
+                warnings=legacy_warning,
+            )
+            if not proposal.ok:
+                raise typer.Exit(code=EXIT_VALIDATION)
+            return
+        if proposal.status == "review_required" and not (
+            allow_review_required and approved_by
+        ):
+            _emit_graph_result(
+                ctx,
+                proposal.to_dict(),
+                human=_proposal_human(proposal),
+                warnings=legacy_warning,
+                recommended_next_action=(
+                    f"Review the plan, then run `potpie graph commit {proposal.plan_id} "
+                    "--approved-by <user-ref> --json` when policy allows."
+                ),
+            )
+            return
+
+        result = host.graph_workbench.commit(
+            proposal.plan_id,
+            pot_id=pot_id,
+            approved_by=approved_by if allow_review_required else None,
+        )
+        _emit_graph_result(
+            ctx,
+            result.to_dict(),
+            human=_commit_human(result),
+            warnings=legacy_warning,
+            recommended_next_action=(
+                "Use `potpie graph propose --file <mutation.json> --json` followed "
+                "by `potpie graph commit <plan_id> --json`."
+            ),
+        )
+        if not result.ok:
+            raise typer.Exit(code=EXIT_VALIDATION)
+
+
+# Static, schema-only mutation skeletons (Stage 5 ergonomics). These are
+# helpers for harnesses writing mutation JSON by hand — placeholders only,
+# never values read from the repo. Keys reference the canonical ontology so
+# the contract tests can pin them against ENTITY_TYPES / EDGE_TYPES.
+_MUTATION_TEMPLATES: dict[str, dict[str, Any]] = {
+    "repo-baseline": {
+        "pot_id": "<pot-id>",
+        "idempotency_key": "baseline:<owner>/<repo>:v1",
+        "created_by": {"surface": "cli", "harness": "<harness>"},
+        "operations": [
+            {
+                "op": "upsert_entity",
+                "subject": {
+                    "key": "repo:<host>/<owner>/<repo>",
+                    "type": "Repository",
+                    "name": "<repo>",
+                    "summary": "<one-line repo purpose>",
+                    "description": "<retrieval card: what the repo is, app type, synonyms a searcher would type>",
+                },
+            },
+            {
+                "op": "assert_claim",
+                "subject": {"key": "repo:<host>/<owner>/<repo>", "type": "Repository"},
+                "predicate": "PROVIDES",
+                "object": {
+                    "key": "feature:<feature-slug>",
+                    "type": "Feature",
+                    "name": "<feature name>",
+                    "summary": "<one-line capability>",
+                    "description": "<retrieval card: what it does, user-facing synonyms, scope>",
+                },
+                "truth": "source_observation",
+                "confidence": 0.9,
+                "description": "<where the source says this — e.g. README features section>",
+                "evidence": [
+                    {
+                        "source_ref": "repo:<owner>/<repo>#README",
+                        "authority": "repository_metadata",
+                    }
+                ],
+            },
+            {
+                "op": "link_entities",
+                "subject": {"key": "service:<service-slug>", "type": "Service"},
+                "predicate": "DEFINED_IN",
+                "object": {"key": "repo:<host>/<owner>/<repo>", "type": "Repository"},
+                "truth": "source_observation",
+                "confidence": 0.9,
+                "description": "<which manifest/workflow defines the service>",
+                "evidence": [
+                    {
+                        "source_ref": "repo:<owner>/<repo>#package.json",
+                        "authority": "repository_metadata",
+                    }
+                ],
+            },
+        ],
+    },
+    "feature": {
+        "pot_id": "<pot-id>",
+        "operations": [
+            {
+                "op": "assert_claim",
+                "subject": {"key": "service:<service-slug>", "type": "Service"},
+                "predicate": "PROVIDES",
+                "object": {
+                    "key": "feature:<feature-slug>",
+                    "type": "Feature",
+                    "name": "<feature name>",
+                    "summary": "<one-line capability>",
+                    "description": "<retrieval card with synonyms and scope>",
+                },
+                "truth": "source_observation",
+                "confidence": 0.9,
+                "description": "<evidence summary>",
+                "evidence": [
+                    {"source_ref": "<ref>", "authority": "repository_metadata"}
+                ],
+            }
+        ],
+    },
+    "preference": {
+        "pot_id": "<pot-id>",
+        "idempotency_key": "preference:<owner>/<repo>:<preference-slug>",
+        "created_by": {"surface": "cli", "harness": "<harness>"},
+        "operations": [
+            {
+                "op": "assert_claim",
+                "subject": {
+                    "key": "preference:<preference-slug>",
+                    "type": "Preference",
+                    "name": "<short preference name>",
+                    "summary": "<one-line prescription>",
+                    "description": "<retrieval card: when it applies, synonyms, scope>",
+                    "properties": {
+                        "policy_kind": "<error_handling|logging|testing|library_choice|file_structure>",
+                        "prescription": "<specific guidance an agent should follow>",
+                        "strength": "<hard|strong|normal|weak>",
+                        "audience": "<repo|service|path|language>",
+                    },
+                },
+                "predicate": "POLICY_APPLIES_TO",
+                "object": {"key": "repo:<host>/<owner>/<repo>", "type": "Repository"},
+                "truth": "preference",
+                "confidence": 0.9,
+                "description": "<where the preference is stated>",
+                "extra": {
+                    "repo": "<host>/<owner>/<repo>",
+                    "service": "<service-slug>",
+                    "file_path": "<optional/path/or/directory>",
+                    "language": "<language>",
+                },
+                "evidence": [{"source_ref": "<ref>", "authority": "user_statement"}],
+            }
+        ],
+    },
+    "preference-policy": {
+        "pot_id": "<pot-id>",
+        "idempotency_key": "preference:<owner>/<repo>:<preference-slug>",
+        "created_by": {"surface": "cli", "harness": "<harness>"},
+        "operations": [
+            {
+                "op": "assert_claim",
+                "subject": {
+                    "key": "preference:<preference-slug>",
+                    "type": "Preference",
+                    "name": "<short preference name>",
+                    "summary": "<one-line prescription>",
+                    "description": "<retrieval card: task words, scope, synonyms>",
+                    "properties": {
+                        "policy_kind": "<error_handling|logging|testing|library_choice|file_structure>",
+                        "prescription": "<specific guidance an agent should follow>",
+                        "strength": "<hard|strong|normal|weak>",
+                        "audience": "<repo|service|path|language>",
+                    },
+                },
+                "predicate": "POLICY_APPLIES_TO",
+                "object": {
+                    "key": "code:<repo-or-service>:<path-or-symbol>",
+                    "type": "CodeAsset",
+                },
+                "truth": "preference",
+                "confidence": 0.9,
+                "description": "<evidence summary and why this policy applies to this scope>",
+                "extra": {
+                    "repo": "<host>/<owner>/<repo>",
+                    "service": "<service-slug>",
+                    "file_path": "<path/or/directory>",
+                    "language": "<language>",
+                },
+                "evidence": [{"source_ref": "<ref>", "authority": "user_statement"}],
+            }
+        ],
+    },
+    "infra-snapshot": {
+        "pot_id": "<pot-id>",
+        "idempotency_key": "infra:<owner>/<repo>:<service-slug>:<environment>",
+        "created_by": {"surface": "cli", "harness": "<harness>"},
+        "operations": [
+            {
+                "op": "link_entities",
+                "subject": {"key": "service:<service-slug>", "type": "Service"},
+                "predicate": "DEPLOYED_TO",
+                "object": {"key": "environment:<environment>", "type": "Environment"},
+                "truth": "source_observation",
+                "confidence": 0.95,
+                "environment": "<environment>",
+                "description": "<source showing service runs in this environment>",
+                "evidence": [
+                    {"source_ref": "<ref>", "authority": "repository_metadata"}
+                ],
+            },
+            {
+                "op": "link_entities",
+                "subject": {"key": "service:<service-slug>", "type": "Service"},
+                "predicate": "USES_ADAPTER",
+                "object": {
+                    "key": "adapter:<domain>:<adapter-slug>",
+                    "type": "Adapter",
+                    "summary": "<adapter/provider selected in this env>",
+                    "description": "<retrieval card: adapter, provider, backend, env>",
+                },
+                "truth": "source_observation",
+                "confidence": 0.9,
+                "environment": "<environment>",
+                "description": "<source showing which adapter/backend is selected>",
+                "evidence": [
+                    {"source_ref": "<ref>", "authority": "repository_metadata"}
+                ],
+            },
+            {
+                "op": "link_entities",
+                "subject": {"key": "service:<service-slug>", "type": "Service"},
+                "predicate": "DEPLOYED_WITH",
+                "object": {
+                    "key": "deployment_target:<environment>:<target-slug>",
+                    "type": "DeploymentTarget",
+                    "summary": "<deployment target/mechanism>",
+                    "description": "<retrieval card: platform, workload, deploy mechanism>",
+                },
+                "truth": "source_observation",
+                "confidence": 0.9,
+                "environment": "<environment>",
+                "description": "<source showing deployment target/mechanism>",
+                "evidence": [
+                    {"source_ref": "<ref>", "authority": "repository_metadata"}
+                ],
+            },
+            {
+                "op": "link_entities",
+                "subject": {"key": "service:<service-slug>", "type": "Service"},
+                "predicate": "CONFIGURES",
+                "object": {
+                    "key": "config:<service-or-env>:<config-name>",
+                    "type": "ConfigVariable",
+                    "summary": "<config variable>",
+                    "description": "<retrieval card: env var/config key and behavior it selects>",
+                },
+                "truth": "source_observation",
+                "confidence": 0.8,
+                "environment": "<environment>",
+                "description": "<source showing this config affects the service/adapter>",
+                "evidence": [
+                    {"source_ref": "<ref>", "authority": "repository_metadata"}
+                ],
+            },
+        ],
+    },
+    "bug-fix": {
+        "pot_id": "<pot-id>",
+        "idempotency_key": "bug-fix:<bug-slug>:<fix-hash>",
+        "created_by": {"surface": "cli", "harness": "<harness>"},
+        "operations": [
+            {
+                "op": "assert_claim",
+                "subject": {
+                    "key": "bug_pattern:<bug-slug>",
+                    "type": "BugPattern",
+                    "name": "<symptom name>",
+                    "summary": "<one-line symptom>",
+                    "description": "<retrieval card: error text, symptoms, synonyms, where it shows up>",
+                    "properties": {
+                        "symptom_signature": "<stable symptom/error signature>",
+                    },
+                },
+                "predicate": "REPRODUCES",
+                "object": {"key": "service:<service-slug>", "type": "Service"},
+                "truth": "agent_claim",
+                "confidence": 0.8,
+                "description": "<how the bug manifests>",
+            },
+            {
+                "op": "assert_claim",
+                "subject": {
+                    "key": "fix:<fix-hash>",
+                    "type": "Fix",
+                    "summary": "<one-line fix>",
+                    "description": "<retrieval card: what fixed it, files touched, verification>",
+                    "properties": {
+                        "fix_steps": "<what changed or what to do>",
+                        "verification_status": "<verified|unverified|failed>",
+                    },
+                },
+                "predicate": "RESOLVED",
+                "object": {"key": "bug_pattern:<bug-slug>", "type": "BugPattern"},
+                "truth": "agent_claim",
+                "confidence": 0.8,
+                "description": "<fix summary + verification status>",
+            },
+            {
+                "op": "assert_claim",
+                "subject": {
+                    "key": "activity:<source>:<verification-id>",
+                    "type": "Activity",
+                },
+                "predicate": "VERIFIED",
+                "object": {"key": "fix:<fix-hash>", "type": "Fix"},
+                "truth": "agent_claim",
+                "confidence": 0.8,
+                "description": "<how the fix was verified, or what remains unverified>",
+            },
+        ],
+    },
+    "decision": {
+        "pot_id": "<pot-id>",
+        "operations": [
+            {
+                "op": "assert_claim",
+                "subject": {
+                    "key": "decision:<decision-hash>",
+                    "type": "Decision",
+                    "name": "<decision title>",
+                    "summary": "<one-line decision>",
+                    "description": "<retrieval card: rationale, alternatives rejected, synonyms>",
+                },
+                "predicate": "DECIDED",
+                "object": {"key": "repo:<host>/<owner>/<repo>", "type": "Repository"},
+                "truth": "user_decision",
+                "confidence": 1.0,
+                "description": "<who decided and why>",
+                "evidence": [{"source_ref": "<ref>", "authority": "user_statement"}],
+            }
+        ],
+    },
+    "timeline-event": {
+        "pot_id": "<pot-id>",
+        "operations": [
+            {
+                "op": "append_event",
+                "verb": "<verb e.g. merged_pr|deployed|decided>",
+                "occurred_at": "<ISO-8601 timestamp>",
+                "description": "<what happened, written for timeline recall>",
+                "actor": {"key": "person:<handle>", "type": "Person"},
+                "targets": [{"key": "service:<service-slug>", "type": "Service"}],
+                "evidence": [{"source_ref": "<ref>", "authority": "external_system"}],
+            }
+        ],
+    },
+    "timeline-change": {
+        "pot_id": "<pot-id>",
+        "idempotency_key": "timeline:<source>:<id>",
+        "created_by": {"surface": "cli", "harness": "<harness>"},
+        "operations": [
+            {
+                "op": "append_event",
+                "verb": "<verb e.g. merged_pr|linear_done|deployed|incident>",
+                "occurred_at": "<ISO-8601 timestamp>",
+                "description": "<what changed, source title, affected behavior, regression keywords>",
+                "actor": {"key": "person:<handle>", "type": "Person"},
+                "targets": [
+                    {"key": "service:<service-slug>", "type": "Service"},
+                    {
+                        "key": "code:<repo-or-service>:<path-or-symbol>",
+                        "type": "CodeAsset",
+                    },
+                ],
+                "mentions": [{"key": "feature:<feature-slug>", "type": "Feature"}],
+                "evidence": [{"source_ref": "<ref>", "authority": "external_system"}],
+            }
+        ],
+    },
+}
+
+
+@graph_app.command("mutation-template")
+def graph_mutation_template(
+    kind: str = typer.Option(
+        "repo-baseline",
+        "--kind",
+        help=f"template kind: {' | '.join(sorted(_MUTATION_TEMPLATES))}",
+    ),
+) -> None:
+    """Print a schema-only mutation skeleton for `graph propose`.
+
+    Pure schema helper: emits placeholders for the harness to fill from
+    sources it has actually read. It never inspects the repository or infers
+    graph facts.
+    """
+    with _graph_command("graph.mutation-template") as ctx:
+        template = _MUTATION_TEMPLATES.get(kind.strip().lower())
+        if template is None:
+            fail(
+                code="unknown_template_kind",
+                message=f"Unknown mutation template kind {kind!r}.",
+                next_action=f"pick one of: {', '.join(sorted(_MUTATION_TEMPLATES))}",
+            )
+        rendered = json.dumps(template, indent=2)
+        emit(
+            graph_success_envelope(
+                command=ctx.command,
+                request_id=ctx.request_id,
+                pot_id=ctx.pot_id,
+                result={"kind": kind, "template": template},
+                warnings=_legacy_warning(
+                    "graph.mutation-template", "graph.describe mutation examples"
+                ),
+                recommended_next_action=(
+                    "Use `potpie graph describe <subgraph> --examples --json` once "
+                    "describe is implemented."
+                ),
+            ).to_dict(),
+            human=rendered,
+        )
+
+
+@graph_app.command("nudge")
+def graph_nudge(
+    event: str = typer.Option(
+        ...,
+        "--event",
+        help=NUDGE_EVENT_HELP,
+    ),
+    session: str = typer.Option(
+        ..., "--session", help="harness session id (dedup key)"
+    ),
+    path: str = typer.Option(
+        None, "--path", help="file path scope (PreToolUse Write/Edit)"
+    ),
+    scope: str = typer.Option(None, "--scope", help="key:value[,key:value]"),
+    query: str = typer.Option(
+        None, "--query", help="symptom/intent text (test_failed etc.)"
+    ),
+    limit: int = typer.Option(5, "--limit", help="max injected items"),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    """Event→action policy brain: inject ranked context, prompt a write, or stay silent.
+
+    Deterministic and free — reads via the local embedder, never calls a model.
+    Hooks forward their event + path here and inject the result.
+    """
+    from domain.nudge import GraphNudgeRequest
+
+    with _graph_command("graph.nudge") as ctx:
+        host = get_host()
+        pot_id = resolve_pot_id(host, pot)
+        ctx.set_pot_id(pot_id)
+        result = host.nudge.nudge(
+            GraphNudgeRequest(
+                pot_id=pot_id,
+                event=event,
+                session_id=session,
+                scope=_parse_scope(scope),
+                path=path,
+                query=query,
+                limit=limit,
+            )
+        )
+        _emit_graph_result(
+            ctx,
+            result.to_dict(),
+            human=_nudge_human(result),
+            warnings=_legacy_warning("graph.nudge", "the installed hook adapter"),
+            recommended_next_action=(
+                "Hooks should read the `result` object from this workbench envelope."
+            ),
+        )
 
 
 @graph_app.command("status")
 def graph_status(pot: str = typer.Option(None, "--pot")) -> None:
-    with contract():
+    with _graph_command("graph.status") as ctx:
         host = get_host()
         pot_id = resolve_pot_id(host, pot)
+        ctx.set_pot_id(pot_id)
         dp = host.graph.data_plane_status(pot_id)
-        emit(
-            {
-                "backend": dp.backend_profile,
-                "ready": dp.backend_ready,
-                "counts": dict(dp.counts),
-                "freshness": dict(dp.freshness),
-                "quality": dict(dp.quality),
-            },
-            human=f"backend={dp.backend_profile} ready={dp.backend_ready} counts={dict(dp.counts)}",
+        versions = {"_global": int(dict(dp.counts).get("claims", 0))}
+        ctx.set_subgraph_versions(versions)
+        payload = _graph_status_payload(host, pot_id, dp)
+        warnings = empty_pot_warnings(host, pot_id)
+        recommended = None
+        if not dp.backend_ready:
+            recommended = (
+                "Run `potpie backend doctor` to inspect graph backend readiness "
+                "and capability-specific failures."
+            )
+        elif warnings:
+            recommended = warnings[0]
+        elif payload.get("health_status") not in {None, "ok"}:
+            recommended = (
+                payload.get("quality", {}).get("recommended_next_action")
+                or "Run `potpie graph quality summary --json` to inspect graph health."
+            )
+        _emit_graph_result(
+            ctx,
+            payload,
+            human=(
+                f"{pot_scope_human(host, pot_id)}\n"
+                f"backend={dp.backend_profile} ready={dp.backend_ready} "
+                f"counts={dict(dp.counts)} health={payload.get('health_status')}"
+            ),
+            warnings=warnings,
+            recommended_next_action=recommended,
         )
+
+
+@graph_app.command("describe")
+def graph_describe(
+    subgraph: str = typer.Argument(None),
+    view: str = typer.Option(None, "--view"),
+    examples: bool = typer.Option(False, "--examples"),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    with _graph_command("graph.describe") as ctx:
+        _set_optional_pot(ctx, pot)
+        payload = describe_contract(
+            subgraph=subgraph,
+            view=view,
+            include_examples=examples,
+        )
+        subgraph_name = payload["subgraph"]["name"]
+        described = payload["view"]["name"] if view else subgraph_name
+        described_view = described.split(".", 1)[1] if "." in described else described
+        _emit_graph_result(
+            ctx,
+            payload,
+            human=_describe_human(payload),
+            recommended_next_action=(
+                f"Use `potpie graph read --subgraph {subgraph_name} --view {described_view} --json` after choosing a scope."
+                if view
+                else "Use `potpie graph describe <subgraph> --view <view> --json` for one backed view."
+            ),
+        )
+
+
+@graph_app.command("neighborhood")
+def graph_neighborhood(
+    entity: str = typer.Option(None, "--entity"),
+    predicate: str = typer.Option(None, "--predicate"),
+    depth: int = typer.Option(2, "--depth"),
+    direction: str = typer.Option("both", "--direction"),
+    limit: int = typer.Option(50, "--limit"),
+    detail: str = typer.Option("summary", "--detail", help="summary | full"),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    with _graph_command("graph.neighborhood") as ctx:
+        if not entity:
+            raise ValueError("--entity is required")
+        normalized_direction = (direction or "both").strip().lower()
+        if normalized_direction not in {"out", "in", "both"}:
+            raise ValueError("--direction must be one of: out, in, both")
+        if depth < 1:
+            raise ValueError("--depth must be >= 1")
+        if limit < 1:
+            raise ValueError("--limit must be >= 1")
+        detail_mode = (detail or "summary").strip().lower()
+        if detail_mode not in {"summary", "full"}:
+            raise ValueError("--detail must be one of: summary, full")
+        host = get_host()
+        _require_backend_capability(
+            host,
+            capability="inspection",
+            method="neighborhood",
+            command="graph neighborhood",
+        )
+        pot_id = resolve_pot_id(host, pot)
+        ctx.set_pot_id(pot_id)
+        predicates = _parse_predicates(predicate)
+        sl = host.backend.inspection.neighborhood(
+            pot_id=pot_id,
+            entity_key=entity,
+            depth=depth,
+            direction=normalized_direction,
+            predicates=predicates,
+            limit=limit,
+        )
+        relations = [_neighborhood_relation(edge) for edge in sl.edges]
+        payload = {
+            "entity_key": entity,
+            "depth": depth,
+            "direction": normalized_direction,
+            "predicates": list(predicates),
+            "detail": detail_mode,
+            "node_count": len(sl.nodes),
+            "relation_count": len(relations),
+            "relations": relations,
+            "truncated": sl.truncated,
+        }
+        if detail_mode == "full":
+            payload["nodes"] = [
+                {
+                    "key": n.key,
+                    "labels": list(n.labels),
+                    "properties": dict(n.properties),
+                }
+                for n in sl.nodes
+            ]
+            payload["edges"] = [
+                {
+                    "predicate": e.predicate,
+                    "from": e.from_key,
+                    "to": e.to_key,
+                    "properties": dict(e.properties),
+                }
+                for e in sl.edges
+            ]
+        _emit_graph_result(
+            ctx,
+            payload,
+            human=_neighborhood_human(payload),
+        )
+
+
+@graph_app.command("propose")
+def graph_propose(
+    file: str = typer.Option(
+        None, "--file", help="mutation JSON path; omit to read stdin"
+    ),
+    ttl: str = typer.Option("1h", "--ttl", help="plan expiry such as 30m, 1h, 2d"),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    with _graph_command("graph.propose") as ctx:
+        host = get_host()
+        pot_id = resolve_pot_id(host, pot)
+        ctx.set_pot_id(pot_id)
+        payload = _load_json(file)
+        result = host.graph_workbench.propose(
+            payload,
+            pot_id=pot_id,
+            ttl_seconds=_parse_ttl_seconds(ttl),
+        )
+        _emit_graph_result(
+            ctx,
+            result.to_dict(),
+            human=_proposal_human(result),
+        )
+        if not result.ok:
+            raise typer.Exit(code=EXIT_VALIDATION)
+
+
+@graph_app.command("commit")
+def graph_commit(
+    plan_id: str = typer.Argument(None),
+    approved_by: str = typer.Option(
+        None, "--approved-by", help="user-ref for medium-risk approval"
+    ),
+    verify: bool = typer.Option(
+        False,
+        "--verify",
+        help="read back committed claim keys and run post-commit quality checks",
+    ),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    with _graph_command("graph.commit") as ctx:
+        if not plan_id:
+            fail(code="validation_error", message="plan_id is required")
+        host = get_host()
+        pot_id = resolve_pot_id(host, pot)
+        ctx.set_pot_id(pot_id)
+        result = host.graph_workbench.commit(
+            plan_id,
+            pot_id=pot_id,
+            approved_by=approved_by,
+            verify=verify,
+        )
+        _emit_graph_result(
+            ctx,
+            result.to_dict(),
+            human=_commit_human(result),
+        )
+        if not result.ok:
+            raise typer.Exit(code=EXIT_VALIDATION)
+        if verify and result.verification is not None and not result.verification.ok:
+            raise typer.Exit(code=EXIT_VALIDATION)
+
+
+@bulk_app.command("apply")
+def graph_bulk_apply(
+    file: str = typer.Option(
+        None,
+        "--file",
+        help="mutation JSON/NDJSON path; omit to read stdin",
+    ),
+    chunk_size: int = typer.Option(
+        100,
+        "--chunk-size",
+        help="semantic operations per proposed chunk",
+    ),
+    start_chunk: int = typer.Option(
+        1,
+        "--start-chunk",
+        help="1-based chunk index to start from when resuming",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="propose chunks but do not commit them",
+    ),
+    continue_on_error: bool = typer.Option(
+        False,
+        "--continue-on-error",
+        help="attempt remaining chunks after a failed proposal or commit",
+    ),
+    verify: bool = typer.Option(
+        False,
+        "--verify",
+        help="include graph data-plane status after the run",
+    ),
+    manifest: str = typer.Option(
+        None,
+        "--manifest",
+        help="write a JSON run manifest after each attempted chunk",
+    ),
+    idempotency_key: str = typer.Option(
+        None,
+        "--idempotency-key",
+        help="base idempotency key; chunk suffixes are added when needed",
+    ),
+    ttl: str = typer.Option("1h", "--ttl", help="plan expiry such as 30m, 1h, 2d"),
+    approved_by: str = typer.Option(
+        None, "--approved-by", help="user-ref for review-required chunks"
+    ),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    """Apply many semantic mutations through propose/commit chunks.
+
+    This is an orchestration helper for agent-authored semantic mutations. It
+    does not scan sources or infer facts; it keeps high-volume writes on the
+    same validated workbench path as ordinary graph updates.
+    """
+    with _graph_command("graph.bulk.apply") as ctx:
+        if chunk_size < 1:
+            raise ValueError("--chunk-size must be >= 1")
+        if start_chunk < 1:
+            raise ValueError("--start-chunk must be >= 1")
+
+        host = get_host()
+        pot_id = resolve_pot_id(host, pot)
+        ctx.set_pot_id(pot_id)
+        ttl_seconds = _parse_ttl_seconds(ttl)
+        source_payloads = _load_bulk_mutation_payloads(file)
+        chunks = _build_bulk_chunks(
+            source_payloads,
+            chunk_size=chunk_size,
+            idempotency_key=idempotency_key,
+        )
+        if start_chunk > len(chunks):
+            raise ValueError(
+                f"--start-chunk {start_chunk} is beyond {len(chunks)} chunks"
+            )
+
+        run = _new_bulk_run_payload(
+            pot_id=pot_id,
+            chunks_total=len(chunks),
+            operations_total=sum(len(chunk["operations"]) for chunk in chunks),
+            chunk_size=chunk_size,
+            dry_run=dry_run,
+            start_chunk=start_chunk,
+            manifest=manifest,
+        )
+        ok = True
+
+        for chunk in chunks:
+            index = int(chunk["index"])
+            if index < start_chunk:
+                run["chunks"].append(_bulk_skipped_chunk(chunk))
+                continue
+
+            entry = _bulk_chunk_entry(chunk)
+            run["chunks_attempted"] += 1
+            run["operations_attempted"] += entry["operation_count"]
+            proposal = host.graph_workbench.propose(
+                chunk["payload"],
+                pot_id=pot_id,
+                ttl_seconds=ttl_seconds,
+            )
+            entry["proposal"] = _bulk_proposal_summary(proposal)
+            entry["plan_id"] = proposal.plan_id
+
+            if not proposal.ok:
+                ok = False
+                entry["ok"] = False
+                entry["status"] = "proposal_failed"
+                run["issues"].extend(_bulk_issues_from_proposal(proposal, index))
+                run["chunks"].append(entry)
+                _write_bulk_manifest(manifest, run)
+                if not continue_on_error:
+                    break
+                continue
+
+            if dry_run:
+                entry["ok"] = True
+                entry["status"] = proposal.status
+                run["chunks_validated"] += 1
+                run["operations_validated"] += entry["operation_count"]
+                run["chunks"].append(entry)
+                _write_bulk_manifest(manifest, run)
+                continue
+
+            if proposal.status == "review_required" and not approved_by:
+                ok = False
+                entry["ok"] = False
+                entry["status"] = "review_required"
+                run["issues"].append(
+                    {
+                        "code": "approval_required",
+                        "message": (
+                            f"chunk {index} requires approval; rerun with "
+                            "--approved-by <user-ref> or inspect the plan"
+                        ),
+                        "severity": "error",
+                        "chunk": index,
+                    }
+                )
+                run["chunks"].append(entry)
+                _write_bulk_manifest(manifest, run)
+                if not continue_on_error:
+                    break
+                continue
+
+            commit = host.graph_workbench.commit(
+                proposal.plan_id,
+                pot_id=pot_id,
+                approved_by=approved_by,
+            )
+            entry["commit"] = _bulk_commit_summary(commit)
+            entry["ok"] = bool(commit.ok)
+            entry["status"] = commit.status
+            if commit.ok:
+                run["chunks_committed"] += 1
+                run["operations_committed"] += entry["operation_count"]
+                if commit.mutation_id:
+                    entry["mutation_id"] = commit.mutation_id
+            else:
+                ok = False
+                run["issues"].append(
+                    {
+                        "code": str(commit.status or "commit_failed"),
+                        "message": commit.detail or "chunk commit failed",
+                        "severity": "error",
+                        "chunk": index,
+                    }
+                )
+            run["chunks"].append(entry)
+            _write_bulk_manifest(manifest, run)
+            if not commit.ok and not continue_on_error:
+                break
+
+        run["ok"] = ok
+        run["status"] = _bulk_run_status(run, dry_run=dry_run, ok=ok)
+        if verify:
+            status = host.graph.data_plane_status(pot_id)
+            run["verification"] = _data_plane_status_payload(status)
+
+        _write_bulk_manifest(manifest, run)
+        _emit_graph_result(
+            ctx,
+            run,
+            human=_bulk_human(run),
+            recommended_next_action=_bulk_next_action(run),
+        )
+        if not ok:
+            raise typer.Exit(code=EXIT_VALIDATION)
+
+
+@graph_app.command("history")
+def graph_history(
+    entity: str = typer.Option(None, "--entity"),
+    claim: str = typer.Option(None, "--claim"),
+    subgraph: str = typer.Option(None, "--subgraph"),
+    plan: str = typer.Option(None, "--plan"),
+    mutation: str = typer.Option(None, "--mutation"),
+    since: str = typer.Option(None, "--since"),
+    until: str = typer.Option(None, "--until"),
+    limit: int = typer.Option(50, "--limit"),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    with _graph_command("graph.history") as ctx:
+        host = get_host()
+        pot_id = resolve_pot_id(host, pot)
+        ctx.set_pot_id(pot_id)
+        since_dt, until_dt = _resolve_time_bounds(since=since, until=until, window=None)
+        result = host.graph_workbench.history(
+            pot_id=pot_id,
+            entity_key=entity,
+            claim_key=claim,
+            subgraph=subgraph,
+            plan_id=plan,
+            mutation_id=mutation,
+            since=since_dt,
+            until=until_dt,
+            limit=limit,
+        )
+        _emit_graph_result(
+            ctx,
+            result.to_dict(),
+            human=_history_human(result),
+        )
+
+
+@inbox_app.command("add")
+def graph_inbox_add(
+    summary: str = typer.Option(None, "--summary"),
+    details: str = typer.Option(None, "--details"),
+    evidence: list[str] | None = typer.Option(None, "--evidence"),
+    source_ref: list[str] | None = typer.Option(None, "--source-ref"),
+    subgraph: list[str] | None = typer.Option(None, "--subgraph"),
+    created_by: str = typer.Option(None, "--created-by"),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    with _graph_command("graph.inbox.add") as ctx:
+        host = get_host()
+        pot_id = resolve_pot_id(host, pot)
+        ctx.set_pot_id(pot_id)
+        result = host.graph_workbench.inbox_add(
+            pot_id=pot_id,
+            summary=summary,
+            details=details,
+            evidence=tuple(evidence or ()),
+            source_refs=tuple(source_ref or ()),
+            suspected_subgraphs=tuple(subgraph or ()),
+            created_by=_parse_created_by(created_by),
+        )
+        _emit_inbox_result(ctx, result)
+
+
+@inbox_app.command("list")
+def graph_inbox_list(
+    status: list[str] | None = typer.Option(None, "--status"),
+    claimed_by: str = typer.Option(None, "--claimed-by"),
+    subgraph: str = typer.Option(None, "--subgraph"),
+    source_ref: str = typer.Option(None, "--source-ref"),
+    since: str = typer.Option(None, "--since"),
+    until: str = typer.Option(None, "--until"),
+    limit: int = typer.Option(50, "--limit"),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    with _graph_command("graph.inbox.list") as ctx:
+        host = get_host()
+        pot_id = resolve_pot_id(host, pot)
+        ctx.set_pot_id(pot_id)
+        since_dt, until_dt = _resolve_time_bounds(since=since, until=until, window=None)
+        result = host.graph_workbench.inbox_list(
+            pot_id=pot_id,
+            status=tuple(status or ()),
+            claimed_by=claimed_by,
+            suspected_subgraph=subgraph,
+            source_ref=source_ref,
+            since=since_dt,
+            until=until_dt,
+            limit=limit,
+        )
+        _emit_inbox_result(ctx, result)
+
+
+@inbox_app.command("show")
+def graph_inbox_show(
+    item_id: str = typer.Argument(None),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    with _graph_command("graph.inbox.show") as ctx:
+        if not item_id:
+            raise ValueError("item_id is required")
+        host = get_host()
+        pot_id = resolve_pot_id(host, pot)
+        ctx.set_pot_id(pot_id)
+        result = host.graph_workbench.inbox_show(pot_id=pot_id, item_id=item_id)
+        _emit_inbox_result(ctx, result)
+
+
+@inbox_app.command("claim")
+def graph_inbox_claim(
+    item_id: str = typer.Argument(None),
+    claimed_by: str = typer.Option(None, "--by", "--claimed-by"),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    with _graph_command("graph.inbox.claim") as ctx:
+        if not item_id:
+            raise ValueError("item_id is required")
+        host = get_host()
+        pot_id = resolve_pot_id(host, pot)
+        ctx.set_pot_id(pot_id)
+        result = host.graph_workbench.inbox_claim(
+            pot_id=pot_id,
+            item_id=item_id,
+            claimed_by=claimed_by,
+        )
+        _emit_inbox_result(ctx, result)
+
+
+@inbox_app.command("mark-applied")
+def graph_inbox_mark_applied(
+    item_id: str = typer.Argument(None),
+    plan: str = typer.Option(None, "--plan"),
+    mutation: str = typer.Option(None, "--mutation"),
+    closed_by: str = typer.Option(None, "--by", "--closed-by"),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    with _graph_command("graph.inbox.mark-applied") as ctx:
+        if not item_id:
+            raise ValueError("item_id is required")
+        host = get_host()
+        pot_id = resolve_pot_id(host, pot)
+        ctx.set_pot_id(pot_id)
+        result = host.graph_workbench.inbox_mark_applied(
+            pot_id=pot_id,
+            item_id=item_id,
+            closed_by=closed_by,
+            linked_plan_id=plan,
+            linked_mutation_id=mutation,
+        )
+        _emit_inbox_result(ctx, result)
+
+
+@inbox_app.command("mark-rejected")
+def graph_inbox_mark_rejected(
+    item_id: str = typer.Argument(None),
+    reason: str = typer.Option(None, "--reason"),
+    closed_by: str = typer.Option(None, "--by", "--closed-by"),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    with _graph_command("graph.inbox.mark-rejected") as ctx:
+        if not item_id:
+            raise ValueError("item_id is required")
+        host = get_host()
+        pot_id = resolve_pot_id(host, pot)
+        ctx.set_pot_id(pot_id)
+        result = host.graph_workbench.inbox_mark_rejected(
+            pot_id=pot_id,
+            item_id=item_id,
+            closed_by=closed_by,
+            rejection_reason=reason,
+        )
+        _emit_inbox_result(ctx, result)
+
+
+@inbox_app.command("close")
+def graph_inbox_close(
+    item_id: str = typer.Argument(None),
+    plan: str = typer.Option(None, "--plan"),
+    mutation: str = typer.Option(None, "--mutation"),
+    reason: str = typer.Option(None, "--reason"),
+    closed_by: str = typer.Option(None, "--by", "--closed-by"),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    with _graph_command("graph.inbox.close") as ctx:
+        if not item_id:
+            raise ValueError("item_id is required")
+        host = get_host()
+        pot_id = resolve_pot_id(host, pot)
+        ctx.set_pot_id(pot_id)
+        result = host.graph_workbench.inbox_close(
+            pot_id=pot_id,
+            item_id=item_id,
+            closed_by=closed_by,
+            linked_plan_id=plan,
+            linked_mutation_id=mutation,
+            rejection_reason=reason,
+        )
+        _emit_inbox_result(ctx, result)
+
+
+@quality_app.command("summary")
+def graph_quality_summary(
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    _run_quality_report(command="graph.quality.summary", report="summary", pot=pot)
+
+
+@quality_app.command("duplicate-candidates")
+def graph_quality_duplicate_candidates(
+    subgraph: str = typer.Option(None, "--subgraph"),
+    limit: int = typer.Option(50, "--limit"),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    _run_quality_report(
+        command="graph.quality.duplicate-candidates",
+        report="duplicate-candidates",
+        pot=pot,
+        subgraph=subgraph,
+        limit=limit,
+    )
+
+
+@quality_app.command("stale-facts")
+def graph_quality_stale_facts(
+    subgraph: str = typer.Option(None, "--subgraph"),
+    limit: int = typer.Option(50, "--limit"),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    _run_quality_report(
+        command="graph.quality.stale-facts",
+        report="stale-facts",
+        pot=pot,
+        subgraph=subgraph,
+        limit=limit,
+    )
+
+
+@quality_app.command("conflicting-claims")
+def graph_quality_conflicting_claims(
+    subgraph: str = typer.Option(None, "--subgraph"),
+    limit: int = typer.Option(50, "--limit"),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    _run_quality_report(
+        command="graph.quality.conflicting-claims",
+        report="conflicting-claims",
+        pot=pot,
+        subgraph=subgraph,
+        limit=limit,
+    )
+
+
+@quality_app.command("orphan-entities")
+def graph_quality_orphan_entities(
+    subgraph: str = typer.Option(None, "--subgraph"),
+    limit: int = typer.Option(50, "--limit"),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    _run_quality_report(
+        command="graph.quality.orphan-entities",
+        report="orphan-entities",
+        pot=pot,
+        subgraph=subgraph,
+        limit=limit,
+    )
+
+
+@quality_app.command("low-confidence")
+def graph_quality_low_confidence(
+    subgraph: str = typer.Option(None, "--subgraph"),
+    limit: int = typer.Option(50, "--limit"),
+    threshold: float = typer.Option(0.5, "--threshold"),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    _run_quality_report(
+        command="graph.quality.low-confidence",
+        report="low-confidence",
+        pot=pot,
+        subgraph=subgraph,
+        limit=limit,
+        confidence_threshold=threshold,
+    )
+
+
+@quality_app.command("projection-drift")
+def graph_quality_projection_drift(
+    subgraph: str = typer.Option(None, "--subgraph"),
+    limit: int = typer.Option(50, "--limit"),
+    pot: str = typer.Option(None, "--pot"),
+) -> None:
+    _run_quality_report(
+        command="graph.quality.projection-drift",
+        report="projection-drift",
+        pot=pot,
+        subgraph=subgraph,
+        limit=limit,
+    )
+
+
+def _run_quality_report(
+    *,
+    command: str,
+    report: str,
+    pot: str | None,
+    subgraph: str | None = None,
+    limit: int = 50,
+    confidence_threshold: float = 0.5,
+) -> None:
+    with _graph_command(command) as ctx:
+        host = get_host()
+        pot_id = resolve_pot_id(host, pot)
+        ctx.set_pot_id(pot_id)
+        result = host.graph_workbench.quality(
+            pot_id=pot_id,
+            report=report,
+            subgraph=subgraph,
+            limit=limit,
+            confidence_threshold=confidence_threshold,
+        )
+        _emit_quality_result(ctx, result)
 
 
 @graph_app.command("inspect")
 def graph_inspect(
-    entity_key: str,
+    entity_key: str = typer.Argument(None),
     depth: int = typer.Option(2, "--depth"),
     pot: str = typer.Option(None, "--pot"),
 ) -> None:
-    with contract():
+    with _graph_command("graph.inspect") as ctx:
+        if not entity_key:
+            raise ValueError("entity_key is required")
         host = get_host()
+        _require_backend_capability(
+            host,
+            capability="inspection",
+            method="neighborhood",
+            command="graph inspect",
+        )
         pot_id = resolve_pot_id(host, pot)
+        ctx.set_pot_id(pot_id)
         sl = host.backend.inspection.neighborhood(
             pot_id=pot_id, entity_key=entity_key, depth=depth
         )
-        emit(
+        _emit_graph_result(
+            ctx,
             {
                 "nodes": [{"key": n.key, "labels": list(n.labels)} for n in sl.nodes],
                 "edges": [
@@ -59,28 +1955,54 @@ def graph_inspect(
                 ],
             },
             human=f"{len(sl.nodes)} nodes, {len(sl.edges)} edges around {entity_key}",
+            warnings=_legacy_warning("graph.inspect", "graph.neighborhood"),
+            recommended_next_action="Use `potpie graph neighborhood --entity <key> --json` once implemented.",
         )
 
 
 @graph_app.command("export")
-def graph_export(file: str, pot: str = typer.Option(None, "--pot")) -> None:
-    with contract():
+def graph_export(
+    file: str = typer.Argument(None), pot: str = typer.Option(None, "--pot")
+) -> None:
+    with _graph_command("graph.export") as ctx:
+        if not file:
+            raise ValueError("file is required")
         host = get_host()
+        _require_backend_capability(
+            host,
+            capability="snapshot",
+            method="export",
+            command="graph export",
+        )
         pot_id = resolve_pot_id(host, pot)
+        ctx.set_pot_id(pot_id)
         manifest = host.backend.snapshot.export(pot_id=pot_id, destination=file)
-        emit(
+        _emit_graph_result(
+            ctx,
             {"location": manifest.location, "claims": manifest.claim_count},
             human=f"exported {manifest.claim_count} claims → {manifest.location}",
         )
 
 
 @graph_app.command("import")
-def graph_import(file: str, pot: str = typer.Option(None, "--pot")) -> None:
-    with contract():
+def graph_import(
+    file: str = typer.Argument(None), pot: str = typer.Option(None, "--pot")
+) -> None:
+    with _graph_command("graph.import") as ctx:
+        if not file:
+            raise ValueError("file is required")
         host = get_host()
+        _require_backend_capability(
+            host,
+            capability="snapshot",
+            method="import_",
+            command="graph import",
+        )
         pot_id = resolve_pot_id(host, pot)
+        ctx.set_pot_id(pot_id)
         manifest = host.backend.snapshot.import_(pot_id=pot_id, source=file)
-        emit(
+        _emit_graph_result(
+            ctx,
             {"location": manifest.location, "claims": manifest.claim_count},
             human=f"imported {manifest.claim_count} claims from {manifest.location}",
         )
@@ -89,15 +2011,23 @@ def graph_import(file: str, pot: str = typer.Option(None, "--pot")) -> None:
 @graph_app.command("repair")
 def graph_repair(
     semantic_index: bool = typer.Option(False, "--semantic-index"),
+    entity_summaries: bool = typer.Option(False, "--entity-summaries"),
     all_: bool = typer.Option(False, "--all"),
     pot: str = typer.Option(None, "--pot"),
 ) -> None:
-    with contract():
+    with _graph_command("graph.repair") as ctx:
         host = get_host()
         pot_id = resolve_pot_id(host, pot)
-        targets = [] if all_ else (["semantic_index"] if semantic_index else [])
+        ctx.set_pot_id(pot_id)
+        targets = []
+        if not all_:
+            if semantic_index:
+                targets.append("semantic_index")
+            if entity_summaries:
+                targets.append("entity_summaries")
         report = host.backend.analytics.repair(pot_id, targets=targets)
-        emit(
+        _emit_graph_result(
+            ctx,
             {"targets": list(report.targets), "repaired": dict(report.repaired)},
             human=report.detail or f"repaired {dict(report.repaired)}",
         )
@@ -156,4 +2086,1406 @@ def backend_doctor() -> None:
         )
 
 
-__all__ = ["backend_app", "graph_app"]
+# --- Graph Surface Lite helpers ---------------------------------------------
+
+
+def _set_optional_pot(ctx: _GraphCliCommandContext, pot: str | None) -> None:
+    host = get_host()
+    if pot:
+        ctx.set_pot_id(resolve_pot_id(host, pot))
+        return
+    active = _safe(lambda: host.pots.active_pot(), None)
+    if active is not None:
+        ctx.set_pot_id(getattr(active, "pot_id", None))
+
+
+def _graph_status_payload(host: Any, pot_id: str, dp) -> dict[str, Any]:
+    caps = _safe(lambda: host.backend.capabilities(), None)
+    implemented = list(caps.implemented()) if caps is not None else []
+    pot_info = pot_scope_info(host, pot_id)
+    quality_summary = _graph_status_quality_summary(host, pot_id, dp)
+    health_status = str(quality_summary.get("health_status") or "unknown")
+    status = GraphWorkbenchStatus(
+        host={
+            "kind": getattr(host, "profile", "local"),
+            "liveness": "ok",
+        },
+        pot={
+            "id": pot_id,
+            "name": pot_info.get("name"),
+            "source_count": pot_info.get("source_count", 0),
+            "selected_backend": dp.backend_profile,
+        },
+        graph_service={
+            "graph_contract_version": "v2",
+            "data_plane_graph_contract_version": DATA_PLANE_CONTRACT_VERSION,
+            "ontology_version": ONTOLOGY_VERSION,
+            "supported_commands": list(GRAPH_WORKBENCH_COMMANDS),
+            "reader_backed_includes": list(dp.reader_backed_includes),
+            "validator_ready": True,
+            "match_mode": dp.match_mode,
+        },
+        backend={
+            "profile": dp.backend_profile,
+            "ready": dp.backend_ready,
+            "detail": dp.detail,
+            "readiness_command": "potpie backend doctor",
+            "recommended_next_action": (
+                (
+                    "Run `potpie backend doctor` to inspect graph backend readiness "
+                    "and capability-specific failures."
+                )
+                if not dp.backend_ready
+                else None
+            ),
+            "implemented_capabilities": implemented,
+            "counts": dict(dp.counts),
+            "freshness": dict(dp.freshness),
+        },
+        ledger={"status": "not_inspected"},
+        skills={"status": "not_inspected"},
+        quality=quality_summary,
+    )
+    payload = status.to_dict()
+    payload["health_status"] = health_status
+    return payload
+
+
+def _graph_status_quality_summary(host: Any, pot_id: str, dp) -> dict[str, Any]:
+    fallback = _data_plane_quality_summary(dp)
+    workbench = getattr(host, "graph_workbench", None)
+    if workbench is None or not getattr(workbench, "quality", None):
+        return fallback
+    try:
+        result = workbench.quality(
+            pot_id=pot_id,
+            report="summary",
+            subgraph=None,
+            limit=20,
+            confidence_threshold=0.5,
+        )
+    except CapabilityNotImplemented as exc:
+        fallback["health_status"] = "unavailable"
+        fallback["status"] = "unavailable"
+        fallback["detail"] = str(exc)
+        return fallback
+    except Exception as exc:
+        fallback["health_status"] = "unavailable"
+        fallback["status"] = "unavailable"
+        fallback["detail"] = f"quality summary unavailable: {exc}"
+        return fallback
+
+    body = result.to_dict()
+    metrics = dict(body.get("metrics") or {})
+    reports = dict(metrics.get("quality_reports") or {})
+    compact_reports = {
+        name: {
+            "status": report.get("status"),
+            "finding_count": report.get("finding_count", 0),
+            "severity_counts": dict(report.get("severity_counts") or {}),
+        }
+        for name, report in reports.items()
+        if isinstance(report, Mapping)
+    }
+    counts = metrics.get("counts") if isinstance(metrics.get("counts"), Mapping) else {}
+    out = {
+        "status": body.get("status"),
+        "health_status": body.get("status"),
+        "source": "quality_summary",
+        "claim_count": counts.get("claims", dict(dp.counts).get("claims")),
+        "quality_counts": dict(metrics.get("quality_counts") or {}),
+        "total_findings": metrics.get("total_findings", body.get("finding_count", 0)),
+        "reports": compact_reports,
+    }
+    if body.get("recommended_next_action"):
+        out["recommended_next_action"] = body["recommended_next_action"]
+    return out
+
+
+def _data_plane_quality_summary(dp) -> dict[str, Any]:
+    quality = dict(getattr(dp, "quality", {}) or {})
+    status = str(quality.get("status") or "unknown")
+    claim_count = quality.get(
+        "claim_count", dict(getattr(dp, "counts", {}) or {}).get("claims")
+    )
+    return {
+        **quality,
+        "status": status,
+        "health_status": status,
+        "source": "data_plane",
+        "claim_count": claim_count,
+        "quality_counts": {},
+        "reports": {},
+        "total_findings": quality.get("open_conflicts", 0),
+    }
+
+
+def _describe_human(payload: Mapping[str, Any]) -> str:
+    subgraph = payload.get("subgraph")
+    if not isinstance(subgraph, Mapping):
+        return "graph contract"
+    view = payload.get("view")
+    if isinstance(view, Mapping):
+        filters = ", ".join(str(v) for v in view.get("supported_filters", ())) or "-"
+        relations = ", ".join(str(v) for v in view.get("inline_relations", ())) or "-"
+        return (
+            f"{view.get('name')} ({view.get('result_shape')})\n"
+            f"purpose: {view.get('purpose')}\n"
+            f"filters: {filters}\n"
+            f"relations: {relations}"
+        )
+    views = subgraph.get("views", ())
+    view_names = ", ".join(str(v.get("name")) for v in views if isinstance(v, Mapping))
+    relation_names = ", ".join(
+        str(r.get("name"))
+        for r in subgraph.get("relation_types", ())
+        if isinstance(r, Mapping)
+    )
+    return (
+        f"{subgraph.get('name')}: {subgraph.get('purpose')}\n"
+        f"views: {view_names}\n"
+        f"relations: {relation_names}"
+    )
+
+
+def _safe(fn, default):
+    try:
+        return fn()
+    except Exception:  # noqa: BLE001
+        return default
+
+
+def _require_backend_capability(
+    host: Any,
+    *,
+    capability: str,
+    method: str,
+    command: str,
+) -> None:
+    caps = host.backend.capabilities()
+    if bool(getattr(caps, capability, False)):
+        return
+    profile = getattr(caps, "profile", getattr(host.backend, "profile", "unknown"))
+    raise CapabilityNotImplemented(
+        f"graph.{profile}.{capability}.{method}",
+        detail=f"{command} is not supported by the active '{profile}' backend",
+        recommended_next_action=(
+            "run 'potpie backend status' to inspect capabilities, or switch to "
+            f"a backend that implements {capability}"
+        ),
+    )
+
+
+def _parse_scope(scope: str | None) -> dict[str, str]:
+    if not scope:
+        return {}
+    out: dict[str, str] = {}
+    for pair in scope.split(","):
+        pair = pair.strip()
+        if not pair:
+            continue
+        if ":" not in pair:
+            raise ValueError(
+                f"invalid --scope entry {pair!r}; expected key:value pairs"
+            )
+        key, value = pair.split(":", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError(
+                f"invalid --scope entry {pair!r}; scope keys must not be empty"
+            )
+        value = value.strip()
+        if not value:
+            raise ValueError(
+                f"invalid --scope entry {pair!r}; scope values must not be empty"
+            )
+        out[key] = value
+    return out
+
+
+def _parse_created_by(value: str | None) -> dict[str, Any]:
+    clean = value.strip() if isinstance(value, str) else ""
+    if not clean:
+        return {"surface": "cli"}
+    if clean.startswith("{"):
+        try:
+            parsed = json.loads(clean)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid --created-by JSON: {exc}") from exc
+        if not isinstance(parsed, dict):
+            raise ValueError("--created-by JSON must be an object")
+        parsed.setdefault("surface", "cli")
+        return parsed
+    return {"surface": "cli", "actor": clean}
+
+
+def _parse_predicates(predicate: str | None) -> tuple[str, ...]:
+    if not predicate:
+        return ()
+    out: list[str] = []
+    for raw in predicate.split(","):
+        value = raw.strip().upper()
+        if value:
+            out.append(value)
+    return tuple(dict.fromkeys(out))
+
+
+def _load_json(file: str | None) -> dict:
+    """Load a mutation payload from a file or stdin."""
+    raw = _read_payload_text(file)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON in mutation payload: {exc}") from exc
+
+
+def _read_payload_text(file: str | None) -> str:
+    if file:
+        try:
+            with open(file, encoding="utf-8") as fh:
+                raw = fh.read()
+        except OSError as exc:
+            raise ValueError(f"cannot read mutation file {file!r}: {exc}") from exc
+    else:
+        raw = sys.stdin.read()
+    if not raw.strip():
+        raise ValueError(
+            "empty mutation payload (provide --file or pipe JSON on stdin)"
+        )
+    return raw
+
+
+def _load_bulk_mutation_payloads(file: str | None) -> list[dict[str, Any]]:
+    raw = _read_payload_text(file)
+    stripped = raw.strip()
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        return _load_bulk_ndjson(stripped)
+    return [_normalize_bulk_payload(parsed, context="mutation payload")]
+
+
+def _load_bulk_ndjson(raw: str) -> list[dict[str, Any]]:
+    payloads: list[dict[str, Any]] = []
+    pending_ops: list[Mapping[str, Any]] = []
+    for line_no, line in enumerate(raw.splitlines(), start=1):
+        clean = line.strip()
+        if not clean or clean.startswith("#"):
+            continue
+        try:
+            parsed = json.loads(clean)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid JSON on NDJSON line {line_no}: {exc}") from exc
+        if _is_batch_payload(parsed):
+            if pending_ops:
+                payloads.append({"operations": list(pending_ops)})
+                pending_ops = []
+            payloads.append(
+                _normalize_bulk_payload(parsed, context=f"NDJSON line {line_no}")
+            )
+            continue
+        if not isinstance(parsed, Mapping):
+            raise ValueError(f"NDJSON line {line_no} must be a JSON object")
+        pending_ops.append(dict(parsed))
+    if pending_ops:
+        payloads.append({"operations": list(pending_ops)})
+    if not payloads:
+        raise ValueError("bulk mutation input did not contain any operations")
+    return payloads
+
+
+def _normalize_bulk_payload(value: Any, *, context: str) -> dict[str, Any]:
+    if isinstance(value, list):
+        operations = value
+        metadata: dict[str, Any] = {}
+    elif isinstance(value, Mapping):
+        if "operations" not in value:
+            operations = [dict(value)]
+            metadata = {}
+        else:
+            raw_ops = value.get("operations")
+            if not isinstance(raw_ops, list):
+                raise ValueError(f"{context} field 'operations' must be a list")
+            operations = raw_ops
+            metadata = {str(k): v for k, v in value.items() if k != "operations"}
+    else:
+        raise ValueError(f"{context} must be a JSON object or array")
+
+    if not operations:
+        raise ValueError(f"{context} contains no operations")
+    clean_ops: list[dict[str, Any]] = []
+    for index, op in enumerate(operations, start=1):
+        if not isinstance(op, Mapping):
+            raise ValueError(f"{context} operation {index} must be a JSON object")
+        clean_ops.append(dict(op))
+    metadata["operations"] = clean_ops
+    return metadata
+
+
+def _is_batch_payload(value: Any) -> bool:
+    return isinstance(value, Mapping) and isinstance(value.get("operations"), list)
+
+
+def _build_bulk_chunks(
+    payloads: list[dict[str, Any]],
+    *,
+    chunk_size: int,
+    idempotency_key: str | None,
+) -> list[dict[str, Any]]:
+    chunks: list[dict[str, Any]] = []
+    chunk_index = 1
+    for payload_index, payload in enumerate(payloads, start=1):
+        metadata = {k: v for k, v in payload.items() if k != "operations"}
+        operations = list(payload["operations"])
+        chunk_count = (len(operations) + chunk_size - 1) // chunk_size
+        base_idempotency = (
+            idempotency_key
+            or str(metadata.get("idempotency_key") or "").strip()
+            or None
+        )
+        for offset in range(0, len(operations), chunk_size):
+            ops = operations[offset : offset + chunk_size]
+            chunk_payload = dict(metadata)
+            if base_idempotency:
+                if chunk_count > 1 or len(payloads) > 1:
+                    chunk_payload["idempotency_key"] = (
+                        f"{base_idempotency}:chunk-{chunk_index:04d}"
+                    )
+                else:
+                    chunk_payload["idempotency_key"] = base_idempotency
+            chunk_payload["operations"] = ops
+            chunks.append(
+                {
+                    "index": chunk_index,
+                    "source_payload_index": payload_index,
+                    "operation_count": len(ops),
+                    "operations": ops,
+                    "idempotency_key": chunk_payload.get("idempotency_key"),
+                    "payload": chunk_payload,
+                }
+            )
+            chunk_index += 1
+    if not chunks:
+        raise ValueError("bulk mutation input did not contain any operations")
+    return chunks
+
+
+def _new_bulk_run_payload(
+    *,
+    pot_id: str,
+    chunks_total: int,
+    operations_total: int,
+    chunk_size: int,
+    dry_run: bool,
+    start_chunk: int,
+    manifest: str | None,
+) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "status": "running",
+        "pot_id": pot_id,
+        "chunks_total": chunks_total,
+        "chunks_attempted": 0,
+        "chunks_validated": 0,
+        "chunks_committed": 0,
+        "operations_total": operations_total,
+        "operations_attempted": 0,
+        "operations_validated": 0,
+        "operations_committed": 0,
+        "chunk_size": chunk_size,
+        "dry_run": dry_run,
+        "start_chunk": start_chunk,
+        "manifest": manifest,
+        "chunks": [],
+        "issues": [],
+    }
+
+
+def _bulk_skipped_chunk(chunk: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "index": chunk["index"],
+        "source_payload_index": chunk["source_payload_index"],
+        "operation_count": chunk["operation_count"],
+        "idempotency_key": chunk.get("idempotency_key"),
+        "ok": True,
+        "status": "skipped",
+    }
+
+
+def _bulk_chunk_entry(chunk: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "index": chunk["index"],
+        "source_payload_index": chunk["source_payload_index"],
+        "operation_count": chunk["operation_count"],
+        "idempotency_key": chunk.get("idempotency_key"),
+        "ok": False,
+        "status": "pending",
+    }
+
+
+def _bulk_proposal_summary(result) -> dict[str, Any]:
+    out = {
+        "ok": result.ok,
+        "plan_id": result.plan_id,
+        "status": result.status,
+        "risk": result.risk,
+        "auto_applicable": result.auto_applicable,
+        "issues": list(result.issues),
+        "rejected_operations": list(result.rejected_operations),
+        "review_required_operations": list(result.review_required_operations),
+        "claim_keys": list(result.claim_keys),
+    }
+    if result.diff:
+        out["diff"] = result.diff.to_dict()
+    return out
+
+
+def _bulk_commit_summary(result) -> dict[str, Any]:
+    out = {
+        "ok": result.ok,
+        "plan_id": result.plan_id,
+        "status": result.status,
+        "risk": result.risk,
+        "mutation_id": result.mutation_id,
+        "detail": result.detail,
+        "claim_keys": list(result.claim_keys),
+    }
+    if result.diff:
+        out["diff"] = result.diff.to_dict()
+    return out
+
+
+def _bulk_issues_from_proposal(result, chunk_index: int) -> list[dict[str, Any]]:
+    issues: list[dict[str, Any]] = []
+    for issue in result.issues or ():
+        if isinstance(issue, Mapping):
+            item = dict(issue)
+        else:
+            item = {"code": "proposal_issue", "message": str(issue)}
+        item.setdefault("severity", "error")
+        item["chunk"] = chunk_index
+        issues.append(item)
+    if not issues:
+        issues.append(
+            {
+                "code": str(result.status or "proposal_failed"),
+                "message": "chunk proposal failed",
+                "severity": "error",
+                "chunk": chunk_index,
+            }
+        )
+    return issues
+
+
+def _bulk_run_status(
+    run: Mapping[str, Any],
+    *,
+    dry_run: bool,
+    ok: bool,
+) -> str:
+    if not ok:
+        if run.get("chunks_committed") or run.get("chunks_validated"):
+            return "partial"
+        return "failed"
+    return "validated" if dry_run else "committed"
+
+
+def _bulk_next_action(run: Mapping[str, Any]) -> str | None:
+    if run.get("ok"):
+        if run.get("dry_run"):
+            return "Rerun without --dry-run to commit the proposed chunks."
+        return None
+    for issue in run.get("issues") or ():
+        if isinstance(issue, Mapping) and issue.get("code") == "approval_required":
+            return "Review the chunk plan, then rerun with --approved-by when policy allows."
+    return "Inspect the failed chunk, fix the mutation input, and rerun with --start-chunk if earlier chunks succeeded."
+
+
+def _bulk_human(run: Mapping[str, Any]) -> str:
+    status = run.get("status")
+    attempted = run.get("chunks_attempted", 0)
+    total = run.get("chunks_total", 0)
+    committed = run.get("chunks_committed", 0)
+    validated = run.get("chunks_validated", 0)
+    ops_committed = run.get("operations_committed", 0)
+    ops_validated = run.get("operations_validated", 0)
+    lines = [
+        (
+            f"{status}: chunks={attempted}/{total} committed={committed} "
+            f"validated={validated} ops_committed={ops_committed} "
+            f"ops_validated={ops_validated}"
+        )
+    ]
+    for issue in list(run.get("issues") or ())[:5]:
+        if isinstance(issue, Mapping):
+            lines.append(
+                f"  [issue chunk={issue.get('chunk')}] "
+                f"{issue.get('code')}: {issue.get('message')}"
+            )
+    return "\n".join(lines)
+
+
+def _write_bulk_manifest(path: str | None, payload: Mapping[str, Any]) -> None:
+    if not path:
+        return
+    try:
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+    except OSError as exc:
+        raise ValueError(f"cannot write bulk manifest {path!r}: {exc}") from exc
+
+
+def _data_plane_status_payload(status) -> dict[str, Any]:
+    return {
+        "pot_id": status.pot_id,
+        "backend_profile": status.backend_profile,
+        "backend_ready": status.backend_ready,
+        "reader_backed_includes": list(status.reader_backed_includes),
+        "counts": dict(status.counts),
+        "freshness": dict(status.freshness),
+        "quality": dict(status.quality),
+        "match_mode": status.match_mode,
+        "detail": status.detail,
+    }
+
+
+def _neighborhood_relation(edge) -> dict[str, Any]:
+    props = dict(edge.properties or {})
+    source_refs = _string_list(props.get("source_refs"))
+    if not source_refs and props.get("source_ref"):
+        source_refs = [_str(props.get("source_ref"))]
+    score = props.get("semantic_similarity")
+    if score is None:
+        score = props.get("score")
+    return {
+        "predicate": edge.predicate,
+        "from": edge.from_key,
+        "to": edge.to_key,
+        "from_key": edge.from_key,
+        "to_key": edge.to_key,
+        "fact": _str(
+            props.get("fact") or props.get("description") or props.get("summary")
+        ),
+        "source_refs": source_refs,
+        "truth": _str(props.get("truth")),
+        "environment": _str(props.get("environment")),
+        "score": float(score) if isinstance(score, (int, float)) else None,
+        "claim_key": _str(props.get("claim_key")),
+        "source_system": _str(props.get("source_system")),
+    }
+
+
+def _neighborhood_human(payload: Mapping[str, Any]) -> str:
+    relations = payload.get("relations") or ()
+    lines = [
+        (
+            f"entity={payload.get('entity_key')} relations={len(relations)} "
+            f"nodes={payload.get('node_count')} detail={payload.get('detail')}"
+        )
+    ]
+    for rel in list(relations)[:20]:
+        if not isinstance(rel, Mapping):
+            continue
+        refs = ", ".join(_string_list(rel.get("source_refs"))) or "no-source-ref"
+        fact = rel.get("fact") or f"{rel.get('from')} -> {rel.get('to')}"
+        lines.append(f"  • {rel.get('predicate')} [{refs}] {fact}")
+    return "\n".join(lines)
+
+
+def _catalog_payload_for_profile(
+    payload: Mapping[str, Any], *, profile: str
+) -> dict[str, Any]:
+    mode = (profile or "full").strip().lower()
+    if mode not in {"full", "read"}:
+        raise ValueError("--profile must be one of: full, read")
+    result = dict(payload)
+    result["profile"] = mode
+    if mode == "full":
+        return result
+
+    read_commands = [
+        command
+        for command in result.get("commands", ())
+        if command
+        in {
+            "status",
+            "catalog",
+            "describe",
+            "search-entities",
+            "read",
+            "neighborhood",
+        }
+    ]
+    result["commands"] = read_commands
+    result["views"] = [_compact_catalog_view(view) for view in result.get("views", ())]
+    if "task_ranking" in result:
+        result["task_ranking"] = [
+            _compact_catalog_ranking(entry, rank=index + 1)
+            for index, entry in enumerate(result.get("task_ranking", ()))
+        ]
+    for key in (
+        "admin_commands",
+        "legacy_commands",
+        "mutation_operations",
+        "review_required_operations",
+        "deferred_operations",
+        "entity_types",
+        "predicates",
+        "transition",
+    ):
+        result.pop(key, None)
+    return result
+
+
+def _compact_catalog_view(view: Mapping[str, Any]) -> dict[str, Any]:
+    out = {
+        key: view[key]
+        for key in (
+            "name",
+            "subgraph",
+            "view",
+            "backed",
+            "description",
+            "result_shape",
+            "required_scope",
+            "required_any_scope",
+            "supported_filters",
+        )
+        if key in view
+    }
+    if "subgraph" in out and "view" in out:
+        out["next_read"] = (
+            f"potpie graph read --subgraph {out['subgraph']} --view {out['view']}"
+        )
+    return out
+
+
+def _compact_catalog_ranking(entry: Mapping[str, Any], *, rank: int) -> dict[str, Any]:
+    out: dict[str, Any] = {"rank": rank}
+    for key in ("view", "subgraph", "score", "matched_terms"):
+        if key in entry:
+            out[key] = entry[key]
+    reason = entry.get("reason") or entry.get("why")
+    if reason:
+        out["reason"] = reason
+    return out
+
+
+def _catalog_human(payload: Mapping[str, Any], *, format_: str) -> str:
+    mode = (format_ or "auto").strip().lower()
+    if mode not in {"auto", "table"}:
+        raise ValueError("--format must be one of: auto, table")
+    if mode == "table" or payload.get("profile") == "read":
+        lines = [
+            f"graph catalog profile={payload.get('profile', 'full')} "
+            f"match={payload.get('match_mode')}"
+        ]
+        task = payload.get("task")
+        if task:
+            lines.append(f"task={task}")
+        rankings = payload.get("task_ranking") or ()
+        if rankings:
+            lines.append("rank | score | view | reason")
+            lines.append("--- | --- | --- | ---")
+            for entry in rankings[:8]:
+                reason = str(entry.get("reason") or "")
+                lines.append(
+                    f"{entry.get('rank')} | {entry.get('score')} | "
+                    f"{entry.get('view')} | {reason}"
+                )
+        lines.append("view | backed | filters")
+        lines.append("--- | --- | ---")
+        for view in payload.get("views", ()):
+            filters = ", ".join(view.get("supported_filters") or ()) or "-"
+            lines.append(
+                f"{view.get('name')} | {str(bool(view.get('backed'))).lower()} | {filters}"
+            )
+        return "\n".join(lines)
+
+    return (
+        f"graph contract v2 / ontology {ONTOLOGY_VERSION} "
+        f"(data-plane={payload['data_plane_graph_contract_version']}, match={payload['match_mode']})\n"
+        f"commands: {', '.join(payload['commands'])}\n"
+        f"views: {', '.join(v['name'] for v in payload['views'])}\n"
+        f"mutation ops: {', '.join(payload['mutation_operations'])}\n"
+        f"review-required: {', '.join(payload['review_required_operations'])}\n"
+        f"deferred: {', '.join(payload['deferred_operations'])}"
+    )
+
+
+def _emit_graph_read(
+    ctx: _GraphCliCommandContext,
+    result,
+    *,
+    format_: str,
+    sort: str,
+    dedupe: str,
+    event_limit: int | None = None,
+    human_prefix: str | None = None,
+    warnings: tuple[str, ...] = (),
+) -> None:
+    if not is_json():
+        _emit_read(
+            result,
+            format_=format_,
+            sort=sort,
+            dedupe=dedupe,
+            event_limit=event_limit,
+            human_prefix=human_prefix,
+            warnings=warnings,
+        )
+        return
+
+    normalized_format = _effective_read_format(result, format_)
+    if normalized_format == "jsonl":
+        rows = _timeline_events(result, sort=sort, dedupe=dedupe, limit=event_limit)
+        if not rows:
+            rows = _raw_item_rows(result)
+        payload = _read_payload(
+            result,
+            format_="raw",
+            sort=sort,
+            dedupe=dedupe,
+            event_limit=event_limit,
+        )
+        if payload.get("detail") != "full":
+            payload.pop("items", None)
+        payload["read_shape"] = "jsonl"
+        payload["rows"] = rows
+        payload["row_count"] = len(rows)
+    else:
+        payload = _read_payload(
+            result,
+            format_=normalized_format,
+            sort=sort,
+            dedupe=dedupe,
+            event_limit=event_limit,
+        )
+    _emit_graph_result(
+        ctx,
+        payload,
+        human=_with_read_context(
+            _read_human(
+                result,
+                format_=normalized_format,
+                sort=sort,
+                dedupe=dedupe,
+                event_limit=event_limit,
+            ),
+            human_prefix=human_prefix,
+            warnings=warnings,
+        ),
+        warnings=warnings,
+    )
+
+
+def _emit_read(
+    result,
+    *,
+    format_: str,
+    sort: str,
+    dedupe: str,
+    event_limit: int | None = None,
+    human_prefix: str | None = None,
+    warnings: tuple[str, ...] = (),
+) -> None:
+    normalized_format = _effective_read_format(result, format_)
+    if normalized_format == "jsonl":
+        rows = _timeline_events(result, sort=sort, dedupe=dedupe, limit=event_limit)
+        if not rows:
+            rows = _raw_item_rows(result)
+        for row in rows:
+            typer.echo(json.dumps(row, default=str))
+        return
+    payload = _read_payload(
+        result,
+        format_=normalized_format,
+        sort=sort,
+        dedupe=dedupe,
+        event_limit=event_limit,
+    )
+    emit(
+        payload,
+        human=_with_read_context(
+            _read_human(
+                result,
+                format_=normalized_format,
+                sort=sort,
+                dedupe=dedupe,
+                event_limit=event_limit,
+            ),
+            human_prefix=human_prefix,
+            warnings=warnings,
+        ),
+    )
+
+
+def _with_read_context(
+    human: str, *, human_prefix: str | None, warnings: tuple[str, ...]
+) -> str:
+    lines: list[str] = []
+    if human_prefix:
+        lines.append(human_prefix)
+    lines.append(human)
+    lines.extend(f"! {warning}" for warning in warnings)
+    return "\n".join(lines)
+
+
+def _read_payload(
+    result,
+    *,
+    format_: str = "raw",
+    sort: str = "auto",
+    dedupe: str = "auto",
+    event_limit: int | None = None,
+) -> dict:
+    payload = result.to_dict()
+    if format_ in ("events", "table"):
+        events = _timeline_events(result, sort=sort, dedupe=dedupe, limit=event_limit)
+        if payload.get("detail") != "full":
+            payload.pop("items", None)
+        payload["read_shape"] = "events"
+        payload["events"] = events
+        payload["event_count"] = len(events)
+        payload["freshness"] = _timeline_freshness(events)
+    return payload
+
+
+def _read_human(
+    result,
+    *,
+    format_: str = "raw",
+    sort: str = "auto",
+    dedupe: str = "auto",
+    event_limit: int | None = None,
+) -> str:
+    if format_ in ("events", "table"):
+        return _timeline_human(
+            result, sort=sort, dedupe=dedupe, event_limit=event_limit
+        )
+    payload = result.to_dict()
+    items = payload.get("items", [])
+    lines = [
+        f"view={payload.get('view')} backed={payload.get('backed')} "
+        f"items={len(items)} quality={payload.get('quality', {}).get('status')}"
+    ]
+    for item in items[:10]:
+        fact = item.get("summary") or item.get("entity_key") or ""
+        lines.append(f"  • [{item.get('entity_type') or '?'}] {fact}")
+    return "\n".join(lines)
+
+
+def _raw_item_rows(result) -> list[dict[str, Any]]:
+    return list(result.to_dict().get("items", []))
+
+
+def _effective_read_format(result, requested: str) -> str:
+    value = (requested or "auto").strip().lower()
+    if value not in {"auto", "raw", "events", "table", "jsonl"}:
+        raise ValueError("--format must be one of: auto, raw, events, table, jsonl")
+    if value == "auto":
+        return "events" if _is_timeline_view(result.to_dict().get("view")) else "raw"
+    return value
+
+
+def _effective_requested_format(*, subgraph: str, view: str, requested: str) -> str:
+    value = (requested or "auto").strip().lower()
+    if value == "auto":
+        return "events" if _is_timeline_view(f"{subgraph}.{view}") else "raw"
+    return value
+
+
+def _service_limit_for_read(
+    *, subgraph: str, view: str, format_: str, requested_limit: int
+) -> int:
+    if _is_timeline_view(f"{subgraph}.{view}") and format_ in {
+        "events",
+        "table",
+        "jsonl",
+    }:
+        return min(max(requested_limit * 8, 40), 200)
+    return requested_limit
+
+
+def _is_timeline_view(view: str | None) -> bool:
+    return str(view or "").strip() == "recent_changes.timeline"
+
+
+def _timeline_events(
+    result,
+    *,
+    sort: str = "auto",
+    dedupe: str = "auto",
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    payload = result.to_dict()
+    if not _is_timeline_view(payload.get("view")):
+        return []
+    dedupe_mode = _normalize_dedupe(dedupe)
+    by_key: dict[str, dict[str, Any]] = {}
+    ordered: list[dict[str, Any]] = []
+    items = getattr(result, "items", None)
+    if items is None:
+        items = payload.get("items", [])
+    for item in items:
+        for event in _events_from_item(item):
+            key = _event_dedupe_key(event, mode=dedupe_mode)
+            if key is not None and key in by_key:
+                existing = by_key[key]
+                if float(event.get("score") or 0.0) > float(
+                    existing.get("score") or 0.0
+                ):
+                    existing.update(event)
+                continue
+            ordered.append(event)
+            if key is not None:
+                by_key[key] = event
+    events = _sort_events(ordered, sort=sort)
+    return events[:limit] if limit is not None and limit >= 0 else events
+
+
+def _events_from_item(item: Mapping[str, Any]) -> list[dict[str, Any]]:
+    payload = dict(item)
+    relations = payload.get("relations")
+    item_score = float(payload.get("score") or 0.0)
+    if isinstance(relations, list):
+        return [
+            _event_from_relation(rel, item_score=item_score)
+            for rel in relations
+            if isinstance(rel, Mapping) and _relation_has_timeline_fact(rel)
+        ]
+    claim = payload.get("claim") if isinstance(payload.get("claim"), Mapping) else {}
+    if claim.get("source_refs") or payload.get("source_refs") or payload.get("summary"):
+        flat_payload = {**claim, **payload}
+        return [_event_from_flat_payload(flat_payload, item_score=item_score)]
+    return []
+
+
+def _relation_has_timeline_fact(rel: Mapping[str, Any]) -> bool:
+    return bool(
+        rel.get("fact") or rel.get("source_refs") or _activity_key_from_relation(rel)
+    )
+
+
+def _event_from_relation(
+    rel: Mapping[str, Any], *, item_score: float
+) -> dict[str, Any]:
+    fact = _str(rel.get("fact"))
+    source_refs = _string_list(rel.get("source_refs"))
+    related_entity = (
+        rel.get("related_entity")
+        if isinstance(rel.get("related_entity"), Mapping)
+        else {}
+    )
+    return {
+        "activity_key": _activity_key_from_relation(rel),
+        "occurred_at": _event_occurred_at(rel, fact=fact),
+        "source_refs": source_refs,
+        "fact": fact,
+        "predicate": _str(rel.get("predicate")),
+        "actor_key": _actor_key_from_relation(rel),
+        "target_key": _target_key_from_relation(rel),
+        "related_key": _str(rel.get("related_key")),
+        "related_name": _str(related_entity.get("name")),
+        "truth": _str(rel.get("truth")),
+        "evidence_strength": _str(rel.get("evidence_strength")),
+        "source_system": _str(rel.get("source_system")),
+        "score": float(rel.get("score") or item_score or 0.0),
+    }
+
+
+def _event_from_flat_payload(
+    payload: Mapping[str, Any], *, item_score: float
+) -> dict[str, Any]:
+    fact = _str(payload.get("fact") or payload.get("summary"))
+    return {
+        "activity_key": _str(payload.get("activity_key")),
+        "occurred_at": _event_occurred_at(payload, fact=fact),
+        "source_refs": _string_list(payload.get("source_refs")),
+        "fact": fact,
+        "predicate": _str(payload.get("predicate")),
+        "actor_key": None,
+        "target_key": _str(payload.get("object_key")),
+        "related_key": _str(payload.get("object_key")),
+        "related_name": None,
+        "truth": _str(payload.get("truth")),
+        "evidence_strength": _str(payload.get("evidence_strength")),
+        "source_system": _str(payload.get("source_system")),
+        "score": float(item_score or 0.0),
+    }
+
+
+def _activity_key_from_relation(rel: Mapping[str, Any]) -> str | None:
+    predicate = _str(rel.get("predicate")).upper()
+    from_key = _str(rel.get("from_key"))
+    to_key = _str(rel.get("to_key"))
+    if predicate in {"TOUCHED", "MENTIONS"}:
+        return from_key
+    if predicate in {"PERFORMED", "AUTHORED"}:
+        return to_key
+    return from_key if from_key.startswith("activity:") else to_key
+
+
+def _actor_key_from_relation(rel: Mapping[str, Any]) -> str | None:
+    predicate = _str(rel.get("predicate")).upper()
+    if predicate in {"PERFORMED", "AUTHORED"}:
+        return _str(rel.get("from_key")) or None
+    return None
+
+
+def _target_key_from_relation(rel: Mapping[str, Any]) -> str | None:
+    predicate = _str(rel.get("predicate")).upper()
+    if predicate in {"TOUCHED", "MENTIONS"}:
+        return _str(rel.get("to_key")) or None
+    return None
+
+
+def _event_occurred_at(
+    payload: Mapping[str, Any], *, fact: str | None = None
+) -> str | None:
+    props = (
+        payload.get("properties")
+        if isinstance(payload.get("properties"), Mapping)
+        else {}
+    )
+    for value in (
+        payload.get("occurred_at"),
+        props.get("occurred_at"),
+    ):
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    if fact:
+        m = re.search(r"\bon (\d{4}-\d{2}-\d{2})\b", fact)
+        if m:
+            return m.group(1)
+    value = payload.get("valid_at")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _normalize_dedupe(value: str) -> str:
+    mode = (value or "auto").strip().lower()
+    if mode == "auto":
+        return "source_ref"
+    if mode not in {"none", "source_ref", "activity"}:
+        raise ValueError("--dedupe must be one of: auto, none, source_ref, activity")
+    return mode
+
+
+def _event_dedupe_key(event: Mapping[str, Any], *, mode: str) -> str | None:
+    if mode == "none":
+        return None
+    if mode == "activity":
+        return _str(event.get("activity_key")) or None
+    refs = _string_list(event.get("source_refs"))
+    if refs:
+        return "source_ref:" + "|".join(sorted(refs))
+    return _str(event.get("activity_key")) or _str(event.get("fact")) or None
+
+
+def _sort_events(events: list[dict[str, Any]], *, sort: str) -> list[dict[str, Any]]:
+    mode = (sort or "auto").strip().lower()
+    if mode == "auto":
+        mode = "occurred_at"
+    if mode not in {"score", "occurred_at"}:
+        raise ValueError("--sort must be one of: auto, score, occurred_at")
+    if mode == "score":
+        return sorted(events, key=lambda e: float(e.get("score") or 0.0), reverse=True)
+    return sorted(
+        events,
+        key=lambda e: (
+            _parse_sort_dt(e.get("occurred_at")),
+            float(e.get("score") or 0.0),
+        ),
+        reverse=True,
+    )
+
+
+def _timeline_freshness(events: list[Mapping[str, Any]]) -> dict[str, Any]:
+    dates = [e.get("occurred_at") for e in events if e.get("occurred_at")]
+    return {
+        "latest_event_at": max(dates) if dates else None,
+        "source_refs_count": len(
+            {ref for e in events for ref in _string_list(e.get("source_refs"))}
+        ),
+        "local_worktree_included": False,
+        "note": "Timeline reads recorded graph events for the whole pot/project across repo sources; uncommitted local changes are not included unless recorded.",
+    }
+
+
+def _timeline_human(
+    result, *, sort: str, dedupe: str, event_limit: int | None = None
+) -> str:
+    events = _timeline_events(result, sort=sort, dedupe=dedupe, limit=event_limit)
+    payload = result.to_dict()
+    lines = [
+        f"view={payload.get('view')} events={len(events)} "
+        f"quality={payload.get('quality', {}).get('status')}",
+        "scope=project-wide pot timeline across registered repo sources; local uncommitted worktree is not included",
+    ]
+    for event in events[:20]:
+        refs = ", ".join(_string_list(event.get("source_refs"))) or "no-source-ref"
+        when = event.get("occurred_at") or "unknown-date"
+        fact = event.get("fact") or event.get("activity_key") or "(no fact)"
+        lines.append(f"  • {when} [{refs}] {fact}")
+    return "\n".join(lines)
+
+
+def _resolve_time_bounds(
+    *, since: str | None, until: str | None, window: str | None
+) -> tuple[datetime | None, datetime | None]:
+    until_dt = _parse_instant(until) if until else None
+    since_dt = _parse_instant(since) if since else None
+    if since_dt is not None:
+        return since_dt, until_dt
+    if window:
+        end = until_dt or datetime.now(timezone.utc)
+        return end - _parse_duration(window), until_dt
+    return None, until_dt
+
+
+def _parse_instant(value: str) -> datetime:
+    raw = value.strip()
+    if not raw:
+        raise ValueError("timestamp must be non-empty")
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError as exc:
+        raise ValueError(f"invalid timestamp {value!r}; expected ISO 8601") from exc
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _parse_duration(value: str) -> timedelta:
+    m = re.fullmatch(r"\s*(\d+)\s*([mhdw])\s*", value.strip().lower())
+    if not m:
+        raise ValueError("--time-window must look like 30m, 24h, 7d, or 2w")
+    amount = int(m.group(1))
+    unit = m.group(2)
+    if unit == "m":
+        return timedelta(minutes=amount)
+    if unit == "h":
+        return timedelta(hours=amount)
+    if unit == "d":
+        return timedelta(days=amount)
+    return timedelta(weeks=amount)
+
+
+def _parse_ttl_seconds(value: str) -> int:
+    try:
+        ttl = _parse_duration(value)
+    except ValueError as exc:
+        raise ValueError("--ttl must look like 30m, 1h, 7d, or 2w") from exc
+    seconds = int(ttl.total_seconds())
+    if seconds <= 0:
+        raise ValueError("--ttl must be positive")
+    return seconds
+
+
+def _parse_sort_dt(value: Any) -> datetime:
+    if isinstance(value, str) and value.strip():
+        raw = value.strip()
+        if re.fullmatch(r"\d{4}-\d{2}-\d{2}", raw):
+            raw = raw + "T00:00:00+00:00"
+        if raw.endswith("Z"):
+            raw = raw[:-1] + "+00:00"
+        try:
+            dt = datetime.fromisoformat(raw)
+            return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+        except ValueError:
+            pass
+    return datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _resolve_repo_scope(repo: str) -> str:
+    value = repo.strip()
+    if not value:
+        raise ValueError("--repo must be non-empty")
+    if value == "current":
+        remote = _current_repo_remote_for_scope()
+        if remote:
+            return remote
+        raise ValueError("--repo current requires a git remote.origin.url")
+    return _normalize_repo_for_scope(value)
+
+
+def _current_repo_remote_for_scope() -> str | None:
+    import subprocess
+
+    try:
+        proc = subprocess.run(
+            ["git", "config", "--get", "remote.origin.url"],
+            capture_output=True,
+            text=True,
+            timeout=1,
+            check=False,
+        )
+    except Exception:  # noqa: BLE001
+        return None
+    if proc.returncode != 0:
+        return None
+    return _normalize_repo_for_scope(proc.stdout.strip())
+
+
+def _normalize_repo_for_scope(value: str) -> str:
+    text = value.strip()
+    if text.endswith(".git"):
+        text = text[:-4]
+    if text.startswith("git@"):
+        text = text[4:].replace(":", "/", 1)
+    elif "://" in text:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(text)
+        path = parsed.path.strip("/")
+        if parsed.netloc and path:
+            text = f"{parsed.netloc}/{path}"
+    return text.strip("/").lower()
+
+
+def _str(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _string_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value] if value else []
+    if isinstance(value, (list, tuple)):
+        return [v for v in value if isinstance(v, str) and v]
+    return []
+
+
+def _nudge_human(result) -> str:
+    if result.silent:
+        return f"silent (event={result.event}): {result.detail or 'nothing to inject'}"
+    lines = [f"event={result.event}"]
+    if result.inject_context:
+        lines.append(result.inject_context)
+    if result.instruction:
+        lines.append(f"instruction: {result.instruction}")
+    if result.injected_keys:
+        lines.append(f"(injected {len(result.injected_keys)} item(s))")
+    return "\n".join(lines)
+
+
+def _mutate_human(result) -> str:
+    if result.would_apply is not None:
+        head = (
+            f"{result.status}: would_apply={result.would_apply} risk={result.risk} "
+            f"accepted={result.operations_accepted} preview={dict(result.preview or {})}"
+        )
+    else:
+        head = (
+            f"{result.status}: risk={result.risk} "
+            f"auto_committed={result.auto_committed} "
+            f"applied={result.operations_applied} {dict(result.mutations_applied)}"
+        )
+    lines = [head]
+    for issue in result.issues:
+        marker = "error" if issue.is_error else "warn"
+        lines.append(f"  [{marker}] {issue.code}: {issue.message}")
+    return "\n".join(lines)
+
+
+def _proposal_human(result) -> str:
+    lines = [
+        (
+            f"{result.status}: plan_id={result.plan_id} risk={result.risk} "
+            f"auto_applicable={result.auto_applicable}"
+        )
+    ]
+    if result.diff:
+        lines.append(f"diff: {result.diff.to_dict()}")
+    for issue in getattr(result, "issues", ()):
+        code = issue.get("code") if isinstance(issue, Mapping) else None
+        message = issue.get("message") if isinstance(issue, Mapping) else None
+        if code or message:
+            lines.append(f"  [issue] {code}: {message}")
+    return "\n".join(lines)
+
+
+def _commit_human(result) -> str:
+    head = f"{result.status}: plan_id={result.plan_id} risk={result.risk}"
+    if result.mutation_id:
+        head += f" mutation_id={result.mutation_id}"
+    lines = [head]
+    verification = getattr(result, "verification", None)
+    if verification is not None:
+        lines.append(
+            "verification: "
+            f"status={verification.status} "
+            f"readback={verification.readback_count}/{len(verification.claim_keys)} "
+            f"quality={verification.quality_status}"
+        )
+        if verification.quality_regressions:
+            lines.append(
+                f"quality_regressions={dict(verification.quality_regressions)}"
+            )
+        if verification.missing_claim_keys:
+            lines.append(f"missing_claim_keys={list(verification.missing_claim_keys)}")
+    if result.detail:
+        lines.append(result.detail)
+    return "\n".join(lines)
+
+
+def _history_human(result) -> str:
+    payload = result.to_dict()
+    entries = payload.get("entries", [])
+    lines = [f"history: entries={len(entries)} filters={payload.get('filters', {})}"]
+    detail = payload.get("detail")
+    if detail:
+        lines.append(str(detail))
+    for entry in entries[:10]:
+        when = entry.get("occurred_at") or "unknown-time"
+        kind = entry.get("kind") or "entry"
+        status = entry.get("status") or "-"
+        summary = entry.get("summary") or entry.get("id")
+        lines.append(f"  • {when} [{kind}:{status}] {summary}")
+    return "\n".join(lines)
+
+
+def _inbox_human(result) -> str:
+    payload = result.to_dict()
+    if payload.get("item"):
+        item = payload["item"]
+        head = (
+            f"inbox {payload.get('action')}: "
+            f"{item.get('item_id')} status={item.get('status')}"
+        )
+        detail = payload.get("detail")
+        return "\n".join([head, str(detail)] if detail else [head])
+    items = payload.get("items", [])
+    lines = [f"inbox {payload.get('action')}: items={len(items)}"]
+    detail = payload.get("detail")
+    if detail:
+        lines.append(str(detail))
+    for item in items[:10]:
+        lines.append(
+            f"  {item.get('item_id')} [{item.get('status')}] {item.get('summary')}"
+        )
+    return "\n".join(lines)
+
+
+def _quality_human(result) -> str:
+    payload = result.to_dict()
+    findings = payload.get("findings", [])
+    lines = [
+        f"quality {payload.get('report')}: status={payload.get('status')} findings={len(findings)}"
+    ]
+    detail = payload.get("detail")
+    if detail:
+        lines.append(str(detail))
+    for finding in findings[:10]:
+        lines.append(
+            f"  {finding.get('finding_id')} [{finding.get('severity')}] "
+            f"{finding.get('summary')}"
+        )
+    return "\n".join(lines)
+
+
+__all__ = ["backend_app", "graph_app", "timeline_app"]

--- a/potpie/context-engine/adapters/inbound/cli/host_cli.py
+++ b/potpie/context-engine/adapters/inbound/cli/host_cli.py
@@ -82,6 +82,7 @@ def build_app() -> typer.Typer:
     app.add_typer(ingest_cmds.ingest_app, name="ingest")
     app.add_typer(ledger.ledger_app, name="ledger")
     app.add_typer(graph.graph_app, name="graph")
+    app.add_typer(graph.timeline_app, name="timeline")
     app.add_typer(graph.backend_app, name="backend")
     app.add_typer(skills_cmds.skills_app, name="skills")
     app.add_typer(cloud.cloud_app, name="cloud")

--- a/potpie/context-engine/adapters/inbound/cli/repo_location.py
+++ b/potpie/context-engine/adapters/inbound/cli/repo_location.py
@@ -1,0 +1,92 @@
+"""Repo-source location normalization shared by CLI entrypoints."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def resolve_repo_location(location: str) -> str:
+    """Resolve repo-source shorthand to a durable, matchable location.
+
+    ``.`` / ``current`` and relative paths registered verbatim are hard to match
+    back to a working tree. Prefer the current repo's normalized remote when
+    available, otherwise store an absolute path.
+    """
+
+    raw = (location or "").strip()
+    if raw.lower() in (".", "current"):
+        cwd = Path.cwd().resolve()
+        remote = current_git_remote(cwd)
+        return remote or str(cwd)
+    if raw.startswith((".", "~")):
+        return str(Path(raw).expanduser().resolve(strict=False))
+    return raw
+
+
+def repo_identity_key(value: str) -> str | None:
+    """Stable local key for matching repo sources/defaults.
+
+    Git remotes are normalized to ``host/owner/repo`` and lower-cased. Paths are
+    resolved but keep their original casing because filesystem semantics vary.
+    """
+
+    raw = (value or "").strip()
+    if not raw:
+        return None
+    if raw.startswith((".", "~")) or Path(raw).is_absolute():
+        return str(Path(raw).expanduser().resolve(strict=False))
+    return normalize_repo_ref(raw)
+
+
+def current_repo_identity(cwd: Path) -> str | None:
+    remote = current_git_remote(cwd)
+    if remote:
+        return remote
+    try:
+        return str(cwd.resolve())
+    except OSError:
+        return str(cwd)
+
+
+def current_git_remote(cwd: Path) -> str | None:
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(cwd), "remote", "get-url", "origin"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except Exception:
+        return None
+    if proc.returncode != 0:
+        return None
+    return normalize_repo_ref(proc.stdout.strip())
+
+
+def normalize_repo_ref(value: str) -> str | None:
+    raw = (value or "").strip()
+    if not raw:
+        return None
+    if raw.endswith(".git"):
+        raw = raw[:-4]
+    if raw.startswith("git@") and ":" in raw:
+        host, path = raw[4:].split(":", 1)
+        return f"{host}/{path}".strip("/").lower()
+    if "://" in raw:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(raw)
+        if parsed.netloc and parsed.path:
+            return f"{parsed.netloc}/{parsed.path.strip('/')}".lower()
+    return raw.strip("/").lower()
+
+
+__all__ = [
+    "current_git_remote",
+    "current_repo_identity",
+    "normalize_repo_ref",
+    "repo_identity_key",
+    "resolve_repo_location",
+]

--- a/potpie/context-engine/adapters/inbound/cli/repo_location.py
+++ b/potpie/context-engine/adapters/inbound/cli/repo_location.py
@@ -78,8 +78,15 @@ def normalize_repo_ref(value: str) -> str | None:
         from urllib.parse import urlparse
 
         parsed = urlparse(raw)
-        if parsed.netloc and parsed.path:
-            return f"{parsed.netloc}/{parsed.path.strip('/')}".lower()
+        host = parsed.hostname or ""
+        try:
+            port = parsed.port
+        except ValueError:
+            port = None
+        if port:
+            host = f"{host}:{port}"
+        if host and parsed.path:
+            return f"{host}/{parsed.path.strip('/')}".lower()
     return raw.strip("/").lower()
 
 

--- a/potpie/context-engine/adapters/inbound/mcp/server.py
+++ b/potpie/context-engine/adapters/inbound/mcp/server.py
@@ -68,20 +68,9 @@ def _error(exc: Exception) -> dict[str, Any]:
 
 
 def _envelope_dict(env: Any) -> dict[str, Any]:
-    return {
-        "ok": True,
-        "pot_id": env.pot_id,
-        "intent": env.intent,
-        "overall_confidence": env.overall_confidence,
-        "items": [
-            {"include": i.include, "score": i.score, "payload": dict(i.payload)}
-            for i in env.items
-        ],
-        "coverage": [{"include": c.include, "status": c.status} for c in env.coverage],
-        "unsupported_includes": [
-            {"name": u.name, "reason": u.reason} for u in env.unsupported_includes
-        ],
-    }
+    payload = env.to_dict()
+    payload["ok"] = True
+    return payload
 
 
 def _nudge_dict(nudge: Any) -> dict[str, Any] | None:

--- a/potpie/context-engine/bootstrap/host_wiring.py
+++ b/potpie/context-engine/bootstrap/host_wiring.py
@@ -43,8 +43,10 @@ from application.services.ingest_service import IngestService
 from application.services.pot_management import LocalPotManagementService
 from application.services.setup_orchestrator import DefaultSetupOrchestrator
 from application.services.skill_manager import DefaultSkillManager
+from bootstrap.observability_runtime import set_observability
 from domain.ports.graph.backend import GraphBackend
 from domain.ports.ledger.client import EventLedgerClientPort
+from domain.ports.observability import ObservabilityPort
 from host.daemon import Daemon
 from host.shell import HostShell, LedgerFacade
 
@@ -71,6 +73,7 @@ def build_host_shell(
     backend: GraphBackend | None = None,
     profile: str = "local",
     ledger_client: EventLedgerClientPort | None = None,
+    observability: ObservabilityPort | None = None,
     settings: Any = None,
 ) -> HostShell:
     """Compose a ``HostShell`` from the default local services + adapters.
@@ -79,6 +82,9 @@ def build_host_shell(
     ``InMemoryGraphBackend``); otherwise one is built from the configured
     profile. Pass ``ledger_client`` to inject a fixture ledger.
     """
+    if observability is not None:
+        set_observability(observability)
+
     backend = backend or build_backend(default_backend_profile(), settings=settings)
     pot_store = LocalPotStore()
 

--- a/potpie/context-engine/tests/unit/test_graph_cli_contract.py
+++ b/potpie/context-engine/tests/unit/test_graph_cli_contract.py
@@ -1,0 +1,1987 @@
+"""CLI contract coverage for Graph Surface Lite."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import replace
+from datetime import datetime, timezone
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from bootstrap import observability_runtime
+from adapters.inbound.cli.commands import _common, graph
+from domain.graph_plans import (
+    GraphIngestionVerificationResult,
+    GraphMutationCommitResult,
+    GraphMutationDiff,
+    GraphMutationProposal,
+)
+from domain.graph_history import GraphHistoryEntry, GraphHistoryResult
+from domain.graph_inbox import GraphInboxItem, GraphInboxResult
+from domain.graph_quality import GraphQualityFinding, GraphQualityResult
+from domain.nudge import GraphNudgeResult
+from domain.graph_views import views_for_catalog
+from domain.ports.services.graph_service import (
+    DataPlaneStatus,
+    GraphCatalogResult,
+    GraphEntityCandidate,
+    GraphEntitySearchResult,
+    GraphReadResult,
+)
+from domain.ports.graph.inspection import GraphEdge, GraphNode, GraphSlice
+from domain.ports.graph.analytics import RepairReport
+from domain.ports.graph.backend import BackendCapabilities
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _reset_json_mode():
+    yield
+    _common.set_json(False)
+
+
+class _Pot:
+    pot_id = "p"
+    name = "default"
+    active = True
+
+
+class _Pots:
+    def active_pot(self):
+        return _Pot()
+
+    def list_pots(self):
+        return [_Pot()]
+
+    def list_sources(self, *, pot_id):
+        return []
+
+
+class _Graph:
+    def __init__(
+        self,
+        read_result: GraphReadResult | None = None,
+        read_error: Exception | None = None,
+        catalog_error: Exception | None = None,
+    ) -> None:
+        self.read_result = read_result
+        self.read_error = read_error
+        self.catalog_error = catalog_error
+        self.read_called = False
+        self.read_request = None
+        self.search_request = None
+
+    def catalog(self, _request):
+        if self.catalog_error is not None:
+            raise self.catalog_error
+        return GraphCatalogResult(
+            graph_contract_version="v1.5",
+            ontology_version="2026-06-graph",
+            commands=("catalog", "read", "search-entities", "mutate"),
+            truth_classes=("agent_claim",),
+            mutation_operations=(
+                "link_entities",
+                "patch_entity",
+                "transition_state",
+                "supersede_claim",
+                "merge_duplicate_entities",
+            ),
+            review_required_operations=(),
+            deferred_operations=(),
+            views=tuple(views_for_catalog()),
+            entity_types=(),
+            predicates=(),
+            match_mode="lexical",
+        )
+
+    def data_plane_status(self, pot_id):
+        return DataPlaneStatus(
+            pot_id=pot_id,
+            backend_profile="memory",
+            backend_ready=True,
+            reader_backed_includes=("timeline",),
+            counts={"claims": 3},
+            freshness={},
+            quality={},
+            match_mode="lexical",
+        )
+
+    def read(self, _request):
+        self.read_called = True
+        self.read_request = _request
+        if self.read_error is not None:
+            raise self.read_error
+        if self.read_result is None:
+            raise AssertionError("read should not be called")
+        return replace(
+            self.read_result,
+            detail=_request.detail,
+            relations=_request.relations,
+        )
+
+    def search_entities(self, request):
+        self.search_request = request
+        supporting_claims = (
+            (
+                {
+                    "claim_key": "claim:widgets-payments",
+                    "predicate": "PROVIDES",
+                },
+            )
+            if request.supporting_claims
+            else ()
+        )
+        return GraphEntitySearchResult(
+            entities=(
+                GraphEntityCandidate(
+                    key="feature:payments",
+                    labels=("Feature",),
+                    summary="Payments capability",
+                    score=0.9,
+                    supporting_claims=supporting_claims,
+                ),
+            ),
+            match_mode="lexical",
+            graph_contract_version="v1.5",
+            ontology_version="2026-06-graph",
+        )
+
+
+class _NotReadyGraph(_Graph):
+    def data_plane_status(self, pot_id):
+        return DataPlaneStatus(
+            pot_id=pot_id,
+            backend_profile="memory",
+            backend_ready=False,
+            reader_backed_includes=("timeline",),
+            counts={"claims": 0},
+            freshness={},
+            quality={"status": "unavailable"},
+            match_mode="lexical",
+            detail="mutation store is unavailable",
+        )
+
+
+class _GraphByPot(_Graph):
+    def __init__(self, counts_by_pot):
+        super().__init__()
+        self.counts_by_pot = counts_by_pot
+
+    def data_plane_status(self, pot_id):
+        return DataPlaneStatus(
+            pot_id=pot_id,
+            backend_profile="memory",
+            backend_ready=True,
+            reader_backed_includes=("timeline",),
+            counts=self.counts_by_pot.get(pot_id, {"claims": 0, "entities": 0}),
+            freshness={},
+            quality={},
+            match_mode="lexical",
+        )
+
+
+class _RecordedSpan:
+    def __init__(self, attrs: dict) -> None:
+        self.attrs = attrs
+        self.error = None
+
+    def set_attribute(self, key, value):
+        self.attrs[key] = value
+
+    def set_attributes(self, attributes):
+        self.attrs.update(dict(attributes))
+
+    def add_event(self, *_args, **_kwargs):
+        pass
+
+    def record_exception(self, exc):
+        self.attrs["exception"] = repr(exc)
+
+    def set_error(self, message=None):
+        self.error = message or True
+
+
+class _RecordingObservability:
+    def __init__(self) -> None:
+        self.spans: list[tuple[str, dict, _RecordedSpan]] = []
+        self.counters: list[tuple[str, int, dict]] = []
+        self.histograms: list[tuple[str, float, dict]] = []
+
+    @contextmanager
+    def span(self, name, *, kind="internal", attributes=None, links=None):
+        del links
+        attrs = {"kind": kind, **dict(attributes or {})}
+        span = _RecordedSpan(attrs)
+        self.spans.append((name, attrs, span))
+        yield span
+
+    def current_traceparent(self):
+        return None
+
+    @contextmanager
+    def baggage(self, **_items):
+        yield
+
+    def counter(self, name, value=1, *, attributes=None):
+        self.counters.append((name, value, dict(attributes or {})))
+
+    def histogram(self, name, value, *, attributes=None):
+        self.histograms.append((name, value, dict(attributes or {})))
+
+    def gauge(self, name, value, *, attributes=None):
+        del name, value, attributes
+
+
+class _Nudge:
+    def __init__(self) -> None:
+        self.request = None
+
+    def nudge(self, request):
+        self.request = request
+        return GraphNudgeResult(
+            ok=True,
+            silent=True,
+            event=request.event.replace("-", "_"),
+            pot_id=request.pot_id,
+            detail="nothing relevant",
+        )
+
+
+class _Workbench:
+    def __init__(
+        self,
+        *,
+        proposal: GraphMutationProposal | None = None,
+        commit_result: GraphMutationCommitResult | None = None,
+        history_result: GraphHistoryResult | None = None,
+        inbox_result: GraphInboxResult | None = None,
+        quality_result: GraphQualityResult | None = None,
+    ) -> None:
+        self.proposal = proposal
+        self.commit_result = commit_result
+        self.history_result = history_result
+        self.inbox_result = inbox_result
+        self.quality_result = quality_result
+        self.propose_calls = []
+        self.commit_calls = []
+        self.history_calls = []
+        self.inbox_calls = []
+        self.quality_calls = []
+
+    def propose(self, payload, *, pot_id, ttl_seconds=None):
+        self.propose_calls.append((payload, pot_id, ttl_seconds))
+        if self.proposal is None:
+            raise AssertionError("propose should not be called")
+        return self.proposal
+
+    def commit(self, plan_id, *, pot_id, approved_by=None, verify=False):
+        self.commit_calls.append((plan_id, pot_id, approved_by, verify))
+        if self.commit_result is None:
+            raise AssertionError("commit should not be called")
+        return self.commit_result
+
+    def history(self, **kwargs):
+        self.history_calls.append(kwargs)
+        if self.history_result is None:
+            raise AssertionError("history should not be called")
+        return self.history_result
+
+    def inbox_add(self, **kwargs):
+        self.inbox_calls.append(("add", kwargs))
+        if self.inbox_result is None:
+            raise AssertionError("inbox_add should not be called")
+        return self.inbox_result
+
+    def inbox_list(self, **kwargs):
+        self.inbox_calls.append(("list", kwargs))
+        if self.inbox_result is None:
+            raise AssertionError("inbox_list should not be called")
+        return self.inbox_result
+
+    def inbox_show(self, **kwargs):
+        self.inbox_calls.append(("show", kwargs))
+        if self.inbox_result is None:
+            raise AssertionError("inbox_show should not be called")
+        return self.inbox_result
+
+    def inbox_claim(self, **kwargs):
+        self.inbox_calls.append(("claim", kwargs))
+        if self.inbox_result is None:
+            raise AssertionError("inbox_claim should not be called")
+        return self.inbox_result
+
+    def inbox_mark_applied(self, **kwargs):
+        self.inbox_calls.append(("mark-applied", kwargs))
+        if self.inbox_result is None:
+            raise AssertionError("inbox_mark_applied should not be called")
+        return self.inbox_result
+
+    def inbox_mark_rejected(self, **kwargs):
+        self.inbox_calls.append(("mark-rejected", kwargs))
+        if self.inbox_result is None:
+            raise AssertionError("inbox_mark_rejected should not be called")
+        return self.inbox_result
+
+    def inbox_close(self, **kwargs):
+        self.inbox_calls.append(("close", kwargs))
+        if self.inbox_result is None:
+            raise AssertionError("inbox_close should not be called")
+        return self.inbox_result
+
+    def quality(self, **kwargs):
+        self.quality_calls.append(kwargs)
+        if self.quality_result is None:
+            raise AssertionError("quality should not be called")
+        return self.quality_result
+
+
+class _Host:
+    def __init__(
+        self,
+        graph_service: _Graph,
+        nudge_service: _Nudge | None = None,
+        backend=None,
+        graph_workbench: _Workbench | None = None,
+    ) -> None:
+        self.graph = graph_service
+        self.graph_workbench = graph_workbench or _Workbench()
+        self.nudge = nudge_service or _Nudge()
+        self.pots = _Pots()
+        self.backend = backend
+
+
+class _Analytics:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def repair(self, pot_id, *, targets):
+        self.calls.append((pot_id, tuple(targets)))
+        return RepairReport(
+            pot_id=pot_id,
+            targets=tuple(targets),
+            repaired={"entity_summaries": 2},
+            detail="repaired 2 entity summaries",
+        )
+
+
+class _Backend:
+    def __init__(self) -> None:
+        self.analytics = _Analytics()
+
+    profile = "memory"
+
+    def capabilities(self) -> BackendCapabilities:
+        return BackendCapabilities(profile=self.profile, inspection=True)
+
+    @property
+    def inspection(self):
+        return _Inspection()
+
+
+class _Inspection:
+    def neighborhood(
+        self,
+        *,
+        pot_id,
+        entity_key,
+        depth=1,
+        direction="both",
+        predicates=(),
+        limit=None,
+    ):
+        return GraphSlice(
+            pot_id=pot_id,
+            nodes=(
+                GraphNode(
+                    key=entity_key, labels=("Service",), properties={"name": "web"}
+                ),
+                GraphNode(key="service:api", labels=("Service",)),
+            ),
+            edges=(
+                GraphEdge(
+                    predicate="DEPENDS_ON",
+                    from_key=entity_key,
+                    to_key="service:api",
+                    properties={
+                        "fact": "web depends on api",
+                        "source_refs": ["repo:manifest"],
+                        "truth": "source_observation",
+                        "environment": "staging",
+                    },
+                ),
+            ),
+        )
+
+
+class _UnsupportedBackend:
+    profile = "neo4j"
+
+    def __init__(self) -> None:
+        self.accessed_ports: list[str] = []
+
+    def capabilities(self) -> BackendCapabilities:
+        return BackendCapabilities(
+            profile=self.profile, inspection=False, snapshot=False
+        )
+
+    @property
+    def inspection(self):
+        self.accessed_ports.append("inspection")
+        raise AssertionError("inspection port should not be reached")
+
+    @property
+    def snapshot(self):
+        self.accessed_ports.append("snapshot")
+        raise AssertionError("snapshot port should not be reached")
+
+
+def _valid_mutation_payload() -> dict:
+    return {
+        "operations": [
+            {
+                "op": "link_entities",
+                "subgraph": "infra_topology",
+                "subject": {"key": "service:payments-api", "type": "Service"},
+                "predicate": "DEPENDS_ON",
+                "object": {"key": "service:ledger-api", "type": "Service"},
+                "truth": "source_observation",
+                "evidence": [{"source_ref": "repo:manifest"}],
+                "description": "payments depends on ledger",
+            }
+        ]
+    }
+
+
+def _bulk_mutation_payload(count: int = 3) -> dict:
+    base = _valid_mutation_payload()["operations"][0]
+    return {
+        "idempotency_key": "bulk:test",
+        "created_by": {"surface": "cli", "harness": "test"},
+        "operations": [
+            {
+                **base,
+                "object": {"key": f"service:ledger-api-{index}", "type": "Service"},
+                "description": f"payments depends on ledger {index}",
+            }
+            for index in range(count)
+        ],
+    }
+
+
+def _proposal(
+    *,
+    ok: bool = True,
+    status: str = "validated",
+    risk: str = "low",
+    plan_id: str = "mutation-plan:test",
+    issues: tuple[dict, ...] = (),
+) -> GraphMutationProposal:
+    return GraphMutationProposal(
+        ok=ok,
+        plan_id=plan_id,
+        status=status,
+        risk=risk,
+        pot_id="p",
+        auto_applicable=status == "validated" and risk == "low",
+        expires_at=datetime(2026, 6, 15, tzinfo=timezone.utc),
+        expected_subgraph_versions={"_global": 0},
+        current_subgraph_versions={"_global": 0},
+        diff=GraphMutationDiff(edge_upserts=1, claim_keys=("claim:test",)),
+        issues=issues,
+        rejected_operations=issues,
+        claim_keys=("claim:test",),
+    )
+
+
+def _commit_result(
+    *,
+    ok: bool = True,
+    status: str = "committed",
+    plan_id: str = "mutation-plan:test",
+    verification: GraphIngestionVerificationResult | None = None,
+) -> GraphMutationCommitResult:
+    return GraphMutationCommitResult(
+        ok=ok,
+        plan_id=plan_id,
+        status=status,
+        risk="low",
+        pot_id="p",
+        mutation_id="mutation-1" if ok else None,
+        applied_at=datetime(2026, 6, 15, tzinfo=timezone.utc) if ok else None,
+        expected_subgraph_versions={"_global": 0},
+        current_subgraph_versions={"_global": 0},
+        new_subgraph_versions={"_global": 1} if ok else {"_global": 0},
+        diff=GraphMutationDiff(edge_upserts=1, claim_keys=("claim:test",)),
+        claim_keys=("claim:test",),
+        verification=verification,
+    )
+
+
+def _history_result() -> GraphHistoryResult:
+    return GraphHistoryResult(
+        ok=True,
+        pot_id="p",
+        filters={"plan": "mutation-plan:test", "limit": 50},
+        entries=(
+            GraphHistoryEntry(
+                kind="plan",
+                id="mutation-plan:test",
+                status="committed",
+                plan_id="mutation-plan:test",
+                mutation_id="mutation-1",
+                occurred_at=datetime(2026, 6, 15, tzinfo=timezone.utc),
+                source_refs=("repo:manifest",),
+                summary="mutation plan committed",
+            ),
+        ),
+        subgraph_versions={"_global": 1},
+    )
+
+
+def _inbox_result(
+    *,
+    action: str = "add",
+    status: str = "pending",
+    ok: bool = True,
+) -> GraphInboxResult:
+    item = GraphInboxItem(
+        item_id="graph-inbox:test",
+        pot_id="p",
+        status=status,
+        summary="Possible graph update",
+        evidence=("github:pr:955",),
+        source_refs=("github:pr:955",),
+        suspected_subgraphs=("debugging",),
+        created_by={"surface": "cli", "actor": "codex"},
+        created_at=datetime(2026, 6, 15, tzinfo=timezone.utc),
+    )
+    return GraphInboxResult(
+        ok=ok,
+        pot_id="p",
+        action=action,
+        item=item if action != "list" else None,
+        items=(item,) if action == "list" else (),
+        filters={"limit": 50} if action == "list" else {},
+        detail=None if ok else "inbox item could not be changed",
+    )
+
+
+def _quality_result(
+    *,
+    report: str = "summary",
+    status: str = "ok",
+) -> GraphQualityResult:
+    finding = GraphQualityFinding(
+        finding_id="quality:low-confidence:test",
+        kind="low-confidence",
+        severity="warning",
+        summary="claim needs stronger evidence",
+        claim_keys=("claim:test",),
+        entity_keys=("service:web", "repo:github.com/acme/web"),
+        predicates=("DEFINED_IN",),
+        source_refs=("repo:manifest",),
+    )
+    return GraphQualityResult(
+        ok=True,
+        pot_id="p",
+        report=report,
+        status=status,
+        findings=() if report == "summary" else (finding,),
+        metrics=(
+            {
+                "counts": {"claims": 3},
+                "quality_counts": {
+                    "duplicate_candidates": 0,
+                    "stale_facts": 0,
+                    "conflicting_claims": 1,
+                    "orphan_entities": 0,
+                    "low_confidence": 0,
+                    "projection_drift": 2,
+                },
+                "quality_reports": {
+                    "conflicting-claims": {
+                        "status": status,
+                        "finding_count": 1,
+                        "severity_counts": {"warning": 1},
+                    },
+                    "projection-drift": {
+                        "status": status,
+                        "finding_count": 2,
+                        "severity_counts": {"error": 2},
+                    },
+                },
+                "total_findings": 3,
+            }
+            if report == "summary"
+            else {"scanned_claims": 3}
+        ),
+        filters={"report": report, "limit": 50},
+        subgraph_versions={"_global": 3},
+    )
+
+
+def _assert_graph_envelope(
+    payload: dict, command: str, *, ok: bool = True, pot_id: str | None = "p"
+) -> dict:
+    assert payload["ok"] is ok
+    assert payload["command"] == command
+    assert payload["request_id"].startswith("req:")
+    assert payload["pot_id"] in {pot_id, None}
+    assert payload["graph_contract_version"] == "v2"
+    assert payload["ontology_version"] == "2026-06-graph"
+    assert "subgraph_versions" in payload
+    assert "warnings" in payload
+    assert "unsupported" in payload
+    assert "recommended_next_action" in payload
+    return payload["result"] or {}
+
+
+def test_graph_entity_search_result_includes_summary() -> None:
+    result = GraphEntitySearchResult(
+        entities=(
+            GraphEntityCandidate(
+                key="service:web",
+                labels=("Service",),
+                name="web",
+                summary="Web frontend service.",
+                description="Web frontend service for browser clients.",
+            ),
+        ),
+        match_mode="lexical",
+        graph_contract_version="v1.5",
+        ontology_version="test",
+    )
+
+    payload = result.to_dict()
+
+    assert payload["entities"][0]["summary"] == "Web frontend service."
+
+
+def test_graph_repair_accepts_entity_summaries_target() -> None:
+    backend = _Backend()
+    _common.set_host(_Host(_Graph(), backend=backend))
+
+    result = CliRunner().invoke(graph.graph_app, ["repair", "--entity-summaries"])
+
+    assert result.exit_code == 0, result.output
+    assert backend.analytics.calls == [("p", ("entity_summaries",))]
+    assert "repaired 2 entity summaries" in result.output
+
+
+@pytest.mark.parametrize(
+    ("args", "capability", "method"),
+    [
+        (["inspect", "service:web"], "inspection", "neighborhood"),
+        (["neighborhood", "--entity", "service:web"], "inspection", "neighborhood"),
+        (["export", "out.json"], "snapshot", "export"),
+        (["import", "in.json"], "snapshot", "import_"),
+    ],
+)
+def test_graph_capability_commands_precheck_backend_capabilities(
+    args: list[str],
+    capability: str,
+    method: str,
+) -> None:
+    _common.set_json(True)
+    backend = _UnsupportedBackend()
+    _common.set_host(_Host(_Graph(), backend=backend))
+
+    result = CliRunner().invoke(graph.graph_app, args)
+
+    assert result.exit_code == _common.EXIT_UNAVAILABLE
+    emitted = json.loads(result.output)
+    _assert_graph_envelope(emitted, f"graph.{args[0]}", ok=False)
+    assert emitted["error"]["code"] == "not_implemented"
+    assert f"graph.neo4j.{capability}.{method}" in emitted["error"]["message"]
+    assert emitted["recommended_next_action"]
+    assert backend.accessed_ports == []
+
+
+def test_graph_mutate_rejection_emits_result_and_exits_nonzero(tmp_path) -> None:
+    _common.set_json(True)
+    proposal = _proposal(
+        ok=False,
+        status="invalid",
+        issues=(
+            {
+                "code": "invalid_endpoints",
+                "message": "invalid endpoint pair",
+                "severity": "error",
+                "op_index": 0,
+            },
+        ),
+    )
+    workbench = _Workbench(proposal=proposal)
+    _common.set_host(_Host(_Graph(), graph_workbench=workbench))
+    payload_file = tmp_path / "mutation.json"
+    payload_file.write_text(json.dumps(_valid_mutation_payload()), encoding="utf-8")
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        ["mutate", "--file", str(payload_file)],
+    )
+
+    assert result.exit_code == 1
+    emitted = json.loads(result.output)
+    detail = _assert_graph_envelope(emitted, "graph.mutate", ok=False)
+    assert detail == {}
+    assert emitted["error"]["code"] == "invalid_endpoints"
+    assert emitted["error"]["detail"]["status"] == "invalid"
+    assert emitted["error"]["detail"]["issues"][0]["code"] == "invalid_endpoints"
+    assert "legacy transition command" in emitted["warnings"][0]
+    assert workbench.commit_calls == []
+
+
+def test_graph_propose_returns_persisted_plan_envelope(tmp_path) -> None:
+    _common.set_json(True)
+    workbench = _Workbench(proposal=_proposal())
+    _common.set_host(_Host(_Graph(), graph_workbench=workbench))
+    payload_file = tmp_path / "mutation.json"
+    payload_file.write_text(json.dumps(_valid_mutation_payload()), encoding="utf-8")
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        ["propose", "--file", str(payload_file), "--ttl", "30m"],
+    )
+
+    assert result.exit_code == 0, result.output
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.propose")
+    assert body["plan_id"] == "mutation-plan:test"
+    assert body["status"] == "validated"
+    assert workbench.propose_calls[0][1:] == ("p", 1800)
+
+
+def test_graph_workbench_commands_emit_v2_observability(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    _common.set_json(True)
+    obs = _RecordingObservability()
+    monkeypatch.setattr(observability_runtime, "_OBSERVABILITY", obs)
+    payload_file = tmp_path / "mutation.json"
+    payload_file.write_text(json.dumps(_valid_mutation_payload()), encoding="utf-8")
+
+    _common.set_host(_Host(_Graph(), graph_workbench=_Workbench(proposal=_proposal())))
+    propose = CliRunner().invoke(
+        graph.graph_app,
+        ["propose", "--file", str(payload_file)],
+    )
+    assert propose.exit_code == 0, propose.output
+
+    _common.set_host(
+        _Host(_Graph(), graph_workbench=_Workbench(inbox_result=_inbox_result()))
+    )
+    inbox = CliRunner().invoke(
+        graph.graph_app,
+        ["inbox", "add", "--summary", "Possible graph update"],
+    )
+    assert inbox.exit_code == 0, inbox.output
+
+    _common.set_host(
+        _Host(
+            _Graph(),
+            graph_workbench=_Workbench(
+                quality_result=_quality_result(report="summary")
+            ),
+        )
+    )
+    quality = CliRunner().invoke(graph.graph_app, ["quality", "summary"])
+    assert quality.exit_code == 0, quality.output
+
+    propose_counter = next(
+        item for item in obs.counters if item[0] == "ce.graph.propose_total"
+    )
+    assert propose_counter[2]["risk"] == "low"
+    assert propose_counter[2]["status"] == "validated"
+    inbox_counter = next(
+        item for item in obs.counters if item[0] == "ce.graph.inbox_total"
+    )
+    assert inbox_counter[2]["operation"] == "add"
+    quality_counter = next(
+        item for item in obs.counters if item[0] == "ce.graph.quality_total"
+    )
+    assert quality_counter[2]["report"] == "summary"
+    assert {span[0] for span in obs.spans} >= {
+        "graph.propose",
+        "graph.inbox",
+        "graph.quality",
+    }
+
+
+def test_graph_commit_applies_plan_id_only() -> None:
+    _common.set_json(True)
+    workbench = _Workbench(commit_result=_commit_result())
+    _common.set_host(_Host(_Graph(), graph_workbench=workbench))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        ["commit", "mutation-plan:test"],
+    )
+
+    assert result.exit_code == 0, result.output
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.commit")
+    assert body["status"] == "committed"
+    assert body["mutation_id"] == "mutation-1"
+    assert workbench.commit_calls == [("mutation-plan:test", "p", None, False)]
+
+
+def test_graph_commit_verify_passes_hard_gate_flag() -> None:
+    _common.set_json(True)
+    workbench = _Workbench(commit_result=_commit_result())
+    _common.set_host(_Host(_Graph(), graph_workbench=workbench))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        ["commit", "mutation-plan:test", "--verify"],
+    )
+
+    assert result.exit_code == 0, result.output
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.commit")
+    assert body["status"] == "committed"
+    assert workbench.commit_calls == [("mutation-plan:test", "p", None, True)]
+
+
+def test_graph_commit_verify_exits_nonzero_when_gate_fails() -> None:
+    _common.set_json(True)
+    verification = GraphIngestionVerificationResult(
+        ok=False,
+        status="degraded",
+        plan_id="mutation-plan:test",
+        pot_id="p",
+        claim_keys=("claim:test",),
+        missing_claim_keys=("claim:test",),
+        quality_status="ok",
+        detail="committed plan did not read back all expected claim keys",
+        recommended_next_action="Inspect graph history for the plan.",
+    )
+    workbench = _Workbench(commit_result=_commit_result(verification=verification))
+    _common.set_host(_Host(_Graph(), graph_workbench=workbench))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        ["commit", "mutation-plan:test", "--verify"],
+    )
+
+    assert result.exit_code == 1
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.commit")
+    assert body["status"] == "committed"
+    assert body["verification"]["ok"] is False
+    assert body["verification"]["missing_claim_keys"] == ["claim:test"]
+
+
+def test_graph_commit_rejects_raw_payload_option() -> None:
+    _common.set_json(True)
+    workbench = _Workbench(commit_result=_commit_result())
+    _common.set_host(_Host(_Graph(), graph_workbench=workbench))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        ["commit", "mutation-plan:test", "--file", "mutation.json"],
+    )
+
+    assert result.exit_code != 0
+    assert workbench.commit_calls == []
+
+
+def test_graph_bulk_apply_chunks_and_commits(tmp_path) -> None:
+    _common.set_json(True)
+    workbench = _Workbench(proposal=_proposal(), commit_result=_commit_result())
+    graph_service = _Graph()
+    _common.set_host(_Host(graph_service, graph_workbench=workbench))
+    payload_file = tmp_path / "bulk.json"
+    manifest_file = tmp_path / "manifest.json"
+    payload_file.write_text(json.dumps(_bulk_mutation_payload(3)), encoding="utf-8")
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        [
+            "bulk",
+            "apply",
+            "--file",
+            str(payload_file),
+            "--chunk-size",
+            "2",
+            "--manifest",
+            str(manifest_file),
+            "--verify",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.bulk.apply")
+    assert body["status"] == "committed"
+    assert body["chunks_total"] == 2
+    assert body["chunks_attempted"] == 2
+    assert body["chunks_committed"] == 2
+    assert body["operations_committed"] == 3
+    assert body["verification"]["counts"] == {"claims": 3}
+    assert len(workbench.propose_calls) == 2
+    assert len(workbench.commit_calls) == 2
+    assert len(workbench.propose_calls[0][0]["operations"]) == 2
+    assert len(workbench.propose_calls[1][0]["operations"]) == 1
+    assert workbench.propose_calls[0][0]["idempotency_key"] == "bulk:test:chunk-0001"
+    assert workbench.propose_calls[1][0]["idempotency_key"] == "bulk:test:chunk-0002"
+    manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
+    assert manifest["status"] == "committed"
+    assert manifest["chunks_committed"] == 2
+
+
+def test_graph_bulk_apply_dry_run_does_not_commit(tmp_path) -> None:
+    _common.set_json(True)
+    workbench = _Workbench(proposal=_proposal(), commit_result=_commit_result())
+    _common.set_host(_Host(_Graph(), graph_workbench=workbench))
+    payload_file = tmp_path / "bulk.ndjson"
+    lines = [json.dumps(op) for op in _bulk_mutation_payload(2)["operations"]]
+    payload_file.write_text("\n".join(lines), encoding="utf-8")
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        [
+            "bulk",
+            "apply",
+            "--file",
+            str(payload_file),
+            "--chunk-size",
+            "1",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.bulk.apply")
+    assert body["status"] == "validated"
+    assert body["chunks_validated"] == 2
+    assert body["operations_validated"] == 2
+    assert workbench.commit_calls == []
+
+
+def test_graph_bulk_apply_stops_on_failed_proposal(tmp_path) -> None:
+    _common.set_json(True)
+    proposal = _proposal(
+        ok=False,
+        status="invalid",
+        issues=(
+            {
+                "code": "invalid_endpoints",
+                "message": "invalid endpoint pair",
+                "severity": "error",
+                "op_index": 0,
+            },
+        ),
+    )
+    workbench = _Workbench(proposal=proposal, commit_result=_commit_result())
+    _common.set_host(_Host(_Graph(), graph_workbench=workbench))
+    payload_file = tmp_path / "bulk.json"
+    payload_file.write_text(json.dumps(_bulk_mutation_payload(3)), encoding="utf-8")
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        [
+            "bulk",
+            "apply",
+            "--file",
+            str(payload_file),
+            "--chunk-size",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 1
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.bulk.apply", ok=False)
+    assert body == {}
+    assert emitted["error"]["code"] == "invalid_endpoints"
+    assert emitted["error"]["detail"]["status"] == "failed"
+    assert emitted["error"]["detail"]["chunks_attempted"] == 1
+    assert workbench.commit_calls == []
+
+
+def test_graph_history_plan_returns_envelope() -> None:
+    _common.set_json(True)
+    workbench = _Workbench(history_result=_history_result())
+    _common.set_host(_Host(_Graph(), graph_workbench=workbench))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        ["history", "--plan", "mutation-plan:test"],
+    )
+
+    assert result.exit_code == 0, result.output
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.history")
+    assert emitted["subgraph_versions"] == {"_global": 1}
+    assert body["entry_count"] == 1
+    assert body["entries"][0]["plan_id"] == "mutation-plan:test"
+    assert workbench.history_calls == [
+        {
+            "pot_id": "p",
+            "entity_key": None,
+            "claim_key": None,
+            "subgraph": None,
+            "plan_id": "mutation-plan:test",
+            "mutation_id": None,
+            "since": None,
+            "until": None,
+            "limit": 50,
+        }
+    ]
+
+
+def test_graph_quality_summary_returns_envelope() -> None:
+    _common.set_json(True)
+    workbench = _Workbench(quality_result=_quality_result(report="summary"))
+    _common.set_host(_Host(_Graph(), graph_workbench=workbench))
+
+    result = CliRunner().invoke(graph.graph_app, ["quality", "summary"])
+
+    assert result.exit_code == 0, result.output
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.quality.summary")
+    assert emitted["subgraph_versions"] == {"_global": 3}
+    assert body["report"] == "summary"
+    assert body["metrics"]["counts"]["claims"] == 3
+    assert workbench.quality_calls == [
+        {
+            "pot_id": "p",
+            "report": "summary",
+            "subgraph": None,
+            "limit": 50,
+            "confidence_threshold": 0.5,
+        }
+    ]
+
+
+def test_graph_quality_low_confidence_passes_filters() -> None:
+    _common.set_json(True)
+    workbench = _Workbench(
+        quality_result=_quality_result(report="low-confidence", status="watch")
+    )
+    _common.set_host(_Host(_Graph(), graph_workbench=workbench))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        [
+            "quality",
+            "low-confidence",
+            "--subgraph",
+            "infra_topology",
+            "--limit",
+            "10",
+            "--threshold",
+            "0.75",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.quality.low-confidence")
+    assert body["finding_count"] == 1
+    assert body["findings"][0]["kind"] == "low-confidence"
+    assert workbench.quality_calls == [
+        {
+            "pot_id": "p",
+            "report": "low-confidence",
+            "subgraph": "infra_topology",
+            "limit": 10,
+            "confidence_threshold": 0.75,
+        }
+    ]
+
+
+def test_graph_inbox_add_returns_pending_item_envelope() -> None:
+    _common.set_json(True)
+    workbench = _Workbench(inbox_result=_inbox_result())
+    _common.set_host(_Host(_Graph(), graph_workbench=workbench))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        [
+            "inbox",
+            "add",
+            "--summary",
+            "Possible graph update",
+            "--evidence",
+            "github:pr:955",
+            "--source-ref",
+            "github:pr:955",
+            "--subgraph",
+            "debugging",
+            "--created-by",
+            "codex",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.inbox.add")
+    assert body["action"] == "add"
+    assert body["item"]["item_id"] == "graph-inbox:test"
+    assert body["item"]["status"] == "pending"
+    assert workbench.inbox_calls == [
+        (
+            "add",
+            {
+                "pot_id": "p",
+                "summary": "Possible graph update",
+                "details": None,
+                "evidence": ("github:pr:955",),
+                "source_refs": ("github:pr:955",),
+                "suspected_subgraphs": ("debugging",),
+                "created_by": {"surface": "cli", "actor": "codex"},
+            },
+        )
+    ]
+
+
+def test_graph_inbox_list_passes_filters() -> None:
+    _common.set_json(True)
+    workbench = _Workbench(inbox_result=_inbox_result(action="list"))
+    _common.set_host(_Host(_Graph(), graph_workbench=workbench))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        [
+            "inbox",
+            "list",
+            "--status",
+            "pending,claimed",
+            "--claimed-by",
+            "user:alice",
+            "--subgraph",
+            "debugging",
+            "--source-ref",
+            "github:pr:955",
+            "--limit",
+            "10",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.inbox.list")
+    assert body["item_count"] == 1
+    assert workbench.inbox_calls[0] == (
+        "list",
+        {
+            "pot_id": "p",
+            "status": ("pending,claimed",),
+            "claimed_by": "user:alice",
+            "suspected_subgraph": "debugging",
+            "source_ref": "github:pr:955",
+            "since": None,
+            "until": None,
+            "limit": 10,
+        },
+    )
+
+
+def test_graph_inbox_claim_passes_actor() -> None:
+    _common.set_json(True)
+    workbench = _Workbench(inbox_result=_inbox_result(action="claim", status="claimed"))
+    _common.set_host(_Host(_Graph(), graph_workbench=workbench))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        ["inbox", "claim", "graph-inbox:test", "--by", "user:alice"],
+    )
+
+    assert result.exit_code == 0, result.output
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.inbox.claim")
+    assert body["item"]["status"] == "claimed"
+    assert workbench.inbox_calls == [
+        (
+            "claim",
+            {
+                "pot_id": "p",
+                "item_id": "graph-inbox:test",
+                "claimed_by": "user:alice",
+            },
+        )
+    ]
+
+
+def test_graph_inbox_mark_applied_passes_plan_and_mutation() -> None:
+    _common.set_json(True)
+    workbench = _Workbench(
+        inbox_result=_inbox_result(action="mark-applied", status="applied")
+    )
+    _common.set_host(_Host(_Graph(), graph_workbench=workbench))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        [
+            "inbox",
+            "mark-applied",
+            "graph-inbox:test",
+            "--plan",
+            "mutation-plan:test",
+            "--mutation",
+            "mutation-1",
+            "--by",
+            "user:alice",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.inbox.mark-applied")
+    assert body["item"]["status"] == "applied"
+    assert workbench.inbox_calls == [
+        (
+            "mark-applied",
+            {
+                "pot_id": "p",
+                "item_id": "graph-inbox:test",
+                "closed_by": "user:alice",
+                "linked_plan_id": "mutation-plan:test",
+                "linked_mutation_id": "mutation-1",
+            },
+        )
+    ]
+
+
+def test_graph_inbox_mark_rejected_and_close_record_reasons() -> None:
+    _common.set_json(True)
+    workbench = _Workbench(
+        inbox_result=_inbox_result(action="mark-rejected", status="rejected")
+    )
+    _common.set_host(_Host(_Graph(), graph_workbench=workbench))
+
+    rejected = CliRunner().invoke(
+        graph.graph_app,
+        [
+            "inbox",
+            "mark-rejected",
+            "graph-inbox:test",
+            "--reason",
+            "not enough evidence",
+            "--by",
+            "user:alice",
+        ],
+    )
+
+    assert rejected.exit_code == 0, rejected.output
+    emitted = json.loads(rejected.output)
+    _assert_graph_envelope(emitted, "graph.inbox.mark-rejected")
+    assert workbench.inbox_calls == [
+        (
+            "mark-rejected",
+            {
+                "pot_id": "p",
+                "item_id": "graph-inbox:test",
+                "closed_by": "user:alice",
+                "rejection_reason": "not enough evidence",
+            },
+        )
+    ]
+
+    workbench = _Workbench(inbox_result=_inbox_result(action="close", status="closed"))
+    _common.set_host(_Host(_Graph(), graph_workbench=workbench))
+    closed = CliRunner().invoke(
+        graph.graph_app,
+        [
+            "inbox",
+            "close",
+            "graph-inbox:test",
+            "--reason",
+            "superseded",
+            "--by",
+            "user:alice",
+        ],
+    )
+
+    assert closed.exit_code == 0, closed.output
+    emitted = json.loads(closed.output)
+    _assert_graph_envelope(emitted, "graph.inbox.close")
+    assert workbench.inbox_calls[0][1]["rejection_reason"] == "superseded"
+
+
+@pytest.mark.parametrize("scope", ["service", "service:"])
+def test_graph_read_rejects_malformed_scope_before_service_call(scope: str) -> None:
+    _common.set_json(True)
+    graph_service = _Graph()
+    _common.set_host(_Host(graph_service))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        [
+            "read",
+            "--subgraph",
+            "debugging",
+            "--view",
+            "prior_occurrences",
+            "--scope",
+            scope,
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert graph_service.read_called is False
+    emitted = json.loads(result.output)
+    _assert_graph_envelope(emitted, "graph.read", ok=False)
+    assert emitted["error"]["code"] == "validation_error"
+    assert "invalid --scope entry" in emitted["error"]["message"]
+
+
+def test_graph_read_unknown_view_uses_error_envelope() -> None:
+    _common.set_json(True)
+    graph_service = _Graph(read_error=ValueError("unknown graph view 'missing.view'"))
+    _common.set_host(_Host(graph_service))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        ["read", "--subgraph", "missing", "--view", "view"],
+    )
+
+    assert result.exit_code == 1
+    assert graph_service.read_called is True
+    emitted = json.loads(result.output)
+    _assert_graph_envelope(emitted, "graph.read", ok=False)
+    assert emitted["error"]["code"] == "validation_error"
+    assert "unknown graph view" in emitted["error"]["message"]
+
+
+def test_graph_read_rejects_fully_qualified_view_before_service_call() -> None:
+    _common.set_json(True)
+    graph_service = _Graph()
+    _common.set_host(_Host(graph_service))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        ["read", "--subgraph", "debugging", "--view", "debugging.prior_occurrences"],
+    )
+
+    assert result.exit_code == 1
+    assert graph_service.read_called is False
+    emitted = json.loads(result.output)
+    _assert_graph_envelope(emitted, "graph.read", ok=False)
+    assert emitted["error"]["code"] == "validation_error"
+    assert "--subgraph <name> --view <view>" in emitted["error"]["message"]
+
+
+def _timeline_env() -> GraphReadResult:
+    return GraphReadResult(
+        graph_contract_version="v1.5",
+        ontology_version="2026-06-graph",
+        view="recent_changes.timeline",
+        subgraph="recent_changes",
+        read_shape="entity_relations",
+        coverage=({"include": "timeline", "status": "complete"},),
+        freshness={"local_worktree_included": False},
+        quality={"status": "ok"},
+        items=(
+            {
+                "entity_key": "activity:github:pr-2",
+                "entity_type": "Activity",
+                "score": 0.9,
+                "summary": 'PR #2 "newer" was merged into acme/widgets.',
+                "source_refs": ["github:pr:2"],
+                "truth": "timeline_event",
+                "relations": [
+                    {
+                        "predicate": "TOUCHED",
+                        "from_key": "activity:github:pr-2",
+                        "to_key": "repo:github.com/acme/widgets",
+                        "fact": 'PR #2 "newer" was merged into acme/widgets on 2026-06-08 by Bob.',
+                        "source_refs": ["github:pr:2"],
+                        "truth": "timeline_event",
+                    },
+                    {
+                        "predicate": "PERFORMED",
+                        "from_key": "person:bob",
+                        "to_key": "activity:github:pr-2",
+                        "fact": 'PR #2 "newer" was merged into acme/widgets on 2026-06-08 by Bob.',
+                        "source_refs": ["github:pr:2"],
+                        "truth": "timeline_event",
+                    },
+                ],
+            },
+            {
+                "entity_key": "activity:github:pr-1",
+                "entity_type": "Activity",
+                "score": 1.0,
+                "summary": 'PR #1 "older" was merged into acme/widgets.',
+                "source_refs": ["github:pr:1"],
+                "truth": "timeline_event",
+                "relations": [
+                    {
+                        "predicate": "TOUCHED",
+                        "from_key": "activity:github:pr-1",
+                        "to_key": "repo:github.com/acme/widgets",
+                        "fact": 'PR #1 "older" was merged into acme/widgets on 2026-06-01 by Alice.',
+                        "source_refs": ["github:pr:1"],
+                        "truth": "timeline_event",
+                    }
+                ],
+            },
+        ),
+    )
+
+
+def test_graph_read_timeline_defaults_to_deduped_event_json() -> None:
+    _common.set_json(True)
+    graph_service = _Graph(read_result=_timeline_env())
+    _common.set_host(_Host(graph_service))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        [
+            "read",
+            "--subgraph",
+            "recent_changes",
+            "--view",
+            "timeline",
+            "--limit",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert graph_service.read_request.limit == 40
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.read")
+    assert "subgraph_versions" not in body
+    assert "unsupported" not in body
+    assert body["read_shape"] == "events"
+    assert body["event_count"] == 1
+    assert body["events"][0]["source_refs"] == ["github:pr:2"]
+    assert body["freshness"]["local_worktree_included"] is False
+    assert "items" not in body
+
+
+def test_graph_read_threads_source_ref_filter() -> None:
+    _common.set_json(True)
+    graph_service = _Graph(read_result=_timeline_env())
+    _common.set_host(_Host(graph_service))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        [
+            "read",
+            "--subgraph",
+            "recent_changes",
+            "--view",
+            "timeline",
+            "--source-ref",
+            "github:pr:2",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert graph_service.read_request.source_refs == ("github:pr:2",)
+
+
+def test_graph_read_raw_json_defaults_to_compact_relations() -> None:
+    _common.set_json(True)
+    graph_service = _Graph(read_result=_timeline_env())
+    _common.set_host(_Host(graph_service))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        [
+            "read",
+            "--subgraph",
+            "recent_changes",
+            "--view",
+            "timeline",
+            "--format",
+            "raw",
+            "--limit",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert graph_service.read_request.detail == "compact"
+    assert graph_service.read_request.relations == "summary"
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.read")
+    assert body["detail"] == "compact"
+    assert body["relations_detail"] == "summary"
+    assert "relations" not in body["items"][0]
+    assert body["items"][0]["relation_count"] == 2
+
+
+def test_graph_read_full_detail_preserves_relation_payload() -> None:
+    _common.set_json(True)
+    graph_service = _Graph(read_result=_timeline_env())
+    _common.set_host(_Host(graph_service))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        [
+            "read",
+            "--subgraph",
+            "recent_changes",
+            "--view",
+            "timeline",
+            "--format",
+            "raw",
+            "--detail",
+            "full",
+            "--relations",
+            "full",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert graph_service.read_request.detail == "full"
+    assert graph_service.read_request.relations == "full"
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.read")
+    assert body["detail"] == "full"
+    assert body["items"][0]["relations"][0]["predicate"] == "TOUCHED"
+
+
+def test_graph_search_entities_omits_supporting_claims_by_default() -> None:
+    _common.set_json(True)
+    graph_service = _Graph()
+    _common.set_host(_Host(graph_service))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        ["search-entities", "payments"],
+    )
+
+    assert result.exit_code == 0
+    assert graph_service.search_request.supporting_claims == 0
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.search-entities")
+    assert body["entities"][0]["supporting_claims"] == []
+
+
+def test_graph_search_entities_supporting_claims_is_opt_in() -> None:
+    _common.set_json(True)
+    graph_service = _Graph()
+    _common.set_host(_Host(graph_service))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        ["search-entities", "payments", "--supporting-claims", "1"],
+    )
+
+    assert result.exit_code == 0
+    assert graph_service.search_request.supporting_claims == 1
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.search-entities")
+    assert body["entities"][0]["supporting_claims"][0]["predicate"] == "PROVIDES"
+
+
+def test_graph_search_entities_threads_source_ref_filter() -> None:
+    _common.set_json(True)
+    graph_service = _Graph()
+    _common.set_host(_Host(graph_service))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        ["search-entities", "payments", "--source-ref", "github:pr:955"],
+    )
+
+    assert result.exit_code == 0
+    assert graph_service.search_request.source_refs == ("github:pr:955",)
+
+
+def test_graph_search_entities_threads_source_facets() -> None:
+    _common.set_json(True)
+    graph_service = _Graph()
+    _common.set_host(_Host(graph_service))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        [
+            "search-entities",
+            "payments",
+            "--source-system",
+            "github",
+            "--source-family",
+            "github",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert graph_service.search_request.source_system == "github"
+    assert graph_service.search_request.source_family == "github"
+
+
+def test_graph_read_emits_v2_observability(monkeypatch: pytest.MonkeyPatch) -> None:
+    _common.set_json(True)
+    obs = _RecordingObservability()
+    monkeypatch.setattr(observability_runtime, "_OBSERVABILITY", obs)
+    graph_service = _Graph(read_result=_timeline_env())
+    _common.set_host(_Host(graph_service))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        ["read", "--subgraph", "recent_changes", "--view", "timeline"],
+    )
+
+    assert result.exit_code == 0, result.output
+    span = next(item for item in obs.spans if item[0] == "graph.read")
+    assert span[1]["command"] == "graph.read"
+    assert span[1]["subgraph"] == "recent_changes"
+    assert span[1]["view"] == "recent_changes.timeline"
+    counter = next(item for item in obs.counters if item[0] == "ce.graph.read_total")
+    assert counter[1] == 1
+    assert counter[2]["result"] == "ok"
+    assert counter[2]["subgraph"] == "recent_changes"
+    assert counter[2]["view"] == "recent_changes.timeline"
+    assert any(item[0] == "ce.graph.read_ms" for item in obs.histograms)
+
+
+def test_graph_nudge_accepts_dash_event_alias() -> None:
+    _common.set_json(True)
+    nudge_service = _Nudge()
+    _common.set_host(_Host(_Graph(), nudge_service=nudge_service))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        ["nudge", "--event", "pre-edit", "--session", "sess-1", "--path", "src/app.py"],
+    )
+
+    assert result.exit_code == 0
+    assert nudge_service.request.event == "pre-edit"
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.nudge")
+    assert body["event"] == "pre_edit"
+    assert "legacy transition command" in emitted["warnings"][0]
+
+
+def test_graph_catalog_json_advertises_v2_workbench_commands() -> None:
+    _common.set_json(True)
+    _common.set_host(_Host(_Graph()))
+
+    result = CliRunner().invoke(graph.graph_app, ["catalog"])
+
+    assert result.exit_code == 0
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.catalog")
+    assert "propose" in body["commands"]
+    assert "commit" in body["commands"]
+    assert "mutate" not in body["commands"]
+    assert "mutate" in body["legacy_commands"]
+    assert body["data_plane_graph_contract_version"] == "v1.5"
+
+
+def test_graph_catalog_task_ranks_relevant_views() -> None:
+    _common.set_json(True)
+    _common.set_host(_Host(_Graph()))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        ["catalog", "--task", "debug staging timeout after deployment"],
+    )
+
+    assert result.exit_code == 0
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.catalog")
+    ranking = body["task_ranking"]
+    ranked_subgraphs = [entry["subgraph"] for entry in ranking]
+    assert ranked_subgraphs.index("debugging") < ranked_subgraphs.index("features")
+    assert ranked_subgraphs.index("recent_changes") < ranked_subgraphs.index("features")
+    assert ranked_subgraphs.index("infra_topology") < ranked_subgraphs.index("features")
+    assert ranked_subgraphs.index("decisions") < ranked_subgraphs.index("features")
+    assert body["views"][0]["name"] == ranking[0]["view"]
+    assert "reason" in ranking[0]
+
+
+def test_graph_catalog_read_profile_returns_compact_contract() -> None:
+    _common.set_json(True)
+    _common.set_host(_Host(_Graph()))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        ["catalog", "--task", "debug staging timeout", "--profile", "read"],
+    )
+
+    assert result.exit_code == 0
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.catalog")
+    assert body["profile"] == "read"
+    assert "read" in body["commands"]
+    assert "commit" not in body["commands"]
+    assert "mutation_operations" not in body
+    assert "entity_types" not in body
+    assert body["views"]
+    assert set(body["views"][0]) <= {
+        "name",
+        "subgraph",
+        "view",
+        "backed",
+        "description",
+        "result_shape",
+        "required_scope",
+        "required_any_scope",
+        "supported_filters",
+        "next_read",
+    }
+    assert body["task_ranking"][0]["rank"] == 1
+    assert "reason" in body["task_ranking"][0]
+    assert "matched_terms" in body["task_ranking"][0]
+
+
+def test_graph_catalog_table_format_uses_compact_human_output() -> None:
+    _common.set_json(False)
+    _common.set_host(_Host(_Graph()))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        ["catalog", "--profile", "read", "--format", "table"],
+    )
+
+    assert result.exit_code == 0
+    assert "graph catalog profile=read" in result.output
+    assert "view | backed | filters" in result.output
+
+
+def test_graph_catalog_table_format_shows_task_ranking_context() -> None:
+    _common.set_json(False)
+    _common.set_host(_Host(_Graph()))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        [
+            "catalog",
+            "--task",
+            "debug staging timeout",
+            "--profile",
+            "read",
+            "--format",
+            "table",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "rank | score | view | reason" in result.output
+    assert "Matched" in result.output
+
+
+def test_graph_catalog_unknown_subgraph_uses_error_envelope() -> None:
+    _common.set_json(True)
+    _common.set_host(_Host(_Graph(catalog_error=ValueError("unknown graph subgraph"))))
+
+    result = CliRunner().invoke(graph.graph_app, ["catalog", "--subgraph", "missing"])
+
+    assert result.exit_code == 1
+    emitted = json.loads(result.output)
+    _assert_graph_envelope(emitted, "graph.catalog", ok=False)
+    assert emitted["error"]["code"] == "validation_error"
+    assert "unknown graph subgraph" in emitted["error"]["message"]
+
+
+def test_graph_status_json_uses_workbench_envelope() -> None:
+    _common.set_json(True)
+    workbench = _Workbench(
+        quality_result=_quality_result(report="summary", status="watch")
+    )
+    _common.set_host(_Host(_Graph(), backend=_Backend(), graph_workbench=workbench))
+
+    result = CliRunner().invoke(graph.graph_app, ["status"])
+
+    assert result.exit_code == 0
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.status")
+    assert emitted["subgraph_versions"] == {"_global": 3}
+    assert body["pot"]["name"] == "default"
+    assert body["pot"]["source_count"] == 0
+    assert body["graph_service"]["supported_commands"][0] == "status"
+    assert body["backend"]["profile"] == "memory"
+    assert body["health_status"] == "watch"
+    assert body["quality"]["source"] == "quality_summary"
+    assert body["quality"]["quality_counts"]["projection_drift"] == 2
+    assert workbench.quality_calls == [
+        {
+            "pot_id": "p",
+            "report": "summary",
+            "subgraph": None,
+            "limit": 20,
+            "confidence_threshold": 0.5,
+        }
+    ]
+
+
+def test_graph_status_not_ready_recommends_backend_doctor() -> None:
+    _common.set_json(True)
+    _common.set_host(_Host(_NotReadyGraph(), backend=_Backend()))
+
+    result = CliRunner().invoke(graph.graph_app, ["status"])
+
+    assert result.exit_code == 0
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.status")
+    assert body["backend"]["ready"] is False
+    assert body["backend"]["detail"] == "mutation store is unavailable"
+    assert body["backend"]["readiness_command"] == "potpie backend doctor"
+    assert "potpie backend doctor" in emitted["recommended_next_action"]
+
+
+def test_graph_status_warns_when_active_repo_pot_is_empty(monkeypatch) -> None:
+    class Pot:
+        def __init__(self, pot_id, name, active=False):
+            self.pot_id = pot_id
+            self.name = name
+            self.active = active
+
+    class Source:
+        kind = "repo"
+        name = "github.com/acme/shop"
+        location = "github.com/acme/shop"
+
+    class Pots:
+        def __init__(self):
+            self.p1 = Pot("p1", "empty", True)
+            self.p2 = Pot("p2", "populated")
+
+        def active_pot(self):
+            return self.p1
+
+        def list_pots(self):
+            return [self.p1, self.p2]
+
+        def list_sources(self, *, pot_id):
+            return [Source()]
+
+    monkeypatch.setattr(
+        graph, "_current_git_remote", lambda cwd: "github.com/acme/shop", raising=False
+    )
+    from adapters.inbound.cli.commands import _common
+
+    monkeypatch.setattr(
+        _common, "_current_git_remote", lambda cwd: "github.com/acme/shop"
+    )
+    _common.set_json(True)
+    host = _Host(_GraphByPot({"p1": {"claims": 0}, "p2": {"claims": 82}}))
+    host.pots = Pots()
+    _common.set_host(host)
+
+    result = CliRunner().invoke(graph.graph_app, ["status"])
+
+    assert result.exit_code == 0, result.output
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.status", pot_id="p1")
+    assert body["pot"]["id"] == "p1"
+    assert emitted["warnings"]
+    assert "p2" in emitted["warnings"][0]
+    assert "82 claims" in emitted["warnings"][0]
+
+
+def test_graph_neighborhood_returns_inspection_slice() -> None:
+    _common.set_json(True)
+    _common.set_host(_Host(_Graph(), backend=_Backend()))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        [
+            "neighborhood",
+            "--entity",
+            "service:web",
+            "--predicate",
+            "DEPENDS_ON",
+            "--direction",
+            "out",
+            "--depth",
+            "2",
+            "--limit",
+            "5",
+            "--detail",
+            "full",
+        ],
+    )
+
+    assert result.exit_code == 0
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.neighborhood")
+    assert body["entity_key"] == "service:web"
+    assert body["predicates"] == ["DEPENDS_ON"]
+    assert body["detail"] == "full"
+    assert body["edges"][0]["from"] == "service:web"
+
+
+def test_graph_neighborhood_defaults_to_relation_summary() -> None:
+    _common.set_json(True)
+    _common.set_host(_Host(_Graph(), backend=_Backend()))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        ["neighborhood", "--entity", "service:web", "--predicate", "DEPENDS_ON"],
+    )
+
+    assert result.exit_code == 0
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.neighborhood")
+    assert body["detail"] == "summary"
+    assert body["relation_count"] == 1
+    assert "edges" not in body
+    assert body["relations"][0]["from_key"] == "service:web"
+    assert body["relations"][0]["to_key"] == "service:api"
+    assert body["relations"][0]["source_refs"] == ["repo:manifest"]
+    assert body["relations"][0]["truth"] == "source_observation"
+
+
+def test_graph_describe_returns_executable_view_contract() -> None:
+    _common.set_json(True)
+    _common.set_host(_Host(_Graph()))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        ["describe", "debugging", "--view", "prior_occurrences", "--examples"],
+    )
+
+    assert result.exit_code == 0
+    emitted = json.loads(result.output)
+    body = _assert_graph_envelope(emitted, "graph.describe")
+    assert body["contract_kind"] == "graph_workbench_ontology"
+    assert body["view"]["name"] == "debugging.prior_occurrences"
+    assert body["view"]["result_shape"] == "entity_relations"
+    assert "REPRODUCES" in body["view"]["inline_relations"]
+    assert body["view"]["examples"][0]["command"].startswith("potpie graph read")
+    assert (
+        emitted["recommended_next_action"]
+        == "Use `potpie graph read --subgraph debugging --view prior_occurrences --json` after choosing a scope."
+    )
+
+
+def test_graph_describe_unknown_view_uses_error_envelope() -> None:
+    _common.set_json(True)
+    _common.set_host(_Host(_Graph()))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        ["describe", "debugging", "--view", "missing"],
+    )
+
+    assert result.exit_code == 1
+    emitted = json.loads(result.output)
+    _assert_graph_envelope(emitted, "graph.describe", ok=False)
+    assert emitted["error"]["code"] == "validation_error"
+    assert "unknown graph view" in emitted["error"]["message"]
+
+
+def test_timeline_recent_passes_project_scope_and_time_window() -> None:
+    _common.set_json(True)
+    graph_service = _Graph(read_result=_timeline_env())
+    _common.set_host(_Host(graph_service))
+
+    result = CliRunner().invoke(
+        graph.timeline_app,
+        ["--time-window", "7d", "--limit", "2"],
+    )
+
+    assert result.exit_code == 0
+    req = graph_service.read_request
+    assert req.subgraph == "recent_changes"
+    assert req.view == "timeline"
+    assert req.scope == {}
+    assert req.limit == 40
+    assert req.since is not None
+    emitted = json.loads(result.output)
+    assert emitted["event_count"] == 2

--- a/potpie/context-engine/tests/unit/test_graph_surface_lite_contract.py
+++ b/potpie/context-engine/tests/unit/test_graph_surface_lite_contract.py
@@ -730,7 +730,7 @@ def test_search_entities_derives_summary_for_old_nodes_without_summary(service) 
         GraphEntitySearchRequest(pot_id="p", query="web auth", type="Service")
     ).to_dict()
 
-    web = result["entities"][0]
+    web = next(entity for entity in result["entities"] if entity["key"] == "service:web")
     assert web["key"] == "service:web"
     assert web["summary"] == "web"
     assert web["description"] == "web"
@@ -824,7 +824,7 @@ def test_search_entities_omits_supporting_claims_by_default(service) -> None:
     ).to_dict()
 
     assert result["entities"]
-    assert result["entities"][0]["supporting_claims"] == []
+    assert all(entity["supporting_claims"] == [] for entity in result["entities"])
 
 
 def test_search_entities_can_include_bounded_supporting_claims(service) -> None:
@@ -849,7 +849,8 @@ def test_search_entities_can_include_bounded_supporting_claims(service) -> None:
         )
     ).to_dict()
 
-    assert len(result["entities"][0]["supporting_claims"]) == 1
+    by_key = {entity["key"]: entity for entity in result["entities"]}
+    assert len(by_key["feature:payments"]["supporting_claims"]) == 1
 
 
 def test_read_projects_canonical_labels_from_key_prefix(service) -> None:

--- a/potpie/context-engine/tests/unit/test_graph_surface_lite_contract.py
+++ b/potpie/context-engine/tests/unit/test_graph_surface_lite_contract.py
@@ -1,0 +1,1046 @@
+"""Graph Surface Lite contract tests (Graph V1.5 Step 0).
+
+Locks the catalog contract, the honest op partitioning, and — critically — that
+the MCP surface still exposes exactly the four ``context_*`` tools (the new
+graph surface is CLI-only in V1.5).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from adapters.outbound.graph.backends.in_memory_backend import InMemoryGraphBackend
+from application.services.graph_service import DefaultGraphService
+from domain.graph_contract import GRAPH_CONTRACT_VERSION, ONTOLOGY_VERSION
+from domain.graph_mutations import ProvenanceContext
+from domain.ports.agent_context import RecordRequest
+from domain.ports.claim_query import ClaimRow
+from domain.ports.services.graph_service import (
+    GraphCatalogRequest,
+    GraphEntitySearchRequest,
+    GraphReadRequest,
+)
+from domain.reconciliation import MutationBatch, MutationResult, MutationSummary
+from domain.semantic_mutations import SemanticMutationRequest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def service() -> DefaultGraphService:
+    return DefaultGraphService(backend=InMemoryGraphBackend())
+
+
+def test_catalog_reports_contract_and_ontology_version(service) -> None:
+    cat = service.catalog(GraphCatalogRequest(pot_id="p")).to_dict()
+    assert cat["graph_contract_version"] == GRAPH_CONTRACT_VERSION == "v1.5"
+    assert cat["ontology_version"] == ONTOLOGY_VERSION
+
+
+def test_catalog_lists_the_four_commands(service) -> None:
+    cat = service.catalog(GraphCatalogRequest(pot_id="p")).to_dict()
+    assert cat["commands"] == ["catalog", "read", "search-entities", "mutate"]
+
+
+def test_catalog_truth_classes(service) -> None:
+    cat = service.catalog(GraphCatalogRequest(pot_id="p")).to_dict()
+    assert "authoritative_fact" in cat["truth_classes"]
+    assert "agent_claim" in cat["truth_classes"]
+    assert "preference" in cat["truth_classes"]
+
+
+def test_catalog_op_partitions_are_honest(service) -> None:
+    cat = service.catalog(GraphCatalogRequest(pot_id="p")).to_dict()
+    # Only applicable ops are advertised as mutation_operations.
+    assert "link_entities" in cat["mutation_operations"]
+    assert "assert_claim" in cat["mutation_operations"]
+    # 7B high-risk corrections are applicable through plan/commit approval.
+    assert "supersede_claim" in cat["mutation_operations"]
+    assert "merge_duplicate_entities" in cat["mutation_operations"]
+    assert "supersede_claim" not in cat["review_required_operations"]
+    assert "merge_duplicate_entities" not in cat["review_required_operations"]
+    # Phase 7A entity correction ops are applicable through plan/commit gating.
+    assert "patch_entity" in cat["mutation_operations"]
+    assert "transition_state" in cat["mutation_operations"]
+    assert "patch_entity" not in cat["deferred_operations"]
+    assert "transition_state" not in cat["deferred_operations"]
+
+
+def test_catalog_shows_backed_and_planned_views(service) -> None:
+    cat = service.catalog(GraphCatalogRequest(pot_id="p")).to_dict()
+    by_name = {v["name"]: v for v in cat["views"]}
+    assert by_name["debugging.prior_occurrences"]["backed"] is True
+    assert by_name["decisions.active_decisions"]["backed"] is True
+    assert by_name["code_topology.ownership_by_path"]["backed"] is True
+    assert by_name["knowledge.document_context"]["backed"] is True
+
+
+def test_catalog_filters_by_subgraph(service) -> None:
+    cat = service.catalog(
+        GraphCatalogRequest(pot_id="p", subgraph="debugging")
+    ).to_dict()
+    assert {v["subgraph"] for v in cat["views"]} == {"debugging"}
+    assert [v["name"] for v in cat["views"]] == ["debugging.prior_occurrences"]
+
+
+def test_catalog_rejects_unknown_subgraph(service) -> None:
+    with pytest.raises(ValueError, match="unknown graph subgraph"):
+        service.catalog(GraphCatalogRequest(pot_id="p", subgraph="missing"))
+
+
+def test_catalog_includes_ranking_inputs(service) -> None:
+    cat = service.catalog(GraphCatalogRequest(pot_id="p")).to_dict()
+    by_name = {v["name"]: v for v in cat["views"]}
+    assert "ranking_inputs" in by_name["debugging.prior_occurrences"]
+    assert (
+        "semantic_similarity"
+        in by_name["debugging.prior_occurrences"]["ranking_inputs"]
+    )
+    assert (
+        "resolution_status"
+        not in by_name["debugging.prior_occurrences"]["ranking_inputs"]
+    )
+
+
+def test_catalog_carries_entity_types_and_predicates(service) -> None:
+    cat = service.catalog(GraphCatalogRequest(pot_id="p")).to_dict()
+    labels = {e["label"] for e in cat["entity_types"]}
+    assert {"Service", "BugPattern", "Preference", "CodeAsset", "Adapter"} <= labels
+    predicates = {p["name"] for p in cat["predicates"]}
+    assert {
+        "DEPENDS_ON",
+        "POLICY_APPLIES_TO",
+        "REPRODUCES",
+        "USES_ADAPTER",
+    } <= predicates
+
+
+def test_catalog_reports_match_mode(service) -> None:
+    # No embedder wired in this backend → lexical, labeled (not silent).
+    cat = service.catalog(GraphCatalogRequest(pot_id="p")).to_dict()
+    assert cat["match_mode"] in ("vector", "lexical")
+
+
+def test_read_assembles_inline_relations_for_view(service) -> None:
+    request = SemanticMutationRequest.parse(
+        {
+            "pot_id": "p",
+            "operations": [
+                {
+                    "op": "link_entities",
+                    "subgraph": "infra_topology",
+                    "subject": {
+                        "key": "service:payments-api",
+                        "type": "Service",
+                        "summary": "Payments API service.",
+                    },
+                    "predicate": "DEPENDS_ON",
+                    "object": {
+                        "key": "service:ledger-api",
+                        "type": "Service",
+                        "description": "Ledger API service.",
+                    },
+                    "truth": "source_observation",
+                    "evidence": [{"source_ref": "repo:manifest"}],
+                    "description": "payments depends on ledger to post entries",
+                }
+            ],
+        }
+    )
+    service.mutate(request)
+
+    env = service.read(
+        GraphReadRequest(
+            pot_id="p",
+            subgraph="infra_topology",
+            view="service_neighborhood",
+            scope={"service": "payments-api"},
+            depth=1,
+        )
+    )
+
+    assert env.read_shape == "entity_relations"
+    by_key = {item["entity_key"]: item for item in env.items}
+    payments = by_key["service:payments-api"]
+    assert payments["entity_type"] == "Service"
+    assert payments["summary"] == "Payments API service."
+    ledger = by_key["service:ledger-api"]
+    assert ledger["summary"] == "Ledger API service."
+    dep_rel = next(
+        rel
+        for rel in payments["relations"]
+        if rel["predicate"] == "DEPENDS_ON" and rel["direction"] == "out"
+    )
+    assert dep_rel["related_key"] == "service:ledger-api"
+    assert any(
+        rel["predicate"] == "DEPENDS_ON"
+        and rel["direction"] == "out"
+        and rel["related_key"] == "service:ledger-api"
+        for rel in payments["relations"]
+    )
+
+
+def test_read_to_dict_defaults_to_compact_relation_summaries(service) -> None:
+    request = SemanticMutationRequest.parse(
+        {
+            "pot_id": "p",
+            "operations": [
+                {
+                    "op": "link_entities",
+                    "subgraph": "infra_topology",
+                    "subject": {"key": "service:payments-api", "type": "Service"},
+                    "predicate": "DEPENDS_ON",
+                    "object": {"key": "service:ledger-api", "type": "Service"},
+                    "truth": "source_observation",
+                    "evidence": [{"source_ref": "repo:manifest"}],
+                    "description": "payments depends on ledger",
+                }
+            ],
+        }
+    )
+    service.mutate(request)
+
+    env = service.read(
+        GraphReadRequest(
+            pot_id="p",
+            subgraph="infra_topology",
+            view="service_neighborhood",
+            scope={"service": "payments-api"},
+            depth=1,
+        )
+    )
+    payload = env.to_dict()
+
+    assert payload["detail"] == "compact"
+    assert payload["relations_detail"] == "summary"
+    item = next(
+        item
+        for item in payload["items"]
+        if item["entity_key"] == "service:payments-api"
+    )
+    assert "relations" not in item
+    assert item["relation_count"] >= 1
+    assert "DEPENDS_ON" in item["relation_predicates"]
+
+
+def test_read_to_dict_full_detail_preserves_relation_payload(service) -> None:
+    request = SemanticMutationRequest.parse(
+        {
+            "pot_id": "p",
+            "operations": [
+                {
+                    "op": "link_entities",
+                    "subgraph": "infra_topology",
+                    "subject": {"key": "service:payments-api", "type": "Service"},
+                    "predicate": "DEPENDS_ON",
+                    "object": {"key": "service:ledger-api", "type": "Service"},
+                    "truth": "source_observation",
+                    "evidence": [{"source_ref": "repo:manifest"}],
+                    "description": "payments depends on ledger",
+                }
+            ],
+        }
+    )
+    service.mutate(request)
+
+    env = service.read(
+        GraphReadRequest(
+            pot_id="p",
+            subgraph="infra_topology",
+            view="service_neighborhood",
+            scope={"service": "payments-api"},
+            depth=1,
+            detail="full",
+            relations="full",
+        )
+    )
+    payload = env.to_dict()
+
+    assert payload["detail"] == "full"
+    item = next(
+        item
+        for item in payload["items"]
+        if item["entity_key"] == "service:payments-api"
+    )
+    assert item["relations"][0]["predicate"] == "DEPENDS_ON"
+    assert "breakdown" in item
+
+
+def test_preferences_view_assembles_structured_policy_relation(service) -> None:
+    request = SemanticMutationRequest.parse(
+        {
+            "pot_id": "p",
+            "operations": [
+                {
+                    "op": "assert_claim",
+                    "subgraph": "decisions",
+                    "subject": {
+                        "key": "preference:cli-errors",
+                        "type": "Preference",
+                        "properties": {
+                            "policy_kind": "error_handling",
+                            "prescription": "Emit structured CLI errors with next actions.",
+                            "strength": "strong",
+                            "audience": "path",
+                        },
+                    },
+                    "predicate": "POLICY_APPLIES_TO",
+                    "object": {
+                        "key": "code:potpie-context-engine:adapters/inbound/cli",
+                        "type": "CodeAsset",
+                    },
+                    "truth": "preference",
+                    "description": "CLI graph commands should return structured errors.",
+                    "extra": {
+                        "file_path": "potpie/context-engine/adapters/inbound/cli",
+                        "language": "python",
+                    },
+                }
+            ],
+        }
+    )
+    service.mutate(request)
+
+    env = service.read(
+        GraphReadRequest(
+            pot_id="p",
+            subgraph="decisions",
+            view="preferences_for_scope",
+            scope={
+                "path": "potpie/context-engine/adapters/inbound/cli/commands/graph.py",
+                "language": "python",
+            },
+            limit=5,
+        )
+    )
+
+    assert env.read_shape == "entity_relations"
+    rels = [rel for item in env.items for rel in item["relations"]]
+    policy_rel = next(rel for rel in rels if rel["predicate"] == "POLICY_APPLIES_TO")
+    assert policy_rel["properties"]["prescription"].startswith("Emit structured CLI")
+    assert policy_rel["properties"]["policy_kind"] == "error_handling"
+
+
+def test_preferences_view_accepts_direct_service_scope(service) -> None:
+    store = service.backend.claim_query
+    store.add(
+        ClaimRow(
+            pot_id="p",
+            predicate="POLICY_APPLIES_TO",
+            subject_key="preference:service-errors",
+            object_key="service:context-engine",
+            claim_key="claim:service-errors",
+            truth="preference",
+            evidence_strength="attested",
+            source_refs=("repo:prefs",),
+            fact="Context engine service code should emit structured errors.",
+            properties={
+                "policy_kind": "error_handling",
+                "prescription": "Emit structured errors from service boundaries.",
+            },
+        )
+    )
+
+    env = service.read(
+        GraphReadRequest(
+            pot_id="p",
+            subgraph="decisions",
+            view="preferences_for_scope",
+            scope={"service": "context-engine"},
+            limit=5,
+        )
+    )
+
+    assert env.unsupported == ()
+    assert env.items
+    assert env.items[0]["entity_key"] == "preference:service-errors"
+
+
+def test_infra_read_accepts_include_unqualified_environment_filter(service) -> None:
+    service.backend.claim_query.add(
+        ClaimRow(
+            pot_id="p",
+            predicate="DEPENDS_ON",
+            subject_key="service:payments-api",
+            object_key="service:ledger-api",
+            claim_key="claim:payments-ledger",
+            truth="source_observation",
+            source_refs=("repo:manifest",),
+            fact="payments depends on ledger",
+        )
+    )
+
+    env = service.read(
+        GraphReadRequest(
+            pot_id="p",
+            subgraph="infra_topology",
+            view="service_neighborhood",
+            scope={
+                "service": "payments-api",
+                "include_unqualified_environment": "true",
+            },
+            environment="prod",
+            depth=1,
+        )
+    )
+
+    assert env.unsupported == ()
+    assert env.items
+    assert env.source_refs == ("repo:manifest",)
+
+
+def test_timeline_read_filters_by_exact_source_ref(service) -> None:
+    store = service.backend.claim_query
+    store.add(
+        ClaimRow(
+            pot_id="p",
+            predicate="TOUCHED",
+            subject_key="activity:github:issue-881",
+            object_key="repo:github.com/potpie-ai/potpie",
+            claim_key="claim:issue-881",
+            truth="timeline_event",
+            source_refs=("github:potpie-ai/potpie#issue/881",),
+            fact="Issue 881 reported graph source-ref lookup gaps.",
+        )
+    )
+    store.add(
+        ClaimRow(
+            pot_id="p",
+            predicate="TOUCHED",
+            subject_key="activity:github:issue-882",
+            object_key="repo:github.com/potpie-ai/potpie",
+            claim_key="claim:issue-882",
+            truth="timeline_event",
+            source_refs=("github:potpie-ai/potpie#issue/882",),
+            fact="Issue 882 is unrelated.",
+        )
+    )
+
+    env = service.read(
+        GraphReadRequest(
+            pot_id="p",
+            subgraph="recent_changes",
+            view="timeline",
+            source_refs=("github:potpie-ai/potpie#issue/881",),
+            limit=10,
+        )
+    )
+
+    assert env.source_refs == ("github:potpie-ai/potpie#issue/881",)
+    assert "activity:github:issue-881" in {item["entity_key"] for item in env.items}
+    assert all(
+        item["source_refs"] == ["github:potpie-ai/potpie#issue/881"]
+        for item in env.items
+    )
+
+
+def test_entity_search_filters_by_exact_source_ref(service) -> None:
+    service.backend.claim_query.add(
+        ClaimRow(
+            pot_id="p",
+            predicate="PROVIDES",
+            subject_key="repo:github.com/potpie-ai/potpie",
+            object_key="feature:context-graph",
+            claim_key="claim:context-graph",
+            truth="source_observation",
+            source_refs=("github:potpie-ai/potpie#pull/955",),
+            fact="The repo provides context graph commands.",
+        )
+    )
+    service.backend.claim_query.add(
+        ClaimRow(
+            pot_id="p",
+            predicate="PROVIDES",
+            subject_key="repo:github.com/potpie-ai/potpie",
+            object_key="feature:other",
+            claim_key="claim:other",
+            truth="source_observation",
+            source_refs=("github:potpie-ai/potpie#pull/956",),
+            fact="The repo provides another feature.",
+        )
+    )
+
+    result = service.search_entities(
+        GraphEntitySearchRequest(
+            pot_id="p",
+            query="context graph",
+            source_refs=("github:potpie-ai/potpie#pull/955",),
+            limit=10,
+        )
+    )
+
+    assert {entity.key for entity in result.entities} == {
+        "repo:github.com/potpie-ai/potpie",
+        "feature:context-graph",
+    }
+
+
+def test_entity_search_external_id_matches_claim_source_ref(service) -> None:
+    service.backend.claim_query.add(
+        ClaimRow(
+            pot_id="p",
+            predicate="TOUCHED",
+            subject_key="activity:github:issue-881",
+            object_key="repo:github.com/potpie-ai/potpie",
+            claim_key="claim:issue-881",
+            truth="timeline_event",
+            source_refs=("github:potpie-ai/potpie#issue/881",),
+            fact="Issue 881 reported graph source-ref lookup gaps.",
+        )
+    )
+
+    result = service.search_entities(
+        GraphEntitySearchRequest(
+            pot_id="p",
+            query="source ref lookup",
+            external_id="github:potpie-ai/potpie#issue/881",
+            limit=10,
+        )
+    )
+
+    assert {entity.key for entity in result.entities} == {
+        "activity:github:issue-881",
+        "repo:github.com/potpie-ai/potpie",
+    }
+
+
+def test_entity_search_filters_by_source_system_and_family(service) -> None:
+    store = service.backend.claim_query
+    store.add(
+        ClaimRow(
+            pot_id="p",
+            predicate="TOUCHED",
+            subject_key="activity:github:issue-881",
+            object_key="repo:github.com/potpie-ai/potpie",
+            claim_key="claim:github-issue",
+            truth="timeline_event",
+            source_system="github",
+            source_refs=("github:potpie-ai/potpie#issue/881",),
+            fact="GitHub issue 881 tracks source-ref lookup.",
+        )
+    )
+    store.add(
+        ClaimRow(
+            pot_id="p",
+            predicate="TOUCHED",
+            subject_key="activity:linear:eng-881",
+            object_key="repo:github.com/potpie-ai/potpie",
+            claim_key="claim:linear-issue",
+            truth="timeline_event",
+            source_system="linear",
+            source_refs=("linear:ENG-881",),
+            fact="Linear issue 881 tracks a different item.",
+        )
+    )
+
+    result = service.search_entities(
+        GraphEntitySearchRequest(
+            pot_id="p",
+            query="issue 881",
+            source_system="github",
+            source_family="github",
+            limit=10,
+        )
+    )
+
+    assert "activity:github:issue-881" in {entity.key for entity in result.entities}
+    assert "activity:linear:eng-881" not in {entity.key for entity in result.entities}
+
+
+def test_read_dedupes_duplicate_inline_relation_rows(service) -> None:
+    store = service.backend.claim_query
+    row = ClaimRow(
+        pot_id="p",
+        predicate="POLICY_APPLIES_TO",
+        subject_key="preference:cli-errors",
+        object_key="code:potpie-context-engine:adapters/inbound/cli",
+        claim_key="claim:cli-errors-policy",
+        truth="preference",
+        evidence_strength="attested",
+        source_ref="repo:cli-guide",
+        source_refs=("repo:cli-guide",),
+        fact="CLI graph commands should return structured errors.",
+        properties={
+            "code_scope": {"language": "python"},
+            "policy_kind": "error_handling",
+            "prescription": "Emit structured CLI errors with next actions.",
+        },
+    )
+    store.add(row)
+    store.add(row)
+
+    env = service.read(
+        GraphReadRequest(
+            pot_id="p",
+            subgraph="decisions",
+            view="preferences_for_scope",
+            scope={"language": "python"},
+            limit=5,
+        )
+    )
+
+    assert env.read_shape == "entity_relations"
+    assert env.inline_relation_count == 2
+    by_key = {item["entity_key"]: item for item in env.items}
+    assert len(by_key["preference:cli-errors"]["relations"]) == 1
+    assert (
+        by_key["preference:cli-errors"]["relations"][0]["related_key"]
+        == "code:potpie-context-engine:adapters/inbound/cli"
+    )
+    assert (
+        len(by_key["code:potpie-context-engine:adapters/inbound/cli"]["relations"]) == 1
+    )
+
+
+def test_features_view_does_not_return_generic_infra_edges(service) -> None:
+    request = SemanticMutationRequest.parse(
+        {
+            "pot_id": "p",
+            "operations": [
+                {
+                    "op": "link_entities",
+                    "subgraph": "infra_topology",
+                    "subject": {"key": "service:search-api", "type": "Service"},
+                    "predicate": "DEFINED_IN",
+                    "object": {
+                        "key": "repo:github.com/acme/widgets",
+                        "type": "Repository",
+                    },
+                    "truth": "source_observation",
+                    "evidence": [{"source_ref": "repo:manifest"}],
+                    "description": "search api lives in widgets repo",
+                },
+                {
+                    "op": "assert_claim",
+                    "subgraph": "features",
+                    "subject": {
+                        "key": "repo:github.com/acme/widgets",
+                        "type": "Repository",
+                    },
+                    "predicate": "PROVIDES",
+                    "object": {
+                        "key": "feature:search",
+                        "type": "Feature",
+                        "summary": "Search capability",
+                    },
+                    "truth": "source_observation",
+                    "evidence": [{"source_ref": "repo:README"}],
+                    "description": "README says widgets provides search.",
+                },
+            ],
+        }
+    )
+    service.mutate(request)
+
+    env = service.read(
+        GraphReadRequest(
+            pot_id="p",
+            subgraph="features",
+            view="feature_context",
+            scope={"anchor_entity_key": "repo:github.com/acme/widgets"},
+        )
+    )
+
+    assert env.read_shape == "entity_relations"
+    rels = [rel for item in env.items for rel in item["relations"]]
+    assert {rel["predicate"] for rel in rels} == {"PROVIDES"}
+
+
+def test_read_returns_unsupported_for_filters_outside_view_contract(service) -> None:
+    env = service.read(
+        GraphReadRequest(
+            pot_id="p",
+            subgraph="debugging",
+            view="prior_occurrences",
+            query="timeout",
+            scope={"service": "api", "language": "python"},
+        )
+    )
+
+    assert env.items == ()
+    assert env.unsupported[0]["name"] == "language"
+    assert env.coverage[0]["status"] == "unsupported"
+
+
+def test_infra_read_keeps_environment_qualified_edges_isolated(service) -> None:
+    store = service.backend.claim_query
+    store.add(
+        ClaimRow(
+            pot_id="p",
+            predicate="DEPENDS_ON",
+            subject_key="service:payments-api",
+            object_key="service:ledger-staging",
+            fact="payments uses staging ledger",
+            environment="staging",
+            subgraph="infra_topology",
+        )
+    )
+    store.add(
+        ClaimRow(
+            pot_id="p",
+            predicate="DEPENDS_ON",
+            subject_key="service:payments-api",
+            object_key="service:ledger-prod",
+            fact="payments uses production ledger",
+            environment="prod",
+            subgraph="infra_topology",
+        )
+    )
+
+    env = service.read(
+        GraphReadRequest(
+            pot_id="p",
+            subgraph="infra_topology",
+            view="service_neighborhood",
+            scope={"service": "payments-api"},
+            environment="staging",
+            depth=1,
+        )
+    )
+
+    rels = [rel for item in env.items for rel in item["relations"]]
+    assert {rel["environment"] for rel in rels} == {"staging"}
+    assert {rel["related_key"] for rel in rels} == {
+        "service:ledger-staging",
+        "service:payments-api",
+    }
+
+
+def test_search_entities_derives_summary_for_old_nodes_without_summary(service) -> None:
+    store = service.backend.claim_query
+    store.add(
+        ClaimRow(
+            pot_id="p",
+            predicate="DEPENDS_ON",
+            subject_key="service:web",
+            object_key="service:auth",
+            fact="web calls auth",
+        )
+    )
+    store.set_entity_label(
+        pot_id="p", entity_key="service:web", labels=("Entity", "Service")
+    )
+    store.set_entity_properties(
+        pot_id="p", entity_key="service:web", properties={"name": "web"}
+    )
+
+    result = service.search_entities(
+        GraphEntitySearchRequest(pot_id="p", query="web auth", type="Service")
+    ).to_dict()
+
+    web = result["entities"][0]
+    assert web["key"] == "service:web"
+    assert web["summary"] == "web"
+    assert web["description"] == "web"
+
+
+def test_search_entities_projects_canonical_labels_from_key_prefix(service) -> None:
+    store = service.backend.claim_query
+    store.add(
+        ClaimRow(
+            pot_id="p",
+            predicate="PROVIDES",
+            subject_key="repo:github.com/potpie-ai/potpie",
+            object_key="feature:context-graph",
+            fact="potpie repo provides context graph memory",
+            properties={"semantic_similarity": 0.9},
+        )
+    )
+    store.set_entity_label(
+        pot_id="p",
+        entity_key="repo:github.com/potpie-ai/potpie",
+        labels=("Entity", "Repository", "Feature", "APIContract"),
+    )
+
+    result = service.search_entities(
+        GraphEntitySearchRequest(pot_id="p", query="context graph", type="Repository")
+    ).to_dict()
+
+    repo = next(
+        e for e in result["entities"] if e["key"] == "repo:github.com/potpie-ai/potpie"
+    )
+    assert repo["labels"] == ["Repository"]
+
+
+def test_search_entities_filters_by_subgraph_truth_and_scope(service) -> None:
+    store = service.backend.claim_query
+    store.add(
+        ClaimRow(
+            pot_id="p",
+            predicate="PROVIDES",
+            subject_key="repo:github.com/acme/widgets",
+            object_key="feature:payments",
+            fact="widgets provides payments",
+            subgraph="features",
+            truth="agent_claim",
+            properties={"semantic_similarity": 0.9},
+        )
+    )
+    store.add(
+        ClaimRow(
+            pot_id="p",
+            predicate="DEPENDS_ON",
+            subject_key="service:payments",
+            object_key="service:ledger",
+            fact="payments depends on ledger",
+            subgraph="infra_topology",
+            truth="source_observation",
+            properties={"semantic_similarity": 0.95},
+        )
+    )
+
+    result = service.search_entities(
+        GraphEntitySearchRequest(
+            pot_id="p",
+            query="payments",
+            type="Feature",
+            subgraph="features",
+            truth="agent_claim",
+            scope={"repo": "github.com/acme/widgets"},
+        )
+    ).to_dict()
+
+    assert [entity["key"] for entity in result["entities"]] == ["feature:payments"]
+
+
+def test_search_entities_omits_supporting_claims_by_default(service) -> None:
+    store = service.backend.claim_query
+    store.add(
+        ClaimRow(
+            pot_id="p",
+            predicate="PROVIDES",
+            subject_key="repo:github.com/acme/widgets",
+            object_key="feature:payments",
+            fact="widgets provides payments",
+            subgraph="features",
+            properties={"semantic_similarity": 0.9},
+        )
+    )
+
+    result = service.search_entities(
+        GraphEntitySearchRequest(pot_id="p", query="payments")
+    ).to_dict()
+
+    assert result["entities"]
+    assert result["entities"][0]["supporting_claims"] == []
+
+
+def test_search_entities_can_include_bounded_supporting_claims(service) -> None:
+    store = service.backend.claim_query
+    store.add(
+        ClaimRow(
+            pot_id="p",
+            predicate="PROVIDES",
+            subject_key="repo:github.com/acme/widgets",
+            object_key="feature:payments",
+            fact="widgets provides payments",
+            subgraph="features",
+            properties={"semantic_similarity": 0.9},
+        )
+    )
+
+    result = service.search_entities(
+        GraphEntitySearchRequest(
+            pot_id="p",
+            query="payments",
+            supporting_claims=1,
+        )
+    ).to_dict()
+
+    assert len(result["entities"][0]["supporting_claims"]) == 1
+
+
+def test_read_projects_canonical_labels_from_key_prefix(service) -> None:
+    store = service.backend.claim_query
+    store.add(
+        ClaimRow(
+            pot_id="p",
+            predicate="PROVIDES",
+            subject_key="repo:github.com/potpie-ai/potpie",
+            object_key="feature:context-graph",
+            fact="potpie repo provides context graph memory",
+            claim_key="claim:provides",
+            subgraph="features",
+        )
+    )
+    store.set_entity_label(
+        pot_id="p",
+        entity_key="repo:github.com/potpie-ai/potpie",
+        labels=("Entity", "Repository", "Feature", "APIContract"),
+    )
+    store.set_entity_label(
+        pot_id="p",
+        entity_key="feature:context-graph",
+        labels=("Entity", "Feature", "Adapter"),
+    )
+
+    env = service.read(
+        GraphReadRequest(
+            pot_id="p",
+            subgraph="features",
+            view="feature_context",
+            scope={"anchor_entity_key": "repo:github.com/potpie-ai/potpie"},
+        )
+    )
+
+    by_key = {item["entity_key"]: item for item in env.items}
+    assert by_key["repo:github.com/potpie-ai/potpie"]["entity_type"] == "Repository"
+    assert by_key["feature:context-graph"]["entity_type"] == "Feature"
+
+
+def test_fix_record_creates_scoped_bug_and_failed_attempt_memory(service) -> None:
+    receipt = service.record(
+        RecordRequest(
+            pot_id="p",
+            record_type="fix",
+            summary="Pass --pot when graph scope is ambiguous.",
+            details={
+                "symptom_signature": "graph read fails with ambiguous pot",
+                "fix_steps": ["Pass --pot or configure the active pot."],
+                "attempted_failed_fixes": ["Retry graph read without a pot."],
+            },
+            scope={"service": "context-engine"},
+        )
+    )
+
+    assert receipt.accepted
+    env = service.read(
+        GraphReadRequest(
+            pot_id="p",
+            subgraph="debugging",
+            view="prior_occurrences",
+            query="ambiguous pot graph read",
+            scope={"service": "context-engine"},
+            limit=10,
+        )
+    )
+
+    rels = [rel for item in env.items for rel in item["relations"]]
+    predicates = {rel["predicate"] for rel in rels}
+    assert {"REPRODUCES", "RESOLVED", "ATTEMPTED_FIX_FAILED"} <= predicates
+
+
+def test_decision_record_creates_decided_and_affects_memory(service) -> None:
+    receipt = service.record(
+        RecordRequest(
+            pot_id="p",
+            record_type="decision",
+            summary="Use semantic graph mutations for durable context writes.",
+            details={
+                "title": "Semantic mutations own context writes",
+                "rationale": "One validated write path keeps graph memory coherent.",
+                "affects_refs": ["service:context-engine", "code:context-engine:graph"],
+            },
+            scope={"service": "context-engine"},
+        )
+    )
+
+    assert receipt.accepted
+    env = service.read(
+        GraphReadRequest(
+            pot_id="p",
+            subgraph="decisions",
+            view="active_decisions",
+            query="semantic mutations context writes",
+            scope={"service": "context-engine"},
+            limit=10,
+        )
+    )
+
+    rels = [rel for item in env.items for rel in item["relations"]]
+    assert {"DECIDED", "AFFECTS"} <= {rel["predicate"] for rel in rels}
+
+
+# --- mutate provenance -------------------------------------------------------
+
+
+class _CapturingMutation:
+    def __init__(self) -> None:
+        self.calls: list[tuple[MutationBatch, str, ProvenanceContext | None]] = []
+
+    def apply(
+        self,
+        plan: MutationBatch,
+        *,
+        expected_pot_id: str,
+        provenance_context: ProvenanceContext | None = None,
+    ) -> MutationResult:
+        self.calls.append((plan, expected_pot_id, provenance_context))
+        return MutationResult(
+            ok=True,
+            mutation_id="mutation-1",
+            mutation_summary=MutationSummary(
+                entity_upserts_applied=len(plan.entity_upserts),
+                edge_upserts_applied=len(plan.edge_upserts),
+                invalidations_applied=len(plan.invalidations),
+            ),
+        )
+
+    def __getattr__(self, name: str) -> Any:
+        raise AssertionError(f"unexpected mutation port call: {name}")
+
+
+def test_mutate_passes_lowered_provenance_to_mutation_port() -> None:
+    backend = InMemoryGraphBackend()
+    mutation = _CapturingMutation()
+    backend._mutation = mutation
+    service = DefaultGraphService(backend=backend)
+    request = SemanticMutationRequest.parse(
+        {
+            "pot_id": "p",
+            "idempotency_key": "idem-1",
+            "created_by": {
+                "surface": "cli",
+                "harness": "codex",
+                "user": "user:alice",
+            },
+            "operations": [
+                {
+                    "op": "link_entities",
+                    "subgraph": "infra_topology",
+                    "subject": {"key": "service:payments-api", "type": "Service"},
+                    "predicate": "DEPENDS_ON",
+                    "object": {"key": "service:ledger-api", "type": "Service"},
+                    "truth": "source_observation",
+                    "evidence": [{"source_ref": "repo:manifest"}],
+                    "description": "payments calls ledger to post entries",
+                }
+            ],
+        }
+    )
+
+    result = service.mutate(request)
+
+    assert result.ok is True
+    assert len(mutation.calls) == 1
+    _batch, expected_pot_id, provenance = mutation.calls[0]
+    assert expected_pot_id == "p"
+    assert provenance is not None
+    assert provenance.source_ref == "idem-1"
+    assert provenance.created_by_agent == "codex"
+    assert provenance.actor_user_id == "user:alice"
+    assert provenance.actor_surface == "cli"
+    assert provenance.actor_client_name == "codex"
+
+
+# --- MCP non-negotiable: exactly four context_* tools -----------------------
+
+
+def test_mcp_exposes_exactly_four_context_tools() -> None:
+    """The Graph Surface Lite surface is CLI-only in V1.5; MCP stays at four."""
+    import asyncio
+
+    from adapters.inbound.mcp import server
+
+    tools = asyncio.run(server.mcp.list_tools())
+    names = {t.name for t in tools}
+    assert names == {
+        "context_resolve",
+        "context_search",
+        "context_record",
+        "context_status",
+    }
+    # No graph_* tools leaked onto the MCP surface.
+    assert not any(n.startswith("graph") for n in names)

--- a/potpie/context-engine/tests/unit/test_observability.py
+++ b/potpie/context-engine/tests/unit/test_observability.py
@@ -16,7 +16,7 @@ from bootstrap.observability_context import (
     get_correlation,
     reset_correlation,
 )
-from bootstrap.observability_runtime import get_observability
+from bootstrap.observability_runtime import get_observability, set_observability
 from domain.ports.observability import NoOpObservability, ObservabilityPort
 
 
@@ -103,7 +103,10 @@ def test_logging_setup_injects_correlation(caplog: pytest.LogCaptureFixture) -> 
 @pytest.mark.unit
 def test_host_shell_wires_process_observability() -> None:
     obs = NoOpObservability()
+    original = get_observability()
 
-    build_host_shell(backend=InMemoryGraphBackend(), observability=obs)
-
-    assert get_observability() is obs
+    try:
+        build_host_shell(backend=InMemoryGraphBackend(), observability=obs)
+        assert get_observability() is obs
+    finally:
+        set_observability(original)

--- a/potpie/context-engine/tests/unit/test_observability.py
+++ b/potpie/context-engine/tests/unit/test_observability.py
@@ -7,13 +7,16 @@ import logging
 import pytest
 
 from adapters.outbound.observability.console import ConsoleObservability
+from adapters.outbound.graph.backends.in_memory_backend import InMemoryGraphBackend
 from bootstrap.ingestion_server import _default_observability
+from bootstrap.host_wiring import build_host_shell
 from bootstrap.observability_context import (
     bind_correlation,
     correlation_scope,
     get_correlation,
     reset_correlation,
 )
+from bootstrap.observability_runtime import get_observability
 from domain.ports.observability import NoOpObservability, ObservabilityPort
 
 
@@ -95,3 +98,12 @@ def test_logging_setup_injects_correlation(caplog: pytest.LogCaptureFixture) -> 
         assert CorrelationFilter().filter(rec) is True
         assert rec.pot_id == "pZ"
         assert rec.event_id == "eZ"
+
+
+@pytest.mark.unit
+def test_host_shell_wires_process_observability() -> None:
+    obs = NoOpObservability()
+
+    build_host_shell(backend=InMemoryGraphBackend(), observability=obs)
+
+    assert get_observability() is obs

--- a/potpie/context-engine/tests/unit/test_repo_location.py
+++ b/potpie/context-engine/tests/unit/test_repo_location.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from adapters.inbound.cli.repo_location import normalize_repo_ref
+
+
+def test_normalize_repo_ref_strips_url_credentials() -> None:
+    assert (
+        normalize_repo_ref("https://user:token@github.com/potpie-ai/potpie.git")
+        == "github.com/potpie-ai/potpie"
+    )
+
+
+def test_normalize_repo_ref_keeps_port_without_credentials() -> None:
+    assert (
+        normalize_repo_ref("https://user:token@git.example.com:8443/acme/repo.git")
+        == "git.example.com:8443/acme/repo"
+    )


### PR DESCRIPTION
## Summary
- Re-derives `feat/cg-07-ce-graph-cli` onto current `main` after cg-06 merged.
- Adds the full `potpie graph` workbench CLI surface, timeline registration, repo-location helper, MCP envelope cleanup, and graph surface contract tests.
- Includes two standalone-greenness reconciliations: removes the replayed duplicate `click` import and lets cg-07 fall back to in-process host wiring until cg-08 lands the daemon client, while preserving explicit observability injection for graph CLI spans.

## Validation
- `uv run --project . ruff check bootstrap/host_wiring.py adapters/inbound/cli/commands/_common.py adapters/inbound/cli/commands/graph.py adapters/inbound/cli/host_cli.py adapters/inbound/cli/repo_location.py adapters/inbound/mcp/server.py tests/unit/test_graph_cli_contract.py tests/unit/test_graph_surface_lite_contract.py tests/unit/test_observability.py`
- `uv run --project . pytest tests/unit/test_pot_diff_sync_cli.py tests/unit/test_pot_jira_project_ingest_cli.py tests/unit/test_sentry_cli.py tests/unit/test_telemetry_context.py tests/unit/test_graph_cli_contract.py tests/unit/test_graph_surface_lite_contract.py tests/unit/test_observability.py`
- `POTPIE_POSTHOG_ENABLED=false uv run --project . pytest tests` → 1963 passed, 36 skipped

## Notes
- A plain local full-suite run without `POTPIE_POSTHOG_ENABLED=false` still trips the documented `.env` PostHog dispatcher ordering issue (`.env` defines `POTPIE_POSTHOG_API_KEY`). The branch validation disables only that local analytics sink; Sentry env behavior remains tested.