### PR TITLE
Add bounded UI dev port fallback

### DIFF
--- a/potpie/context-engine/adapters/inbound/http/ui/frontend/package.json
+++ b/potpie/context-engine/adapters/inbound/http/ui/frontend/package.json
@@ -4,7 +4,8 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "node scripts/dev.mjs",
+    "test:dev-port": "node --test scripts/dev-port.test.mjs",
     "build": "tsc -b && vite build",
     "preview": "vite preview"
   },

--- a/potpie/context-engine/adapters/inbound/http/ui/frontend/package.json
+++ b/potpie/context-engine/adapters/inbound/http/ui/frontend/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "node scripts/dev.mjs",
+    "test": "npm run test:dev-port",
     "test:dev-port": "node --test scripts/dev-port.test.mjs",
-    "build": "tsc -b && vite build",
+    "build": "npm run test:dev-port && tsc -b && vite build",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/potpie/context-engine/adapters/inbound/http/ui/frontend/scripts/dev-port.mjs
+++ b/potpie/context-engine/adapters/inbound/http/ui/frontend/scripts/dev-port.mjs
@@ -1,0 +1,82 @@
+export const DEV_PORT_MIN = 3000;
+export const DEV_PORT_MAX = 3099;
+
+export function portRange(minPort = DEV_PORT_MIN, maxPort = DEV_PORT_MAX) {
+  if (!Number.isInteger(minPort) || !Number.isInteger(maxPort)) {
+    throw new TypeError("dev server port bounds must be integers");
+  }
+  if (minPort < 1 || maxPort > 65535 || minPort > maxPort) {
+    throw new RangeError("dev server port bounds must be a valid TCP range");
+  }
+
+  return Array.from(
+    { length: maxPort - minPort + 1 },
+    (_, index) => minPort + index,
+  );
+}
+
+export function isAddressInUse(error) {
+  for (let current = error; current; current = current.cause) {
+    if (current && current.code === "EADDRINUSE") {
+      return true;
+    }
+    if (
+      current &&
+      typeof current.message === "string" &&
+      /^Port \d+ is already in use$/.test(current.message)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export async function startServerInRange({
+  createServer,
+  minPort = DEV_PORT_MIN,
+  maxPort = DEV_PORT_MAX,
+} = {}) {
+  if (typeof createServer !== "function") {
+    throw new TypeError("createServer is required");
+  }
+
+  let lastAddressInUseError;
+  for (const port of portRange(minPort, maxPort)) {
+    let server;
+    try {
+      server = await createServer({
+        server: {
+          port,
+          strictPort: true,
+        },
+      });
+      await server.listen();
+      return { port, server };
+    } catch (error) {
+      await closeQuietly(server);
+      if (!isAddressInUse(error)) {
+        throw error;
+      }
+      lastAddressInUseError = error;
+    }
+  }
+
+  const error = new Error(
+    `No available port found for the Potpie UI dev server in ${minPort}-${maxPort}.`,
+  );
+  error.code = "POTPIE_UI_DEV_PORTS_EXHAUSTED";
+  error.cause = lastAddressInUseError;
+  throw error;
+}
+
+async function closeQuietly(server) {
+  if (!server || typeof server.close !== "function") {
+    return;
+  }
+  try {
+    await server.close();
+  } catch {
+    // The server may never have finished binding. The original bind error is
+    // the useful signal, so cleanup failures are intentionally ignored.
+  }
+}

--- a/potpie/context-engine/adapters/inbound/http/ui/frontend/scripts/dev-port.mjs
+++ b/potpie/context-engine/adapters/inbound/http/ui/frontend/scripts/dev-port.mjs
@@ -1,6 +1,25 @@
 export const DEV_PORT_MIN = 3000;
 export const DEV_PORT_MAX = 3099;
 
+export function assertNoCliArgs(args) {
+  if (!Array.isArray(args)) {
+    throw new TypeError("dev server CLI args must be an array");
+  }
+  if (args.length === 0) {
+    return;
+  }
+
+  const error = new Error(
+    [
+      "Potpie UI dev server does not accept extra Vite CLI flags.",
+      `Unsupported argument(s): ${args.join(" ")}`,
+      "Run `npm run dev` without extra arguments; the launcher owns the 3000-3099 port policy.",
+    ].join("\n"),
+  );
+  error.code = "POTPIE_UI_DEV_UNSUPPORTED_ARGS";
+  throw error;
+}
+
 export function portRange(minPort = DEV_PORT_MIN, maxPort = DEV_PORT_MAX) {
   if (!Number.isInteger(minPort) || !Number.isInteger(maxPort)) {
     throw new TypeError("dev server port bounds must be integers");
@@ -20,6 +39,8 @@ export function isAddressInUse(error) {
     if (current && current.code === "EADDRINUSE") {
       return true;
     }
+    // Vite v5 strictPort wraps the underlying bind failure with this message
+    // instead of preserving EADDRINUSE on the public error object.
     if (
       current &&
       typeof current.message === "string" &&

--- a/potpie/context-engine/adapters/inbound/http/ui/frontend/scripts/dev-port.test.mjs
+++ b/potpie/context-engine/adapters/inbound/http/ui/frontend/scripts/dev-port.test.mjs
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  isAddressInUse,
+  portRange,
+  startServerInRange,
+} from "./dev-port.mjs";
+
+test("portRange returns an inclusive ordered TCP range", () => {
+  assert.deepEqual(portRange(3000, 3003), [3000, 3001, 3002, 3003]);
+});
+
+test("portRange rejects invalid bounds", () => {
+  assert.throws(() => portRange(3002, 3001), RangeError);
+  assert.throws(() => portRange(0, 3001), RangeError);
+  assert.throws(() => portRange(3000.5, 3001), TypeError);
+});
+
+test("isAddressInUse recognizes direct and wrapped bind failures", () => {
+  const direct = Object.assign(new Error("busy"), { code: "EADDRINUSE" });
+  const wrapped = new Error("wrapped", { cause: direct });
+  const viteStrictPort = new Error("Port 3000 is already in use");
+
+  assert.equal(isAddressInUse(direct), true);
+  assert.equal(isAddressInUse(wrapped), true);
+  assert.equal(isAddressInUse(viteStrictPort), true);
+  assert.equal(isAddressInUse(new Error("other")), false);
+});
+
+test("startServerInRange binds the first available port with strictPort", async () => {
+  const calls = [];
+  const server = {
+    listen: async () => {},
+    close: async () => {},
+  };
+
+  const result = await startServerInRange({
+    minPort: 3000,
+    maxPort: 3001,
+    createServer: async (config) => {
+      calls.push(config);
+      return server;
+    },
+  });
+
+  assert.equal(result.port, 3000);
+  assert.equal(result.server, server);
+  assert.deepEqual(calls, [
+    {
+      server: {
+        port: 3000,
+        strictPort: true,
+      },
+    },
+  ]);
+});
+
+test("startServerInRange skips occupied ports and closes failed servers", async () => {
+  const closedPorts = [];
+
+  const result = await startServerInRange({
+    minPort: 3000,
+    maxPort: 3002,
+    createServer: async (config) => {
+      const port = config.server.port;
+      return {
+        listen: async () => {
+          if (port < 3002) {
+            throw Object.assign(new Error(`busy ${port}`), {
+              code: "EADDRINUSE",
+            });
+          }
+        },
+        close: async () => {
+          closedPorts.push(port);
+        },
+      };
+    },
+  });
+
+  assert.equal(result.port, 3002);
+  assert.deepEqual(closedPorts, [3000, 3001]);
+});
+
+test("startServerInRange fails clearly when the range is exhausted", async () => {
+  await assert.rejects(
+    () =>
+      startServerInRange({
+        minPort: 3000,
+        maxPort: 3001,
+        createServer: async () => ({
+          listen: async () => {
+            throw Object.assign(new Error("busy"), { code: "EADDRINUSE" });
+          },
+        }),
+      }),
+    (error) => {
+      assert.equal(error.code, "POTPIE_UI_DEV_PORTS_EXHAUSTED");
+      assert.match(error.message, /3000-3001/);
+      return true;
+    },
+  );
+});
+
+test("startServerInRange rethrows non-port failures", async () => {
+  const failure = new Error("config failed");
+
+  await assert.rejects(
+    () =>
+      startServerInRange({
+        minPort: 3000,
+        maxPort: 3001,
+        createServer: async () => ({
+          listen: async () => {
+            throw failure;
+          },
+        }),
+      }),
+    failure,
+  );
+});

--- a/potpie/context-engine/adapters/inbound/http/ui/frontend/scripts/dev-port.test.mjs
+++ b/potpie/context-engine/adapters/inbound/http/ui/frontend/scripts/dev-port.test.mjs
@@ -2,10 +2,26 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  assertNoCliArgs,
   isAddressInUse,
   portRange,
   startServerInRange,
 } from "./dev-port.mjs";
+
+test("assertNoCliArgs accepts the plain dev command", () => {
+  assert.doesNotThrow(() => assertNoCliArgs([]));
+});
+
+test("assertNoCliArgs rejects ignored Vite CLI flags loudly", () => {
+  assert.throws(
+    () => assertNoCliArgs(["--host", "0.0.0.0"]),
+    (error) => {
+      assert.equal(error.code, "POTPIE_UI_DEV_UNSUPPORTED_ARGS");
+      assert.match(error.message, /--host 0\.0\.0\.0/);
+      return true;
+    },
+  );
+});
 
 test("portRange returns an inclusive ordered TCP range", () => {
   assert.deepEqual(portRange(3000, 3003), [3000, 3001, 3002, 3003]);

--- a/potpie/context-engine/adapters/inbound/http/ui/frontend/scripts/dev.mjs
+++ b/potpie/context-engine/adapters/inbound/http/ui/frontend/scripts/dev.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+import { createServer } from "vite";
+
+import {
+  DEV_PORT_MAX,
+  DEV_PORT_MIN,
+  startServerInRange,
+} from "./dev-port.mjs";
+
+try {
+  const { port, server } = await startServerInRange({ createServer });
+  console.log(
+    `Potpie UI dev server selected port ${port} (range ${DEV_PORT_MIN}-${DEV_PORT_MAX}).`,
+  );
+  server.printUrls();
+  server.bindCLIShortcuts({ print: true });
+} catch (error) {
+  console.error(formatDevServerError(error));
+  process.exitCode = 1;
+}
+
+function formatDevServerError(error) {
+  if (error && error.code === "POTPIE_UI_DEV_PORTS_EXHAUSTED") {
+    return [
+      error.message,
+      "Free one of those ports, or change DEV_PORT_MIN/DEV_PORT_MAX in scripts/dev-port.mjs.",
+    ].join("\n");
+  }
+  return error && error.stack ? error.stack : String(error);
+}

--- a/potpie/context-engine/adapters/inbound/http/ui/frontend/scripts/dev.mjs
+++ b/potpie/context-engine/adapters/inbound/http/ui/frontend/scripts/dev.mjs
@@ -3,12 +3,14 @@
 import { createServer } from "vite";
 
 import {
+  assertNoCliArgs,
   DEV_PORT_MAX,
   DEV_PORT_MIN,
   startServerInRange,
 } from "./dev-port.mjs";
 
 try {
+  assertNoCliArgs(process.argv.slice(2));
   const { port, server } = await startServerInRange({ createServer });
   console.log(
     `Potpie UI dev server selected port ${port} (range ${DEV_PORT_MIN}-${DEV_PORT_MAX}).`,
@@ -26,6 +28,9 @@ function formatDevServerError(error) {
       error.message,
       "Free one of those ports, or change DEV_PORT_MIN/DEV_PORT_MAX in scripts/dev-port.mjs.",
     ].join("\n");
+  }
+  if (error && error.code === "POTPIE_UI_DEV_UNSUPPORTED_ARGS") {
+    return error.message;
   }
   return error && error.stack ? error.stack : String(error);
 }

--- a/potpie/context-engine/adapters/inbound/http/ui/frontend/vite.config.ts
+++ b/potpie/context-engine/adapters/inbound/http/ui/frontend/vite.config.ts
@@ -3,7 +3,8 @@ import react from "@vitejs/plugin-react";
 
 // Served by the daemon under /ui, so assets must resolve relative to /ui/.
 // For local dev (`npm run dev`) point the proxy at your running daemon port
-// (see `cat ~/.potpie/daemon.json`), then browse http://localhost:5173/ui/.
+// (see `cat ~/.potpie/daemon.json`). The dev launcher prefers
+// http://localhost:3000/ui/ and falls back through port 3099.
 export default defineConfig({
   base: "/ui/",
   plugins: [react()],


### PR DESCRIPTION
## Summary

- Replaces the graph explorer frontend dev script with a small Vite launcher that prefers port 3000 and retries sequentially through 3099.
- Keeps the bounded retry loop atomic by asking Vite to bind each candidate with `strictPort: true` instead of doing a separate preflight port scan.
- Adds focused Node tests for range validation, Vite bind-error detection, fallback behavior, exhaustion errors, unsupported extra dev args, and non-port failure handling.
- Wires the port tests into `npm run build`, so `make ui-build` now runs them before producing the bundle.

Fixes #969.

## Review Fixes

- Extra `npm run dev -- ...` Vite flags now fail loudly instead of being silently ignored by the custom launcher.
- The Vite v5 strict-port error text match is documented in code as a compatibility boundary.
- The new port-policy tests are now part of the normal frontend build path.

## Validation

- `npm test`
- `npm run build`
- `node scripts/dev.mjs --host 0.0.0.0` fails loudly for unsupported args
- runtime smoke: `scripts/dev.mjs` selects port 3000 when free
- runtime smoke: with 3000 occupied, `scripts/dev.mjs` selects port 3001
- `git diff --check`
- `make ui-build`
- thermo-nuclear code-quality re-audit on final diff: no file-size, boundary, spaghetti-branching, silent-arg-drop, or test-discoverability blockers remain

## Notes

`make ui-build` runs `npm install` and reports existing npm advisories in the dependency tree. This PR leaves dependency upgrades out of scope for the port-selection change.