### PR TITLE
fix(cli): surface uv-tool install facts in doctor and docs

### DIFF
--- a/docs/context-graph/cli-flow.md
+++ b/docs/context-graph/cli-flow.md
@@ -177,8 +177,20 @@ control plane, Graph Service data plane, GraphBackend capabilities/projections,
 Event Ledger binding and consumer backlog, Skill Manager drift, login state when
 relevant, and next action.
 
-`doctor` is local-profile diagnostics: paths, logs, auth/socket state,
-migrations, and skill drift.
+`doctor` is local-profile diagnostics: daemon/backend readiness, CLI install
+facts (uv tool env, PATH, python shebang), and recommended follow-up commands.
+Do not use `python -m pip show potpie-context-engine` for local dev installs —
+the package lives in the uv tool environment. Prefer `uv tool list`,
+`which -a potpie`, and `make cli-status`.
+
+```bash
+uv tool list
+which -a potpie
+head -n 1 "$(command -v potpie)"
+make cli-status
+potpie doctor
+potpie --json doctor
+```
 
 ### Local Daemon Admin
 

--- a/potpie/context-engine/adapters/inbound/cli/cli_install_status.py
+++ b/potpie/context-engine/adapters/inbound/cli/cli_install_status.py
@@ -100,7 +100,7 @@ def _python_from_script(script_path: str | None) -> str | None:
     try:
         with open(script_path, encoding="utf-8") as handle:
             first = handle.readline().strip()
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return None
     if first.startswith("#!"):
         return first[2:].strip() or None

--- a/potpie/context-engine/adapters/inbound/cli/cli_install_status.py
+++ b/potpie/context-engine/adapters/inbound/cli/cli_install_status.py
@@ -1,0 +1,150 @@
+"""Diagnostics for how the ``potpie`` CLI is installed on the host."""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any
+
+CLI_TOOL_NAME = "potpie-context-engine"
+CLI_EXECUTABLE = "potpie"
+
+_DIAGNOSTIC_COMMANDS = (
+    "uv tool list",
+    "which -a potpie",
+    'head -n 1 "$(command -v potpie)"',
+    "make cli-status",
+)
+
+
+def collect_cli_install_status() -> dict[str, Any]:
+    """Return install facts for ``potpie doctor`` and ``make cli-status``."""
+    paths_on_path = _potpie_paths_on_path()
+    primary_path = paths_on_path[0] if paths_on_path else None
+    python_interpreter = _python_from_script(primary_path) if primary_path else None
+    python_version = _python_version(python_interpreter)
+    uv_tool = _uv_tool_status()
+    package_version = _installed_package_version()
+
+    return {
+        "package_name": CLI_TOOL_NAME,
+        "package_version": package_version,
+        "on_path": bool(paths_on_path),
+        "paths": paths_on_path,
+        "primary_path": primary_path,
+        "python_interpreter": python_interpreter,
+        "python_version": python_version,
+        "runtime_python": sys.executable,
+        "runtime_python_version": ".".join(map(str, sys.version_info[:3])),
+        "uv_available": shutil.which("uv") is not None,
+        "uv_tool_installed": uv_tool.get("installed"),
+        "uv_tool_version": uv_tool.get("version"),
+        "install_method": "uv_tool" if uv_tool.get("installed") else None,
+        "diagnostic_commands": list(_DIAGNOSTIC_COMMANDS),
+        "pip_show_note": (
+            "Do not use `python -m pip show potpie-context-engine` for local dev "
+            "installs: `python` may be absent from PATH and the package lives in "
+            "the uv tool environment. Prefer `uv tool list`, `which -a potpie`, "
+            "and `make cli-status`."
+        ),
+    }
+
+
+def cli_install_human(status: dict[str, Any]) -> str:
+    if not status.get("on_path"):
+        return "cli: potpie NOT on PATH (run: make cli-install)"
+    pkg = str(status.get("package_name") or CLI_TOOL_NAME)
+    ver = status.get("package_version") or status.get("uv_tool_version") or "unknown"
+    path = status.get("primary_path") or "unknown"
+    py = status.get("python_version")
+    via = status.get("install_method")
+    parts = [f"cli: {pkg} {ver}", f"path={path}"]
+    if via:
+        parts.append(f"via={via}")
+    if py:
+        parts.append(f"python={py}")
+    return " ".join(parts)
+
+
+def _installed_package_version() -> str | None:
+    try:
+        return version(CLI_TOOL_NAME)
+    except PackageNotFoundError:
+        return None
+
+
+def _potpie_paths_on_path() -> list[str]:
+    seen: set[str] = set()
+    paths: list[str] = []
+    for directory in os.environ.get("PATH", "").split(os.pathsep):
+        if not directory:
+            continue
+        candidate = os.path.join(directory, CLI_EXECUTABLE)
+        if not (os.path.isfile(candidate) or os.path.islink(candidate)):
+            continue
+        resolved = os.path.realpath(candidate)
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        paths.append(candidate)
+    return paths
+
+
+def _python_from_script(script_path: str | None) -> str | None:
+    if not script_path:
+        return None
+    try:
+        with open(script_path, encoding="utf-8") as handle:
+            first = handle.readline().strip()
+    except OSError:
+        return None
+    if first.startswith("#!"):
+        return first[2:].strip() or None
+    return None
+
+
+def _python_version(interpreter: str | None) -> str | None:
+    if not interpreter:
+        return None
+    try:
+        proc = subprocess.run(
+            [interpreter, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    output = (proc.stdout or proc.stderr or "").strip()
+    match = re.search(r"(\d+\.\d+(?:\.\d+)?)", output)
+    return match.group(1) if match else output or None
+
+
+def _uv_tool_status() -> dict[str, Any]:
+    if shutil.which("uv") is None:
+        return {"installed": False, "version": None}
+    try:
+        proc = subprocess.run(
+            ["uv", "tool", "list"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return {"installed": False, "version": None}
+    if proc.returncode != 0:
+        return {"installed": False, "version": None}
+    for line in proc.stdout.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("-"):
+            continue
+        name, _, ver = stripped.partition(" ")
+        if name == CLI_TOOL_NAME:
+            return {"installed": True, "version": ver.removeprefix("v") or None}
+    return {"installed": False, "version": None}

--- a/potpie/context-engine/adapters/inbound/cli/commands/bootstrap.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/bootstrap.py
@@ -11,6 +11,10 @@ from pathlib import Path
 
 import typer
 
+from adapters.inbound.cli.cli_install_status import (
+    cli_install_human,
+    collect_cli_install_status,
+)
 from adapters.inbound.cli.commands._common import (
     EXIT_DEGRADED,
     contract,
@@ -266,9 +270,11 @@ def register(root: typer.Typer) -> None:
             pot_id = getattr(pot, "pot_id", "") if pot is not None else ""
             readiness = host.backend.mutation.readiness(pot_id)
             daemon_status = host.daemon.status()
+            cli_install = collect_cli_install_status()
             emit(
                 {
                     "daemon": daemon_status,
+                    "cli_install": cli_install,
                     "backend_profile": host.backend.profile,
                     "backend_ready": readiness.ready,
                     "backend_readiness": {
@@ -289,6 +295,7 @@ def register(root: typer.Typer) -> None:
                 },
                 human=(
                     f"daemon: {daemon_status['mode']} (up={daemon_status.get('up')})\n"
+                    f"{cli_install_human(cli_install)}\n"
                     f"backend: {host.backend.profile} ready={readiness.ready} "
                     f"caps={', '.join(caps.implemented())}\n"
                     f"ledger: {host.ledger.status().binding} "

--- a/potpie/context-engine/adapters/inbound/cli/templates/agent_bundle/.agents/skills/potpie-cli/SKILL.md
+++ b/potpie/context-engine/adapters/inbound/cli/templates/agent_bundle/.agents/skills/potpie-cli/SKILL.md
@@ -13,6 +13,9 @@ ordinary project-memory context, prefer the relevant use-case skill first.
 ```bash
 potpie doctor
 potpie --json doctor
+make cli-status
+uv tool list
+which -a potpie
 potpie login <api-key> --url <host>
 potpie pot list
 potpie pot use <pot-id-or-alias>
@@ -74,6 +77,8 @@ written with graph workbench mutations. Do not use pot-level connector queueing 
 deterministic local code scans as the agent ingestion path.
 Do not use scanner-driven graph updates.
 
-For CLI failures, stay in this skill: run `potpie doctor`, inspect JSON output
-when useful, check API URL/key config, confirm pot scope, and verify source
+For CLI failures, stay in this skill: run `potpie doctor`, `make cli-status`, or
+`uv tool list` for install facts. Do not use `python -m pip show
+potpie-context-engine` for local uv-tool installs. Inspect JSON output when
+useful, check API URL/key config, confirm pot scope, and verify source
 registration before changing project code.

--- a/potpie/context-engine/tests/unit/test_cli_install_status.py
+++ b/potpie/context-engine/tests/unit/test_cli_install_status.py
@@ -46,6 +46,7 @@ def test_collect_cli_install_status_from_uv_tool(monkeypatch: pytest.MonkeyPatch
     assert status["on_path"] is True
     assert status["primary_path"] == "/Users/me/.local/bin/potpie"
     assert status["uv_tool_installed"] is True
+    assert status["uv_tool_version"] == "0.1.0"
     assert status["install_method"] == "uv_tool"
     assert status["python_version"] == "3.12.12"
     assert "uv tool list" in status["diagnostic_commands"]
@@ -57,6 +58,12 @@ def test_cli_install_human_when_missing_from_path() -> None:
     human = cis.cli_install_human({"on_path": False})
     assert "NOT on PATH" in human
     assert "make cli-install" in human
+
+
+def test_python_from_script_ignores_binary_executable(tmp_path) -> None:
+    binary = tmp_path / "potpie"
+    binary.write_bytes(b"\xff\xfe\xfd\xfc")
+    assert cis._python_from_script(str(binary)) is None
 
 
 def test_doctor_includes_cli_install(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/potpie/context-engine/tests/unit/test_cli_install_status.py
+++ b/potpie/context-engine/tests/unit/test_cli_install_status.py
@@ -1,0 +1,101 @@
+"""CLI install diagnostics for uv-tool installs."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from adapters.inbound.cli import cli_install_status as cis
+from adapters.inbound.cli.commands import bootstrap
+from adapters.inbound.cli import host_cli as cli_main
+
+pytestmark = pytest.mark.unit
+
+runner = CliRunner()
+
+
+def test_collect_cli_install_status_from_uv_tool(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cis.shutil, "which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr(
+        cis,
+        "_potpie_paths_on_path",
+        lambda: ["/Users/me/.local/bin/potpie"],
+    )
+    monkeypatch.setattr(
+        cis,
+        "_python_from_script",
+        lambda _path: "/Users/me/.local/share/uv/tools/potpie-context-engine/bin/python3",
+    )
+    monkeypatch.setattr(cis, "_python_version", lambda _path: "3.12.12")
+    monkeypatch.setattr(cis, "_installed_package_version", lambda: "0.1.0")
+    monkeypatch.setattr(
+        cis.subprocess,
+        "run",
+        lambda *args, **kwargs: MagicMock(
+            returncode=0,
+            stdout="potpie-context-engine v0.1.0\n- potpie\n",
+            stderr="",
+        ),
+    )
+
+    status = cis.collect_cli_install_status()
+
+    assert status["on_path"] is True
+    assert status["primary_path"] == "/Users/me/.local/bin/potpie"
+    assert status["uv_tool_installed"] is True
+    assert status["install_method"] == "uv_tool"
+    assert status["python_version"] == "3.12.12"
+    assert "uv tool list" in status["diagnostic_commands"]
+    assert "make cli-status" in status["diagnostic_commands"]
+    assert "pip show" in status["pip_show_note"]
+
+
+def test_cli_install_human_when_missing_from_path() -> None:
+    human = cis.cli_install_human({"on_path": False})
+    assert "NOT on PATH" in human
+    assert "make cli-install" in human
+
+
+def test_doctor_includes_cli_install(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_host = MagicMock()
+    mock_host.daemon.status.return_value = {"mode": "in_process", "up": True}
+    mock_host.backend.profile = "falkordb"
+    mock_host.backend.capabilities.return_value.implemented.return_value = [
+        "graph.read"
+    ]
+    mock_host.backend.mutation.readiness.return_value = MagicMock(
+        ready=True,
+        profile="falkordb",
+        capability_ready={"mutation": True},
+        detail=None,
+    )
+    mock_host.pots.active_pot.return_value = None
+    mock_host.ledger.status.return_value = MagicMock(available=True, binding="local")
+    monkeypatch.setattr(bootstrap, "get_host", lambda: mock_host)
+    monkeypatch.setattr(
+        bootstrap,
+        "collect_cli_install_status",
+        lambda: {
+            "package_name": "potpie-context-engine",
+            "package_version": "0.1.0",
+            "on_path": True,
+            "primary_path": "/Users/me/.local/bin/potpie",
+            "python_version": "3.12.12",
+            "install_method": "uv_tool",
+        },
+    )
+
+    result = runner.invoke(cli_main.app, ["--json", "doctor"])
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["cli_install"]["install_method"] == "uv_tool"
+    assert payload["cli_install"]["primary_path"] == "/Users/me/.local/bin/potpie"
+
+    result = runner.invoke(cli_main.app, ["doctor"])
+    assert result.exit_code == 0, result.stdout
+    assert "cli: potpie-context-engine 0.1.0" in result.stdout
+    assert "via=uv_tool" in result.stdout


### PR DESCRIPTION
**Summary**

- Local dev installs potpie via uv tool (make cli-install), not system pip, so python -m pip show potpie-context-engine often fails or reports a false negative.
- Add cli_install_status and wire it into potpie doctor (human + JSON) with PATH, uv tool version, Python shebang, and recommended diagnostic commands.
- Update cli-flow.md and the bundled potpie-cli skill to prefer uv tool list, which -a potpie, make cli-status, and potpie doctor over pip show.
<img width="760" height="332" alt="Screenshot 2026-06-24 at 4 53 24 PM" src="https://github.com/user-attachments/assets/17883f06-6cb9-4019-949b-0dbd60f95506" />


