### PR TITLE
[codex] Cap Sentry SDK below 3.0

### DIFF
--- a/potpie/context-engine/pyproject.toml
+++ b/potpie/context-engine/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "typer>=0.15.0",
     "uvicorn[standard]>=0.32.0",
     "pydantic>=2.0",
-    "sentry-sdk>=2.61.1",
+    "sentry-sdk>=2.61.1,<3.0.0",
     # Default CLI backend is FalkorDBLite on Python 3.12+.
     "falkordblite>=0.10.0; python_version >= '3.12'",
     # redis 8 enables maintenance notifications that break FalkorDBLite's

--- a/uv.lock
+++ b/uv.lock
@@ -2209,7 +2209,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
     { name = "sentence-transformers", marker = "extra == 'all'", specifier = ">=5.1.2" },
     { name = "sentence-transformers", marker = "extra == 'embeddings'", specifier = ">=5.1.2" },
-    { name = "sentry-sdk", specifier = ">=2.61.1" },
+    { name = "sentry-sdk", specifier = ">=2.61.1,<3.0.0" },
     { name = "sqlalchemy", marker = "extra == 'all'", specifier = ">=2.0" },
     { name = "sqlalchemy", marker = "extra == 'postgres'", specifier = ">=2.0" },
     { name = "typer", specifier = ">=0.15.0" },


### PR DESCRIPTION
## Summary

Cap `potpie-context-engine`'s `sentry-sdk` dependency below 3.0 and refresh the lock metadata.

## Root cause

The package metadata allowed any `sentry-sdk>=2.61.1`. In prerelease-enabled uv installs, that can resolve to Sentry SDK 3.0 alpha builds, which emit the warning that SDK 3.0 will not continue development when `sentry_sdk.init()` is called.

## Impact

Fresh installs stay on the maintained Sentry SDK 2.x line, avoiding the SDK 3.0 warning in the CLI metrics bootstrap path.

## Validation

- `uv pip compile potpie/context-engine/pyproject.toml --python-version 3.12 --prerelease allow --quiet | rg "sentry-sdk==|3\.0\.0a"` resolved `sentry-sdk==2.63.0`
- `uv run --locked pytest tests/unit/test_sentry_metrics_runtime.py tests/unit/test_sentry_runtime.py -q` passed: 13 tests
