### PR TITLE
Preserve existing agent instructions

### DIFF
--- a/docs/context-graph/cli-flow.md
+++ b/docs/context-graph/cli-flow.md
@@ -350,7 +350,9 @@ skills directory:
 | Codex | `$HOME/.agents/skills/<skill>/SKILL.md` |
 
 Use `--scope project --path .` when a repo-local install should be committed or
-shared with the repository.
+shared with the repository. Instruction files such as `AGENTS.md` and
+`CLAUDE.md` are merged through Potpie managed blocks; existing user-authored
+content is preserved and Potpie only appends or updates its marked section.
 
 ## Output Contract
 

--- a/potpie/context-engine/adapters/inbound/cli/README.md
+++ b/potpie/context-engine/adapters/inbound/cli/README.md
@@ -46,6 +46,11 @@ bundle into an agent harness (`commands/skills.py` → `HostShell.skills`). The
 default scope is global, so skills are installed once into the selected
 harness's user-level skills directory:
 
+The shipped templates live under `adapters/inbound/cli/templates/`: project
+bundles in `agent_bundle/` and `claude_bundle/`, compact global instruction
+blocks in `global_agent_bundle/`, and the Claude Code plugin in
+`claude_plugin/`.
+
 | Harness | Global path |
 |---------|-------------|
 | Cursor | `~/.cursor/skills/<skill>/SKILL.md` |
@@ -55,7 +60,9 @@ harness's user-level skills directory:
 
 For harnesses with documented file-backed global instructions, install/update
 also refreshes a compact Potpie managed block in `~/.claude/CLAUDE.md` and
-`~/.codex/AGENTS.md`.
+`~/.codex/AGENTS.md`. Existing user-authored content is preserved; Potpie only
+appends or updates the `<!-- potpie-start -->` / `<!-- potpie-end -->` managed
+section.
 
 Remove one global skill with `potpie skills remove <id> --agent claude`, or
 delete every globally installed Potpie skill for a harness with
@@ -66,7 +73,9 @@ Use `--scope project --path .` for repo-local installs. The bundle keeps the
 agent surface to the four tools above and encodes feature / debugging / review /
 operations / docs / onboarding workflows as `context_resolve` recipes. Agents
 see only an advisory `skills` block in `context_status` with missing/outdated
-skills and the exact install command.
+skills and the exact install command. Repo-local `AGENTS.md` and `CLAUDE.md`
+files are merged the same way as global instruction files, so setup does not
+replace existing agent instructions.
 
 ## MCP
 

--- a/potpie/context-engine/adapters/inbound/cli/templates/agent_bundle/AGENTS.md
+++ b/potpie/context-engine/adapters/inbound/cli/templates/agent_bundle/AGENTS.md
@@ -1,3 +1,4 @@
+<!-- potpie-start -->
 # Context Engine
 
 This project uses Potpie for project memory. Before non-trivial work, read the
@@ -211,3 +212,4 @@ Use these repo-local skills under `.agents/skills/`:
   propose/commit/history, inbox, quality, and nudge handling.
 - `potpie-cli` - CLI setup, pot/source commands, graph commands, and
   troubleshooting, including pot scope and setup failures.
+<!-- potpie-end -->

--- a/potpie/context-engine/adapters/inbound/cli/templates/global_agent_bundle/AGENTS.md
+++ b/potpie/context-engine/adapters/inbound/cli/templates/global_agent_bundle/AGENTS.md
@@ -1,8 +1,8 @@
 <!-- potpie-start -->
 Potpie is durable project memory: repo/source mappings, decisions, infra,
-changes, bugs, docs, and preferences for agents. At task start, check whether
-this repo is mapped in Potpie in parallel with normal inspection when useful
-(`potpie --json source list`, `potpie --json graph status`; skip if unavailable).
-Use Potpie skills to align high-level project/task context before code work;
-record only durable learnings after.
+changes, bugs, docs, and preferences for agents. Use it when it can materially
+help with repo context, prior decisions, architecture, bugs, or durable history.
+Do not run Potpie checks for simple Q&A or trivial edits. When useful, check
+mapping/graph health once per session (`potpie --json source list`,
+`potpie --json graph status`; skip if unavailable). Record only durable learnings.
 <!-- potpie-end -->

--- a/potpie/context-engine/adapters/inbound/cli/templates/global_agent_bundle/CLAUDE.md
+++ b/potpie/context-engine/adapters/inbound/cli/templates/global_agent_bundle/CLAUDE.md
@@ -1,8 +1,8 @@
 <!-- potpie-start -->
 Potpie is durable project memory: repo/source mappings, decisions, infra,
-changes, bugs, docs, and preferences for agents. At task start, check whether
-this repo is mapped in Potpie in parallel with normal inspection when useful
-(`potpie --json source list`, `potpie --json graph status`; skip if unavailable).
-Use Potpie skills to align high-level project/task context before code work;
-record only durable learnings after.
+changes, bugs, docs, and preferences for agents. Use it when it can materially
+help with repo context, prior decisions, architecture, bugs, or durable history.
+Do not run Potpie checks for simple Q&A or trivial edits. When useful, check
+mapping/graph health once per session (`potpie --json source list`,
+`potpie --json graph status`; skip if unavailable). Record only durable learnings.
 <!-- potpie-end -->

--- a/potpie/context-engine/adapters/outbound/skills/agent_installer.py
+++ b/potpie/context-engine/adapters/outbound/skills/agent_installer.py
@@ -77,13 +77,19 @@ def iter_template_files() -> list[tuple[Path, str]]:
 def _merge_managed_markdown(existing: str, section: str) -> tuple[str, str]:
     """Return (merged_content, action) where action is 'unchanged'|'updated'|'created'."""
     normalized_section = section.strip()
+    unmarked_section = _strip_managed_markers(normalized_section)
     if _MANAGED_MARKER_RE.search(existing):
         merged = _MANAGED_MARKER_RE.sub(normalized_section, existing)
         if merged == existing:
             return existing, "unchanged"
         return merged, "updated"
-    if existing.strip() == _strip_managed_markers(normalized_section).strip():
+    if existing.strip() == unmarked_section.strip():
         merged = normalized_section + "\n"
+        if merged == existing:
+            return existing, "unchanged"
+        return merged, "updated"
+    if unmarked_section in existing:
+        merged = existing.replace(unmarked_section, normalized_section, 1)
         if merged == existing:
             return existing, "unchanged"
         return merged, "updated"

--- a/potpie/context-engine/adapters/outbound/skills/agent_installer.py
+++ b/potpie/context-engine/adapters/outbound/skills/agent_installer.py
@@ -74,17 +74,13 @@ def iter_template_files() -> list[tuple[Path, str]]:
     return _iter_bundle_files("agent_bundle")
 
 
-def _merge_managed_markdown(
-    existing: str, section: str, *, force: bool
-) -> tuple[str, str]:
+def _merge_managed_markdown(existing: str, section: str) -> tuple[str, str]:
     """Return (merged_content, action) where action is 'unchanged'|'updated'|'created'."""
     normalized_section = section.strip()
     if _MANAGED_MARKER_RE.search(existing):
         merged = _MANAGED_MARKER_RE.sub(normalized_section, existing)
         if merged == existing:
             return existing, "unchanged"
-        if not force:
-            return existing, "skipped"
         return merged, "updated"
     if existing.strip() == _strip_managed_markers(normalized_section).strip():
         merged = normalized_section + "\n"
@@ -185,10 +181,7 @@ def _install_bundle(
         if out_path.name in merge_files:
             section = content
             existing = target.read_text(encoding="utf-8") if target.exists() else ""
-            merged, action = _merge_managed_markdown(existing, section, force=force)
-            if action == "skipped":
-                result.skipped.append(out_path.as_posix())
-                continue
+            merged, action = _merge_managed_markdown(existing, section)
             if action == "unchanged":
                 result.unchanged.append(out_path.as_posix())
                 continue

--- a/potpie/context-engine/adapters/outbound/skills/agent_installer.py
+++ b/potpie/context-engine/adapters/outbound/skills/agent_installer.py
@@ -13,7 +13,7 @@ _MANAGED_MARKER_RE = re.compile(
     r"<!-- (?:context-engine|potpie)-start -->.*?<!-- (?:context-engine|potpie)-end -->",
     re.DOTALL,
 )
-_DEFAULT_MERGE_FILES = frozenset({"CLAUDE.md"})
+_DEFAULT_MERGE_FILES = frozenset({"AGENTS.md", "CLAUDE.md"})
 
 AGENT_TYPES = ("default", "codex", "claude", "claude-plugin", "cursor", "opencode")
 _SOURCE_SKILLS_PREFIX = ".agents/skills/"
@@ -78,17 +78,33 @@ def _merge_managed_markdown(
     existing: str, section: str, *, force: bool
 ) -> tuple[str, str]:
     """Return (merged_content, action) where action is 'unchanged'|'updated'|'created'."""
+    normalized_section = section.strip()
     if _MANAGED_MARKER_RE.search(existing):
-        merged = _MANAGED_MARKER_RE.sub(section.strip(), existing)
+        merged = _MANAGED_MARKER_RE.sub(normalized_section, existing)
         if merged == existing:
             return existing, "unchanged"
         if not force:
             return existing, "skipped"
         return merged, "updated"
+    if existing.strip() == _strip_managed_markers(normalized_section).strip():
+        merged = normalized_section + "\n"
+        if merged == existing:
+            return existing, "unchanged"
+        return merged, "updated"
     # No marker found — append the section
     separator = "\n\n" if existing.strip() else ""
-    merged = existing.rstrip() + separator + section.strip() + "\n"
-    return merged, "created"
+    merged = existing.rstrip() + separator + normalized_section + "\n"
+    action = "updated" if existing.strip() else "created"
+    return merged, action
+
+
+def _strip_managed_markers(section: str) -> str:
+    lines = section.strip().splitlines()
+    if len(lines) >= 2 and lines[0].strip().endswith("-start -->"):
+        lines = lines[1:]
+    if lines and lines[-1].strip().endswith("-end -->"):
+        lines = lines[:-1]
+    return "\n".join(lines).strip()
 
 
 def _remap_skills_path(rel_path: Path, target_prefix: str) -> Path | None:
@@ -307,12 +323,6 @@ def install_agent_bundle(
             remap=_claude_skills_bundle_remap,
         )
     elif normalized == "claude-plugin":
-        # Works from a source checkout. NB for wheel distribution: the monorepo
-        # .gitignore ignores ``*.json``, and Hatchling's VCS-aware selector then
-        # omits the plugin's plugin.json/marketplace.json/hooks.json from the wheel
-        # even with an ``include`` glob. Shipping those in a wheel needs a
-        # ``[tool.hatch.build] artifacts`` override or a .gitignore exception
-        # (deliberately deferred: plugin install is dev/source only for now).
         _install_bundle(
             root,
             "claude_plugin",

--- a/potpie/context-engine/pyproject.toml
+++ b/potpie/context-engine/pyproject.toml
@@ -93,6 +93,9 @@ potpie-daemon = "host.daemon_main:main"
 [tool.hatch.build.force-include]
 "adapters/inbound/cli/ui/assets/potpie-logo-static.json" = "adapters/inbound/cli/ui/assets/potpie-logo-static.json"
 "adapters/inbound/cli/ui/assets/potpie.png" = "adapters/inbound/cli/ui/assets/potpie.png"
+"adapters/inbound/cli/templates/claude_plugin/.claude-plugin/marketplace.json" = "adapters/inbound/cli/templates/claude_plugin/.claude-plugin/marketplace.json"
+"adapters/inbound/cli/templates/claude_plugin/.claude-plugin/plugin.json" = "adapters/inbound/cli/templates/claude_plugin/.claude-plugin/plugin.json"
+"adapters/inbound/cli/templates/claude_plugin/hooks/hooks.json" = "adapters/inbound/cli/templates/claude_plugin/hooks/hooks.json"
 
 [tool.hatch.build.targets.wheel]
 packages = ["domain", "application", "adapters", "bootstrap", "benchmarks", "host"]

--- a/potpie/context-engine/tests/conftest.py
+++ b/potpie/context-engine/tests/conftest.py
@@ -96,25 +96,19 @@ def _reset_product_analytics_state():
     events.
     """
 
-    try:
-        from adapters.inbound.cli.telemetry import product_analytics
-
-        product_analytics._flush_product_analytics_dispatcher()
-        product_analytics._dispatcher = product_analytics._ProductAnalyticsDispatcher()
-        product_analytics._sink = product_analytics.NoOpProductAnalyticsSink()
-    except Exception:
-        pass
+    _reset_product_analytics_globals()
 
     yield
 
-    try:
-        from adapters.inbound.cli.telemetry import product_analytics
+    _reset_product_analytics_globals()
 
-        product_analytics._flush_product_analytics_dispatcher()
-        product_analytics._dispatcher = product_analytics._ProductAnalyticsDispatcher()
-        product_analytics._sink = product_analytics.NoOpProductAnalyticsSink()
-    except Exception:
-        pass
+
+def _reset_product_analytics_globals() -> None:
+    from adapters.inbound.cli.telemetry import product_analytics
+
+    product_analytics._flush_product_analytics_dispatcher()
+    product_analytics._dispatcher = product_analytics._ProductAnalyticsDispatcher()
+    product_analytics._sink = product_analytics.NoOpProductAnalyticsSink()
 
 
 @pytest.fixture(autouse=True)

--- a/potpie/context-engine/tests/conftest.py
+++ b/potpie/context-engine/tests/conftest.py
@@ -87,6 +87,37 @@ def _reset_cli_state():
 
 
 @pytest.fixture(autouse=True)
+def _reset_product_analytics_state():
+    """Keep product analytics globals isolated between tests.
+
+    The CLI uses one module-global background dispatcher per process. In the test
+    process, earlier CLI/setup tests can leave queued analytics payloads behind;
+    reset the dispatcher and sink so dispatcher tests only observe their own
+    events.
+    """
+
+    try:
+        from adapters.inbound.cli.telemetry import product_analytics
+
+        product_analytics._flush_product_analytics_dispatcher()
+        product_analytics._dispatcher = product_analytics._ProductAnalyticsDispatcher()
+        product_analytics._sink = product_analytics.NoOpProductAnalyticsSink()
+    except Exception:
+        pass
+
+    yield
+
+    try:
+        from adapters.inbound.cli.telemetry import product_analytics
+
+        product_analytics._flush_product_analytics_dispatcher()
+        product_analytics._dispatcher = product_analytics._ProductAnalyticsDispatcher()
+        product_analytics._sink = product_analytics.NoOpProductAnalyticsSink()
+    except Exception:
+        pass
+
+
+@pytest.fixture(autouse=True)
 def _no_real_browser(monkeypatch: pytest.MonkeyPatch) -> None:
     """Never open a real browser during tests.
 

--- a/potpie/context-engine/tests/unit/test_agent_installer.py
+++ b/potpie/context-engine/tests/unit/test_agent_installer.py
@@ -79,7 +79,7 @@ def test_install_global_agent_instructions_merges_compact_agents_md(
     managed = text.split("<!-- potpie-start -->", 1)[1].split(
         "<!-- potpie-end -->", 1
     )[0]
-    assert result.created == ["AGENTS.md"]
+    assert result.updated == ["AGENTS.md"]
     assert "# Personal defaults" in text
     assert "Potpie is durable project memory" in text
     assert "potpie --json source list" in text
@@ -158,7 +158,7 @@ def test_skill_manager_repairs_support_files_when_skill_is_current(
     assert calls == [None]
 
 
-def test_install_agent_bundle_skips_conflicting_files_without_force(
+def test_install_agent_bundle_merges_existing_agents_md_without_force(
     tmp_path: Path,
 ) -> None:
     repo = tmp_path / "repo"
@@ -169,11 +169,16 @@ def test_install_agent_bundle_skips_conflicting_files_without_force(
 
     result = install_agent_bundle(repo)
 
-    assert "AGENTS.md" in result.skipped
-    assert target.read_text(encoding="utf-8") == "local edits\n"
+    text = target.read_text(encoding="utf-8")
+    assert "AGENTS.md" in result.updated
+    assert "local edits" in text
+    assert "<!-- potpie-start -->" in text
+    assert "# Context Engine" in text
 
 
-def test_install_agent_bundle_overwrites_with_force(tmp_path: Path) -> None:
+def test_install_agent_bundle_does_not_overwrite_agents_md_with_force(
+    tmp_path: Path,
+) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     (repo / ".git").mkdir()
@@ -182,8 +187,37 @@ def test_install_agent_bundle_overwrites_with_force(tmp_path: Path) -> None:
 
     result = install_agent_bundle(repo, force=True)
 
+    text = target.read_text(encoding="utf-8")
     assert "AGENTS.md" in result.updated
-    assert "# Context Engine" in target.read_text(encoding="utf-8")
+    assert "local edits" in text
+    assert "<!-- potpie-start -->" in text
+    assert "# Context Engine" in text
+
+
+def test_install_agent_bundle_wraps_old_unmarked_agents_md(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    target = repo / "AGENTS.md"
+    marked_template = next(
+        content
+        for rel, content in iter_template_files()
+        if rel.as_posix() == "AGENTS.md"
+    )
+    old_unmarked = (
+        marked_template.split("\n", 1)[1]
+        .rsplit("\n<!-- potpie-end -->", 1)[0]
+        .strip()
+        + "\n"
+    )
+    target.write_text(old_unmarked, encoding="utf-8")
+
+    result = install_agent_bundle(repo, force=True)
+
+    text = target.read_text(encoding="utf-8")
+    assert "AGENTS.md" in result.updated
+    assert text.count("# Context Engine") == 1
+    assert "<!-- potpie-start -->" in text
 
 
 # --- Claude bundle tests ---
@@ -217,7 +251,7 @@ def test_install_agent_bundle_claude_merges_into_existing_claude_md(
 
     result = install_agent_bundle(repo, agent="claude")
 
-    assert "CLAUDE.md" in result.created
+    assert "CLAUDE.md" in result.updated
     content = (repo / "CLAUDE.md").read_text(encoding="utf-8")
     assert "# My Project" in content
     assert "Existing content." in content

--- a/potpie/context-engine/tests/unit/test_agent_installer.py
+++ b/potpie/context-engine/tests/unit/test_agent_installer.py
@@ -220,6 +220,29 @@ def test_install_agent_bundle_wraps_old_unmarked_agents_md(tmp_path: Path) -> No
     assert "<!-- potpie-start -->" in text
 
 
+def test_install_agent_bundle_updates_marked_agents_md_without_force(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    target = repo / "AGENTS.md"
+    target.write_text(
+        "# Local Setup\n\n<!-- potpie-start -->\nstale\n<!-- potpie-end -->\n\nKeep me.\n",
+        encoding="utf-8",
+    )
+
+    result = install_agent_bundle(repo)
+
+    text = target.read_text(encoding="utf-8")
+    assert "AGENTS.md" in result.updated
+    assert "# Local Setup" in text
+    assert "Keep me." in text
+    assert "stale" not in text
+    assert "# Context Engine" in text
+    assert text.count("<!-- potpie-start -->") == 1
+
+
 # --- Claude bundle tests ---
 
 
@@ -288,20 +311,25 @@ def test_install_agent_bundle_claude_updates_section_with_force(tmp_path: Path) 
     assert "# Project" in content
 
 
-def test_install_agent_bundle_claude_skips_changed_section_without_force(
+def test_install_agent_bundle_claude_updates_changed_section_without_force(
     tmp_path: Path,
 ) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     (repo / ".git").mkdir()
     (repo / "CLAUDE.md").write_text(
-        "<!-- potpie-start -->\nCUSTOM\n<!-- potpie-end -->\n",
+        "# Project\n\n<!-- potpie-start -->\nCUSTOM\n<!-- potpie-end -->\n\nKeep me.\n",
         encoding="utf-8",
     )
 
     result = install_agent_bundle(repo, agent="claude")
 
-    assert "CLAUDE.md" in result.skipped
+    content = (repo / "CLAUDE.md").read_text(encoding="utf-8")
+    assert "CLAUDE.md" in result.updated
+    assert "# Project" in content
+    assert "Keep me." in content
+    assert "CUSTOM" not in content
+    assert "context_resolve" in content
 
 
 def test_install_agent_bundle_claude_plugin_lays_out_plugin_dir(tmp_path: Path) -> None:

--- a/potpie/context-engine/tests/unit/test_agent_installer.py
+++ b/potpie/context-engine/tests/unit/test_agent_installer.py
@@ -220,6 +220,43 @@ def test_install_agent_bundle_wraps_old_unmarked_agents_md(tmp_path: Path) -> No
     assert "<!-- potpie-start -->" in text
 
 
+def test_install_agent_bundle_replaces_embedded_unmarked_agents_md(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    target = repo / "AGENTS.md"
+    marked_template = next(
+        content
+        for rel, content in iter_template_files()
+        if rel.as_posix() == "AGENTS.md"
+    )
+    old_unmarked = (
+        marked_template.split("\n", 1)[1]
+        .rsplit("\n<!-- potpie-end -->", 1)[0]
+        .strip()
+    )
+    target.write_text(
+        "# My notes\n\nSome custom project instructions.\n\n"
+        f"{old_unmarked}\n\n"
+        "## Team notes\n\nKeep these too.\n",
+        encoding="utf-8",
+    )
+
+    result = install_agent_bundle(repo)
+
+    text = target.read_text(encoding="utf-8")
+    assert "AGENTS.md" in result.updated
+    assert "# My notes" in text
+    assert "Some custom project instructions." in text
+    assert "## Team notes" in text
+    assert "Keep these too." in text
+    assert text.count("# Context Engine") == 1
+    assert text.count("<!-- potpie-start -->") == 1
+    assert text.count("<!-- potpie-end -->") == 1
+
+
 def test_install_agent_bundle_updates_marked_agents_md_without_force(
     tmp_path: Path,
 ) -> None:

--- a/potpie/context-engine/tests/unit/test_skill_manager_global_targets.py
+++ b/potpie/context-engine/tests/unit/test_skill_manager_global_targets.py
@@ -99,6 +99,33 @@ def test_skill_manager_installs_project_scope(monkeypatch, tmp_path: Path) -> No
     assert rerun.changed == ()
 
 
+def test_project_scope_install_preserves_existing_agents_md(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CONTEXT_ENGINE_HOME", str(tmp_path / "potpie"))
+    host = build_host_shell(backend=InMemoryGraphBackend())
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    agents_md = repo / "AGENTS.md"
+    agents_md.write_text("# Existing Setup\n\nKeep this.\n", encoding="utf-8")
+
+    result = host.skills.install(
+        agent="codex",
+        skill_id="potpie-cli",
+        path=str(repo),
+        scope="project",
+    )
+
+    text = agents_md.read_text(encoding="utf-8")
+    assert result.metadata["scope"] == "project"
+    assert "# Existing Setup" in text
+    assert "Keep this." in text
+    assert "<!-- potpie-start -->" in text
+    assert "# Context Engine" in text
+    assert (repo / ".agents" / "skills" / "potpie-cli" / "SKILL.md").exists()
+
+
 def test_skill_manager_removes_all_global_harness_skills(
     monkeypatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

- Merge Potpie-managed `AGENTS.md` and `CLAUDE.md` blocks instead of overwriting user-authored instruction files.
- Make global Potpie agent instructions conditional so harnesses do not run Potpie checks before every answer.
- Add tests for global/project instruction preservation, old unmarked block migration, and analytics state isolation.
- Include Claude plugin JSON files in the built wheel so installed CLI `claude-plugin` installs are complete.

## Validation

- `uv run --extra dev ruff check adapters/outbound/skills/agent_installer.py tests/conftest.py tests/unit/test_agent_installer.py tests/unit/test_skill_manager_global_targets.py`
- `git diff --check`
- `uv run --extra dev --extra postgres --extra github --extra reconciliation-agent pytest tests/unit` (`1794 passed, 1 skipped`)
- Installed-wheel CLI e2e from a fresh temp venv: built the wheel, installed `potpie`, reran global and project skill installs for supported harnesses, verified existing instructions were preserved with one Potpie managed block, exercised `potpie setup`, and verified Claude plugin files from the wheel.