### PR TITLE
Fix Linear CLI OAuth callback ports

### DIFF
--- a/potpie/context-engine/adapters/inbound/cli/auth/auth_commands.py
+++ b/potpie/context-engine/adapters/inbound/cli/auth/auth_commands.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import secrets
-import threading
 import time
 import urllib.parse
 import webbrowser
@@ -30,6 +29,7 @@ from adapters.outbound.cli_auth.linear_read_client import (
 from adapters.inbound.cli.auth.linear_read import run_linear_use_flow
 from adapters.outbound.cli_auth.callback_server import (
     OAuthCallbackResult,
+    start_oauth_callback_server,
     wait_for_oauth_callback,
 )
 from adapters.outbound.cli_auth.credentials_store import (
@@ -65,9 +65,9 @@ from adapters.outbound.cli_auth.provider_config import (
     authorization_url,
     get_callback_host,
     get_callback_path,
-    get_callback_port,
+    get_callback_port_candidates,
     get_client_id,
-    get_redirect_uri,
+    get_redirect_uri_for_port,
     get_scopes,
 )
 from adapters.outbound.cli_auth.token_exchange import exchange_authorization_code
@@ -298,92 +298,82 @@ def _run_linear_oauth_flow(*, force: bool = False, add: bool = False) -> None:
         raise typer.Exit(code=1)
 
     try:
-        redirect_uri = get_redirect_uri()
-        port = get_callback_port()
+        port_candidates = get_callback_port_candidates()
         host = get_callback_host()
         callback_path = get_callback_path()
     except ValueError as exc:
         emit_error("Linear OAuth redirect is invalid", str(exc), verbose=v)
         raise typer.Exit(code=1) from exc
-    state = secrets.token_urlsafe(24)
-    code_verifier, code_challenge = generate_pkce_pair()
-    auth_url = _build_linear_authorization_url(
-        redirect_uri=redirect_uri,
-        state=state,
-        code_challenge=code_challenge,
-    )
 
-    callback_result: OAuthCallbackResult | None = None
-    callback_error: BaseException | None = None
-
-    def _capture_callback() -> None:
-        nonlocal callback_result, callback_error
-        try:
-            callback_result = _wait_for_callback(
-                host=host,
-                port=port,
-                path=callback_path,
-            )
-        except BaseException as exc:
-            callback_error = exc
-
-    server_thread = threading.Thread(target=_capture_callback, daemon=True)
-    server_thread.start()
-    time.sleep(0.15)
-    if callback_error is not None:
+    primary_port = port_candidates[0]
+    try:
+        callback_server = start_oauth_callback_server(
+            host=host,
+            port=primary_port,
+            path=callback_path,
+            fallback_ports=port_candidates[1:],
+        )
+    except OSError as exc:
         emit_error(
             "OAuth callback failed to start",
-            str(callback_error),
+            str(exc),
             verbose=v,
-            exc=callback_error if v else None,
+            exc=exc if v else None,
         )
-        raise typer.Exit(code=EXIT_AUTH) from callback_error
+        raise typer.Exit(code=EXIT_AUTH) from exc
 
-    if not j:
-        print_plain_line(
-            "Opening browser for Linear authentication...",
-            as_json=False,
+    try:
+        redirect_uri = get_redirect_uri_for_port(callback_server.port)
+        state = secrets.token_urlsafe(24)
+        code_verifier, code_challenge = generate_pkce_pair()
+        auth_url = _build_linear_authorization_url(
+            redirect_uri=redirect_uri,
+            state=state,
+            code_challenge=code_challenge,
         )
-        if add:
+
+        if not j:
+            if callback_server.port != primary_port:
+                print_plain_line(
+                    f"Port {primary_port} is busy; using {callback_server.port} for OAuth callback.",
+                    as_json=False,
+                )
             print_plain_line(
-                "Choose the Linear workspace to connect in the browser.",
+                "Opening browser for Linear authentication...",
                 as_json=False,
             )
-        print_plain_line(
-            f"If the browser does not open, visit:\n{auth_url}",
-            as_json=False,
-        )
-
-    opened = webbrowser.open(auth_url, new=1)
-    if not opened and not j:
-        print_plain_line(
-            "Could not open a browser automatically; use the URL above.",
-            as_json=False,
-        )
-
-    server_thread.join(timeout=_OAUTH_CALLBACK_TIMEOUT + 5.0)
-
-    if callback_error is not None:
-        if isinstance(callback_error, TimeoutError):
-            emit_error("OAuth callback timed out", str(callback_error), verbose=v)
-        else:
-            emit_error(
-                "OAuth callback failed",
-                str(callback_error),
-                verbose=v,
-                exc=callback_error if v else None,
+            if add:
+                print_plain_line(
+                    "Choose the Linear workspace to connect in the browser.",
+                    as_json=False,
+                )
+            print_plain_line(
+                f"If the browser does not open, visit:\n{auth_url}",
+                as_json=False,
             )
-        raise typer.Exit(code=EXIT_AUTH) from callback_error
 
-    if callback_result is None:
+        opened = webbrowser.open(auth_url, new=1)
+        if not opened and not j:
+            print_plain_line(
+                "Could not open a browser automatically; use the URL above.",
+                as_json=False,
+            )
+
+        callback = callback_server.wait(timeout=_OAUTH_CALLBACK_TIMEOUT)
+    except TimeoutError as exc:
+        emit_error("OAuth callback timed out", str(exc), verbose=v)
+        raise typer.Exit(code=EXIT_AUTH) from exc
+    except Exception as exc:
         emit_error(
-            "OAuth callback timed out",
-            f"No response on {redirect_uri} within {_OAUTH_CALLBACK_TIMEOUT:.0f}s.",
+            "OAuth callback failed",
+            str(exc),
             verbose=v,
+            exc=exc if v else None,
         )
-        raise typer.Exit(code=EXIT_AUTH)
+        raise typer.Exit(code=EXIT_AUTH) from exc
+    finally:
+        callback_server.close()
 
-    callback = callback_result
     if callback.error:
         msg = callback.error
         if callback.error_description:

--- a/potpie/context-engine/adapters/outbound/cli_auth/callback_server.py
+++ b/potpie/context-engine/adapters/outbound/cli_auth/callback_server.py
@@ -6,7 +6,7 @@ import html
 import threading
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import Any
+from typing import Any, Sequence
 from urllib.parse import parse_qs, urlparse
 
 
@@ -22,12 +22,60 @@ class OAuthCallbackResult:
         return bool(self.code) and not self.error
 
 
+@dataclass
+class OAuthCallbackServer:
+    host: str
+    port: int
+    path: str
+    result: OAuthCallbackResult
+    _done: threading.Event
+    _server: HTTPServer
+    _thread: threading.Thread
+
+    def wait(self, *, timeout: float = 300.0) -> OAuthCallbackResult:
+        expected_path = self.path if self.path.startswith("/") else f"/{self.path}"
+        if not self._done.wait(timeout=timeout):
+            raise TimeoutError(
+                f"Timed out after {timeout:.0f}s waiting for OAuth callback on "
+                f"http://{self.host}:{self.port}{expected_path}"
+            )
+        return self.result
+
+    def close(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=2.0)
+
+
 def _oauth_callback_failure_html(error: str | None) -> str:
     escaped_error = html.escape(error or "No authorization code received")
     return (
         "<html><body><h1>Authentication failed</h1>"
         f"<p>{escaped_error}</p>"
         "</body></html>"
+    )
+
+
+def start_oauth_callback_server(
+    *,
+    host: str = "localhost",
+    port: int,
+    path: str = "/callback",
+    fallback_ports: Sequence[int] = (),
+) -> OAuthCallbackServer:
+    """Start a local callback server, trying fallback ports when the base is busy."""
+    errors: list[OSError] = []
+    for candidate in _unique_ports((port, *fallback_ports)):
+        try:
+            return _start_oauth_callback_server(host=host, port=candidate, path=path)
+        except OSError as exc:
+            errors.append(exc)
+    ports = ", ".join(
+        str(candidate) for candidate in _unique_ports((port, *fallback_ports))
+    )
+    detail = "; ".join(str(exc) for exc in errors)
+    raise OSError(
+        f"Could not bind OAuth callback server on {host} port(s) {ports}: {detail}"
     )
 
 
@@ -39,6 +87,19 @@ def wait_for_oauth_callback(
     timeout: float = 300.0,
 ) -> OAuthCallbackResult:
     """Block until the provider redirects to the local callback URL."""
+    server = start_oauth_callback_server(host=host, port=port, path=path)
+    try:
+        return server.wait(timeout=timeout)
+    finally:
+        server.close()
+
+
+def _start_oauth_callback_server(
+    *,
+    host: str,
+    port: int,
+    path: str,
+) -> OAuthCallbackServer:
     result = OAuthCallbackResult()
     done = threading.Event()
     expected_path = path if path.startswith("/") else f"/{path}"
@@ -79,17 +140,26 @@ def wait_for_oauth_callback(
     server.timeout = 1.0
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
-    try:
-        if not done.wait(timeout=timeout):
-            raise TimeoutError(
-                f"Timed out after {timeout:.0f}s waiting for OAuth callback on "
-                f"http://{host}:{port}{expected_path}"
-            )
-        return result
-    finally:
-        server.shutdown()
-        server.server_close()
-        thread.join(timeout=2.0)
+    return OAuthCallbackServer(
+        host=host,
+        port=port,
+        path=expected_path,
+        result=result,
+        _done=done,
+        _server=server,
+        _thread=thread,
+    )
+
+
+def _unique_ports(ports: Sequence[int]) -> tuple[int, ...]:
+    seen: set[int] = set()
+    candidates: list[int] = []
+    for port in ports:
+        if not 1 <= port <= 65535 or port in seen:
+            continue
+        seen.add(port)
+        candidates.append(port)
+    return tuple(candidates)
 
 
 def _first(params: dict[str, list[str]], key: str) -> str | None:

--- a/potpie/context-engine/adapters/outbound/cli_auth/provider_config.py
+++ b/potpie/context-engine/adapters/outbound/cli_auth/provider_config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from typing import Literal
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 from adapters.outbound.cli_auth._oauth_client_ids import (
     LINEAR_CLIENT_ID as PACKAGE_LINEAR_CLIENT_ID,
@@ -14,7 +14,8 @@ Provider = Literal["linear", "github", "atlassian", "jira", "confluence"]
 OAuthProvider = Literal["linear"]
 AtlassianProduct = Literal["jira", "confluence"]
 
-DEFAULT_CALLBACK_PORT = 8080
+DEFAULT_CALLBACK_PORT = 28757
+DEFAULT_FALLBACK_CALLBACK_PORTS = (28763,)
 DEFAULT_CALLBACK_PATH = "/callback"
 DEFAULT_REDIRECT_URI = (
     f"http://localhost:{DEFAULT_CALLBACK_PORT}{DEFAULT_CALLBACK_PATH}"
@@ -60,6 +61,28 @@ def get_callback_port() -> int:
         except ValueError:
             pass
     return int(_parsed_redirect_uri().port or DEFAULT_CALLBACK_PORT)
+
+
+def get_callback_port_candidates() -> tuple[int, ...]:
+    base_port = get_callback_port()
+    if _callback_config_overridden():
+        return (base_port,)
+    return (base_port, *DEFAULT_FALLBACK_CALLBACK_PORTS)
+
+
+def _callback_config_overridden() -> bool:
+    return bool(
+        os.getenv("POTPIE_CLI_OAUTH_REDIRECT_URI", "").strip()
+        or os.getenv("POTPIE_CLI_OAUTH_CALLBACK_PORT", "").strip()
+    )
+
+
+def get_redirect_uri_for_port(port: int) -> str:
+    if not 1 <= port <= 65535:
+        raise ValueError("OAuth callback port must be between 1 and 65535.")
+    parsed = _parsed_redirect_uri()
+    netloc = f"{parsed.hostname or DEFAULT_CALLBACK_HOST}:{port}"
+    return urlunparse(parsed._replace(netloc=netloc))
 
 
 def get_client_id(provider: OAuthProvider) -> str:

--- a/potpie/context-engine/tests/unit/test_cli_linear.py
+++ b/potpie/context-engine/tests/unit/test_cli_linear.py
@@ -14,6 +14,7 @@ from adapters.outbound.cli_auth.callback_server import (
     OAuthCallbackResult,
     _first,
     _oauth_callback_failure_html,
+    start_oauth_callback_server,
     wait_for_oauth_callback,
 )
 import base64
@@ -24,6 +25,10 @@ from adapters.outbound.cli_auth import token_exchange as tx
 from adapters.outbound.cli_auth import integration_session as session
 import typer
 from adapters.inbound.cli.auth import auth_commands
+from adapters.outbound.cli_auth.provider_config import (
+    DEFAULT_CALLBACK_PORT,
+    DEFAULT_FALLBACK_CALLBACK_PORTS,
+)
 import json
 # --- test_callback_server.py ---
 
@@ -104,6 +109,24 @@ def test_wait_for_oauth_callback_error_query() -> None:
 
     assert result.ok is False
     assert result.error == "access_denied"
+
+
+def test_start_oauth_callback_server_uses_fallback_port() -> None:
+    primary = _free_port()
+    fallback = _free_port()
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as occupied:
+        occupied.bind(("127.0.0.1", primary))
+        occupied.listen(1)
+        server = start_oauth_callback_server(
+            host="127.0.0.1",
+            port=primary,
+            path="/callback",
+            fallback_ports=(fallback,),
+        )
+    try:
+        assert server.port == fallback
+    finally:
+        server.close()
 
 
 def test_wait_for_oauth_callback_wrong_path_returns_404() -> None:
@@ -402,16 +425,57 @@ def test_ensure_valid_linear_returns_tokens_when_not_due(
 # --- test_auth_commands_linear_oauth.py ---
 
 
-class _ImmediateThread:
-    def __init__(self, target=None, daemon=None) -> None:
-        self._target = target
+class _FakeCallbackServer:
+    def __init__(
+        self,
+        *,
+        result: OAuthCallbackResult | None = None,
+        port: int = DEFAULT_CALLBACK_PORT,
+        wait_exc: BaseException | None = None,
+    ) -> None:
+        self.host = "localhost"
+        self.port = port
+        self.path = "/callback"
+        self.result = result or OAuthCallbackResult(code="auth-code", state="state-xyz")
+        self.wait_exc = wait_exc
+        self.closed = False
 
-    def start(self) -> None:
-        if self._target:
-            self._target()
+    def wait(self, *, timeout: float = 300.0) -> OAuthCallbackResult:
+        if self.wait_exc is not None:
+            raise self.wait_exc
+        return self.result
 
-    def join(self, timeout=None) -> None:
-        return None
+    def close(self) -> None:
+        self.closed = True
+
+
+def _stub_callback_server(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    result: OAuthCallbackResult | None = None,
+    port: int = DEFAULT_CALLBACK_PORT,
+    start_exc: BaseException | None = None,
+    wait_exc: BaseException | None = None,
+) -> _FakeCallbackServer:
+    server = _FakeCallbackServer(result=result, port=port, wait_exc=wait_exc)
+
+    def _start(**_kwargs: object) -> _FakeCallbackServer:
+        if start_exc is not None:
+            raise start_exc
+        return server
+
+    monkeypatch.setattr(auth_commands, "start_oauth_callback_server", _start)
+    monkeypatch.setattr(
+        auth_commands,
+        "get_callback_port_candidates",
+        lambda: (DEFAULT_CALLBACK_PORT, *DEFAULT_FALLBACK_CALLBACK_PORTS),
+    )
+    monkeypatch.setattr(
+        auth_commands,
+        "get_redirect_uri_for_port",
+        lambda actual_port: f"http://localhost:{actual_port}/callback",
+    )
+    return server
 
 
 def test_run_linear_oauth_flow_success(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -434,10 +498,6 @@ def test_run_linear_oauth_flow_success(monkeypatch: pytest.MonkeyPatch) -> None:
         lambda _p: next(status_reads),
     )
     monkeypatch.setattr(auth_commands, "get_client_id", lambda _p: "client-id")
-    monkeypatch.setattr(
-        auth_commands, "get_redirect_uri", lambda: "http://localhost:8080/callback"
-    )
-    monkeypatch.setattr(auth_commands, "get_callback_port", lambda: 8080)
     monkeypatch.setattr(auth_commands, "get_callback_host", lambda: "localhost")
     monkeypatch.setattr(auth_commands, "get_callback_path", lambda: "/callback")
     monkeypatch.setattr(auth_commands.secrets, "token_urlsafe", lambda _n: "state-xyz")
@@ -447,12 +507,7 @@ def test_run_linear_oauth_flow_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         auth_commands, "webbrowser", MagicMock(open=MagicMock(return_value=True))
     )
-    monkeypatch.setattr(auth_commands.threading, "Thread", _ImmediateThread)
-    monkeypatch.setattr(
-        auth_commands,
-        "_wait_for_callback",
-        lambda **_kwargs: OAuthCallbackResult(code="auth-code", state="state-xyz"),
-    )
+    _stub_callback_server(monkeypatch)
     monkeypatch.setattr(
         auth_commands,
         "exchange_authorization_code",
@@ -540,20 +595,14 @@ def test_run_linear_oauth_flow_expired_reauth_message(
     monkeypatch.setattr(auth_commands, "token_needs_refresh", lambda _x: True)
     monkeypatch.setattr(auth_commands, "_try_refresh_linear_session", lambda: False)
     monkeypatch.setattr(auth_commands, "get_client_id", lambda _p: "client-id")
-    monkeypatch.setattr(
-        auth_commands, "get_redirect_uri", lambda: "http://localhost:8080/callback"
-    )
-    monkeypatch.setattr(auth_commands, "get_callback_port", lambda: 8080)
     monkeypatch.setattr(auth_commands, "get_callback_host", lambda: "localhost")
     monkeypatch.setattr(auth_commands, "get_callback_path", lambda: "/callback")
     monkeypatch.setattr(auth_commands.secrets, "token_urlsafe", lambda _n: "state-xyz")
     monkeypatch.setattr(auth_commands, "generate_pkce_pair", lambda: ("v", "c"))
     monkeypatch.setattr(auth_commands, "webbrowser", MagicMock())
-    monkeypatch.setattr(auth_commands.threading, "Thread", _ImmediateThread)
-    monkeypatch.setattr(
-        auth_commands,
-        "_wait_for_callback",
-        lambda **_kwargs: OAuthCallbackResult(code="c", state="state-xyz"),
+    _stub_callback_server(
+        monkeypatch,
+        result=OAuthCallbackResult(code="c", state="state-xyz"),
     )
     monkeypatch.setattr(
         auth_commands,
@@ -593,10 +642,6 @@ def test_run_linear_oauth_flow_state_mismatch(monkeypatch: pytest.MonkeyPatch) -
         lambda _p: {"authenticated": False},
     )
     monkeypatch.setattr(auth_commands, "get_client_id", lambda _p: "client-id")
-    monkeypatch.setattr(
-        auth_commands, "get_redirect_uri", lambda: "http://localhost:8080/callback"
-    )
-    monkeypatch.setattr(auth_commands, "get_callback_port", lambda: 8080)
     monkeypatch.setattr(auth_commands, "get_callback_host", lambda: "localhost")
     monkeypatch.setattr(auth_commands, "get_callback_path", lambda: "/callback")
     monkeypatch.setattr(
@@ -604,11 +649,9 @@ def test_run_linear_oauth_flow_state_mismatch(monkeypatch: pytest.MonkeyPatch) -
     )
     monkeypatch.setattr(auth_commands, "generate_pkce_pair", lambda: ("v", "c"))
     monkeypatch.setattr(auth_commands, "webbrowser", MagicMock())
-    monkeypatch.setattr(auth_commands.threading, "Thread", _ImmediateThread)
-    monkeypatch.setattr(
-        auth_commands,
-        "_wait_for_callback",
-        lambda **_kwargs: OAuthCallbackResult(code="c", state="wrong-state"),
+    _stub_callback_server(
+        monkeypatch,
+        result=OAuthCallbackResult(code="c", state="wrong-state"),
     )
     captured: list[tuple[str, str]] = []
     monkeypatch.setattr(
@@ -632,20 +675,14 @@ def test_run_linear_oauth_flow_missing_code(monkeypatch: pytest.MonkeyPatch) -> 
         lambda _p: {"authenticated": False},
     )
     monkeypatch.setattr(auth_commands, "get_client_id", lambda _p: "client-id")
-    monkeypatch.setattr(
-        auth_commands, "get_redirect_uri", lambda: "http://localhost:8080/callback"
-    )
-    monkeypatch.setattr(auth_commands, "get_callback_port", lambda: 8080)
     monkeypatch.setattr(auth_commands, "get_callback_host", lambda: "localhost")
     monkeypatch.setattr(auth_commands, "get_callback_path", lambda: "/callback")
     monkeypatch.setattr(auth_commands.secrets, "token_urlsafe", lambda _n: "state-xyz")
     monkeypatch.setattr(auth_commands, "generate_pkce_pair", lambda: ("v", "c"))
     monkeypatch.setattr(auth_commands, "webbrowser", MagicMock())
-    monkeypatch.setattr(auth_commands.threading, "Thread", _ImmediateThread)
-    monkeypatch.setattr(
-        auth_commands,
-        "_wait_for_callback",
-        lambda **_kwargs: OAuthCallbackResult(state="state-xyz"),
+    _stub_callback_server(
+        monkeypatch,
+        result=OAuthCallbackResult(state="state-xyz"),
     )
     captured: list[tuple[str, str]] = []
     monkeypatch.setattr(
@@ -669,20 +706,14 @@ def test_run_linear_oauth_flow_oauth_error(monkeypatch: pytest.MonkeyPatch) -> N
         lambda _p: {"authenticated": False},
     )
     monkeypatch.setattr(auth_commands, "get_client_id", lambda _p: "client-id")
-    monkeypatch.setattr(
-        auth_commands, "get_redirect_uri", lambda: "http://localhost:8080/callback"
-    )
-    monkeypatch.setattr(auth_commands, "get_callback_port", lambda: 8080)
     monkeypatch.setattr(auth_commands, "get_callback_host", lambda: "localhost")
     monkeypatch.setattr(auth_commands, "get_callback_path", lambda: "/callback")
     monkeypatch.setattr(auth_commands.secrets, "token_urlsafe", lambda _n: "state-xyz")
     monkeypatch.setattr(auth_commands, "generate_pkce_pair", lambda: ("v", "c"))
     monkeypatch.setattr(auth_commands, "webbrowser", MagicMock())
-    monkeypatch.setattr(auth_commands.threading, "Thread", _ImmediateThread)
-    monkeypatch.setattr(
-        auth_commands,
-        "_wait_for_callback",
-        lambda **_kwargs: OAuthCallbackResult(
+    _stub_callback_server(
+        monkeypatch,
+        result=OAuthCallbackResult(
             error="access_denied",
             error_description="user denied",
             state="state-xyz",
@@ -713,20 +744,14 @@ def test_run_linear_oauth_flow_exchange_failure(
         lambda _p: {"authenticated": False},
     )
     monkeypatch.setattr(auth_commands, "get_client_id", lambda _p: "client-id")
-    monkeypatch.setattr(
-        auth_commands, "get_redirect_uri", lambda: "http://localhost:8080/callback"
-    )
-    monkeypatch.setattr(auth_commands, "get_callback_port", lambda: 8080)
     monkeypatch.setattr(auth_commands, "get_callback_host", lambda: "localhost")
     monkeypatch.setattr(auth_commands, "get_callback_path", lambda: "/callback")
     monkeypatch.setattr(auth_commands.secrets, "token_urlsafe", lambda _n: "state-xyz")
     monkeypatch.setattr(auth_commands, "generate_pkce_pair", lambda: ("v", "c"))
     monkeypatch.setattr(auth_commands, "webbrowser", MagicMock())
-    monkeypatch.setattr(auth_commands.threading, "Thread", _ImmediateThread)
-    monkeypatch.setattr(
-        auth_commands,
-        "_wait_for_callback",
-        lambda **_kwargs: OAuthCallbackResult(code="code", state="state-xyz"),
+    _stub_callback_server(
+        monkeypatch,
+        result=OAuthCallbackResult(code="code", state="state-xyz"),
     )
     monkeypatch.setattr(
         auth_commands,
@@ -755,15 +780,10 @@ def _oauth_setup(monkeypatch: pytest.MonkeyPatch, *, json_mode: bool = False) ->
         lambda _p: {"authenticated": False},
     )
     monkeypatch.setattr(auth_commands, "get_client_id", lambda _p: "client-id")
-    monkeypatch.setattr(
-        auth_commands, "get_redirect_uri", lambda: "http://localhost:8080/callback"
-    )
-    monkeypatch.setattr(auth_commands, "get_callback_port", lambda: 8080)
     monkeypatch.setattr(auth_commands, "get_callback_host", lambda: "localhost")
     monkeypatch.setattr(auth_commands, "get_callback_path", lambda: "/callback")
     monkeypatch.setattr(auth_commands.secrets, "token_urlsafe", lambda _n: "state-xyz")
     monkeypatch.setattr(auth_commands, "generate_pkce_pair", lambda: ("v", "c"))
-    monkeypatch.setattr(auth_commands.time, "sleep", lambda _s: None)
 
 
 def test_run_linear_oauth_flow_callback_start_failure(
@@ -771,12 +791,7 @@ def test_run_linear_oauth_flow_callback_start_failure(
 ) -> None:
     _oauth_setup(monkeypatch)
     monkeypatch.setattr(auth_commands, "webbrowser", MagicMock())
-    monkeypatch.setattr(auth_commands.threading, "Thread", _ImmediateThread)
-
-    def _boom(**_kwargs: object) -> OAuthCallbackResult:
-        raise RuntimeError("port in use")
-
-    monkeypatch.setattr(auth_commands, "_wait_for_callback", _boom)
+    _stub_callback_server(monkeypatch, start_exc=OSError("port in use"))
     captured: list[tuple[str, str]] = []
     monkeypatch.setattr(
         auth_commands,
@@ -797,12 +812,7 @@ def test_run_linear_oauth_flow_callback_timeout_after_join(
     _oauth_setup(monkeypatch)
     browser = MagicMock()
     monkeypatch.setattr(auth_commands, "webbrowser", browser)
-    monkeypatch.setattr(auth_commands.threading, "Thread", _ImmediateThread)
-
-    def _timeout(**_kwargs: object) -> OAuthCallbackResult:
-        raise TimeoutError("timed out waiting")
-
-    monkeypatch.setattr(auth_commands, "_wait_for_callback", _timeout)
+    _stub_callback_server(monkeypatch, wait_exc=TimeoutError("timed out waiting"))
     captured: list[tuple[str, str]] = []
     monkeypatch.setattr(
         auth_commands,
@@ -816,25 +826,45 @@ def test_run_linear_oauth_flow_callback_timeout_after_join(
     assert any("timed out" in msg.lower() for _t, msg in captured)
 
 
-def test_run_linear_oauth_flow_callback_none_result(
+def test_run_linear_oauth_flow_fallback_port_updates_redirect(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _oauth_setup(monkeypatch)
-    monkeypatch.setattr(auth_commands, "webbrowser", MagicMock())
-    monkeypatch.setattr(auth_commands.threading, "Thread", _ImmediateThread)
-    monkeypatch.setattr(auth_commands, "_wait_for_callback", lambda **_kwargs: None)
-    captured: list[tuple[str, str]] = []
+    fallback_port = DEFAULT_FALLBACK_CALLBACK_PORTS[0]
+    browser = MagicMock()
+    browser.open.return_value = True
+    monkeypatch.setattr(auth_commands, "webbrowser", browser)
+    _stub_callback_server(
+        monkeypatch,
+        port=fallback_port,
+        result=OAuthCallbackResult(code="c", state="state-xyz"),
+    )
+    exchanged: list[str] = []
     monkeypatch.setattr(
         auth_commands,
-        "emit_error",
-        lambda title, message, **kwargs: captured.append((title, message)),
+        "exchange_authorization_code",
+        lambda *_a, **kwargs: exchanged.append(kwargs["redirect_uri"])
+        or {"access_token": "a", "expires_at": 9999999999.0},
+    )
+    set_store(InMemoryCredentialStore())
+    lines: list[str] = []
+    monkeypatch.setattr(
+        auth_commands,
+        "print_plain_line",
+        lambda message, **kwargs: lines.append(message),
+    )
+    monkeypatch.setattr(
+        auth_commands,
+        "get_integration_status",
+        lambda _p: {"authenticated": True, "login": "Ada", "auth_type": "oauth"},
     )
 
-    with pytest.raises(typer.Exit):
-        auth_commands._run_linear_oauth_flow(force=True)
+    auth_commands._run_linear_oauth_flow(force=True)
 
-    assert captured
-    assert any("timed out" in title.lower() for title, _msg in captured)
+    assert any(f"using {fallback_port}" in line for line in lines)
+    assert exchanged == [f"http://localhost:{fallback_port}/callback"]
+    browser.open.assert_called_once()
+    assert f"localhost%3A{fallback_port}" in browser.open.call_args.args[0]
 
 
 def test_run_linear_oauth_flow_webbrowser_not_opened(
@@ -844,11 +874,9 @@ def test_run_linear_oauth_flow_webbrowser_not_opened(
     browser = MagicMock()
     browser.open.return_value = False
     monkeypatch.setattr(auth_commands, "webbrowser", browser)
-    monkeypatch.setattr(auth_commands.threading, "Thread", _ImmediateThread)
-    monkeypatch.setattr(
-        auth_commands,
-        "_wait_for_callback",
-        lambda **_kwargs: OAuthCallbackResult(code="c", state="state-xyz"),
+    _stub_callback_server(
+        monkeypatch,
+        result=OAuthCallbackResult(code="c", state="state-xyz"),
     )
     monkeypatch.setattr(
         auth_commands,
@@ -873,6 +901,21 @@ def test_run_linear_oauth_flow_webbrowser_not_opened(
     assert any("Could not open a browser" in line for line in lines)
 
 
+def test_run_linear_oauth_flow_closes_callback_server_when_browser_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _oauth_setup(monkeypatch)
+    browser = MagicMock()
+    browser.open.side_effect = RuntimeError("browser unavailable")
+    monkeypatch.setattr(auth_commands, "webbrowser", browser)
+    server = _stub_callback_server(monkeypatch)
+
+    with pytest.raises(typer.Exit):
+        auth_commands._run_linear_oauth_flow(force=True)
+
+    assert server.closed is True
+
+
 def test_run_linear_oauth_flow_invalid_redirect(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -885,10 +928,10 @@ def test_run_linear_oauth_flow_invalid_redirect(
     )
     monkeypatch.setattr(auth_commands, "get_client_id", lambda _p: "client-id")
 
-    def _bad_redirect() -> str:
+    def _bad_redirect() -> tuple[int, ...]:
         raise ValueError("bad redirect")
 
-    monkeypatch.setattr(auth_commands, "get_redirect_uri", _bad_redirect)
+    monkeypatch.setattr(auth_commands, "get_callback_port_candidates", _bad_redirect)
     captured: list[tuple[str, str]] = []
     monkeypatch.setattr(
         auth_commands,

--- a/potpie/context-engine/tests/unit/test_cli_linear.py
+++ b/potpie/context-engine/tests/unit/test_cli_linear.py
@@ -439,6 +439,7 @@ class _FakeCallbackServer:
         self.result = result or OAuthCallbackResult(code="auth-code", state="state-xyz")
         self.wait_exc = wait_exc
         self.closed = False
+        self.start_calls: list[dict[str, object]] = []
 
     def wait(self, *, timeout: float = 300.0) -> OAuthCallbackResult:
         if self.wait_exc is not None:
@@ -459,7 +460,8 @@ def _stub_callback_server(
 ) -> _FakeCallbackServer:
     server = _FakeCallbackServer(result=result, port=port, wait_exc=wait_exc)
 
-    def _start(**_kwargs: object) -> _FakeCallbackServer:
+    def _start(**kwargs: object) -> _FakeCallbackServer:
+        server.start_calls.append(kwargs)
         if start_exc is not None:
             raise start_exc
         return server
@@ -507,7 +509,7 @@ def test_run_linear_oauth_flow_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         auth_commands, "webbrowser", MagicMock(open=MagicMock(return_value=True))
     )
-    _stub_callback_server(monkeypatch)
+    callback_server = _stub_callback_server(monkeypatch)
     monkeypatch.setattr(
         auth_commands,
         "exchange_authorization_code",
@@ -530,6 +532,14 @@ def test_run_linear_oauth_flow_success(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert store.get_integration_tokens("linear").get("access_token") == "access"
     assert printed and printed[-1].get("ok") is True
+    assert callback_server.start_calls == [
+        {
+            "host": "localhost",
+            "port": DEFAULT_CALLBACK_PORT,
+            "path": "/callback",
+            "fallback_ports": DEFAULT_FALLBACK_CALLBACK_PORTS,
+        }
+    ]
 
 
 def test_run_linear_oauth_flow_already_connected(
@@ -623,9 +633,11 @@ def test_run_linear_oauth_flow_expired_reauth_message(
     monkeypatch.setattr(
         auth_commands,
         "get_integration_status",
-        lambda _p: status_queue.pop(0)
-        if status_queue
-        else {"authenticated": True, "login": "Ada", "auth_type": "oauth"},
+        lambda _p: (
+            status_queue.pop(0)
+            if status_queue
+            else {"authenticated": True, "login": "Ada", "auth_type": "oauth"}
+        ),
     )
 
     auth_commands._run_linear_oauth_flow()
@@ -843,8 +855,10 @@ def test_run_linear_oauth_flow_fallback_port_updates_redirect(
     monkeypatch.setattr(
         auth_commands,
         "exchange_authorization_code",
-        lambda *_a, **kwargs: exchanged.append(kwargs["redirect_uri"])
-        or {"access_token": "a", "expires_at": 9999999999.0},
+        lambda *_a, **kwargs: (
+            exchanged.append(kwargs["redirect_uri"])
+            or {"access_token": "a", "expires_at": 9999999999.0}
+        ),
     )
     set_store(InMemoryCredentialStore())
     lines: list[str] = []

--- a/potpie/context-engine/tests/unit/test_cli_linear_shared.py
+++ b/potpie/context-engine/tests/unit/test_cli_linear_shared.py
@@ -20,6 +20,7 @@ from adapters.outbound.cli_auth.integration_profile import (
 from adapters.outbound.cli_auth.http import AuthHttpError
 from adapters.inbound.cli.commands._common import set_store
 from tests._auth_fakes import InMemoryCredentialStore
+from adapters.outbound.cli_auth import provider_config
 from adapters.outbound.cli_auth.integration_verify import (
     _verify_linear,
     verify_integration_access,
@@ -1232,9 +1233,14 @@ def test_verify_integration_access_unknown_provider() -> None:
 # --- test_provider_config.py ---
 
 
-def test_get_client_id_requires_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_client_id_uses_packaged_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LINEAR_CLIENT_ID", raising=False)
-    assert get_client_id("linear") == ""
+    monkeypatch.setattr(
+        provider_config,
+        "PACKAGE_LINEAR_CLIENT_ID",
+        "packaged-linear-client-id",
+    )
+    assert get_client_id("linear") == "packaged-linear-client-id"
 
 
 def test_get_client_id_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/potpie/context-engine/tests/unit/test_cli_linear_shared.py
+++ b/potpie/context-engine/tests/unit/test_cli_linear_shared.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from __future__ import annotations
+from types import SimpleNamespace
+
 import typer
 import pytest
 from typer.testing import CliRunner
@@ -1233,14 +1235,20 @@ def test_verify_integration_access_unknown_provider() -> None:
 # --- test_provider_config.py ---
 
 
-def test_get_client_id_uses_packaged_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_client_id_uses_configured_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.delenv("LINEAR_CLIENT_ID", raising=False)
-    monkeypatch.setattr(
-        provider_config,
-        "PACKAGE_LINEAR_CLIENT_ID",
-        "packaged-linear-client-id",
-    )
-    assert get_client_id("linear") == "packaged-linear-client-id"
+    expected = "configured-linear-client-id"
+    if hasattr(provider_config, "PACKAGE_LINEAR_CLIENT_ID"):
+        monkeypatch.setattr(provider_config, "PACKAGE_LINEAR_CLIENT_ID", expected)
+    else:
+        monkeypatch.setattr(
+            provider_config,
+            "load_runtime_settings",
+            lambda: SimpleNamespace(linear_client_id=expected),
+        )
+    assert get_client_id("linear") == expected
 
 
 def test_get_client_id_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/potpie/context-engine/tests/unit/test_cli_linear_shared.py
+++ b/potpie/context-engine/tests/unit/test_cli_linear_shared.py
@@ -25,14 +25,18 @@ from adapters.outbound.cli_auth.integration_verify import (
     verify_integration_access,
 )
 from adapters.outbound.cli_auth.provider_config import (
+    DEFAULT_CALLBACK_PORT,
+    DEFAULT_FALLBACK_CALLBACK_PORTS,
     LINEAR_TOKEN_URL,
     authorization_url,
     get_callback_host,
     get_callback_path,
     get_callback_port,
+    get_callback_port_candidates,
     get_client_id,
     get_client_secret,
     get_redirect_uri,
+    get_redirect_uri_for_port,
     get_scopes,
     token_url,
 )
@@ -857,15 +861,22 @@ def test_get_integration_status_unknown_provider(
 
 
 def test_get_integration_status_github_unauthenticated(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
     status = cs.get_integration_status("github")
-    assert status == {"provider": "github", "authenticated": False, "auth_type": "oauth"}
+    assert status == {
+        "provider": "github",
+        "authenticated": False,
+        "auth_type": "oauth",
+    }
 
 
 def test_get_integration_status_github_authenticated(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, keychain: dict[tuple[str, str], str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    keychain: dict[tuple[str, str], str],
 ) -> None:
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
     cs.write_provider_credentials(
@@ -1240,6 +1251,19 @@ def test_redirect_and_callback_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
     assert get_callback_host() == "127.0.0.1"
     assert get_callback_path() == "/custom/callback"
     assert get_callback_port() == 9001
+    assert get_callback_port_candidates() == (9001,)
+
+
+def test_default_callback_port_is_five_digit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("POTPIE_CLI_OAUTH_REDIRECT_URI", raising=False)
+    monkeypatch.delenv("POTPIE_CLI_OAUTH_CALLBACK_PORT", raising=False)
+    assert DEFAULT_CALLBACK_PORT == 28757
+    assert DEFAULT_FALLBACK_CALLBACK_PORTS == (28763,)
+    assert get_callback_port() == DEFAULT_CALLBACK_PORT
+    assert get_callback_port_candidates() == (
+        DEFAULT_CALLBACK_PORT,
+        *DEFAULT_FALLBACK_CALLBACK_PORTS,
+    )
 
 
 def test_get_callback_port_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1249,6 +1273,17 @@ def test_get_callback_port_env_override(monkeypatch: pytest.MonkeyPatch) -> None
     )
     monkeypatch.setenv("POTPIE_CLI_OAUTH_CALLBACK_PORT", "9999")
     assert get_callback_port() == 9999
+    assert get_callback_port_candidates() == (9999,)
+
+
+def test_get_redirect_uri_for_port_rewrites_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "POTPIE_CLI_OAUTH_REDIRECT_URI",
+        "http://127.0.0.1:9001/custom/callback",
+    )
+    assert get_redirect_uri_for_port(9002) == "http://127.0.0.1:9002/custom/callback"
 
 
 def test_linear_oauth_urls() -> None:


### PR DESCRIPTION
## Summary

- Move Linear CLI OAuth off a common localhost callback port.
- Add a fixed fallback callback port for the default Linear auth flow.
- Bind the local callback server before opening Linear so the authorization URL and token exchange use the actual listening port.
- Keep explicit callback port or redirect URI overrides from inventing additional fallback ports.

## Validation

- `uv run ruff check adapters/inbound/cli/auth/auth_commands.py adapters/outbound/cli_auth/provider_config.py adapters/outbound/cli_auth/callback_server.py tests/unit/test_cli_linear.py tests/unit/test_cli_linear_shared.py`
- `uv run ruff format --check adapters/inbound/cli/auth/auth_commands.py adapters/outbound/cli_auth/provider_config.py adapters/outbound/cli_auth/callback_server.py tests/unit/test_cli_linear.py tests/unit/test_cli_linear_shared.py`
- `uv run pytest tests/unit/test_cli_linear.py tests/unit/test_cli_linear_shared.py`

Closes #967