### PR TITLE
fix(cli): normalize --json parse-time errors to structured JSON envelope

### DIFF
--- a/potpie/context-engine/adapters/inbound/cli/commands/_common.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/_common.py
@@ -19,7 +19,7 @@ import os
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Callable, Final, Iterator, NoReturn
+from typing import Any, Callable, Final, Iterator, NoReturn, Sequence
 
 import click
 import typer
@@ -70,6 +70,19 @@ def set_json(value: bool) -> None:
 
 def is_json() -> bool:
     return bool(_state["json"])
+
+
+def bootstrap_output_flags_from_argv(argv: Sequence[str] | None = None) -> None:
+    """Apply ``--json`` / ``--verbose`` before Typer finishes parsing.
+
+    The root callback only runs after a command line parses successfully. Early
+    bootstrap keeps parse-time failures on the documented JSON error contract.
+    """
+    args = tuple(argv or ())
+    if "--json" in args:
+        set_json(True)
+    if "--verbose" in args or "-v" in args:
+        set_verbose(True)
 
 
 def set_verbose(value: bool) -> None:
@@ -617,6 +630,7 @@ __all__ = [
     "EXIT_OK",
     "EXIT_UNAVAILABLE",
     "EXIT_VALIDATION",
+    "bootstrap_output_flags_from_argv",
     "contract",
     "emit",
     "fail",

--- a/potpie/context-engine/adapters/inbound/cli/commands/_common.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/_common.py
@@ -79,10 +79,11 @@ def bootstrap_output_flags_from_argv(argv: Sequence[str] | None = None) -> None:
     bootstrap keeps parse-time failures on the documented JSON error contract.
     """
     args = tuple(argv or ())
-    if "--json" in args:
-        set_json(True)
-    if "--verbose" in args or "-v" in args:
-        set_verbose(True)
+    scan_args = args
+    if "--" in args:
+        scan_args = args[: args.index("--")]
+    set_json("--json" in scan_args)
+    set_verbose("--verbose" in scan_args or "-v" in scan_args)
 
 
 def set_verbose(value: bool) -> None:

--- a/potpie/context-engine/adapters/inbound/cli/host_cli.py
+++ b/potpie/context-engine/adapters/inbound/cli/host_cli.py
@@ -136,6 +136,7 @@ def _click_error_message(exc: Exception) -> str:
 
 def run_cli(argv: list[str] | None = None) -> None:
     """Invoke the Typer app with the documented parse-error contract."""
+    import click
     from typer._click.exceptions import Abort, ClickException
 
     from adapters.inbound.cli.ui.output import configure_cli_logging, configure_error_output
@@ -148,9 +149,9 @@ def run_cli(argv: list[str] | None = None) -> None:
 
     try:
         app(args, standalone_mode=False)
+    except (Abort, click.Abort):
+        raise typer.Exit(code=1) from None
     except ClickException as exc:
-        if isinstance(exc, Abort):
-            raise
         if is_json():
             fail(
                 code="usage_error",

--- a/potpie/context-engine/adapters/inbound/cli/host_cli.py
+++ b/potpie/context-engine/adapters/inbound/cli/host_cli.py
@@ -30,7 +30,15 @@ from adapters.inbound.cli.commands import (
 from adapters.inbound.cli.commands import query as query_cmds
 from adapters.inbound.cli.commands import skills as skills_cmds
 from adapters.inbound.cli.commands import ui as ui_cmds
-from adapters.inbound.cli.commands._common import set_json, set_verbose
+from adapters.inbound.cli.commands._common import (
+    EXIT_VALIDATION,
+    bootstrap_output_flags_from_argv,
+    fail,
+    is_json,
+    is_verbose,
+    set_json,
+    set_verbose,
+)
 from adapters.inbound.cli.telemetry.context import bind_telemetry_context
 
 
@@ -119,8 +127,48 @@ def build_app() -> typer.Typer:
 app = build_app()
 
 
+def _click_error_message(exc: Exception) -> str:
+    formatter = getattr(exc, "format_message", None)
+    if callable(formatter):
+        return str(formatter())
+    return str(exc)
+
+
+def run_cli(argv: list[str] | None = None) -> None:
+    """Invoke the Typer app with the documented parse-error contract."""
+    from typer._click.exceptions import Abort, ClickException
+
+    from adapters.inbound.cli.ui.output import configure_cli_logging, configure_error_output
+
+    args = list(argv if argv is not None else sys.argv[1:])
+    bootstrap_output_flags_from_argv(args)
+    if is_json():
+        configure_error_output(as_json=True)
+    configure_cli_logging(is_verbose())
+
+    try:
+        app(args, standalone_mode=False)
+    except ClickException as exc:
+        if isinstance(exc, Abort):
+            raise
+        if is_json():
+            fail(
+                code="usage_error",
+                message=_click_error_message(exc),
+                next_action="run the command with --help for usage",
+                exit_code=EXIT_VALIDATION,
+            )
+        exc.show(file=sys.stderr)
+        sys.exit(exc.exit_code)
+
+
 def main() -> None:
-    app()
+    try:
+        run_cli()
+    except typer.Exit as exc:
+        # Typer's Exit is not a SystemExit; convert so console-script wrappers
+        # exit cleanly without printing exception chains/tracebacks.
+        raise SystemExit(exc.exit_code or 0) from None
 
 
 if __name__ == "__main__":

--- a/potpie/context-engine/tests/unit/test_cli_usage_errors.py
+++ b/potpie/context-engine/tests/unit/test_cli_usage_errors.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import patch
 
+import click
 import pytest
 import typer
+from typer._click.exceptions import Abort as TyperAbort
 from typer.testing import CliRunner
 
 from adapters.inbound.cli import host_cli
@@ -86,3 +89,26 @@ def test_bootstrap_output_flags_ignore_positional_after_double_dash() -> None:
     )
     assert not _common.is_json()
     assert not _common.is_verbose()
+
+
+@pytest.mark.parametrize("abort_exc", [TyperAbort(), click.Abort()])
+def test_run_cli_abort_exits_cleanly(
+    abort_exc: BaseException,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with patch.object(host_cli, "app", side_effect=abort_exc):
+        with pytest.raises(typer.Exit) as exc_info:
+            host_cli.run_cli(["pot", "list"])
+
+    assert exc_info.value.exit_code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_main_converts_abort_to_system_exit() -> None:
+    with patch.object(host_cli, "app", side_effect=TyperAbort()):
+        with pytest.raises(SystemExit) as exc_info:
+            host_cli.main()
+
+    assert exc_info.value.code == 1

--- a/potpie/context-engine/tests/unit/test_cli_usage_errors.py
+++ b/potpie/context-engine/tests/unit/test_cli_usage_errors.py
@@ -1,0 +1,66 @@
+"""Parse-time CLI failures must honor the --json error contract."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from adapters.inbound.cli import host_cli
+from adapters.inbound.cli.commands import _common
+
+
+@pytest.fixture(autouse=True)
+def _reset_cli_output_state() -> None:
+    _common.set_json(False)
+    _common.set_verbose(False)
+    yield
+    _common.set_json(False)
+    _common.set_verbose(False)
+
+
+def test_missing_argument_emits_structured_json_via_run_cli(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(typer.Exit) as exc_info:
+        host_cli.run_cli(["--json", "pot", "create"])
+
+    assert exc_info.value.exit_code == _common.EXIT_VALIDATION
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["code"] == "usage_error"
+    assert "NAME" in payload["message"]
+    assert payload["recommended_next_action"]
+
+
+def test_unknown_subcommand_emits_structured_json_via_run_cli(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(typer.Exit) as exc_info:
+        host_cli.run_cli(["--json", "pot", "nope"])
+
+    assert exc_info.value.exit_code == _common.EXIT_VALIDATION
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["code"] == "usage_error"
+    assert "nope" in payload["message"]
+    assert payload["recommended_next_action"]
+
+
+def test_missing_argument_keeps_typer_text_in_human_mode(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        host_cli.run_cli(["pot", "create"])
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "Missing argument" in captured.err or "Missing argument" in captured.out
+
+
+def test_cli_runner_still_uses_typer_for_direct_app_invoke() -> None:
+    result = CliRunner().invoke(host_cli.app, ["--json", "pot", "create"])
+    assert result.exit_code == 2
+    assert "Missing argument" in result.output

--- a/potpie/context-engine/tests/unit/test_cli_usage_errors.py
+++ b/potpie/context-engine/tests/unit/test_cli_usage_errors.py
@@ -64,3 +64,25 @@ def test_cli_runner_still_uses_typer_for_direct_app_invoke() -> None:
     result = CliRunner().invoke(host_cli.app, ["--json", "pot", "create"])
     assert result.exit_code == 2
     assert "Missing argument" in result.output
+
+
+def test_bootstrap_output_flags_reset_per_argv() -> None:
+    _common.bootstrap_output_flags_from_argv(["--json", "pot", "list"])
+    assert _common.is_json()
+    assert not _common.is_verbose()
+
+    _common.bootstrap_output_flags_from_argv(["pot", "list"])
+    assert not _common.is_json()
+    assert not _common.is_verbose()
+
+    _common.bootstrap_output_flags_from_argv(["-v", "pot", "list"])
+    assert not _common.is_json()
+    assert _common.is_verbose()
+
+
+def test_bootstrap_output_flags_ignore_positional_after_double_dash() -> None:
+    _common.bootstrap_output_flags_from_argv(
+        ["source", "add", "repo", ".", "--", "--json", "--verbose"]
+    )
+    assert not _common.is_json()
+    assert not _common.is_verbose()

--- a/potpie/context-engine/tests/unit/test_cli_usage_errors.py
+++ b/potpie/context-engine/tests/unit/test_cli_usage_errors.py
@@ -82,6 +82,10 @@ def test_bootstrap_output_flags_reset_per_argv() -> None:
     assert not _common.is_json()
     assert _common.is_verbose()
 
+    _common.bootstrap_output_flags_from_argv(["pot", "list"])
+    assert not _common.is_json()
+    assert not _common.is_verbose()
+
 
 def test_bootstrap_output_flags_ignore_positional_after_double_dash() -> None:
     _common.bootstrap_output_flags_from_argv(


### PR DESCRIPTION
## Summary

Fixes inconsistent CLI error output for parse-time failures when using `--json`.

Before this change, missing arguments and unknown subcommands bypassed Potpie's documented JSON error contract and fell back to Typer/Click's human error text with exit code `2`. That broke automation that expects a single predictable error shape from `potpie --json`.

This PR ensures parse-time failures go through the same structured error path as runtime validation errors.

## Problem

The CLI documents a stable `--json` contract in `docs/context-graph/cli-flow.md`:

- exit `1` for command/validation failures
- flat JSON: `{code, message, detail, recommended_next_action}`

But parse-time failures behaved differently:

| Failure | Before | After |
|---|---|---|
| `potpie --json pot create` | Typer text, exit `2` | JSON `usage_error`, exit `1` |
| `potpie --json pot nope` | Typer text, exit `2` | JSON `usage_error`, exit `1` |
| `potpie pot create` (human) | Typer text, exit `2` | unchanged |

### Root cause

`--json` was only enabled in the root Typer callback in `host_cli.py`, which runs **after** the command line parses successfully. When parsing failed early, JSON mode was never activated and `_common.fail()` was never reached.

There was also a traceback on exit because `typer.Exit` is not a `SystemExit`, so the console-script wrapper did not exit cleanly.

## Solution

1. **`bootstrap_output_flags_from_argv()`** in `_common.py`  
   Pre-scans `argv` for `--json` / `--verbose` before Typer finishes parsing.

2. **`run_cli()`** in `host_cli.py`  
   - Invokes the app with `standalone_mode=False`
   - Catches Typer/Click parse exceptions
   - In JSON mode: routes to `fail()` with `code: usage_error` and exit `1`
   - In human mode: preserves Typer text and exits with Click's code

3. **`main()` cleanup**  
   Converts `typer.Exit` to `SystemExit` so `potpie` exits cleanly without tracebacks.

## Example

```bash
$ potpie --json pot create
{"code": "usage_error", "message": "Missing argument 'NAME'.", "detail": null, "recommended_next_action": "run the command with --help for usage"}
$ echo $?
1
