### PR TITLE
Add root CLI version option

### DIFF
--- a/potpie/context-engine/adapters/inbound/cli/host_cli.py
+++ b/potpie/context-engine/adapters/inbound/cli/host_cli.py
@@ -11,6 +11,10 @@ composition root for the agent surface.
 
 from __future__ import annotations
 
+import platform
+import sys
+from importlib import metadata
+
 import typer
 
 from adapters.inbound.cli.commands import auth as auth_cmds
@@ -30,6 +34,21 @@ from adapters.inbound.cli.commands._common import set_json, set_verbose
 from adapters.inbound.cli.telemetry.context import bind_telemetry_context
 
 
+def _package_version() -> str:
+    try:
+        return metadata.version("potpie-context-engine")
+    except metadata.PackageNotFoundError:
+        return "0.1.0"
+
+
+def _version_callback(value: bool) -> None:
+    if not value:
+        return
+    typer.echo(f"potpie-context-engine {_package_version()}")
+    typer.echo(f"python {platform.python_version()} ({sys.executable})")
+    raise typer.Exit()
+
+
 def build_app() -> typer.Typer:
     app = typer.Typer(
         name="potpie",
@@ -44,6 +63,13 @@ def build_app() -> typer.Typer:
         json_: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
         verbose: bool = typer.Option(
             False, "--verbose", "-v", help="Verbose tracebacks on errors."
+        ),
+        version: bool = typer.Option(
+            False,
+            "--version",
+            callback=_version_callback,
+            is_eager=True,
+            help="Show version information and exit.",
         ),
     ) -> None:
         from adapters.inbound.cli.telemetry import sentry_runtime, settings

--- a/potpie/context-engine/tests/unit/test_cli_bootstrap_status.py
+++ b/potpie/context-engine/tests/unit/test_cli_bootstrap_status.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import json
+import platform
+import sys
 from typing import Union
 from unittest.mock import MagicMock
 
@@ -39,6 +41,15 @@ class _FakeSetupMetrics:
         attributes: dict[str, Union[str, bool]] | None = None,
     ) -> None:
         self.calls.append(_MetricCall(name, {} if attributes is None else attributes))
+
+
+def test_root_version_option_exits_with_cli_and_python_details() -> None:
+    result = runner.invoke(cli_main.app, ["--version"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "potpie-context-engine " in result.stdout
+    assert f"python {platform.python_version()}" in result.stdout
+    assert sys.executable in result.stdout
 
 
 def test_status_host_path_emits_report(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- Add root-level `potpie --version` support.
- Print the `potpie-context-engine` package version plus Python runtime details.
- Add a unit test for the version option.

Closes #924

## Verification

- `uv run pytest tests/unit/test_cli_bootstrap_status.py -q`
- `uv run ruff check adapters/inbound/cli/host_cli.py tests/unit/test_cli_bootstrap_status.py`
- `potpie --version`
