### PR TITLE
[codex] bump packages to b3

### DIFF
--- a/potpie/context-engine/adapters/inbound/http/app.py
+++ b/potpie/context-engine/adapters/inbound/http/app.py
@@ -12,7 +12,7 @@ from adapters.inbound.http.webhooks.router import webhooks_router
 from bootstrap.logging_setup import configure_logging
 
 try:
-    __version__ = importlib.metadata.version("context-engine")
+    __version__ = importlib.metadata.version("potpie-context-engine")
 except importlib.metadata.PackageNotFoundError:
     __version__ = "0.0.0"
 

--- a/potpie/context-engine/pyproject.toml
+++ b/potpie/context-engine/pyproject.toml
@@ -7,7 +7,7 @@ path = "oauth_client_id_injection_hook.py"
 
 [project]
 name = "potpie-context-engine"
-version = "0.1.0b2"
+version = "0.1.0b3"
 description = "Context graph API, webhooks, CLI, and MCP."
 requires-python = ">=3.12,<3.15"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "potpie"
-version = "2.0.0b2"
+version = "2.0.0b3"
 description = "Potpie context engine"
 readme = "README.md"
 requires-python = ">=3.12,<3.15"
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Software Development",
 ]
 dependencies = [
-    "potpie-context-engine[all]==0.1.0b2",
+    "potpie-context-engine[all]==0.1.0b3",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -2462,7 +2462,7 @@ wheels = [
 
 [[package]]
 name = "potpie"
-version = "2.0.0b2"
+version = "2.0.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "potpie-context-engine", extra = ["all"] },
@@ -2497,7 +2497,7 @@ dev = [
 
 [[package]]
 name = "potpie-context-engine"
-version = "0.1.0b2"
+version = "0.1.0b3"
 source = { editable = "potpie/context-engine" }
 dependencies = [
     { name = "falkordblite" },


### PR DESCRIPTION
## Summary
- Bump the root `potpie` package from `2.0.0b2` to `2.0.0b3`.
- Bump `potpie-context-engine` from `0.1.0b2` to `0.1.0b3` and update the root dependency pin.
- Refresh `uv.lock` for the local editable package metadata.
- Fix the HTTP app metadata lookup to read the actual `potpie-context-engine` distribution version.

## Impact
- Installed package metadata and the FastAPI app version now report beta 3 consistently.
- The root package depends on the matching beta 3 context engine package.

## Validation
- `uv lock`
- `uv run --package potpie-context-engine python - <<'PY' ...` verified `potpie-context-engine` and HTTP `__version__` both report `0.1.0b3`.
- `uv run --package potpie python - <<'PY' ...` verified `potpie` reports `2.0.0b3` and `potpie-context-engine` reports `0.1.0b3`.
- `rg` scan found no remaining `2.0.0b2`, `0.1.0b2`, or `metadata.version("context-engine")` references in the relevant repo files.