### PR TITLE
Fix `pot create --repo .` not registering the current repo

### DIFF
--- a/potpie/context-engine/adapters/inbound/cli/commands/pots.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/pots.py
@@ -150,8 +150,8 @@ def register_repo_source(
     ``make_default`` is false.
     """
     resolved_location = resolve_repo_location(location)
+    repo_key = repo_identity_key(resolved_location)
     repo_default_set = False
-    repo_key: str | None = None
     repo_default_setter = None
     if make_default:
         repo_default_setter = getattr(host.pots, "set_repo_default", None)
@@ -168,7 +168,6 @@ def register_repo_source(
         name=name,
     )
     if make_default:
-        repo_key = repo_identity_key(resolved_location)
         if not repo_key:
             fail(
                 code="repo_unresolved",
@@ -184,7 +183,7 @@ def register_repo_source(
         "location": resolved_location,
         "pot_id": pot_id,
         "repo_default_set": repo_default_set,
-        **({"repo_key": repo_key} if repo_key else {}),
+        "repo_key": repo_key,
         "registration_only": True,
     }
 
@@ -225,6 +224,7 @@ def pot_create(
             )
             payload["source"] = source
             payload["repo_default_set"] = source["repo_default_set"]
+            payload["repo_key"] = source["repo_key"]
             human = (
                 f"{human}\n"
                 f"registered source {source['kind']}:{source['name']} "

--- a/potpie/context-engine/adapters/inbound/cli/commands/pots.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/pots.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timezone
+from typing import Any
 
 import httpx
 import typer
@@ -134,18 +135,105 @@ def _repo_key_from_option(repo: str) -> str:
     return repo_key
 
 
+def register_repo_source(
+    host: Any,
+    *,
+    pot_id: str,
+    location: str,
+    name: str | None = None,
+    make_default: bool = True,
+) -> dict[str, object]:
+    """Register a repo source using the same path as ``source add repo``.
+
+    Resolves ``.`` / ``current`` to git remote or absolute path, persists
+    ``location`` on the source row, and sets the repo-local default unless
+    ``make_default`` is false.
+    """
+    resolved_location = resolve_repo_location(location)
+    repo_default_set = False
+    repo_key: str | None = None
+    repo_default_setter = None
+    if make_default:
+        repo_default_setter = getattr(host.pots, "set_repo_default", None)
+        if not callable(repo_default_setter):
+            fail(
+                code="repo_default_unavailable",
+                message="This host does not support repo default bindings.",
+                next_action="upgrade the local context-engine host",
+            )
+    src = host.pots.add_source(
+        pot_id=pot_id,
+        kind="repo",
+        location=resolved_location,
+        name=name,
+    )
+    if make_default:
+        repo_key = repo_identity_key(resolved_location)
+        if not repo_key:
+            fail(
+                code="repo_unresolved",
+                message="Could not resolve the repository identity.",
+                next_action="pass a repo location such as '<owner>/<repo>'",
+            )
+        repo_default_setter(repo=repo_key, pot_id=pot_id)
+        repo_default_set = True
+    return {
+        "source_id": src.source_id,
+        "kind": src.kind,
+        "name": src.name,
+        "location": resolved_location,
+        "pot_id": pot_id,
+        "repo_default_set": repo_default_set,
+        **({"repo_key": repo_key} if repo_key else {}),
+        "registration_only": True,
+    }
+
+
 @pot_app.command("create")
 def pot_create(
     name: str,
-    repo: str = typer.Option(None, "--repo"),
+    repo: str = typer.Option(
+        None,
+        "--repo",
+        help="Register a repo source after create (same resolution as `source add repo`).",
+    ),
     use: bool = typer.Option(False, "--use"),
+    no_default: bool = typer.Option(
+        False,
+        "--no-default",
+        help="With --repo, do not set this pot as the repo-local default.",
+    ),
 ) -> None:
     with contract():
-        pot = get_host().pots.create_pot(name=name, repo=repo, use=use)
-        emit(
-            {"id": pot.pot_id, "name": pot.name, "active": pot.active},
-            human=f"created pot '{pot.name}' ({pot.pot_id}){' [active]' if pot.active else ''}",
+        host = get_host()
+        pot = host.pots.create_pot(name=name, use=use)
+        payload: dict[str, object] = {
+            "id": pot.pot_id,
+            "name": pot.name,
+            "active": pot.active,
+        }
+        human = (
+            f"created pot '{pot.name}' ({pot.pot_id})"
+            f"{' [active]' if pot.active else ''}"
         )
+        if repo is not None:
+            source = register_repo_source(
+                host,
+                pot_id=pot.pot_id,
+                location=repo,
+                make_default=not no_default,
+            )
+            payload["source"] = source
+            payload["repo_default_set"] = source["repo_default_set"]
+            human = (
+                f"{human}\n"
+                f"registered source {source['kind']}:{source['name']} "
+                f"({source['source_id']}) at {source['location']} in pot {pot.pot_id}"
+            )
+            if source["repo_default_set"]:
+                human = f"{human}\nset repo default -> {pot.pot_id}"
+            human = f"{human}\nno ingestion or scan started"
+        emit(payload, human=human)
 
 
 @pot_app.command("use")
@@ -439,42 +527,37 @@ def source_add(
         # Registration establishes the repo→pot mapping, so the target is the
         # explicit/active pot — never inferred from existing registrations.
         pot_id = resolve_pot_id(host, pot, infer_from_repo=False)
-        resolved_location = (
-            resolve_repo_location(location) if is_repo else location
-        )
         started_ms = now_ms()
         capture_project_binding_event(
             "cli_onboarding_repo_source_add_started",
             entrypoint="direct_command",
             properties={"source_kind": source_kind},
         )
-        repo_default_set = False
         try:
-            repo_default_setter = None
-            if is_repo and make_default:
-                repo_default_setter = getattr(host.pots, "set_repo_default", None)
-                if not callable(repo_default_setter):
-                    fail(
-                        code="repo_default_unavailable",
-                        message="This host does not support repo default bindings.",
-                        next_action="upgrade the local context-engine host",
-                    )
-            src = host.pots.add_source(
-                pot_id=pot_id,
-                kind=source_kind,
-                location=resolved_location,
-                name=name,
-            )
-            if is_repo and make_default:
-                repo_key = repo_identity_key(resolved_location)
-                if not repo_key:
-                    fail(
-                        code="repo_unresolved",
-                        message="Could not resolve the repository identity.",
-                        next_action="pass a repo location such as '<owner>/<repo>'",
-                    )
-                repo_default_setter(repo=repo_key, pot_id=pot_id)
-                repo_default_set = True
+            if is_repo:
+                payload = register_repo_source(
+                    host,
+                    pot_id=pot_id,
+                    location=location,
+                    name=name,
+                    make_default=make_default,
+                )
+            else:
+                src = host.pots.add_source(
+                    pot_id=pot_id,
+                    kind=source_kind,
+                    location=location,
+                    name=name,
+                )
+                payload = {
+                    "source_id": src.source_id,
+                    "kind": src.kind,
+                    "name": src.name,
+                    "location": location,
+                    "pot_id": pot_id,
+                    "repo_default_set": False,
+                    "registration_only": True,
+                }
         except Exception as exc:  # noqa: BLE001
             capture_project_binding_event(
                 "cli_onboarding_repo_source_add_failed",
@@ -490,24 +573,18 @@ def source_add(
             "cli_onboarding_repo_source_add_completed",
             entrypoint="direct_command",
             properties={
-                "source_kind": src.kind,
+                "source_kind": payload.get("kind", source_kind),
                 "step_state": "done",
                 "duration_ms": elapsed_ms(started_ms),
             },
         )
+        resolved_location = payload.get("location", location)
+        repo_default_set = bool(payload.get("repo_default_set"))
         emit(
-            {
-                "source_id": src.source_id,
-                "kind": src.kind,
-                "name": src.name,
-                "location": resolved_location,
-                "pot_id": pot_id,
-                "repo_default_set": repo_default_set,
-                "registration_only": True,
-            },
+            payload,
             human=(
-                f"registered source {src.kind}:{src.name} ({src.source_id}) "
-                f"at {resolved_location} in pot {pot_id}\n"
+                f"registered source {payload['kind']}:{payload['name']} "
+                f"({payload['source_id']}) at {resolved_location} in pot {pot_id}\n"
                 + (f"set repo default -> {pot_id}\n" if repo_default_set else "")
                 + "no ingestion or scan started"
             ),

--- a/potpie/context-engine/adapters/inbound/cli/commands/pots.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/pots.py
@@ -135,6 +135,36 @@ def _repo_key_from_option(repo: str) -> str:
     return repo_key
 
 
+def _matching_repo_source(
+    host: Any,
+    *,
+    pot_id: str,
+    resolved_location: str,
+    repo_key: str | None,
+) -> Any | None:
+    list_sources = getattr(host.pots, "list_sources", None)
+    if not callable(list_sources):
+        return None
+    try:
+        sources = list_sources(pot_id=pot_id)
+    except Exception:  # noqa: BLE001 - duplicate detection must not block registration
+        return None
+    for source in sources or []:
+        if getattr(source, "kind", None) != "repo":
+            continue
+        refs = (
+            str(getattr(source, "location", "") or "").strip(),
+            str(getattr(source, "name", "") or "").strip(),
+        )
+        if repo_key:
+            if any(repo_identity_key(ref) == repo_key for ref in refs if ref):
+                return source
+            continue
+        if resolved_location in refs:
+            return source
+    return None
+
+
 def register_repo_source(
     host: Any,
     *,
@@ -161,12 +191,21 @@ def register_repo_source(
                 message="This host does not support repo default bindings.",
                 next_action="upgrade the local context-engine host",
             )
-    src = host.pots.add_source(
+    existing = _matching_repo_source(
+        host,
         pot_id=pot_id,
-        kind="repo",
-        location=resolved_location,
-        name=name,
+        resolved_location=resolved_location,
+        repo_key=repo_key,
     )
+    if existing is not None:
+        src = existing
+    else:
+        src = host.pots.add_source(
+            pot_id=pot_id,
+            kind="repo",
+            location=resolved_location,
+            name=name,
+        )
     if make_default:
         if not repo_key:
             fail(

--- a/potpie/context-engine/adapters/inbound/cli/ui/setup_ux.py
+++ b/potpie/context-engine/adapters/inbound/cli/ui/setup_ux.py
@@ -17,6 +17,7 @@ from typing import Any
 import click
 
 from adapters.inbound.cli.commands._common import get_store
+from adapters.inbound.cli.repo_location import resolve_repo_location
 from adapters.inbound.cli.telemetry.onboarding_events import (
     capture_github_prompt_outcome,
     capture_github_prompt_shown,
@@ -554,6 +555,7 @@ def maybe_prompt_github_login(
 
 def _register_repo_source(*, repo: str) -> str:
     from adapters.inbound.cli.commands._common import get_host
+    from adapters.inbound.cli.commands.pots import register_repo_source
 
     started_ms = now_ms()
     capture_project_binding_event(
@@ -571,7 +573,15 @@ def _register_repo_source(*, repo: str) -> str:
         )
         return "skipped"
     existing = host.pots.list_sources(pot_id=active.pot_id)
-    if any(s.kind == "repo" and s.name == repo for s in existing):
+    resolved = resolve_repo_location(repo)
+    if any(
+        s.kind == "repo"
+        and (
+            getattr(s, "location", None) == resolved
+            or getattr(s, "name", None) == resolved
+        )
+        for s in existing
+    ):
         capture_project_binding_event(
             "cli_onboarding_repo_source_add_completed",
             entrypoint="post_setup_first_pot",
@@ -579,7 +589,7 @@ def _register_repo_source(*, repo: str) -> str:
         )
         return "skipped"
     try:
-        host.pots.add_source(pot_id=active.pot_id, kind="repo", location=repo)
+        register_repo_source(host, pot_id=active.pot_id, location=repo)
     except Exception as exc:  # noqa: BLE001
         capture_project_binding_event(
             "cli_onboarding_repo_source_add_failed",
@@ -627,7 +637,7 @@ def _maybe_prompt_first_pot(
 
     repo_str = str(repo.resolve()) if repo is not None else None
     name_source = "default" if name == default_pot_name else "custom"
-    pot = get_host().pots.create_pot(name=name, repo=repo_str, use=True)
+    pot = get_host().pots.create_pot(name=name, use=True)
     capture_project_binding_event(
         "cli_onboarding_first_pot_created",
         entrypoint="post_setup_first_pot",

--- a/potpie/context-engine/adapters/outbound/pots/local_pot_store.py
+++ b/potpie/context-engine/adapters/outbound/pots/local_pot_store.py
@@ -71,6 +71,8 @@ class LocalPotStore:
     def create(
         self, *, name: str, repo: str | None = None, use: bool = False
     ) -> dict[str, Any]:
+        """Create a pot. Repo registration belongs on ``add_source`` via the CLI."""
+        _ = repo
         state = self._load()
         # Reuse an existing pot by name (idempotent setup).
         for pid, row in state.get("pots", {}).items():
@@ -82,14 +84,6 @@ class LocalPotStore:
         pot_id = f"pot_{uuid.uuid4().hex[:12]}"
         row = {"pot_id": pot_id, "name": name, "archived": False}
         state.setdefault("pots", {})[pot_id] = row
-        if repo:
-            state.setdefault("sources", {}).setdefault(pot_id, []).append(
-                {
-                    "source_id": f"src_{uuid.uuid4().hex[:8]}",
-                    "kind": "repo",
-                    "name": repo,
-                }
-            )
         if use or state.get("active") is None:
             state["active"] = pot_id
         self._save(state)

--- a/potpie/context-engine/tests/unit/test_pot_create_repo.py
+++ b/potpie/context-engine/tests/unit/test_pot_create_repo.py
@@ -1,0 +1,107 @@
+"""``pot create --repo`` must match ``source add repo`` normalization."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+
+import pytest
+from typer.testing import CliRunner
+
+from adapters.inbound.cli import repo_location
+from adapters.inbound.cli.commands import _common, pots
+from domain.ports.services.pot_management import PotInfo, SourceInfo
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _reset_cli_state() -> None:
+    yield
+    _common.set_json(False)
+    _common.set_host(None)
+
+
+@dataclass
+class _Pots:
+    created: list[dict[str, object]] = field(default_factory=list)
+    sources: list[dict[str, str | None]] = field(default_factory=list)
+    repo_defaults: dict[str, str] = field(default_factory=dict)
+    active_id: str | None = None
+
+    def create_pot(self, *, name: str, repo: str | None = None, use: bool = False) -> PotInfo:
+        self.created.append({"name": name, "use": use})
+        pot_id = "pot-new"
+        if use:
+            self.active_id = pot_id
+        return PotInfo(pot_id=pot_id, name=name, active=use)
+
+    def add_source(
+        self, *, pot_id: str, kind: str, location: str, name: str | None = None
+    ) -> SourceInfo:
+        self.sources.append(
+            {"pot_id": pot_id, "kind": kind, "location": location, "name": name}
+        )
+        return SourceInfo(
+            source_id="src-new",
+            kind=kind,
+            name=name or location,
+            location=location,
+        )
+
+    def set_repo_default(self, *, repo: str, pot_id: str) -> None:
+        self.repo_defaults[repo] = pot_id
+
+
+@dataclass
+class _Host:
+    pots: _Pots
+
+
+def test_pot_create_repo_dot_uses_source_add_normalization(monkeypatch) -> None:
+    monkeypatch.setattr(
+        repo_location, "current_git_remote", lambda cwd: "github.com/acme/shop"
+    )
+    fake_pots = _Pots()
+    _common.set_host(_Host(pots=fake_pots))
+    _common.set_json(True)
+
+    result = CliRunner().invoke(
+        pots.pot_app,
+        ["create", "flow-test", "--use", "--repo", "."],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["id"] == "pot-new"
+    assert payload["repo_default_set"] is True
+    assert payload["source"]["location"] == "github.com/acme/shop"
+    assert fake_pots.created == [{"name": "flow-test", "use": True}]
+    assert fake_pots.sources == [
+        {
+            "pot_id": "pot-new",
+            "kind": "repo",
+            "location": "github.com/acme/shop",
+            "name": None,
+        }
+    ]
+    assert fake_pots.repo_defaults == {"github.com/acme/shop": "pot-new"}
+
+
+def test_pot_create_repo_no_default_skips_repo_default(monkeypatch) -> None:
+    monkeypatch.setattr(
+        repo_location, "current_git_remote", lambda cwd: "github.com/acme/shop"
+    )
+    fake_pots = _Pots()
+    _common.set_host(_Host(pots=fake_pots))
+    _common.set_json(True)
+
+    result = CliRunner().invoke(
+        pots.pot_app,
+        ["create", "flow-test", "--repo", ".", "--no-default"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["repo_default_set"] is False
+    assert fake_pots.repo_defaults == {}

--- a/potpie/context-engine/tests/unit/test_pot_create_repo.py
+++ b/potpie/context-engine/tests/unit/test_pot_create_repo.py
@@ -75,6 +75,8 @@ def test_pot_create_repo_dot_uses_source_add_normalization(monkeypatch) -> None:
     payload = json.loads(result.output)
     assert payload["id"] == "pot-new"
     assert payload["repo_default_set"] is True
+    assert payload["repo_key"] == "github.com/acme/shop"
+    assert payload["source"]["repo_key"] == "github.com/acme/shop"
     assert payload["source"]["location"] == "github.com/acme/shop"
     assert fake_pots.created == [{"name": "flow-test", "use": True}]
     assert fake_pots.sources == [
@@ -104,4 +106,6 @@ def test_pot_create_repo_no_default_skips_repo_default(monkeypatch) -> None:
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
     assert payload["repo_default_set"] is False
+    assert payload["repo_key"] == "github.com/acme/shop"
+    assert payload["source"]["repo_key"] == "github.com/acme/shop"
     assert fake_pots.repo_defaults == {}

--- a/potpie/context-engine/tests/unit/test_pot_create_repo.py
+++ b/potpie/context-engine/tests/unit/test_pot_create_repo.py
@@ -28,22 +28,44 @@ class _Pots:
     sources: list[dict[str, str | None]] = field(default_factory=list)
     repo_defaults: dict[str, str] = field(default_factory=dict)
     active_id: str | None = None
+    _pots_by_name: dict[str, str] = field(default_factory=dict)
 
     def create_pot(self, *, name: str, repo: str | None = None, use: bool = False) -> PotInfo:
         self.created.append({"name": name, "use": use})
-        pot_id = "pot-new"
+        pot_id = self._pots_by_name.get(name, "pot-new")
+        if name not in self._pots_by_name:
+            self._pots_by_name[name] = pot_id
         if use:
             self.active_id = pot_id
         return PotInfo(pot_id=pot_id, name=name, active=use)
 
+    def list_sources(self, *, pot_id: str) -> list[SourceInfo]:
+        return [
+            SourceInfo(
+                source_id=row["source_id"],
+                kind=row["kind"],
+                name=row["name"] or row["location"],
+                location=row["location"],
+            )
+            for row in self.sources
+            if row["pot_id"] == pot_id
+        ]
+
     def add_source(
         self, *, pot_id: str, kind: str, location: str, name: str | None = None
     ) -> SourceInfo:
+        source_id = f"src-{len(self.sources) + 1}"
         self.sources.append(
-            {"pot_id": pot_id, "kind": kind, "location": location, "name": name}
+            {
+                "source_id": source_id,
+                "pot_id": pot_id,
+                "kind": kind,
+                "location": location,
+                "name": name,
+            }
         )
         return SourceInfo(
-            source_id="src-new",
+            source_id=source_id,
             kind=kind,
             name=name or location,
             location=location,
@@ -81,12 +103,58 @@ def test_pot_create_repo_dot_uses_source_add_normalization(monkeypatch) -> None:
     assert fake_pots.created == [{"name": "flow-test", "use": True}]
     assert fake_pots.sources == [
         {
+            "source_id": "src-1",
             "pot_id": "pot-new",
             "kind": "repo",
             "location": "github.com/acme/shop",
             "name": None,
         }
     ]
+    assert fake_pots.repo_defaults == {"github.com/acme/shop": "pot-new"}
+
+
+def test_pot_create_repo_is_idempotent_when_pot_and_source_exist(monkeypatch) -> None:
+    monkeypatch.setattr(
+        repo_location, "current_git_remote", lambda cwd: "github.com/acme/shop"
+    )
+    fake_pots = _Pots()
+    _common.set_host(_Host(pots=fake_pots))
+    _common.set_json(True)
+    runner = CliRunner()
+
+    first = runner.invoke(
+        pots.pot_app,
+        ["create", "flow-test", "--use", "--repo", "."],
+    )
+    second = runner.invoke(
+        pots.pot_app,
+        ["create", "flow-test", "--use", "--repo", "."],
+    )
+
+    assert first.exit_code == 0, first.output
+    assert second.exit_code == 0, second.output
+    assert len(fake_pots.sources) == 1
+    assert fake_pots.created == [
+        {"name": "flow-test", "use": True},
+        {"name": "flow-test", "use": True},
+    ]
+    assert fake_pots.repo_defaults == {"github.com/acme/shop": "pot-new"}
+
+
+def test_register_repo_source_skips_duplicate_matching_identity(monkeypatch) -> None:
+    monkeypatch.setattr(
+        repo_location, "current_git_remote", lambda cwd: "github.com/acme/shop"
+    )
+    fake_pots = _Pots()
+    host = _Host(pots=fake_pots)
+
+    first = pots.register_repo_source(host, pot_id="pot-new", location="github.com/acme/shop")
+    second = pots.register_repo_source(
+        host, pot_id="pot-new", location=".", make_default=False
+    )
+
+    assert first["source_id"] == second["source_id"]
+    assert len(fake_pots.sources) == 1
     assert fake_pots.repo_defaults == {"github.com/acme/shop": "pot-new"}
 
 

--- a/potpie/context-engine/tests/unit/test_source_cli_contract.py
+++ b/potpie/context-engine/tests/unit/test_source_cli_contract.py
@@ -100,6 +100,7 @@ def test_source_add_json_marks_registration_only() -> None:
         "pot_id": "pot-1",
         "registration_only": True,
         "repo_default_set": False,
+        "repo_key": "owner/repo",
     }
     assert fake_pots.repo_defaults == {}
 


### PR DESCRIPTION
## Summary

- `pot create --repo .` previously stored a raw `"."` source with `location: null` and did not set the repo-local default, unlike `source add repo .`
- Add shared `register_repo_source()` used by both `source add repo` and `pot create --repo` so repo paths are resolved (git remote or absolute path), `location` is persisted, and the repo default is set
- Remove broken inline repo registration from `LocalPotStore.create()`; align post-setup pot creation in `setup_ux.py`
- Add `--no-default` to `pot create` (mirrors `source add --no-default`); JSON output includes `source`, `repo_default_set`, and `repo_key` when `--repo` is used

## Test plan

- [ ] `potpie pot create my-pot --use --repo .` — source shows resolved `location` (not `"."` / `null`), repo default is set
- [ ] `potpie pot create my-pot --repo . --no-default` — source registered, repo default not set
- [ ] `potpie source add repo .` — behavior unchanged
- [ ] `pytest potpie/context-engine/tests/unit/test_pot_create_repo.py -q`