### PR TITLE
Fix baked Sentry environment defaults

### DIFF
--- a/potpie/context-engine/bootstrap/sentry_settings.py
+++ b/potpie/context-engine/bootstrap/sentry_settings.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from importlib import metadata
 from typing import ClassVar, Final
 
+from adapters.inbound.cli.telemetry import _build_defaults as build_defaults
+
 _FALSE_VALUES: Final[frozenset[str]] = frozenset({"0", "false", "no", "off"})
 
 
@@ -26,17 +28,32 @@ class SentrySettings:
 
 
 def load_sentry_settings() -> SentrySettings:
-    dsn = _env("POTPIE_SENTRY_DSN") or _env("SENTRY_DSN")
-    telemetry_disabled = _is_truthy_flag("POTPIE_TELEMETRY_DISABLED")
-    sentry_disabled = _is_falsey_flag("POTPIE_SENTRY_ENABLED")
+    dsn = (
+        _env("POTPIE_SENTRY_DSN")
+        or _env("SENTRY_DSN")
+        or _baked(build_defaults.POTPIE_SENTRY_DSN)
+    )
+    telemetry_disabled = _is_truthy_config(
+        "POTPIE_TELEMETRY_DISABLED",
+        build_defaults.POTPIE_TELEMETRY_DISABLED,
+    )
+    sentry_disabled = _is_falsey_config(
+        "POTPIE_SENTRY_ENABLED",
+        build_defaults.POTPIE_SENTRY_ENABLED,
+    )
     return SentrySettings(
         enabled=dsn is not None and not telemetry_disabled and not sentry_disabled,
         dsn=dsn,
         environment=telemetry_environment(),
         release=_env("POTPIE_SENTRY_RELEASE")
         or _env("SENTRY_RELEASE")
+        or _baked(build_defaults.POTPIE_SENTRY_RELEASE)
         or default_cli_release(),
-        dist=_env("POTPIE_SENTRY_DIST") or _env("SENTRY_DIST"),
+        dist=(
+            _env("POTPIE_SENTRY_DIST")
+            or _env("SENTRY_DIST")
+            or _baked(build_defaults.POTPIE_SENTRY_DIST)
+        ),
     )
 
 
@@ -49,7 +66,12 @@ def default_cli_release() -> str:
 
 
 def telemetry_environment() -> str:
-    return _env("POTPIE_SENTRY_ENVIRONMENT") or _env("SENTRY_ENVIRONMENT") or "dev"
+    return (
+        _env("POTPIE_SENTRY_ENVIRONMENT")
+        or _env("SENTRY_ENVIRONMENT")
+        or _baked(build_defaults.POTPIE_SENTRY_ENVIRONMENT)
+        or "dev"
+    )
 
 
 def _env(name: str) -> str | None:
@@ -60,14 +82,26 @@ def _env(name: str) -> str | None:
     return stripped or None
 
 
-def _is_falsey_flag(name: str) -> bool:
-    value = os.getenv(name)
-    return value is not None and value.strip().lower() in _FALSE_VALUES
+def _baked(value: str) -> str | None:
+    stripped = value.strip()
+    return stripped or None
 
 
-def _is_truthy_flag(name: str) -> bool:
+def _flag_config(name: str, baked: str) -> str | None:
     value = os.getenv(name)
-    if value is None:
-        return False
-    normalized = value.strip().lower()
-    return normalized != "" and normalized not in _FALSE_VALUES
+    if value is not None:
+        return value.strip().lower()
+    baked_value = _baked(baked)
+    if baked_value is None:
+        return None
+    return baked_value.lower()
+
+
+def _is_falsey_config(name: str, baked: str = "") -> bool:
+    value = _flag_config(name, baked)
+    return value is not None and value in _FALSE_VALUES
+
+
+def _is_truthy_config(name: str, baked: str = "") -> bool:
+    value = _flag_config(name, baked)
+    return value is not None and value != "" and value not in _FALSE_VALUES

--- a/potpie/context-engine/tests/unit/test_telemetry_settings.py
+++ b/potpie/context-engine/tests/unit/test_telemetry_settings.py
@@ -189,16 +189,23 @@ def test_sentry_runtime_global_opt_out_overrides_baked_enablement(
     assert settings.enabled is False
 
 
-def test_shared_sentry_settings_ignore_cli_baked_defaults(
+def test_shared_sentry_settings_use_baked_defaults(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
         build_defaults, "POTPIE_SENTRY_DSN", "https://baked@example.invalid/1"
     )
     monkeypatch.setattr(build_defaults, "POTPIE_SENTRY_ENVIRONMENT", "production")
+    monkeypatch.setattr(build_defaults, "POTPIE_SENTRY_RELEASE", "potpie-cli@baked")
+    monkeypatch.setattr(build_defaults, "POTPIE_SENTRY_DIST", "sha-baked")
+    monkeypatch.setattr(build_defaults, "POTPIE_SENTRY_ENABLED", "1")
+    monkeypatch.setattr(build_defaults, "POTPIE_TELEMETRY_DISABLED", "0")
 
     settings = shared_sentry_settings.load_sentry_settings()
 
-    assert settings.enabled is False
-    assert settings.dsn is None
-    assert settings.environment == "dev"
+    assert settings.enabled is True
+    assert settings.dsn == "https://baked@example.invalid/1"
+    assert settings.environment == "production"
+    assert shared_sentry_settings.telemetry_environment() == "production"
+    assert settings.release == "potpie-cli@baked"
+    assert settings.dist == "sha-baked"


### PR DESCRIPTION
## Summary
- Make shared/bootstrap Sentry settings read baked wheel telemetry defaults when runtime env vars are absent.
- Align bootstrap Sentry precedence with the CLI telemetry path: runtime env, baked defaults, then fallback.
- Update the regression test so shared Sentry settings keep `prod_oss`-style baked environments instead of falling back to `dev`.

## Root Cause
The CLI telemetry settings read baked wheel defaults, but `bootstrap.sentry_settings` only read runtime env vars and then defaulted to `dev`. If bootstrap Sentry metrics initialized first, Sentry could be configured with `dev` even when the wheel contained `POTPIE_SENTRY_ENVIRONMENT=prod_oss`.

## Verification
- `python3 -m py_compile potpie/context-engine/bootstrap/sentry_settings.py`
- `uv run --directory potpie/context-engine pytest tests/unit/test_telemetry_settings.py tests/unit/test_sentry_metrics_runtime.py tests/unit/test_product_analytics.py`
- Rebuilt beta wheels locally and installed into a clean Python 3.13 venv; verified both CLI and bootstrap settings resolve `prod_oss`.
