### PR TITLE
Add pre-merge CLI journey integration gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,7 +113,9 @@ jobs:
           version: "0.10.7"
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
 
       - name: Install dependencies
         run: uv sync --frozen --all-packages --no-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,6 +112,9 @@ jobs:
         with:
           version: "0.10.7"
 
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Install dependencies
         run: uv sync --frozen --all-packages --no-cache
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,11 +92,12 @@ jobs:
         env:
           POSTGRES_SERVER: "postgresql://postgres:postgres@localhost:5432/postgres"
           ENV: "development"
-        run: uv run --project . pytest tests
+        run: uv run --project . pytest tests -m "not premerge_journey"
 
   premerge-cli-journey:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 5
 
     steps:
       - name: Checkout
@@ -121,6 +122,8 @@ jobs:
         run: uv sync --frozen --all-packages --no-cache
 
       - name: Run pre-merge CLI journey test
+        env:
+          PREMERGE_JOURNEY_REQUIRED: "1"
         run: uv run --project potpie/context-engine pytest potpie/context-engine/tests/integration/test_premerge_cli_journey.py -v
 
   potpie-sandbox:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,30 @@ jobs:
           ENV: "development"
         run: uv run --project . pytest tests
 
+  premerge-cli-journey:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "0.10.7"
+
+      - name: Install dependencies
+        run: uv sync --frozen --all-packages --no-cache
+
+      - name: Run pre-merge CLI journey test
+        run: uv run --project potpie/context-engine pytest potpie/context-engine/tests/integration/test_premerge_cli_journey.py -v
+
   potpie-sandbox:
     runs-on: ubuntu-latest
     strategy:

--- a/potpie/context-engine/pyproject.toml
+++ b/potpie/context-engine/pyproject.toml
@@ -144,6 +144,7 @@ markers = [
     "unit: unit tests",
     "integration: integration tests (no external services required, but exercise real third-party libs)",
     "cli_auth_e2e: opt-in live CLI auth tests (Linear/Jira/Confluence); requires RUN_CLI_AUTH_E2E=1",
+    "premerge_journey: dedicated pre-merge CLI journey test (Rust required; run in premerge-cli-journey job only)",
 ]
 
 [dependency-groups]

--- a/potpie/context-engine/tests/integration/test_premerge_cli_journey.py
+++ b/potpie/context-engine/tests/integration/test_premerge_cli_journey.py
@@ -19,7 +19,7 @@ from typing import Any
 
 import pytest
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.premerge_journey]
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 _CONTEXT_ENGINE_PROJECT = "potpie/context-engine"
@@ -85,15 +85,16 @@ def _isolated_env(tmp_path: Path) -> dict[str, str]:
     home = tmp_path / "home"
     xdg.mkdir(parents=True, exist_ok=True)
     home.mkdir(parents=True, exist_ok=True)
+    source_home = Path(os.environ.get("HOME", Path.home()))
     env = os.environ.copy()
     env["XDG_CONFIG_HOME"] = str(xdg)
     env["HOME"] = str(home)
     env["CONTEXT_ENGINE_HOST_MODE"] = "in_process"
     env["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
-    for key in ("RUSTUP_HOME", "CARGO_HOME"):
-        value = os.environ.get(key)
-        if value:
-            env[key] = value
+    # Keep rustup/cargo on the host toolchain when HOME is redirected for Potpie
+    # config isolation — otherwise `cargo` exists on PATH but has no toolchain.
+    env.setdefault("RUSTUP_HOME", os.environ.get("RUSTUP_HOME", str(source_home / ".rustup")))
+    env.setdefault("CARGO_HOME", os.environ.get("CARGO_HOME", str(source_home / ".cargo")))
     return env
 
 
@@ -116,13 +117,16 @@ def test_premerge_journey_from_fresh_clone_creates_context_graph(tmp_path: Path)
     clone_root = tmp_path / "repo-clone"
     env = _isolated_env(tmp_path)
     if not _has_usable_rust_toolchain(env):
-        pytest.skip("Rust toolchain (cargo) is required for fresh-clone workspace sync")
+        message = "Rust toolchain (cargo) is required for fresh-clone workspace sync"
+        if os.environ.get("PREMERGE_JOURNEY_REQUIRED") == "1":
+            pytest.fail(message)
+        pytest.skip(message)
 
     _run(
         ["git", "clone", "--depth", "1", str(_REPO_ROOT), str(clone_root)],
         cwd=tmp_path,
         env=env,
-        timeout=180,
+        timeout=60,
         step="git clone",
     )
 
@@ -130,7 +134,7 @@ def test_premerge_journey_from_fresh_clone_creates_context_graph(tmp_path: Path)
         ["uv", "sync", "--frozen", "--all-packages", "--no-cache"],
         cwd=clone_root,
         env=env,
-        timeout=1200,
+        timeout=240,
         step="uv sync",
     )
 
@@ -146,7 +150,7 @@ def test_premerge_journey_from_fresh_clone_creates_context_graph(tmp_path: Path)
         "embedded",
         "--yes",
         "--in-process",
-        timeout=600,
+        timeout=120,
     )
     setup = _unwrap_result(setup_payload)
     assert setup.get("ok") is True
@@ -155,7 +159,7 @@ def test_premerge_journey_from_fresh_clone_creates_context_graph(tmp_path: Path)
     }
     assert step_states.get("source") in {"done", "skipped"}
 
-    source_payload = _run_json_cli(clone_root, env, "source", "add", "repo", ".", timeout=180)
+    source_payload = _run_json_cli(clone_root, env, "source", "add", "repo", ".", timeout=60)
     source_add = _unwrap_result(source_payload)
     assert source_add.get("kind") == "repo"
     assert source_add.get("registration_only") is True
@@ -213,7 +217,7 @@ def test_premerge_journey_from_fresh_clone_creates_context_graph(tmp_path: Path)
         "mutate",
         "--file",
         str(mutation_file),
-        timeout=300,
+        timeout=60,
     )
     mutate = _unwrap_result(mutate_payload)
     assert mutate.get("status") in {"applied", "committed"}
@@ -233,12 +237,12 @@ def test_premerge_journey_from_fresh_clone_creates_context_graph(tmp_path: Path)
         "service:journey-service",
         "--limit",
         "10",
-        timeout=180,
+        timeout=60,
     )
     read_result = _unwrap_result(read_payload)
     assert read_result.get("items"), "expected graph read to return journey topology items"
 
-    status_payload = _run_json_cli(clone_root, env, "graph", "status", timeout=180)
+    status_payload = _run_json_cli(clone_root, env, "graph", "status", timeout=60)
     status = _unwrap_result(status_payload)
     claim_count = int(
         (((status.get("backend") or {}).get("counts") or {}).get("claims") or 0)

--- a/potpie/context-engine/tests/integration/test_premerge_cli_journey.py
+++ b/potpie/context-engine/tests/integration/test_premerge_cli_journey.py
@@ -1,0 +1,225 @@
+"""Pre-merge journey test: fresh clone -> install -> setup -> graph mutation.
+
+This test validates the critical first-user path inside an isolated temp
+environment:
+1) clone the repository into a brand-new directory,
+2) install dependencies from lockfiles,
+3) run non-interactive setup,
+4) create graph data through ``potpie graph mutate``,
+5) verify the graph can be queried.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_CONTEXT_ENGINE_PROJECT = "potpie/context-engine"
+
+
+def _run(
+    cmd: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    timeout: int,
+    step: str,
+) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        f"{step} failed\n"
+        f"command: {' '.join(cmd)}\n"
+        f"exit_code: {proc.returncode}\n"
+        f"stdout:\n{proc.stdout}\n"
+        f"stderr:\n{proc.stderr}"
+    )
+    return proc
+
+
+def _run_json_cli(
+    clone_root: Path,
+    env: dict[str, str],
+    *args: str,
+    timeout: int = 300,
+) -> dict[str, Any]:
+    proc = _run(
+        ["uv", "run", "--project", _CONTEXT_ENGINE_PROJECT, "potpie", "--json", *args],
+        cwd=clone_root,
+        env=env,
+        timeout=timeout,
+        step=f"potpie {' '.join(args)}",
+    )
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:  # pragma: no cover - assertion helper
+        raise AssertionError(
+            f"Expected JSON output for 'potpie {' '.join(args)}' but got:\n{proc.stdout}"
+        ) from exc
+
+
+def _unwrap_result(payload: dict[str, Any]) -> dict[str, Any]:
+    result = payload.get("result")
+    if isinstance(result, dict):
+        return result
+    return payload
+
+
+def _isolated_env(tmp_path: Path) -> dict[str, str]:
+    xdg = tmp_path / "xdg"
+    home = tmp_path / "home"
+    xdg.mkdir(parents=True, exist_ok=True)
+    home.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env["XDG_CONFIG_HOME"] = str(xdg)
+    env["HOME"] = str(home)
+    env["CONTEXT_ENGINE_HOST_MODE"] = "in_process"
+    env["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
+    return env
+
+
+def test_premerge_journey_from_fresh_clone_creates_context_graph(tmp_path: Path) -> None:
+    clone_root = tmp_path / "repo-clone"
+    env = _isolated_env(tmp_path)
+
+    _run(
+        ["git", "clone", "--depth", "1", str(_REPO_ROOT), str(clone_root)],
+        cwd=tmp_path,
+        env=env,
+        timeout=180,
+        step="git clone",
+    )
+
+    _run(
+        ["uv", "sync", "--frozen", "--all-packages", "--no-cache"],
+        cwd=clone_root,
+        env=env,
+        timeout=1200,
+        step="uv sync",
+    )
+
+    setup_payload = _run_json_cli(
+        clone_root,
+        env,
+        "setup",
+        "--repo",
+        ".",
+        "--agent",
+        "claude",
+        "--backend",
+        "embedded",
+        "--yes",
+        "--in-process",
+        timeout=600,
+    )
+    setup = _unwrap_result(setup_payload)
+    assert setup.get("ok") is True
+    step_states = {
+        row.get("step"): row.get("state") for row in setup.get("steps", []) if isinstance(row, dict)
+    }
+    assert step_states.get("source") in {"done", "skipped"}
+
+    source_payload = _run_json_cli(clone_root, env, "source", "add", "repo", ".", timeout=180)
+    source_add = _unwrap_result(source_payload)
+    assert source_add.get("kind") == "repo"
+    assert source_add.get("registration_only") is True
+
+    mutation_file = tmp_path / "journey-mutation.json"
+    mutation_file.write_text(
+        json.dumps(
+            {
+                "operations": [
+                    {
+                        "op": "upsert_entity",
+                        "subject": {
+                            "key": "service:journey-service",
+                            "type": "Service",
+                            "name": "journey-service",
+                            "summary": "Service used by the pre-merge journey test.",
+                            "description": "Synthetic service entity for end-to-end CI validation.",
+                        },
+                    },
+                    {
+                        "op": "upsert_entity",
+                        "subject": {
+                            "key": "service:journey-ledger",
+                            "type": "Service",
+                            "name": "journey-ledger",
+                            "summary": "Dependency used by the pre-merge journey test.",
+                            "description": "Synthetic dependency entity for end-to-end CI validation.",
+                        },
+                    },
+                    {
+                        "op": "link_entities",
+                        "subgraph": "infra_topology",
+                        "subject": {"key": "service:journey-service", "type": "Service"},
+                        "predicate": "DEPENDS_ON",
+                        "object": {"key": "service:journey-ledger", "type": "Service"},
+                        "truth": "source_observation",
+                        "description": "journey service depends on journey ledger",
+                        "evidence": [
+                            {
+                                "source_ref": "test:premerge-journey",
+                                "authority": "repository_metadata",
+                            }
+                        ],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    mutate_payload = _run_json_cli(
+        clone_root,
+        env,
+        "graph",
+        "mutate",
+        "--file",
+        str(mutation_file),
+        timeout=300,
+    )
+    mutate = _unwrap_result(mutate_payload)
+    assert mutate.get("status") in {"applied", "committed"}
+    diff_counts = mutate.get("diff") or {}
+    assert int(diff_counts.get("edge_upserts", 0)) >= 1
+
+    read_payload = _run_json_cli(
+        clone_root,
+        env,
+        "graph",
+        "read",
+        "--subgraph",
+        "infra_topology",
+        "--view",
+        "service_neighborhood",
+        "--scope",
+        "service:journey-service",
+        "--limit",
+        "10",
+        timeout=180,
+    )
+    read_result = _unwrap_result(read_payload)
+    assert read_result.get("items"), "expected graph read to return journey topology items"
+
+    status_payload = _run_json_cli(clone_root, env, "graph", "status", timeout=180)
+    status = _unwrap_result(status_payload)
+    claim_count = int(
+        (((status.get("backend") or {}).get("counts") or {}).get("claims") or 0)
+    )
+    assert claim_count >= 1

--- a/potpie/context-engine/tests/integration/test_premerge_cli_journey.py
+++ b/potpie/context-engine/tests/integration/test_premerge_cli_journey.py
@@ -90,13 +90,18 @@ def _isolated_env(tmp_path: Path) -> dict[str, str]:
     env["HOME"] = str(home)
     env["CONTEXT_ENGINE_HOST_MODE"] = "in_process"
     env["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
+    for key in ("RUSTUP_HOME", "CARGO_HOME"):
+        value = os.environ.get(key)
+        if value:
+            env[key] = value
     return env
 
 
-def _has_usable_rust_toolchain() -> bool:
+def _has_usable_rust_toolchain(env: dict[str, str]) -> bool:
     try:
         proc = subprocess.run(
             ["cargo", "--version"],
+            env=env,
             capture_output=True,
             text=True,
             timeout=10,
@@ -108,11 +113,10 @@ def _has_usable_rust_toolchain() -> bool:
 
 
 def test_premerge_journey_from_fresh_clone_creates_context_graph(tmp_path: Path) -> None:
-    if not _has_usable_rust_toolchain():
-        pytest.skip("Rust toolchain (cargo) is required for fresh-clone workspace sync")
-
     clone_root = tmp_path / "repo-clone"
     env = _isolated_env(tmp_path)
+    if not _has_usable_rust_toolchain(env):
+        pytest.skip("Rust toolchain (cargo) is required for fresh-clone workspace sync")
 
     _run(
         ["git", "clone", "--depth", "1", str(_REPO_ROOT), str(clone_root)],

--- a/potpie/context-engine/tests/integration/test_premerge_cli_journey.py
+++ b/potpie/context-engine/tests/integration/test_premerge_cli_journey.py
@@ -93,7 +93,24 @@ def _isolated_env(tmp_path: Path) -> dict[str, str]:
     return env
 
 
+def _has_usable_rust_toolchain() -> bool:
+    try:
+        proc = subprocess.run(
+            ["cargo", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return False
+    return proc.returncode == 0
+
+
 def test_premerge_journey_from_fresh_clone_creates_context_graph(tmp_path: Path) -> None:
+    if not _has_usable_rust_toolchain():
+        pytest.skip("Rust toolchain (cargo) is required for fresh-clone workspace sync")
+
     clone_root = tmp_path / "repo-clone"
     env = _isolated_env(tmp_path)
 


### PR DESCRIPTION
## Summary
- add a new context-engine integration test that simulates a fresh user journey (clone, install, setup, source registration, graph mutation/read checks)
- keep the test isolated with temp HOME/XDG directories and non-interactive CLI setup
- add a dedicated `premerge-cli-journey` GitHub Actions job to run this journey test on PRs

## Test plan
- [x] `uv run --project potpie/context-engine ruff check potpie/context-engine/tests/integration/test_premerge_cli_journey.py`
- [x] `uv run --project potpie/context-engine pytest potpie/context-engine/tests/integration/test_premerge_cli_journey.py -v`

Made with [Cursor](https://cursor.com)