### PR TITLE
Fix stale CLI skill examples and graph scope validation

### DIFF
--- a/potpie/context-engine/adapters/inbound/cli/commands/graph.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/graph.py
@@ -441,6 +441,8 @@ def _error_code_from_result(payload: Mapping[str, Any]) -> str:
 
 
 def _error_message_from_result(payload: Mapping[str, Any]) -> str:
+    if payload.get("message"):
+        return str(payload["message"])
     if payload.get("detail"):
         return str(payload["detail"])
     issues = payload.get("issues")
@@ -2903,6 +2905,21 @@ def _emit_graph_read(
     human_prefix: str | None = None,
     warnings: tuple[str, ...] = (),
 ) -> None:
+    normalized_format = _effective_read_format(result, format_)
+    payload = _read_payload(
+        result,
+        format_="raw" if normalized_format == "jsonl" else normalized_format,
+        sort=sort,
+        dedupe=dedupe,
+        event_limit=event_limit,
+    )
+    if payload.get("ok", True) is False:
+        human = _error_message_from_result(payload)
+        if human_prefix:
+            human = "\n".join((human_prefix, human))
+        _emit_graph_result(ctx, payload, human=human, warnings=warnings)
+        raise typer.Exit(code=EXIT_VALIDATION)
+
     if not is_json():
         _emit_read(
             result,
@@ -2915,7 +2932,6 @@ def _emit_graph_read(
         )
         return
 
-    normalized_format = _effective_read_format(result, format_)
     if normalized_format == "jsonl":
         rows = _timeline_events(result, sort=sort, dedupe=dedupe, limit=event_limit)
         if not rows:

--- a/potpie/context-engine/adapters/inbound/cli/templates/agent_bundle/.agents/skills/potpie-cli/SKILL.md
+++ b/potpie/context-engine/adapters/inbound/cli/templates/agent_bundle/.agents/skills/potpie-cli/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: potpie-cli
+version: "2"
 description: "Use when the task is centered on running, explaining, configuring, or troubleshooting the `potpie` command: doctor, login, pot management, source registration, search, graph workbench reads/writes, and pot scope behavior."
 ---
 
@@ -46,9 +47,9 @@ suggested `pot default set --repo current <pot>` command before continuing.
 
 ```bash
 potpie search "query"
-potpie --json search "query" -n 15
-potpie search "query" --node-labels PullRequest,Decision
-potpie search "query" --with-temporal
+potpie --json search "query"
+potpie search "query" --include decisions,features
+potpie search "query" --pot <pot-id-or-alias>
 ```
 
 ## Graph Workbench

--- a/potpie/context-engine/adapters/outbound/skills/agent_installer.py
+++ b/potpie/context-engine/adapters/outbound/skills/agent_installer.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import inspect
 import re
+import shlex
 from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
+from functools import lru_cache
 from importlib import resources
 from pathlib import Path
 from typing import Iterable
@@ -14,6 +17,7 @@ _MANAGED_MARKER_RE = re.compile(
     re.DOTALL,
 )
 _DEFAULT_MERGE_FILES = frozenset({"AGENTS.md", "CLAUDE.md"})
+_BASH_BLOCK_RE = re.compile(r"```bash\s*\n(.*?)\n```", re.DOTALL)
 
 AGENT_TYPES = ("default", "codex", "claude", "claude-plugin", "cursor", "opencode")
 _SOURCE_SKILLS_PREFIX = ".agents/skills/"
@@ -131,11 +135,192 @@ def _normalize_skill_ids(skill_ids: Iterable[str] | None) -> frozenset[str] | No
     return frozenset(sid.strip() for sid in skill_ids if sid and sid.strip())
 
 
+def _is_skill_markdown(rel_path: Path) -> bool:
+    return rel_path.name == "SKILL.md" and "skills" in rel_path.parts
+
+
+def _selected_skill_matches(
+    rel_path: Path, selected: frozenset[str] | None
+) -> bool:
+    if selected is None:
+        return True
+    sid = _skill_id_for_path(rel_path) or _skill_id_from_generic_skill_path(rel_path)
+    return sid in selected
+
+
+def _skill_id_from_generic_skill_path(rel_path: Path) -> str | None:
+    parts = rel_path.parts
+    for idx, part in enumerate(parts[:-1]):
+        if part == "skills" and idx + 1 < len(parts):
+            return parts[idx + 1]
+    return None
+
+
 def _include_selected_skills(
     rel_path: Path, selected: frozenset[str] | None
 ) -> bool:
     sid = _skill_id_for_path(rel_path)
     return sid is not None and (selected is None or sid in selected)
+
+
+def validate_packaged_skill_command_snippets(
+    *, skill_ids: Iterable[str] | None = None
+) -> None:
+    """Validate packaged Potpie CLI snippets before install/update.
+
+    This intentionally validates only ``potpie`` commands in bash fences. Skills
+    may contain other shell commands whose correctness depends on the user's repo.
+    """
+    selected = _normalize_skill_ids(skill_ids)
+    for bundle_name in ("agent_bundle", "claude_plugin"):
+        for rel_path, content in _iter_bundle_files(bundle_name):
+            if not _is_skill_markdown(rel_path):
+                continue
+            if not _selected_skill_matches(rel_path, selected):
+                continue
+            validate_skill_command_snippets(content, rel_path=rel_path)
+
+
+def validate_skill_command_snippets(content: str, *, rel_path: Path) -> None:
+    errors: list[str] = []
+    for line in _iter_potpie_bash_lines(content):
+        try:
+            tokens = shlex.split(line, comments=True)
+        except ValueError as exc:
+            errors.append(f"{line!r}: {exc}")
+            continue
+        if not tokens or tokens[0] != "potpie":
+            continue
+        error = _validate_potpie_command_tokens(tokens)
+        if error:
+            errors.append(error)
+    if errors:
+        prefix = f"invalid Potpie command snippets in {rel_path.as_posix()}: "
+        raise ValueError(prefix + "; ".join(errors))
+
+
+def _iter_potpie_bash_lines(content: str) -> Iterable[str]:
+    for block in _BASH_BLOCK_RE.findall(content):
+        pending = ""
+        for raw in block.splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("$ "):
+                line = line[2:].lstrip()
+            if pending:
+                line = f"{pending} {line}"
+            if line.endswith("\\"):
+                pending = line[:-1].rstrip()
+                continue
+            pending = ""
+            if line == "potpie" or line.startswith("potpie "):
+                yield line
+        if pending and (pending == "potpie" or pending.startswith("potpie ")):
+            yield pending
+
+
+def _validate_potpie_command_tokens(tokens: list[str]) -> str | None:
+    specs = _potpie_command_option_specs()
+    root_options = _potpie_root_options()
+    idx = 1
+    while idx < len(tokens) and tokens[idx].startswith("-"):
+        opt = _option_name(tokens[idx])
+        if opt not in root_options:
+            return f"{' '.join(tokens)} uses unsupported root option {opt}"
+        idx += 1
+
+    match: tuple[tuple[str, ...], int, frozenset[str]] | None = None
+    for end in range(idx + 1, len(tokens) + 1):
+        token = tokens[end - 1]
+        if token.startswith("-"):
+            break
+        path = tuple(tokens[idx:end])
+        options = specs.get(path)
+        if options is not None:
+            match = (path, end, options)
+    if match is None:
+        command = " ".join(tokens[idx : idx + 3]) or "(missing command)"
+        return f"{' '.join(tokens)} uses unknown potpie command {command!r}"
+
+    path, end, command_options = match
+    for token in tokens[end:]:
+        if not token.startswith("-") or token == "-":
+            continue
+        opt = _option_name(token)
+        if opt not in command_options:
+            command = " ".join(path)
+            return f"{' '.join(tokens)} uses unsupported option {opt} for potpie {command}"
+    return None
+
+
+def _option_name(token: str) -> str:
+    return token.split("=", 1)[0]
+
+
+@lru_cache(maxsize=1)
+def _potpie_command_option_specs() -> dict[tuple[str, ...], frozenset[str]]:
+    from adapters.inbound.cli.host_cli import app
+
+    specs: dict[tuple[str, ...], frozenset[str]] = {}
+    _collect_typer_command_specs(app, path=(), out=specs)
+    return specs
+
+
+@lru_cache(maxsize=1)
+def _potpie_root_options() -> frozenset[str]:
+    from adapters.inbound.cli.host_cli import app
+
+    callback = app.registered_callback
+    if callback is None or callback.callback is None:
+        return frozenset()
+    return _callback_option_decls(callback.callback)
+
+
+def _collect_typer_command_specs(
+    typer_app, *, path: tuple[str, ...], out: dict[tuple[str, ...], frozenset[str]]
+) -> None:
+    for command in typer_app.registered_commands:
+        if command.callback is None:
+            continue
+        out[(*path, _typer_command_name(command))] = _callback_option_decls(
+            command.callback
+        )
+    for group in typer_app.registered_groups:
+        _collect_typer_command_specs(
+            group.typer_instance,
+            path=(*path, group.name),
+            out=out,
+        )
+
+
+def _typer_command_name(command) -> str:
+    if command.name:
+        return str(command.name)
+    return command.callback.__name__.replace("_", "-")
+
+
+def _callback_option_decls(callback: Callable[..., object]) -> frozenset[str]:
+    from typer.models import OptionInfo
+
+    options: set[str] = set()
+    for parameter in inspect.signature(callback).parameters.values():
+        default = parameter.default
+        if not isinstance(default, OptionInfo):
+            continue
+        for decl in default.param_decls:
+            options.update(_split_option_decl(str(decl)))
+    return frozenset(options)
+
+
+def _split_option_decl(decl: str) -> tuple[str, ...]:
+    if not decl.startswith("-"):
+        return ()
+    out: list[str] = []
+    for part in decl.split("/"):
+        if part.startswith("-"):
+            out.append(part)
+    return tuple(out)
 
 
 def _install_file(
@@ -177,6 +362,8 @@ def _install_bundle(
     for rel_path, content in _iter_bundle_files(bundle_name):
         if include is not None and not include(rel_path):
             continue
+        if _is_skill_markdown(rel_path):
+            validate_skill_command_snippets(content, rel_path=rel_path)
         out_path = rel_path if remap is None else remap(rel_path)
         if out_path is None:
             continue

--- a/potpie/context-engine/application/services/graph_service.py
+++ b/potpie/context-engine/application/services/graph_service.py
@@ -220,38 +220,44 @@ class DefaultGraphService:
         unsupported = _unsupported_read_filters(request, contract)
         missing = _missing_required_read_scope(request, contract)
         if unsupported or missing:
-            unsupported_items = tuple(
-                [*unsupported]
-                + [
-                    {
-                        "name": contract.name,
-                        "reason": "missing_required_scope",
-                        "detail": {
-                            "required_scope": list(contract.required_scope),
-                            "required_any_scope": list(contract.required_any_scope),
-                        },
-                    }
-                ]
-                if missing
-                else unsupported
+            missing_item = {
+                "name": contract.name,
+                "reason": "missing_required_scope",
+                "detail": {
+                    "required_scope": list(contract.required_scope),
+                    "required_any_scope": list(contract.required_any_scope),
+                },
+            }
+            unsupported_items = (
+                tuple([*unsupported, missing_item]) if missing else unsupported
+            )
+            quality_reason = (
+                "missing_required_scope" if missing else "unsupported_filter"
             )
             return GraphReadResult(
                 view=contract.name,
                 subgraph=contract.subgraph,
+                ok=not missing,
+                status="missing_required_scope" if missing else None,
+                message=(
+                    _missing_required_scope_message(contract) if missing else None
+                ),
                 items=(),
                 coverage=(
                     {
                         "include": spec.v1_include,
-                        "status": "unsupported" if unsupported else "empty",
+                        "status": "unsupported"
+                        if unsupported or missing
+                        else "empty",
                         "candidate_pool": 0,
                     },
                 ),
                 freshness=_read_freshness(None, backend_freshness={}),
                 quality={
-                    "status": "unsupported" if unsupported else "empty",
-                    "reason": "unsupported_filter"
-                    if unsupported
-                    else "missing_required_scope",
+                    "status": "unsupported"
+                    if unsupported or missing
+                    else "empty",
+                    "reason": quality_reason,
                 },
                 source_refs=(),
                 match_mode=self._match_mode(),
@@ -636,6 +642,16 @@ def _missing_required_read_scope(
             _read_scope_has(request, key) for key in contract.required_any_scope
         )
     )
+
+
+def _missing_required_scope_message(contract: ViewContract) -> str:
+    requirements: list[str] = []
+    if contract.required_scope:
+        requirements.append("all of " + ", ".join(contract.required_scope))
+    if contract.required_any_scope:
+        requirements.append("one of " + ", ".join(contract.required_any_scope))
+    required = "; ".join(requirements) or "a required scope"
+    return f"graph read view {contract.name!r} requires {required}"
 
 
 def _read_scope_has(request: GraphReadRequest, key: str) -> bool:

--- a/potpie/context-engine/application/services/skill_manager.py
+++ b/potpie/context-engine/application/services/skill_manager.py
@@ -11,6 +11,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from adapters.outbound.skills.claude_target import ProjectAgentTarget
+from adapters.outbound.skills.agent_installer import (
+    validate_packaged_skill_command_snippets,
+)
 from adapters.outbound.skills.bundle_catalog import (
     RECOMMENDED_SKILL_IDS,
     catalog_by_id,
@@ -104,6 +107,7 @@ class DefaultSkillManager:
                 continue
             if installed.get(sid) == info.version:
                 continue
+            validate_packaged_skill_command_snippets(skill_ids=(sid,))
             target.install(skill_id=sid, version=info.version, path=path)
             changed.append(sid)
         self._install_support_files(target, path=path)
@@ -131,6 +135,7 @@ class DefaultSkillManager:
         for sid in ids:
             info = catalog.get(sid)
             if info and installed.get(sid) != info.version:
+                validate_packaged_skill_command_snippets(skill_ids=(sid,))
                 target.install(skill_id=sid, version=info.version)
                 changed.append(sid)
         self._install_support_files(target, path=path)

--- a/potpie/context-engine/domain/ports/services/graph_service.py
+++ b/potpie/context-engine/domain/ports/services/graph_service.py
@@ -136,6 +136,9 @@ class GraphReadResult:
 
     view: str
     subgraph: str
+    ok: bool = True
+    status: str | None = None
+    message: str | None = None
     items: tuple[Mapping[str, Any], ...] = ()
     coverage: tuple[Mapping[str, Any], ...] = ()
     freshness: Mapping[str, Any] = field(default_factory=dict)
@@ -158,8 +161,8 @@ class GraphReadResult:
     def to_dict(self) -> dict[str, Any]:
         detail = _normalize_read_detail(self.detail)
         relations = _normalize_read_relations(self.relations)
-        return {
-            "ok": True,
+        out = {
+            "ok": self.ok,
             "graph_contract_version": self.graph_contract_version,
             "ontology_version": self.ontology_version,
             "view": self.view,
@@ -184,6 +187,11 @@ class GraphReadResult:
             "warnings": list(self.warnings),
             "as_of": self.as_of.isoformat() if self.as_of else None,
         }
+        if self.status:
+            out["status"] = self.status
+        if self.message:
+            out["message"] = self.message
+        return out
 
 
 @dataclass(frozen=True, slots=True)

--- a/potpie/context-engine/tests/unit/test_agent_installer.py
+++ b/potpie/context-engine/tests/unit/test_agent_installer.py
@@ -6,12 +6,14 @@ from pathlib import Path
 
 import pytest
 
+import adapters.outbound.skills.agent_installer as agent_installer
 from adapters.outbound.skills.agent_installer import (
     install_global_agent_instructions,
     install_agent_bundle,
     install_skill_bundle,
     iter_template_files,
     resolve_install_root,
+    validate_packaged_skill_command_snippets,
 )
 from adapters.outbound.skills.claude_target import FileBackedAgentTarget
 from application.services.skill_manager import DefaultSkillManager
@@ -63,6 +65,36 @@ def test_install_skill_bundle_writes_to_global_root(tmp_path: Path) -> None:
     assert "potpie-cli/SKILL.md" in result.created
     assert (root / "potpie-cli" / "SKILL.md").exists()
     assert {path.name for path in root.iterdir()} == {"potpie-cli"}
+
+
+def test_packaged_skill_command_snippets_match_cli_surface() -> None:
+    validate_packaged_skill_command_snippets()
+
+
+def test_install_skill_bundle_rejects_invalid_potpie_snippet(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    bad_skill = """---
+name: potpie-cli
+description: bad snippet
+---
+
+```bash
+potpie search "query" --node-labels PullRequest,Decision
+```
+"""
+
+    def fake_bundle_files(bundle_name: str):
+        if bundle_name != "agent_bundle":
+            return []
+        return [(Path(".agents/skills/potpie-cli/SKILL.md"), bad_skill)]
+
+    monkeypatch.setattr(agent_installer, "_iter_bundle_files", fake_bundle_files)
+
+    with pytest.raises(ValueError, match="unsupported option --node-labels"):
+        install_skill_bundle(tmp_path, skill_ids=("potpie-cli",))
+
+    assert not (tmp_path / "potpie-cli" / "SKILL.md").exists()
 
 
 def test_install_global_agent_instructions_merges_compact_agents_md(

--- a/potpie/context-engine/tests/unit/test_bundle_catalog.py
+++ b/potpie/context-engine/tests/unit/test_bundle_catalog.py
@@ -26,7 +26,7 @@ def test_catalog_fields_are_populated_from_skill_front_matter() -> None:
     catalog = catalog_by_id()
     cli = catalog["potpie-cli"]
     assert cli.title == "Potpie CLI"
-    assert cli.version == "1"
+    assert cli.version == "2"
     assert "Potpie CLI" in cli.description or "potpie" in cli.description.lower()
 
     graph = catalog["potpie-graph"]

--- a/potpie/context-engine/tests/unit/test_graph_cli_contract.py
+++ b/potpie/context-engine/tests/unit/test_graph_cli_contract.py
@@ -1434,6 +1434,54 @@ def test_graph_read_unknown_view_uses_error_envelope() -> None:
     assert "unknown graph view" in emitted["error"]["message"]
 
 
+def test_graph_read_missing_required_scope_result_is_error_envelope() -> None:
+    _common.set_json(True)
+    graph_service = _Graph(
+        read_result=GraphReadResult(
+            graph_contract_version="v1.5",
+            ontology_version="2026-06-graph",
+            view="features.feature_context",
+            subgraph="features",
+            ok=False,
+            status="missing_required_scope",
+            message=(
+                "graph read view 'features.feature_context' requires one of "
+                "scope, service, repo, anchor_entity_key, query"
+            ),
+            coverage=(
+                {
+                    "include": "features",
+                    "status": "unsupported",
+                    "candidate_pool": 0,
+                },
+            ),
+            quality={"status": "unsupported", "reason": "missing_required_scope"},
+            unsupported=(
+                {
+                    "name": "features.feature_context",
+                    "reason": "missing_required_scope",
+                },
+            ),
+        )
+    )
+    _common.set_host(_Host(graph_service))
+
+    result = CliRunner().invoke(
+        graph.graph_app,
+        ["read", "--subgraph", "features", "--view", "feature_context"],
+    )
+
+    assert result.exit_code == 1
+    assert graph_service.read_called is True
+    emitted = json.loads(result.output)
+    _assert_graph_envelope(emitted, "graph.read", ok=False)
+    assert emitted["error"]["code"] == "missing_required_scope"
+    assert emitted["unsupported"][0]["reason"] == "missing_required_scope"
+    assert (
+        emitted["error"]["detail"]["quality"]["reason"] == "missing_required_scope"
+    )
+
+
 def test_graph_read_rejects_fully_qualified_view_before_service_call() -> None:
     _common.set_json(True)
     graph_service = _Graph()

--- a/potpie/context-engine/tests/unit/test_graph_surface_lite_contract.py
+++ b/potpie/context-engine/tests/unit/test_graph_surface_lite_contract.py
@@ -664,6 +664,26 @@ def test_read_returns_unsupported_for_filters_outside_view_contract(service) -> 
     assert env.coverage[0]["status"] == "unsupported"
 
 
+def test_read_missing_required_scope_is_validation_failure(service) -> None:
+    env = service.read(
+        GraphReadRequest(
+            pot_id="p",
+            subgraph="features",
+            view="feature_context",
+            limit=5,
+        )
+    )
+
+    body = env.to_dict()
+    assert body["ok"] is False
+    assert body["status"] == "missing_required_scope"
+    assert "requires one of" in body["message"]
+    assert env.items == ()
+    assert env.unsupported[0]["reason"] == "missing_required_scope"
+    assert env.coverage[0]["status"] == "unsupported"
+    assert env.quality["reason"] == "missing_required_scope"
+
+
 def test_infra_read_keeps_environment_qualified_edges_isolated(service) -> None:
     store = service.backend.claim_query
     store.add(


### PR DESCRIPTION
## Summary

Fix two CLI contract mismatches:

- refresh `potpie-cli` search examples so they only use supported flags
- make `graph read` fail clearly when a required view scope is missing

## Checks

- focused pytest suites for skill install/catalog and graph read contracts
- `ruff check` on touched Python files
- built `potpie` CLI smoke tests against the restarted daemon

Fixes #956
Fixes #957
