### PR TITLE
Fix graph CLI required input help

### DIFF
--- a/potpie/context-engine/adapters/inbound/cli/commands/graph.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/graph.py
@@ -1277,7 +1277,7 @@ def graph_describe(
 
 @graph_app.command("neighborhood")
 def graph_neighborhood(
-    entity: str = typer.Option(None, "--entity"),
+    entity: str = typer.Option(..., "--entity"),
     predicate: str = typer.Option(None, "--predicate"),
     depth: int = typer.Option(2, "--depth"),
     direction: str = typer.Option("both", "--direction"),
@@ -1286,8 +1286,6 @@ def graph_neighborhood(
     pot: str = typer.Option(None, "--pot"),
 ) -> None:
     with _graph_command("graph.neighborhood") as ctx:
-        if not entity:
-            raise ValueError("--entity is required")
         normalized_direction = (direction or "both").strip().lower()
         if normalized_direction not in {"out", "in", "both"}:
             raise ValueError("--direction must be one of: out, in, both")
@@ -1926,13 +1924,11 @@ def _run_quality_report(
 
 @graph_app.command("inspect")
 def graph_inspect(
-    entity_key: str = typer.Argument(None),
+    entity_key: str = typer.Argument(...),
     depth: int = typer.Option(2, "--depth"),
     pot: str = typer.Option(None, "--pot"),
 ) -> None:
     with _graph_command("graph.inspect") as ctx:
-        if not entity_key:
-            raise ValueError("entity_key is required")
         host = get_host()
         _require_backend_capability(
             host,
@@ -1962,11 +1958,9 @@ def graph_inspect(
 
 @graph_app.command("export")
 def graph_export(
-    file: str = typer.Argument(None), pot: str = typer.Option(None, "--pot")
+    file: str = typer.Argument(...), pot: str = typer.Option(None, "--pot")
 ) -> None:
     with _graph_command("graph.export") as ctx:
-        if not file:
-            raise ValueError("file is required")
         host = get_host()
         _require_backend_capability(
             host,
@@ -1986,11 +1980,9 @@ def graph_export(
 
 @graph_app.command("import")
 def graph_import(
-    file: str = typer.Argument(None), pot: str = typer.Option(None, "--pot")
+    file: str = typer.Argument(...), pot: str = typer.Option(None, "--pot")
 ) -> None:
     with _graph_command("graph.import") as ctx:
-        if not file:
-            raise ValueError("file is required")
         host = get_host()
         _require_backend_capability(
             host,

--- a/potpie/context-engine/tests/unit/test_graph_cli_contract.py
+++ b/potpie/context-engine/tests/unit/test_graph_cli_contract.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 from dataclasses import replace
 from datetime import datetime, timezone
 import json
+import re
 
 import pytest
 from typer.testing import CliRunner
@@ -35,6 +36,12 @@ from domain.ports.graph.analytics import RepairReport
 from domain.ports.graph.backend import BackendCapabilities
 
 pytestmark = pytest.mark.unit
+
+_ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+def _plain_cli_output(output: str) -> str:
+    return _ANSI_RE.sub("", output)
 
 
 @pytest.fixture(autouse=True)
@@ -669,6 +676,57 @@ def test_graph_repair_accepts_entity_summaries_target() -> None:
     assert result.exit_code == 0, result.output
     assert backend.analytics.calls == [("p", ("entity_summaries",))]
     assert "repaired 2 entity summaries" in result.output
+
+
+@pytest.mark.parametrize(
+    ("command", "required_marker", "optional_marker", "missing_message"),
+    [
+        (
+            "neighborhood",
+            "--entity",
+            None,
+            "Missing option '--entity'",
+        ),
+        (
+            "inspect",
+            "ENTITY_KEY",
+            "[ENTITY_KEY]",
+            "Missing argument 'ENTITY_KEY'",
+        ),
+        (
+            "export",
+            "FILE",
+            "[FILE]",
+            "Missing argument 'FILE'",
+        ),
+        (
+            "import",
+            "FILE",
+            "[FILE]",
+            "Missing argument 'FILE'",
+        ),
+    ],
+)
+def test_graph_required_inputs_are_declared_in_help(
+    command: str,
+    required_marker: str,
+    optional_marker: str | None,
+    missing_message: str,
+) -> None:
+    help_result = CliRunner().invoke(graph.graph_app, [command, "--help"])
+
+    assert help_result.exit_code == 0, help_result.output
+    help_output = _plain_cli_output(help_result.output)
+    assert required_marker in help_output
+    assert "[required]" in help_output
+    if optional_marker is not None:
+        assert optional_marker not in help_output
+
+    missing_result = CliRunner().invoke(graph.graph_app, [command])
+    missing_output = _plain_cli_output(missing_result.output)
+
+    assert missing_result.exit_code == 2
+    assert missing_message in missing_output
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Mark graph command inputs as required in Typer signatures so help output no longer shows optional placeholders for required values.
- Cover `graph neighborhood --entity`, `graph inspect ENTITY_KEY`, `graph export FILE`, and matching `graph import FILE` behavior.
- Add contract tests for help output and missing-input parser errors.

## Verification

- `uv run pytest tests/unit/test_graph_cli_contract.py -q`
- `uv run --with ruff ruff check adapters/inbound/cli/commands/graph.py tests/unit/test_graph_cli_contract.py`
