### PR TITLE
fix: wheel creation default environment

### DIFF
--- a/potpie/context-engine/adapters/inbound/cli/telemetry/_build_defaults.py
+++ b/potpie/context-engine/adapters/inbound/cli/telemetry/_build_defaults.py
@@ -2,10 +2,12 @@
 
 Values are written to ``_build_config.py`` by the Hatch build hook
 (``oauth_client_id_injection_hook.py``). In a source checkout, the generated
-module is absent and every constant resolves to an empty string.
+module is absent and build-time constants resolve to empty strings.
 """
 
 from __future__ import annotations
+
+DEFAULT_POTPIE_SENTRY_ENVIRONMENT = "prod_oss"
 
 try:
     from adapters.inbound.cli.telemetry._build_config import (
@@ -31,4 +33,3 @@ except ImportError:
     POTPIE_PRODUCT_ANALYTICS_ENABLED = ""
     POTPIE_POSTHOG_API_KEY = ""
     POTPIE_POSTHOG_HOST = ""
-

--- a/potpie/context-engine/adapters/inbound/cli/telemetry/settings.py
+++ b/potpie/context-engine/adapters/inbound/cli/telemetry/settings.py
@@ -87,7 +87,7 @@ def telemetry_environment() -> str:
         _env("POTPIE_SENTRY_ENVIRONMENT")
         or _env("SENTRY_ENVIRONMENT")
         or _baked(build_defaults.POTPIE_SENTRY_ENVIRONMENT)
-        or "dev"
+        or build_defaults.DEFAULT_POTPIE_SENTRY_ENVIRONMENT
     )
 
 

--- a/potpie/context-engine/bootstrap/sentry_settings.py
+++ b/potpie/context-engine/bootstrap/sentry_settings.py
@@ -70,7 +70,7 @@ def telemetry_environment() -> str:
         _env("POTPIE_SENTRY_ENVIRONMENT")
         or _env("SENTRY_ENVIRONMENT")
         or _baked(build_defaults.POTPIE_SENTRY_ENVIRONMENT)
-        or "dev"
+        or build_defaults.DEFAULT_POTPIE_SENTRY_ENVIRONMENT
     )
 
 

--- a/potpie/context-engine/build_config_values.py
+++ b/potpie/context-engine/build_config_values.py
@@ -25,6 +25,8 @@ TELEMETRY_NAMES = (
     "POTPIE_POSTHOG_HOST",
 )
 
+DEFAULT_POTPIE_SENTRY_ENVIRONMENT = "prod_oss"
+
 
 def oauth_config_values(environ: Mapping[str, str] | None = None) -> dict[str, str]:
     return {
@@ -45,7 +47,9 @@ def telemetry_config_values(
         ),
         "POTPIE_SENTRY_DSN": _env("POTPIE_SENTRY_DSN", environ),
         "POTPIE_SENTRY_ENVIRONMENT": _env_or_default(
-            "POTPIE_SENTRY_ENVIRONMENT", "production", environ
+            "POTPIE_SENTRY_ENVIRONMENT",
+            DEFAULT_POTPIE_SENTRY_ENVIRONMENT,
+            environ,
         ),
         "POTPIE_SENTRY_RELEASE": _env("POTPIE_SENTRY_RELEASE", environ),
         "POTPIE_SENTRY_DIST": _env("POTPIE_SENTRY_DIST", environ)

--- a/potpie/context-engine/tests/unit/test_build_hook_config.py
+++ b/potpie/context-engine/tests/unit/test_build_hook_config.py
@@ -10,7 +10,7 @@ def test_telemetry_build_config_defaults_dist_to_github_sha() -> None:
         "POTPIE_TELEMETRY_DISABLED": "0",
         "POTPIE_SENTRY_ENABLED": "1",
         "POTPIE_SENTRY_DSN": "",
-        "POTPIE_SENTRY_ENVIRONMENT": "production",
+        "POTPIE_SENTRY_ENVIRONMENT": "prod_oss",
         "POTPIE_SENTRY_RELEASE": "",
         "POTPIE_SENTRY_DIST": "abc123",
         "POTPIE_POSTHOG_ENABLED": "1",

--- a/potpie/context-engine/tests/unit/test_telemetry_settings.py
+++ b/potpie/context-engine/tests/unit/test_telemetry_settings.py
@@ -45,6 +45,14 @@ def test_sentry_settings_disabled_without_dsn(monkeypatch: pytest.MonkeyPatch) -
 
     assert settings.enabled is False
     assert settings.dsn is None
+    assert settings.environment == "prod_oss"
+
+
+def test_telemetry_environment_defaults_to_prod_oss_without_runtime_or_baked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert cli_telemetry_environment() == "prod_oss"
+    assert shared_sentry_settings.telemetry_environment() == "prod_oss"
 
 
 def test_sentry_settings_respects_global_kill_switch(


### PR DESCRIPTION
## Summary
- Change the context-engine wheel/runtime telemetry environment default from `dev`/`production` fallbacks to `prod_oss`.
- Reuse the shared default in CLI telemetry settings and Sentry bootstrap when runtime or baked config is absent.
- Update build hook and telemetry unit tests to cover the `prod_oss` fallback.

## Root Cause
The wheel build config and runtime fallback paths did not consistently use the OSS production telemetry environment. When baked config was missing or stale, CLI telemetry and Sentry bootstrap could still resolve to `dev`.

## Validation
- `uv run pytest tests/unit/test_telemetry_settings.py tests/unit/test_build_hook_config.py`
- `uv run ruff check build_config_values.py adapters/inbound/cli/telemetry/_build_defaults.py adapters/inbound/cli/telemetry/settings.py bootstrap/sentry_settings.py tests/unit/test_build_hook_config.py tests/unit/test_telemetry_settings.py`
- Built and reinstalled local wheels, restarted daemon, and verified installed CLI telemetry resolves to `prod_oss`.
- Ran `potpie doctor`, `potpie --json graph status`, and Potpie graph search/read queries successfully.
