### PR TITLE
Bake CLI telemetry IDs into the Python wheel

### DIFF
--- a/potpie/context-engine/adapters/inbound/cli/telemetry/_build_defaults.py
+++ b/potpie/context-engine/adapters/inbound/cli/telemetry/_build_defaults.py
@@ -1,0 +1,34 @@
+"""Telemetry defaults shipped with the package at build time.
+
+Values are written to ``_build_config.py`` by the Hatch build hook
+(``oauth_client_id_injection_hook.py``). In a source checkout, the generated
+module is absent and every constant resolves to an empty string.
+"""
+
+from __future__ import annotations
+
+try:
+    from adapters.inbound.cli.telemetry._build_config import (
+        POTPIE_POSTHOG_API_KEY,
+        POTPIE_POSTHOG_ENABLED,
+        POTPIE_POSTHOG_HOST,
+        POTPIE_PRODUCT_ANALYTICS_ENABLED,
+        POTPIE_SENTRY_DIST,
+        POTPIE_SENTRY_DSN,
+        POTPIE_SENTRY_ENABLED,
+        POTPIE_SENTRY_ENVIRONMENT,
+        POTPIE_SENTRY_RELEASE,
+        POTPIE_TELEMETRY_DISABLED,
+    )
+except ImportError:
+    POTPIE_TELEMETRY_DISABLED = ""
+    POTPIE_SENTRY_ENABLED = ""
+    POTPIE_SENTRY_DSN = ""
+    POTPIE_SENTRY_ENVIRONMENT = ""
+    POTPIE_SENTRY_RELEASE = ""
+    POTPIE_SENTRY_DIST = ""
+    POTPIE_POSTHOG_ENABLED = ""
+    POTPIE_PRODUCT_ANALYTICS_ENABLED = ""
+    POTPIE_POSTHOG_API_KEY = ""
+    POTPIE_POSTHOG_HOST = ""
+

--- a/potpie/context-engine/adapters/inbound/cli/telemetry/settings.py
+++ b/potpie/context-engine/adapters/inbound/cli/telemetry/settings.py
@@ -4,11 +4,10 @@ import os
 from dataclasses import dataclass
 from typing import ClassVar, Final
 
+from adapters.inbound.cli.telemetry import _build_defaults as build_defaults
 from bootstrap.sentry_settings import (
     SentrySettings,
     default_cli_release,
-    load_sentry_settings,
-    telemetry_environment,
 )
 
 _FALSE_VALUES: Final[frozenset[str]] = frozenset({"0", "false", "no", "off"})
@@ -27,16 +26,68 @@ class ProductAnalyticsSettings:
     host: str
 
 
+def load_sentry_settings() -> SentrySettings:
+    dsn = (
+        _env("POTPIE_SENTRY_DSN")
+        or _env("SENTRY_DSN")
+        or _baked(build_defaults.POTPIE_SENTRY_DSN)
+    )
+    telemetry_disabled = _is_truthy_config(
+        "POTPIE_TELEMETRY_DISABLED",
+        build_defaults.POTPIE_TELEMETRY_DISABLED,
+    )
+    sentry_disabled = _is_falsey_config(
+        "POTPIE_SENTRY_ENABLED",
+        build_defaults.POTPIE_SENTRY_ENABLED,
+    )
+    return SentrySettings(
+        enabled=dsn is not None and not telemetry_disabled and not sentry_disabled,
+        dsn=dsn,
+        environment=telemetry_environment(),
+        release=_env("POTPIE_SENTRY_RELEASE")
+        or _env("SENTRY_RELEASE")
+        or _baked(build_defaults.POTPIE_SENTRY_RELEASE)
+        or default_cli_release(),
+        dist=(
+            _env("POTPIE_SENTRY_DIST")
+            or _env("SENTRY_DIST")
+            or _baked(build_defaults.POTPIE_SENTRY_DIST)
+        ),
+    )
+
+
 def load_product_analytics_settings() -> ProductAnalyticsSettings:
-    api_key = _env("POTPIE_POSTHOG_API_KEY")
-    telemetry_disabled = _is_truthy_flag("POTPIE_TELEMETRY_DISABLED")
-    product_disabled = _is_falsey_flag("POTPIE_POSTHOG_ENABLED") or _is_falsey_flag(
-        "POTPIE_PRODUCT_ANALYTICS_ENABLED"
+    api_key = _env("POTPIE_POSTHOG_API_KEY") or _baked(
+        build_defaults.POTPIE_POSTHOG_API_KEY
+    )
+    telemetry_disabled = _is_truthy_config(
+        "POTPIE_TELEMETRY_DISABLED",
+        build_defaults.POTPIE_TELEMETRY_DISABLED,
+    )
+    product_disabled = _is_falsey_config(
+        "POTPIE_POSTHOG_ENABLED",
+        build_defaults.POTPIE_POSTHOG_ENABLED,
+    ) or _is_falsey_config(
+        "POTPIE_PRODUCT_ANALYTICS_ENABLED",
+        build_defaults.POTPIE_PRODUCT_ANALYTICS_ENABLED,
     )
     return ProductAnalyticsSettings(
         enabled=api_key is not None and not telemetry_disabled and not product_disabled,
         api_key=api_key,
-        host=_env("POTPIE_POSTHOG_HOST") or "https://us.i.posthog.com",
+        host=(
+            _env("POTPIE_POSTHOG_HOST")
+            or _baked(build_defaults.POTPIE_POSTHOG_HOST)
+            or "https://us.i.posthog.com"
+        ),
+    )
+
+
+def telemetry_environment() -> str:
+    return (
+        _env("POTPIE_SENTRY_ENVIRONMENT")
+        or _env("SENTRY_ENVIRONMENT")
+        or _baked(build_defaults.POTPIE_SENTRY_ENVIRONMENT)
+        or "dev"
     )
 
 
@@ -48,17 +99,29 @@ def _env(name: str) -> str | None:
     return stripped or None
 
 
-def _is_falsey_flag(name: str) -> bool:
-    value = os.getenv(name)
-    return value is not None and value.strip().lower() in _FALSE_VALUES
+def _baked(value: str) -> str | None:
+    stripped = value.strip()
+    return stripped or None
 
 
-def _is_truthy_flag(name: str) -> bool:
+def _flag_config(name: str, baked: str) -> str | None:
     value = os.getenv(name)
-    if value is None:
-        return False
-    normalized = value.strip().lower()
-    return normalized != "" and normalized not in _FALSE_VALUES
+    if value is not None:
+        return value.strip().lower()
+    baked_value = _baked(baked)
+    if baked_value is None:
+        return None
+    return baked_value.lower()
+
+
+def _is_falsey_config(name: str, baked: str = "") -> bool:
+    value = _flag_config(name, baked)
+    return value is not None and value in _FALSE_VALUES
+
+
+def _is_truthy_config(name: str, baked: str = "") -> bool:
+    value = _flag_config(name, baked)
+    return value is not None and value != "" and value not in _FALSE_VALUES
 
 
 __all__ = [

--- a/potpie/context-engine/build_config_values.py
+++ b/potpie/context-engine/build_config_values.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
+OAUTH_OUT = Path("adapters/outbound/cli_auth/_build_config.py")
+TELEMETRY_OUT = Path("adapters/inbound/cli/telemetry/_build_config.py")
+
+HEADER = """\
+# Auto-generated at wheel build time - do not edit manually.
+# Override any value at runtime by setting the corresponding environment variable.
+"""
+
+TELEMETRY_NAMES = (
+    "POTPIE_TELEMETRY_DISABLED",
+    "POTPIE_SENTRY_ENABLED",
+    "POTPIE_SENTRY_DSN",
+    "POTPIE_SENTRY_ENVIRONMENT",
+    "POTPIE_SENTRY_RELEASE",
+    "POTPIE_SENTRY_DIST",
+    "POTPIE_POSTHOG_ENABLED",
+    "POTPIE_PRODUCT_ANALYTICS_ENABLED",
+    "POTPIE_POSTHOG_API_KEY",
+    "POTPIE_POSTHOG_HOST",
+)
+
+
+def oauth_config_values(environ: Mapping[str, str] | None = None) -> dict[str, str]:
+    return {
+        "LINEAR_CLIENT_ID": _env("LINEAR_CLIENT_ID", environ),
+        "POTPIE_GITHUB_CLIENT_ID": _env("POTPIE_GITHUB_CLIENT_ID", environ),
+    }
+
+
+def telemetry_config_values(
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    values = {
+        "POTPIE_TELEMETRY_DISABLED": _env_or_default(
+            "POTPIE_TELEMETRY_DISABLED", "0", environ
+        ),
+        "POTPIE_SENTRY_ENABLED": _env_or_default(
+            "POTPIE_SENTRY_ENABLED", "1", environ
+        ),
+        "POTPIE_SENTRY_DSN": _env("POTPIE_SENTRY_DSN", environ),
+        "POTPIE_SENTRY_ENVIRONMENT": _env_or_default(
+            "POTPIE_SENTRY_ENVIRONMENT", "production", environ
+        ),
+        "POTPIE_SENTRY_RELEASE": _env("POTPIE_SENTRY_RELEASE", environ),
+        "POTPIE_SENTRY_DIST": _env("POTPIE_SENTRY_DIST", environ)
+        or _env("GITHUB_SHA", environ),
+        "POTPIE_POSTHOG_ENABLED": _env_or_default(
+            "POTPIE_POSTHOG_ENABLED", "1", environ
+        ),
+        "POTPIE_PRODUCT_ANALYTICS_ENABLED": _env_or_default(
+            "POTPIE_PRODUCT_ANALYTICS_ENABLED", "1", environ
+        ),
+        "POTPIE_POSTHOG_API_KEY": _env("POTPIE_POSTHOG_API_KEY", environ),
+        "POTPIE_POSTHOG_HOST": _env_or_default(
+            "POTPIE_POSTHOG_HOST", "https://us.i.posthog.com", environ
+        ),
+    }
+    return {name: values[name] for name in TELEMETRY_NAMES}
+
+
+def write_python_constants(path: Path, values: Mapping[str, str]) -> None:
+    path.write_text(
+        HEADER + "".join(f"{name} = {value!r}\n" for name, value in values.items()),
+        encoding="utf-8",
+    )
+
+
+def _env(name: str, environ: Mapping[str, str] | None = None) -> str:
+    source = os.environ if environ is None else environ
+    value = source.get(name)
+    if value is None:
+        return ""
+    return value.strip()
+
+
+def _env_or_default(
+    name: str,
+    default: str,
+    environ: Mapping[str, str] | None = None,
+) -> str:
+    return _env(name, environ) or default

--- a/potpie/context-engine/oauth_client_id_injection_hook.py
+++ b/potpie/context-engine/oauth_client_id_injection_hook.py
@@ -1,40 +1,49 @@
-"""Hatch build hook: inject OAuth client IDs into the wheel at build time.
+"""Hatch build hook: inject public defaults into the wheel at build time.
 
 During ``hatch build`` / ``uv build``, reads ``LINEAR_CLIENT_ID`` and
 ``POTPIE_GITHUB_CLIENT_ID`` from the build environment and writes
 ``adapters/outbound/cli_auth/_build_config.py`` so installed users do not need
 to configure those variables locally.
 
-Both are public OAuth client identifiers (not secrets). Runtime env vars still
-take precedence for local development overrides.
+It also writes ``adapters/inbound/cli/telemetry/_build_config.py`` with public
+CLI telemetry ingest defaults (Sentry DSN and PostHog project API key). Runtime
+env vars still take precedence for local development overrides and opt-outs.
 """
 
 from __future__ import annotations
 
-import os
+import importlib.util
 from pathlib import Path
+from types import ModuleType
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 
-_OUT = Path("adapters/outbound/cli_auth/_build_config.py")
-
-_HEADER = """\
-# Auto-generated at wheel build time — do not edit manually.
-# Override any value at runtime by setting the corresponding environment variable.
-"""
+_CONFIG_VALUES = "build_config_values.py"
 
 
 class OAuthClientIdInjectionHook(BuildHookInterface):
-    """Inject public OAuth client IDs from the build environment into the wheel."""
+    """Inject public OAuth and telemetry defaults into the wheel."""
 
     def initialize(self, version: str, build_data: dict) -> None:
-        linear_client_id = os.getenv("LINEAR_CLIENT_ID", "").strip()
-        github_client_id = os.getenv("POTPIE_GITHUB_CLIENT_ID", "").strip()
-
-        _OUT.write_text(
-            _HEADER
-            + f"LINEAR_CLIENT_ID = {linear_client_id!r}\n"
-            + f"POTPIE_GITHUB_CLIENT_ID = {github_client_id!r}\n",
-            encoding="utf-8",
+        config_values = _load_config_values_module()
+        config_values.write_python_constants(
+            config_values.OAUTH_OUT,
+            config_values.oauth_config_values(),
         )
-        build_data["artifacts"].append(str(_OUT))
+        config_values.write_python_constants(
+            config_values.TELEMETRY_OUT,
+            config_values.telemetry_config_values(),
+        )
+        build_data.setdefault("artifacts", []).extend(
+            [str(config_values.OAUTH_OUT), str(config_values.TELEMETRY_OUT)]
+        )
+
+
+def _load_config_values_module() -> ModuleType:
+    path = Path(__file__).with_name(_CONFIG_VALUES)
+    spec = importlib.util.spec_from_file_location("_potpie_build_config_values", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load build config helper: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/potpie/context-engine/pyproject.toml
+++ b/potpie/context-engine/pyproject.toml
@@ -113,6 +113,8 @@ include = [
 
 [tool.hatch.build.targets.sdist]
 include = [
+    "build_config_values.py",
+    "oauth_client_id_injection_hook.py",
     "domain",
     "domain/playbooks/**/*.md",
     "application",

--- a/potpie/context-engine/tests/unit/test_build_hook_config.py
+++ b/potpie/context-engine/tests/unit/test_build_hook_config.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import build_config_values
+
+
+def test_telemetry_build_config_defaults_dist_to_github_sha() -> None:
+    values = build_config_values.telemetry_config_values({"GITHUB_SHA": "abc123"})
+
+    assert values == {
+        "POTPIE_TELEMETRY_DISABLED": "0",
+        "POTPIE_SENTRY_ENABLED": "1",
+        "POTPIE_SENTRY_DSN": "",
+        "POTPIE_SENTRY_ENVIRONMENT": "production",
+        "POTPIE_SENTRY_RELEASE": "",
+        "POTPIE_SENTRY_DIST": "abc123",
+        "POTPIE_POSTHOG_ENABLED": "1",
+        "POTPIE_PRODUCT_ANALYTICS_ENABLED": "1",
+        "POTPIE_POSTHOG_API_KEY": "",
+        "POTPIE_POSTHOG_HOST": "https://us.i.posthog.com",
+    }
+
+
+def test_telemetry_build_config_explicit_dist_wins_over_github_sha(
+) -> None:
+    values = build_config_values.telemetry_config_values(
+        {
+            "GITHUB_SHA": "abc123",
+            "POTPIE_SENTRY_DIST": "explicit-dist",
+        }
+    )
+
+    assert values["POTPIE_SENTRY_DIST"] == "explicit-dist"
+
+
+def test_write_python_constants(tmp_path) -> None:
+    out = tmp_path / "_build_config.py"
+
+    build_config_values.write_python_constants(out, {"A": "x", "B": ""})
+
+    assert out.read_text(encoding="utf-8").splitlines() == [
+        "# Auto-generated at wheel build time - do not edit manually.",
+        "# Override any value at runtime by setting the corresponding environment variable.",
+        "A = 'x'",
+        "B = ''",
+    ]

--- a/potpie/context-engine/tests/unit/test_product_analytics.py
+++ b/potpie/context-engine/tests/unit/test_product_analytics.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+import pytest
+
+from adapters.inbound.cli.telemetry import _build_defaults as build_defaults
 from adapters.inbound.cli.telemetry import product_analytics
 from adapters.inbound.cli.telemetry.context import TelemetryContext
 from adapters.inbound.cli.telemetry.product_analytics import (
@@ -13,6 +16,30 @@ from adapters.inbound.cli.telemetry.product_analytics import (
     set_product_analytics_sink,
 )
 from adapters.inbound.cli.telemetry.settings import load_product_analytics_settings
+
+_PRODUCT_ANALYTICS_ENV_NAMES = (
+    "POTPIE_TELEMETRY_DISABLED",
+    "POTPIE_POSTHOG_ENABLED",
+    "POTPIE_PRODUCT_ANALYTICS_ENABLED",
+    "POTPIE_POSTHOG_API_KEY",
+    "POTPIE_POSTHOG_HOST",
+)
+
+_BUILD_DEFAULT_NAMES = (
+    "POTPIE_TELEMETRY_DISABLED",
+    "POTPIE_POSTHOG_ENABLED",
+    "POTPIE_PRODUCT_ANALYTICS_ENABLED",
+    "POTPIE_POSTHOG_API_KEY",
+    "POTPIE_POSTHOG_HOST",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_product_analytics_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in _PRODUCT_ANALYTICS_ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+    for name in _BUILD_DEFAULT_NAMES:
+        monkeypatch.setattr(build_defaults, name, "")
 
 
 @dataclass
@@ -40,9 +67,6 @@ def _telemetry_context() -> TelemetryContext:
 
 
 def test_product_analytics_settings_require_api_key(monkeypatch) -> None:
-    monkeypatch.delenv("POTPIE_POSTHOG_API_KEY", raising=False)
-    monkeypatch.delenv("POTPIE_TELEMETRY_DISABLED", raising=False)
-
     settings = load_product_analytics_settings()
 
     assert settings.enabled is False
@@ -57,6 +81,61 @@ def test_product_analytics_settings_respect_kill_switch(monkeypatch) -> None:
 
     assert settings.enabled is False
     assert settings.api_key == "phc_test"
+
+
+def test_product_analytics_settings_use_baked_config_without_runtime_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(build_defaults, "POTPIE_TELEMETRY_DISABLED", "0")
+    monkeypatch.setattr(build_defaults, "POTPIE_POSTHOG_ENABLED", "1")
+    monkeypatch.setattr(build_defaults, "POTPIE_PRODUCT_ANALYTICS_ENABLED", "1")
+    monkeypatch.setattr(build_defaults, "POTPIE_POSTHOG_API_KEY", "phc_baked")
+    monkeypatch.setattr(build_defaults, "POTPIE_POSTHOG_HOST", "https://baked.invalid")
+
+    settings = load_product_analytics_settings()
+
+    assert settings.enabled is True
+    assert settings.api_key == "phc_baked"
+    assert settings.host == "https://baked.invalid"
+
+
+def test_product_analytics_runtime_env_overrides_baked_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(build_defaults, "POTPIE_POSTHOG_API_KEY", "phc_baked")
+    monkeypatch.setattr(build_defaults, "POTPIE_POSTHOG_HOST", "https://baked.invalid")
+    monkeypatch.setenv("POTPIE_POSTHOG_API_KEY", "phc_runtime")
+    monkeypatch.setenv("POTPIE_POSTHOG_HOST", "https://runtime.invalid")
+
+    settings = load_product_analytics_settings()
+
+    assert settings.enabled is True
+    assert settings.api_key == "phc_runtime"
+    assert settings.host == "https://runtime.invalid"
+
+
+@pytest.mark.parametrize(
+    ("env_name", "env_value"),
+    [
+        ("POTPIE_TELEMETRY_DISABLED", "1"),
+        ("POTPIE_POSTHOG_ENABLED", "0"),
+        ("POTPIE_PRODUCT_ANALYTICS_ENABLED", "0"),
+    ],
+)
+def test_product_analytics_runtime_opt_out_overrides_baked_enablement(
+    monkeypatch: pytest.MonkeyPatch,
+    env_name: str,
+    env_value: str,
+) -> None:
+    monkeypatch.setattr(build_defaults, "POTPIE_TELEMETRY_DISABLED", "0")
+    monkeypatch.setattr(build_defaults, "POTPIE_POSTHOG_ENABLED", "1")
+    monkeypatch.setattr(build_defaults, "POTPIE_PRODUCT_ANALYTICS_ENABLED", "1")
+    monkeypatch.setattr(build_defaults, "POTPIE_POSTHOG_API_KEY", "phc_baked")
+    monkeypatch.setenv(env_name, env_value)
+
+    settings = load_product_analytics_settings()
+
+    assert settings.enabled is False
 
 
 def test_capture_event_uses_existing_telemetry_identity(monkeypatch) -> None:

--- a/potpie/context-engine/tests/unit/test_telemetry_settings.py
+++ b/potpie/context-engine/tests/unit/test_telemetry_settings.py
@@ -2,17 +2,46 @@ from __future__ import annotations
 
 import pytest
 
+from adapters.inbound.cli.telemetry import _build_defaults as build_defaults
+from bootstrap import sentry_settings as shared_sentry_settings
 from adapters.inbound.cli.telemetry.settings import (
-    load_sentry_settings,
-    telemetry_environment,
+    load_sentry_settings as load_cli_sentry_settings,
+    telemetry_environment as cli_telemetry_environment,
+)
+
+_SENTRY_ENV_NAMES = (
+    "POTPIE_TELEMETRY_DISABLED",
+    "POTPIE_SENTRY_ENABLED",
+    "POTPIE_SENTRY_DSN",
+    "SENTRY_DSN",
+    "POTPIE_SENTRY_ENVIRONMENT",
+    "SENTRY_ENVIRONMENT",
+    "POTPIE_SENTRY_RELEASE",
+    "SENTRY_RELEASE",
+    "POTPIE_SENTRY_DIST",
+    "SENTRY_DIST",
+)
+
+_BUILD_DEFAULT_NAMES = (
+    "POTPIE_TELEMETRY_DISABLED",
+    "POTPIE_SENTRY_ENABLED",
+    "POTPIE_SENTRY_DSN",
+    "POTPIE_SENTRY_ENVIRONMENT",
+    "POTPIE_SENTRY_RELEASE",
+    "POTPIE_SENTRY_DIST",
 )
 
 
-def test_sentry_settings_disabled_without_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("POTPIE_SENTRY_DSN", raising=False)
-    monkeypatch.delenv("SENTRY_DSN", raising=False)
+@pytest.fixture(autouse=True)
+def _clear_sentry_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in _SENTRY_ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+    for name in _BUILD_DEFAULT_NAMES:
+        monkeypatch.setattr(build_defaults, name, "")
 
-    settings = load_sentry_settings()
+
+def test_sentry_settings_disabled_without_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = load_cli_sentry_settings()
 
     assert settings.enabled is False
     assert settings.dsn is None
@@ -24,7 +53,7 @@ def test_sentry_settings_respects_global_kill_switch(
     monkeypatch.setenv("POTPIE_SENTRY_DSN", "https://public@example.invalid/1")
     monkeypatch.setenv("POTPIE_TELEMETRY_DISABLED", "1")
 
-    settings = load_sentry_settings()
+    settings = load_cli_sentry_settings()
 
     assert settings.enabled is False
     assert settings.dsn == "https://public@example.invalid/1"
@@ -38,7 +67,7 @@ def test_sentry_settings_ignores_blank_global_kill_switch(
     monkeypatch.setenv("POTPIE_SENTRY_ENABLED", "")
     monkeypatch.setenv("SENTRY_ENABLED", "")
 
-    settings = load_sentry_settings()
+    settings = load_cli_sentry_settings()
 
     assert settings.enabled is True
     assert settings.dsn == "https://public@example.invalid/1"
@@ -50,7 +79,7 @@ def test_sentry_settings_respects_sentry_kill_switch(
     monkeypatch.setenv("POTPIE_SENTRY_DSN", "https://public@example.invalid/1")
     monkeypatch.setenv("POTPIE_SENTRY_ENABLED", "0")
 
-    settings = load_sentry_settings()
+    settings = load_cli_sentry_settings()
 
     assert settings.enabled is False
 
@@ -67,12 +96,12 @@ def test_potpie_sentry_env_wins_over_generic_sentry_env(
     monkeypatch.setenv("POTPIE_SENTRY_DIST", "cli-dist")
     monkeypatch.setenv("SENTRY_DIST", "generic-dist")
 
-    settings = load_sentry_settings()
+    settings = load_cli_sentry_settings()
 
     assert settings.enabled is True
     assert settings.dsn == "https://potpie@example.invalid/1"
     assert settings.environment == "staging"
-    assert telemetry_environment() == "staging"
+    assert cli_telemetry_environment() == "staging"
     assert settings.release == "potpie-cli@test"
     assert settings.dist == "cli-dist"
 
@@ -81,9 +110,95 @@ def test_sentry_settings_default_release_is_potpie_cli(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("SENTRY_DSN", "https://public@example.invalid/1")
-    monkeypatch.delenv("POTPIE_SENTRY_RELEASE", raising=False)
-    monkeypatch.delenv("SENTRY_RELEASE", raising=False)
 
-    settings = load_sentry_settings()
+    settings = load_cli_sentry_settings()
 
     assert settings.release.startswith("potpie-cli@")
+
+
+def test_sentry_settings_use_baked_config_without_runtime_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        build_defaults, "POTPIE_SENTRY_DSN", "https://baked@example.invalid/1"
+    )
+    monkeypatch.setattr(build_defaults, "POTPIE_SENTRY_ENABLED", "1")
+    monkeypatch.setattr(build_defaults, "POTPIE_TELEMETRY_DISABLED", "0")
+    monkeypatch.setattr(build_defaults, "POTPIE_SENTRY_ENVIRONMENT", "production")
+    monkeypatch.setattr(build_defaults, "POTPIE_SENTRY_RELEASE", "potpie-cli@baked")
+    monkeypatch.setattr(build_defaults, "POTPIE_SENTRY_DIST", "sha-baked")
+
+    settings = load_cli_sentry_settings()
+
+    assert settings.enabled is True
+    assert settings.dsn == "https://baked@example.invalid/1"
+    assert settings.environment == "production"
+    assert cli_telemetry_environment() == "production"
+    assert settings.release == "potpie-cli@baked"
+    assert settings.dist == "sha-baked"
+
+
+def test_sentry_runtime_env_overrides_baked_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        build_defaults, "POTPIE_SENTRY_DSN", "https://baked@example.invalid/1"
+    )
+    monkeypatch.setattr(build_defaults, "POTPIE_SENTRY_ENVIRONMENT", "production")
+    monkeypatch.setattr(build_defaults, "POTPIE_SENTRY_RELEASE", "potpie-cli@baked")
+    monkeypatch.setattr(build_defaults, "POTPIE_SENTRY_DIST", "sha-baked")
+    monkeypatch.setenv("POTPIE_SENTRY_DSN", "https://runtime@example.invalid/1")
+    monkeypatch.setenv("POTPIE_SENTRY_ENVIRONMENT", "staging")
+    monkeypatch.setenv("POTPIE_SENTRY_RELEASE", "potpie-cli@runtime")
+    monkeypatch.setenv("POTPIE_SENTRY_DIST", "sha-runtime")
+
+    settings = load_cli_sentry_settings()
+
+    assert settings.enabled is True
+    assert settings.dsn == "https://runtime@example.invalid/1"
+    assert settings.environment == "staging"
+    assert settings.release == "potpie-cli@runtime"
+    assert settings.dist == "sha-runtime"
+
+
+def test_sentry_runtime_opt_out_overrides_baked_enablement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        build_defaults, "POTPIE_SENTRY_DSN", "https://baked@example.invalid/1"
+    )
+    monkeypatch.setattr(build_defaults, "POTPIE_SENTRY_ENABLED", "1")
+    monkeypatch.setenv("POTPIE_SENTRY_ENABLED", "0")
+
+    settings = load_cli_sentry_settings()
+
+    assert settings.enabled is False
+
+
+def test_sentry_runtime_global_opt_out_overrides_baked_enablement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        build_defaults, "POTPIE_SENTRY_DSN", "https://baked@example.invalid/1"
+    )
+    monkeypatch.setattr(build_defaults, "POTPIE_TELEMETRY_DISABLED", "0")
+    monkeypatch.setenv("POTPIE_TELEMETRY_DISABLED", "1")
+
+    settings = load_cli_sentry_settings()
+
+    assert settings.enabled is False
+
+
+def test_shared_sentry_settings_ignore_cli_baked_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        build_defaults, "POTPIE_SENTRY_DSN", "https://baked@example.invalid/1"
+    )
+    monkeypatch.setattr(build_defaults, "POTPIE_SENTRY_ENVIRONMENT", "production")
+
+    settings = shared_sentry_settings.load_sentry_settings()
+
+    assert settings.enabled is False
+    assert settings.dsn is None
+    assert settings.environment == "dev"


### PR DESCRIPTION
## Summary

Bake CLI telemetry defaults into the `potpie-context-engine` wheel using the existing Hatch build hook path.

This adds generated wheel config for Sentry and PostHog ingest defaults while keeping runtime env vars authoritative and preserving runtime opt-out flags.

Closes #933

## Validation

- `uv run --project potpie/context-engine pytest potpie/context-engine/tests/unit/test_telemetry_settings.py potpie/context-engine/tests/unit/test_product_analytics.py potpie/context-engine/tests/unit/test_build_hook_config.py -q`
- `uv run --project potpie/context-engine ruff check potpie/context-engine/adapters/inbound/cli/telemetry/settings.py potpie/context-engine/adapters/inbound/cli/telemetry/_build_defaults.py potpie/context-engine/build_config_values.py potpie/context-engine/oauth_client_id_injection_hook.py potpie/context-engine/tests/unit/test_telemetry_settings.py potpie/context-engine/tests/unit/test_product_analytics.py potpie/context-engine/tests/unit/test_build_hook_config.py`
- `POTPIE_SENTRY_DSN=https://sentry.example.invalid/1 POTPIE_POSTHOG_API_KEY=phc_fake POTPIE_SENTRY_ENVIRONMENT=production GITHUB_SHA=abc123def456 uv build`
- Inspected the built wheel and confirmed telemetry `_build_config.py` is included with fake Sentry/PostHog values and `POTPIE_SENTRY_DIST = 'abc123def456'`.