### PR TITLE
fix(cli): show pot resolution reason in source list output

### DIFF
--- a/potpie/context-engine/adapters/inbound/cli/commands/_common.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/_common.py
@@ -317,22 +317,25 @@ def _cli_metric_attributes(
     return attributes
 
 
-def resolve_pot_id(
+def resolve_pot_scope(
     host: Any, explicit: str | None = None, *, infer_from_repo: bool = True
-) -> str:
-    """Resolve ``--pot`` ref → id, else current-repo pot, else active pot.
+) -> tuple[str, str]:
+    """Resolve pot id and how it was chosen for CLI scope hints.
 
-    ``infer_from_repo=False`` skips current-repo inference and goes straight to
-    the active pot. Source registration uses this: ``source add repo .`` is the
-    command that *establishes* the repo→pot mapping, so inferring its target
-    from existing registrations would route the new source to the wrong pot
-    (or fail as ambiguous when other pots already track the same repo).
+  ``resolved_via`` is one of ``explicit``, ``repo_default``, ``linked_repo``, or
+  ``active_pot``. See :func:`resolve_pot_id` for resolution order.
+
+  ``infer_from_repo=False`` skips current-repo inference and goes straight to
+  the active pot. Source registration uses this: ``source add repo .`` is the
+  command that *establishes* the repo→pot mapping, so inferring its target
+  from existing registrations would route the new source to the wrong pot
+  (or fail as ambiguous when other pots already track the same repo).
     """
     pots = host.pots
     if explicit:
         for pot in pots.list_pots():
             if explicit in (pot.pot_id, pot.name):
-                return pot.pot_id
+                return pot.pot_id, "explicit"
         fail(
             code="pot_not_found",
             message=f"No pot matching '{explicit}'.",
@@ -341,14 +344,14 @@ def resolve_pot_id(
     repo_identity = _current_repo_identity() if infer_from_repo else None
     default_pot = _repo_default_pot_id(host, repo_identity)
     if default_pot:
-        return default_pot
+        return default_pot, "repo_default"
     matches = _pots_matching_current_repo(host) if infer_from_repo else []
     active = pots.active_pot()
     if len(matches) == 1:
-        return matches[0][0]
+        return matches[0][0], "linked_repo"
     if len(matches) > 1:
         if active is not None and any(active.pot_id == pid for pid, _ in matches):
-            return active.pot_id
+            return active.pot_id, "active_pot"
         names = ", ".join(f"{name} ({pid})" for pid, name in matches)
         fail(
             code="ambiguous_pot",
@@ -361,7 +364,15 @@ def resolve_pot_id(
             message="No active pot, and the current repo is not registered as a source in any pot.",
             next_action="run 'potpie setup', or create a pot with 'potpie pot create <name> --use' and register this repo with 'potpie source add repo .'",
         )
-    return active.pot_id
+    return active.pot_id, "active_pot"
+
+
+def resolve_pot_id(
+    host: Any, explicit: str | None = None, *, infer_from_repo: bool = True
+) -> str:
+    """Resolve ``--pot`` ref → id, else current-repo pot, else active pot."""
+    pot_id, _ = resolve_pot_scope(host, explicit, infer_from_repo=infer_from_repo)
+    return pot_id
 
 
 def current_repo_identity_for_cli() -> str | None:
@@ -414,15 +425,38 @@ def pot_scope_info(host: Any, pot_id: str) -> dict[str, Any]:
     }
 
 
-def pot_scope_human(host: Any, pot_id: str) -> str:
+def pot_scope_resolution_human(
+    resolved_via: str, *, repo: str | None = None
+) -> str:
+    if resolved_via == "explicit":
+        return "via --pot"
+    if resolved_via == "repo_default":
+        return (
+            f"via repo default for {repo}" if repo else "via repo default"
+        )
+    if resolved_via == "linked_repo":
+        return f"via linked repo {repo}" if repo else "via linked repo"
+    return "via active pot"
+
+
+def pot_scope_human(
+    host: Any,
+    pot_id: str,
+    *,
+    resolved_via: str | None = None,
+    repo: str | None = None,
+) -> str:
     info = pot_scope_info(host, pot_id)
     counts = info.get("counts") or {}
     claims = counts.get("claims", 0)
     entities = counts.get("entities", 0)
-    return (
+    scope = (
         f"pot={info.get('name')} ({pot_id}) "
         f"sources={info.get('source_count', 0)} claims={claims} entities={entities}"
     )
+    if resolved_via:
+        scope += f" {pot_scope_resolution_human(resolved_via, repo=repo)}"
+    return scope
 
 
 def empty_pot_warnings(host: Any, pot_id: str) -> tuple[str, ...]:
@@ -629,9 +663,11 @@ __all__ = [
     "pot_graph_counts",
     "pot_scope_human",
     "pot_scope_info",
+    "pot_scope_resolution_human",
     "pot_source_count",
     "repo_pot_candidates",
     "resolve_pot_id",
+    "resolve_pot_scope",
     "set_host",
     "set_store",
     "set_json",

--- a/potpie/context-engine/adapters/inbound/cli/commands/pots.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/pots.py
@@ -15,8 +15,10 @@ from adapters.inbound.cli.commands._common import (
     fail,
     get_host,
     pot_scope_info,
+    pot_scope_resolution_human,
     repo_pot_candidates,
     resolve_pot_id,
+    resolve_pot_scope,
 )
 from adapters.inbound.cli.telemetry.onboarding_events import (
     capture_project_binding_event,
@@ -518,12 +520,32 @@ def source_add(
 def source_list(pot: str = typer.Option(None, "--pot")) -> None:
     with contract():
         host = get_host()
-        pot_id = resolve_pot_id(host, pot)
+        pot_id, resolved_via = resolve_pot_scope(host, pot)
         sources = host.pots.list_sources(pot_id=pot_id)
         pot_info = pot_scope_info(host, pot_id)
+        repo = (
+            current_repo_identity_for_cli()
+            if resolved_via in {"repo_default", "linked_repo"}
+            else None
+        )
+        counts = pot_info.get("counts") or {}
+        header = "\n".join(
+            [
+                (
+                    f"pot={pot_info['name']} ({pot_id}) "
+                    f"{pot_scope_resolution_human(resolved_via, repo=repo)}"
+                ),
+                (
+                    f"sources={len(sources)} claims={counts.get('claims', 0)} "
+                    f"entities={counts.get('entities', 0)}"
+                ),
+            ]
+        )
         emit(
             {
                 "pot_id": pot_id,
+                "resolved_via": resolved_via,
+                "repo": repo,
                 "pot": pot_info,
                 "source_count": len(sources),
                 "sources": [
@@ -538,10 +560,7 @@ def source_list(pot: str = typer.Option(None, "--pot")) -> None:
             },
             human="\n".join(
                 [
-                    (
-                        f"pot={pot_info['name']} ({pot_id}) "
-                        f"sources={len(sources)} claims={(pot_info.get('counts') or {}).get('claims', 0)}"
-                    ),
+                    header,
                     *(
                         f"  {s.kind}: {getattr(s, 'location', s.name)} ({s.source_id})"
                         for s in sources
@@ -549,11 +568,7 @@ def source_list(pot: str = typer.Option(None, "--pot")) -> None:
                 ]
             )
             if sources
-            else (
-                f"pot={pot_info['name']} ({pot_id}) "
-                f"sources=0 claims={(pot_info.get('counts') or {}).get('claims', 0)}\n"
-                "(no sources)"
-            ),
+            else f"{header}\n(no sources)",
         )
 
 

--- a/potpie/context-engine/tests/unit/test_cli_ergonomics.py
+++ b/potpie/context-engine/tests/unit/test_cli_ergonomics.py
@@ -188,6 +188,64 @@ def test_source_list_plain_output_includes_location() -> None:
     assert "repo: github.com/acme/shop (src_shop)" in result.output
 
 
+def test_source_list_plain_output_shows_active_pot_resolution(monkeypatch) -> None:
+    monkeypatch.setattr(_common, "_current_git_remote", lambda cwd: None)
+    src = _Source("repo", "shop", "github.com/acme/shop")
+    pots_service = _Pots(
+        [_Pot("p1", "shop", True)], {"p1": [src]}, active=_Pot("p1", "shop", True)
+    )
+    _common.set_host(_Host(pots_service))
+
+    result = CliRunner().invoke(pots.source_app, ["list"])
+
+    assert result.exit_code == 0, result.output
+    assert "via active pot" in result.output
+
+
+def test_source_list_plain_output_shows_repo_default_resolution(monkeypatch) -> None:
+    monkeypatch.setattr(
+        _common, "_current_git_remote", lambda cwd: "github.com/acme/shop"
+    )
+    match = _Source("repo", "github.com/acme/shop")
+    active = _Pot("p3", "fresh", True)
+    pots_service = _Pots(
+        [_Pot("p1", "shop"), _Pot("p2", "shop-fork"), active],
+        {"p1": [match], "p2": [match]},
+        active=active,
+    )
+    pots_service.repo_defaults["github.com/acme/shop"] = "p2"
+    _common.set_host(_Host(pots_service))
+
+    result = CliRunner().invoke(pots.source_app, ["list"])
+
+    assert result.exit_code == 0, result.output
+    assert "via repo default for github.com/acme/shop" in result.output
+    assert "shop-fork (p2)" in result.output
+
+
+def test_source_list_json_includes_resolved_via(monkeypatch) -> None:
+    monkeypatch.setattr(
+        _common, "_current_git_remote", lambda cwd: "github.com/acme/shop"
+    )
+    match = _Source("repo", "github.com/acme/shop")
+    pots_service = _Pots(
+        [_Pot("p1", "shop"), _Pot("p2", "shop-fork")],
+        {"p1": [match], "p2": [match]},
+        active=None,
+    )
+    pots_service.repo_defaults["github.com/acme/shop"] = "p2"
+    _common.set_host(_Host(pots_service))
+    _common.set_json(True)
+
+    result = CliRunner().invoke(pots.source_app, ["list"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["resolved_via"] == "repo_default"
+    assert payload["repo"] == "github.com/acme/shop"
+    assert payload["pot_id"] == "p2"
+
+
 def test_source_add_targets_active_pot_even_when_repo_matches_other_pots(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
Summary
* potpie source list resolves pot scope through repo default before the active pot (by design), but human output previously only showed the resolved pot name/id and counts — not why that pot was chosen.
* Add resolve_pot_scope() and pot_scope_resolution_human() so source list reports how the pot was selected: via --pot, via repo default for <repo>, via linked repo <repo>, or via active pot.
* Extend JSON output with resolved_via and repo for machine-readable scope debugging. Pot resolution order is unchanged.

Before:
`pot=ansible (pot_af415ba4ffe2) sources=2 claims=187
  repo: github.com/ansible/ansible (src_549d6848)`

After:
`pot=ansible (pot_af415ba4ffe2) via repo default for github.com/potpie-ai/potpie
sources=2 claims=187 entities=103
  repo: github.com/ansible/ansible (src_549d6848)`

<img width="596" height="223" alt="Screenshot 2026-06-24 at 2 02 55 PM" src="https://github.com/user-attachments/assets/a8fb278b-8e78-4831-8805-9a292837a911" />


