### PR TITLE
Embed dotenv build defaults in wheel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ seed/.state/
 
 .omo
 .prsplit
+.env_old

--- a/potpie/context-engine/.gitignore
+++ b/potpie/context-engine/.gitignore
@@ -1,2 +1,3 @@
 # OAuth client IDs generated at wheel build time (see oauth_client_id_injection_hook.py)
 adapters/outbound/cli_auth/_build_config.py
+adapters/inbound/cli/telemetry/_build_config.py

--- a/potpie/context-engine/build_config_values.py
+++ b/potpie/context-engine/build_config_values.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import ast
 import os
 from collections.abc import Mapping
 from pathlib import Path
+from typing import Final
 
 OAUTH_OUT = Path("adapters/outbound/cli_auth/_build_config.py")
 TELEMETRY_OUT = Path("adapters/inbound/cli/telemetry/_build_config.py")
+OAUTH_NAMES = ("LINEAR_CLIENT_ID", "POTPIE_GITHUB_CLIENT_ID")
 
 HEADER = """\
 # Auto-generated at wheel build time - do not edit manually.
@@ -24,45 +27,53 @@ TELEMETRY_NAMES = (
     "POTPIE_POSTHOG_API_KEY",
     "POTPIE_POSTHOG_HOST",
 )
+TELEMETRY_INPUT_NAMES = (*TELEMETRY_NAMES, "GITHUB_SHA")
 
 DEFAULT_POTPIE_SENTRY_ENVIRONMENT = "prod_oss"
+_DOTENV_SEARCH_START: Final[Path] = Path(__file__).resolve().parent
 
 
-def oauth_config_values(environ: Mapping[str, str] | None = None) -> dict[str, str]:
+def oauth_config_values(
+    environ: Mapping[str, str] | None = None,
+    *,
+    dotenv_start: Path | None = None,
+) -> dict[str, str]:
+    source = _merged_build_environ(environ, dotenv_start=dotenv_start)
     return {
-        "LINEAR_CLIENT_ID": _env("LINEAR_CLIENT_ID", environ),
-        "POTPIE_GITHUB_CLIENT_ID": _env("POTPIE_GITHUB_CLIENT_ID", environ),
+        "LINEAR_CLIENT_ID": _env("LINEAR_CLIENT_ID", source),
+        "POTPIE_GITHUB_CLIENT_ID": _env("POTPIE_GITHUB_CLIENT_ID", source),
     }
 
 
 def telemetry_config_values(
     environ: Mapping[str, str] | None = None,
+    *,
+    dotenv_start: Path | None = None,
 ) -> dict[str, str]:
+    source = _merged_build_environ(environ, dotenv_start=dotenv_start)
     values = {
         "POTPIE_TELEMETRY_DISABLED": _env_or_default(
-            "POTPIE_TELEMETRY_DISABLED", "0", environ
+            "POTPIE_TELEMETRY_DISABLED", "0", source
         ),
-        "POTPIE_SENTRY_ENABLED": _env_or_default(
-            "POTPIE_SENTRY_ENABLED", "1", environ
-        ),
-        "POTPIE_SENTRY_DSN": _env("POTPIE_SENTRY_DSN", environ),
+        "POTPIE_SENTRY_ENABLED": _env_or_default("POTPIE_SENTRY_ENABLED", "1", source),
+        "POTPIE_SENTRY_DSN": _env("POTPIE_SENTRY_DSN", source),
         "POTPIE_SENTRY_ENVIRONMENT": _env_or_default(
             "POTPIE_SENTRY_ENVIRONMENT",
             DEFAULT_POTPIE_SENTRY_ENVIRONMENT,
-            environ,
+            source,
         ),
-        "POTPIE_SENTRY_RELEASE": _env("POTPIE_SENTRY_RELEASE", environ),
-        "POTPIE_SENTRY_DIST": _env("POTPIE_SENTRY_DIST", environ)
-        or _env("GITHUB_SHA", environ),
+        "POTPIE_SENTRY_RELEASE": _env("POTPIE_SENTRY_RELEASE", source),
+        "POTPIE_SENTRY_DIST": _env("POTPIE_SENTRY_DIST", source)
+        or _env("GITHUB_SHA", source),
         "POTPIE_POSTHOG_ENABLED": _env_or_default(
-            "POTPIE_POSTHOG_ENABLED", "1", environ
+            "POTPIE_POSTHOG_ENABLED", "1", source
         ),
         "POTPIE_PRODUCT_ANALYTICS_ENABLED": _env_or_default(
-            "POTPIE_PRODUCT_ANALYTICS_ENABLED", "1", environ
+            "POTPIE_PRODUCT_ANALYTICS_ENABLED", "1", source
         ),
-        "POTPIE_POSTHOG_API_KEY": _env("POTPIE_POSTHOG_API_KEY", environ),
+        "POTPIE_POSTHOG_API_KEY": _env("POTPIE_POSTHOG_API_KEY", source),
         "POTPIE_POSTHOG_HOST": _env_or_default(
-            "POTPIE_POSTHOG_HOST", "https://us.i.posthog.com", environ
+            "POTPIE_POSTHOG_HOST", "https://us.i.posthog.com", source
         ),
     }
     return {name: values[name] for name in TELEMETRY_NAMES}
@@ -73,6 +84,33 @@ def write_python_constants(path: Path, values: Mapping[str, str]) -> None:
         HEADER + "".join(f"{name} = {value!r}\n" for name, value in values.items()),
         encoding="utf-8",
     )
+
+
+def prefer_existing_config_values(
+    path: Path,
+    values: Mapping[str, str],
+) -> dict[str, str]:
+    """Keep generated sdist values when a wheel build lacks build env inputs."""
+    existing = _read_python_constants(path)
+    if not existing:
+        return dict(values)
+    merged = dict(values)
+    for name in values:
+        if name in existing:
+            merged[name] = existing[name]
+    return merged
+
+
+def has_build_config_inputs(
+    names: tuple[str, ...],
+    environ: Mapping[str, str] | None = None,
+    *,
+    dotenv_start: Path | None = None,
+) -> bool:
+    source = os.environ if environ is None else environ
+    if any(name in source for name in names):
+        return True
+    return _find_nearest_dotenv(dotenv_start or _DOTENV_SEARCH_START) is not None
 
 
 def _env(name: str, environ: Mapping[str, str] | None = None) -> str:
@@ -89,3 +127,87 @@ def _env_or_default(
     environ: Mapping[str, str] | None = None,
 ) -> str:
     return _env(name, environ) or default
+
+
+def _merged_build_environ(
+    environ: Mapping[str, str] | None = None,
+    *,
+    dotenv_start: Path | None = None,
+) -> Mapping[str, str]:
+    source = os.environ if environ is None else environ
+    if dotenv_start is None and environ is not None:
+        return source
+
+    dotenv = _read_nearest_dotenv(dotenv_start or _DOTENV_SEARCH_START)
+    if not dotenv:
+        return source
+
+    merged = dict(dotenv)
+    merged.update(source)
+    return merged
+
+
+def _read_nearest_dotenv(start: Path) -> dict[str, str]:
+    path = _find_nearest_dotenv(start)
+    if path is None:
+        return {}
+
+    values: dict[str, str] = {}
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return {}
+    for line in lines:
+        parsed = _parse_dotenv_line(line)
+        if parsed is None:
+            continue
+        key, value = parsed
+        values[key] = value
+    return values
+
+
+def _find_nearest_dotenv(start: Path) -> Path | None:
+    cur = start.resolve()
+    if cur.is_file():
+        cur = cur.parent
+    for ancestor in (cur, *cur.parents):
+        candidate = ancestor / ".env"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _parse_dotenv_line(line: str) -> tuple[str, str] | None:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return None
+    if stripped.lower().startswith("export "):
+        stripped = stripped[7:].strip()
+    if "=" not in stripped:
+        return None
+    key, value = stripped.split("=", 1)
+    key = key.strip()
+    if not key or not key.replace("_", "").isalnum() or key[0].isdigit():
+        return None
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1]
+    return key, value
+
+
+def _read_python_constants(path: Path) -> dict[str, str]:
+    try:
+        module = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError):
+        return {}
+
+    values: dict[str, str] = {}
+    for node in module.body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if not isinstance(target, ast.Name):
+            continue
+        if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+            values[target.id] = node.value.value
+    return values

--- a/potpie/context-engine/oauth_client_id_injection_hook.py
+++ b/potpie/context-engine/oauth_client_id_injection_hook.py
@@ -1,9 +1,11 @@
 """Hatch build hook: inject public defaults into the wheel at build time.
 
 During ``hatch build`` / ``uv build``, reads ``LINEAR_CLIENT_ID`` and
-``POTPIE_GITHUB_CLIENT_ID`` from the build environment and writes
-``adapters/outbound/cli_auth/_build_config.py`` so installed users do not need
-to configure those variables locally.
+``POTPIE_GITHUB_CLIENT_ID`` from the build environment or source-tree ``.env``
+and writes ``adapters/outbound/cli_auth/_build_config.py`` so installed users
+do not need to configure those variables locally. When a wheel is built from
+the generated sdist, the hook preserves existing generated values because the
+source-tree ``.env`` is no longer present.
 
 It also writes ``adapters/inbound/cli/telemetry/_build_config.py`` with public
 CLI telemetry ingest defaults (Sentry DSN and PostHog project API key). Runtime
@@ -26,13 +28,27 @@ class OAuthClientIdInjectionHook(BuildHookInterface):
 
     def initialize(self, version: str, build_data: dict) -> None:
         config_values = _load_config_values_module()
+        oauth_values = config_values.oauth_config_values()
+        telemetry_values = config_values.telemetry_config_values()
+        if not config_values.has_build_config_inputs(config_values.OAUTH_NAMES):
+            oauth_values = config_values.prefer_existing_config_values(
+                config_values.OAUTH_OUT,
+                oauth_values,
+            )
+        if not config_values.has_build_config_inputs(
+            config_values.TELEMETRY_INPUT_NAMES
+        ):
+            telemetry_values = config_values.prefer_existing_config_values(
+                config_values.TELEMETRY_OUT,
+                telemetry_values,
+            )
         config_values.write_python_constants(
             config_values.OAUTH_OUT,
-            config_values.oauth_config_values(),
+            oauth_values,
         )
         config_values.write_python_constants(
             config_values.TELEMETRY_OUT,
-            config_values.telemetry_config_values(),
+            telemetry_values,
         )
         build_data.setdefault("artifacts", []).extend(
             [str(config_values.OAUTH_OUT), str(config_values.TELEMETRY_OUT)]

--- a/potpie/context-engine/tests/unit/test_build_hook_config.py
+++ b/potpie/context-engine/tests/unit/test_build_hook_config.py
@@ -1,6 +1,72 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import build_config_values
+
+
+def test_oauth_build_config_loads_nearest_dotenv(tmp_path: Path) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "LINEAR_CLIENT_ID=file-linear",
+                "export POTPIE_GITHUB_CLIENT_ID='file-github'",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    nested = tmp_path / "potpie" / "context-engine"
+    nested.mkdir(parents=True)
+
+    values = build_config_values.oauth_config_values({}, dotenv_start=nested)
+
+    assert values == {
+        "LINEAR_CLIENT_ID": "file-linear",
+        "POTPIE_GITHUB_CLIENT_ID": "file-github",
+    }
+
+
+def test_build_config_environ_overrides_dotenv(tmp_path: Path) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "LINEAR_CLIENT_ID=file-linear\nPOTPIE_GITHUB_CLIENT_ID=file-github\n",
+        encoding="utf-8",
+    )
+
+    values = build_config_values.oauth_config_values(
+        {
+            "LINEAR_CLIENT_ID": "env-linear",
+            "POTPIE_GITHUB_CLIENT_ID": "env-github",
+        },
+        dotenv_start=tmp_path,
+    )
+
+    assert values == {
+        "LINEAR_CLIENT_ID": "env-linear",
+        "POTPIE_GITHUB_CLIENT_ID": "env-github",
+    }
+
+
+def test_build_config_input_detection(tmp_path: Path) -> None:
+    assert not build_config_values.has_build_config_inputs(
+        build_config_values.OAUTH_NAMES,
+        {},
+        dotenv_start=tmp_path,
+    )
+
+    assert build_config_values.has_build_config_inputs(
+        build_config_values.OAUTH_NAMES,
+        {"LINEAR_CLIENT_ID": ""},
+        dotenv_start=tmp_path,
+    )
+
+    (tmp_path / ".env").write_text("UNRELATED=1\n", encoding="utf-8")
+    assert build_config_values.has_build_config_inputs(
+        build_config_values.OAUTH_NAMES,
+        {},
+        dotenv_start=tmp_path,
+    )
 
 
 def test_telemetry_build_config_defaults_dist_to_github_sha() -> None:
@@ -20,8 +86,7 @@ def test_telemetry_build_config_defaults_dist_to_github_sha() -> None:
     }
 
 
-def test_telemetry_build_config_explicit_dist_wins_over_github_sha(
-) -> None:
+def test_telemetry_build_config_explicit_dist_wins_over_github_sha() -> None:
     values = build_config_values.telemetry_config_values(
         {
             "GITHUB_SHA": "abc123",
@@ -30,6 +95,24 @@ def test_telemetry_build_config_explicit_dist_wins_over_github_sha(
     )
 
     assert values["POTPIE_SENTRY_DIST"] == "explicit-dist"
+
+
+def test_telemetry_build_config_loads_dotenv(tmp_path: Path) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "POTPIE_POSTHOG_API_KEY=file-posthog",
+                "POTPIE_SENTRY_DSN=file-sentry",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    values = build_config_values.telemetry_config_values({}, dotenv_start=tmp_path)
+
+    assert values["POTPIE_POSTHOG_API_KEY"] == "file-posthog"
+    assert values["POTPIE_SENTRY_DSN"] == "file-sentry"
 
 
 def test_write_python_constants(tmp_path) -> None:
@@ -43,3 +126,15 @@ def test_write_python_constants(tmp_path) -> None:
         "A = 'x'",
         "B = ''",
     ]
+
+
+def test_prefer_existing_config_values(tmp_path: Path) -> None:
+    out = tmp_path / "_build_config.py"
+    build_config_values.write_python_constants(out, {"A": "old", "B": "kept"})
+
+    values = build_config_values.prefer_existing_config_values(
+        out,
+        {"A": "", "B": "default", "C": "new"},
+    )
+
+    assert values == {"A": "old", "B": "kept", "C": "new"}


### PR DESCRIPTION
## Summary

This PR fixes context-engine wheel builds so public OAuth and telemetry defaults from the source-tree `.env` are embedded reliably when building with `uv build --package potpie-context-engine`.

## Root Cause

`uv build` builds a source distribution first, then builds the wheel from that extracted sdist. The first build step can see the repo `.env`, but the second step cannot, so the build hook could regenerate `_build_config.py` with empty values during the wheel pass.

## Changes

- Read nearest source-tree `.env` values during build config generation, while keeping explicit environment variables as overrides.
- Preserve generated `_build_config.py` values when the wheel is built from an sdist that no longer has `.env` available.
- Add tests for dotenv lookup, env precedence, build input detection, telemetry defaults, and sdist value preservation.
- Ignore the generated telemetry `_build_config.py` file, matching the existing OAuth generated config ignore rule.
- Add `.env_old` to the root ignore list.

## Validation

- `uv run pytest tests/unit/test_build_hook_config.py tests/unit/test_env_bootstrap.py`
- `uv run ruff check build_config_values.py oauth_client_id_injection_hook.py tests/unit/test_build_hook_config.py`
- `uv run ruff format --check build_config_values.py oauth_client_id_injection_hook.py tests/unit/test_build_hook_config.py`
- `uv build --package potpie-context-engine --clear`
- Verified the rebuilt wheel contains non-empty embedded Linear, GitHub, Sentry, and PostHog defaults by redacted length only.