### PR TITLE
Add next actions after source add for empty pots

### DIFF
--- a/potpie/context-engine/adapters/inbound/cli/commands/pots.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/pots.py
@@ -11,6 +11,7 @@ import typer
 from adapters.inbound.cli.commands._common import (
     contract,
     current_repo_identity_for_cli,
+    empty_pot_warnings,
     emit,
     fail,
     get_host,
@@ -132,6 +133,43 @@ def _repo_key_from_option(repo: str) -> str:
     if not repo_key:
         raise ValueError("--repo must resolve to a git remote or path")
     return repo_key
+
+
+def _source_add_next_action(
+    host: object,
+    *,
+    source_kind: str,
+    location: str,
+    pot_id: str,
+) -> str | None:
+    if source_kind.lower() != "repo":
+        return None
+    pot_info = pot_scope_info(host, pot_id)
+    counts = pot_info.get("counts") or {}
+    if "claims" not in counts:
+        return None
+    if int(counts.get("claims", 0) or 0) != 0:
+        return None
+    warnings = empty_pot_warnings(host, pot_id)
+    if warnings:
+        return warnings[0]
+    repo_ref = location or "current"
+    return (
+        f"pot {pot_info.get('name')} ({pot_id}) is still empty after source registration. "
+        f"Next: inspect linked pots with `potpie pot linked --repo {repo_ref}`, "
+        "switch to a populated pot, or start a graph mutation workflow with "
+        "`potpie graph mutation-template --kind repo-baseline`."
+    )
+
+
+def _source_add_next_block(*, recommended_next_action: str, repo_ref: str) -> str:
+    return (
+        "next actions:\n"
+        f"- check linked pots: potpie pot linked --repo {repo_ref}\n"
+        "- switch if one is already populated: potpie pot use <id-or-name>\n"
+        "- if this pot should be filled manually, start with:\n"
+        "  potpie graph mutation-template --kind repo-baseline"
+    )
 
 
 @pot_app.command("create")
@@ -439,9 +477,7 @@ def source_add(
         # Registration establishes the repo→pot mapping, so the target is the
         # explicit/active pot — never inferred from existing registrations.
         pot_id = resolve_pot_id(host, pot, infer_from_repo=False)
-        resolved_location = (
-            resolve_repo_location(location) if is_repo else location
-        )
+        resolved_location = resolve_repo_location(location) if is_repo else location
         started_ms = now_ms()
         capture_project_binding_event(
             "cli_onboarding_repo_source_add_started",
@@ -495,21 +531,35 @@ def source_add(
                 "duration_ms": elapsed_ms(started_ms),
             },
         )
+        recommended_next_action = _source_add_next_action(
+            host,
+            source_kind=src.kind,
+            location=resolved_location,
+            pot_id=pot_id,
+        )
+        payload = {
+            "source_id": src.source_id,
+            "kind": src.kind,
+            "name": src.name,
+            "location": resolved_location,
+            "pot_id": pot_id,
+            "repo_default_set": repo_default_set,
+            "registration_only": True,
+        }
+        if recommended_next_action:
+            payload["recommended_next_action"] = recommended_next_action
         emit(
-            {
-                "source_id": src.source_id,
-                "kind": src.kind,
-                "name": src.name,
-                "location": resolved_location,
-                "pot_id": pot_id,
-                "repo_default_set": repo_default_set,
-                "registration_only": True,
-            },
+            payload,
             human=(
                 f"registered source {src.kind}:{src.name} ({src.source_id}) "
                 f"at {resolved_location} in pot {pot_id}\n"
                 + (f"set repo default -> {pot_id}\n" if repo_default_set else "")
                 + "no ingestion or scan started"
+                + (
+                    f"\n{_source_add_next_block(recommended_next_action=recommended_next_action, repo_ref=resolved_location)}"
+                    if recommended_next_action
+                    else ""
+                )
             ),
         )
 

--- a/potpie/context-engine/tests/unit/test_cli_ergonomics.py
+++ b/potpie/context-engine/tests/unit/test_cli_ergonomics.py
@@ -84,6 +84,7 @@ class _Host:
     def __init__(self, pots_service, daemon=None) -> None:
         self.pots = pots_service
         self.daemon = daemon
+        self.graph = None
 
 
 class _Daemon:
@@ -92,6 +93,19 @@ class _Daemon:
 
     def discovery(self):
         return {"base_url": "http://127.0.0.1:8765"}
+
+
+class _GraphStatus:
+    def __init__(self, counts) -> None:
+        self.counts = counts
+
+
+class _Graph:
+    def __init__(self, counts_by_pot) -> None:
+        self._counts_by_pot = counts_by_pot
+
+    def data_plane_status(self, pot_id):
+        return _GraphStatus(self._counts_by_pot.get(pot_id, {}))
 
 
 # --- source add repo . / current --------------------------------------------
@@ -159,6 +173,51 @@ def test_source_add_repo_no_default_skips_repo_default(monkeypatch) -> None:
     payload = json.loads(result.output)
     assert payload["repo_default_set"] is False
     assert pots_service.repo_defaults == {}
+
+
+def test_source_add_repo_plain_output_shows_next_action_for_empty_pot(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        repo_location, "current_git_remote", lambda cwd: "github.com/acme/shop"
+    )
+    pots_service = _Pots(
+        [_Pot("p1", "shop", True)], {}, active=_Pot("p1", "shop", True)
+    )
+    host = _Host(pots_service)
+    host.graph = _Graph({"p1": {"claims": 0, "entities": 0}})
+    _common.set_host(host)
+
+    result = CliRunner().invoke(pots.source_app, ["add", "repo", "."])
+
+    assert result.exit_code == 0, result.output
+    assert "no ingestion or scan started" in result.output
+    assert "next actions:" in result.output
+    assert "check linked pots:" in result.output
+    assert "switch if one is already populated:" in result.output
+    assert "potpie graph mutation-template --kind repo-baseline" in result.output
+
+
+def test_source_add_repo_json_omits_next_action_when_pot_has_claims(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        repo_location, "current_git_remote", lambda cwd: "github.com/acme/shop"
+    )
+    pots_service = _Pots(
+        [_Pot("p1", "shop", True)], {}, active=_Pot("p1", "shop", True)
+    )
+    host = _Host(pots_service)
+    host.graph = _Graph({"p1": {"claims": 12, "entities": 4}})
+    _common.set_host(host)
+    _common.set_json(True)
+
+    result = CliRunner().invoke(pots.source_app, ["add", "repo", "."])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["registration_only"] is True
+    assert "recommended_next_action" not in payload
 
 
 def test_source_list_includes_location() -> None:

--- a/potpie/context-engine/tests/unit/test_source_cli_contract.py
+++ b/potpie/context-engine/tests/unit/test_source_cli_contract.py
@@ -47,6 +47,20 @@ class _Pots:
 @dataclass
 class _Host:
     pots: _Pots
+    graph: object | None = None
+
+
+@dataclass
+class _GraphStatus:
+    counts: dict[str, int]
+
+
+@dataclass
+class _Graph:
+    counts_by_pot: dict[str, dict[str, int]]
+
+    def data_plane_status(self, pot_id: str) -> _GraphStatus:
+        return _GraphStatus(counts=self.counts_by_pot.get(pot_id, {}))
 
 
 def test_source_add_plain_output_is_registration_only() -> None:
@@ -119,3 +133,26 @@ def test_source_add_repo_default_reports_unavailable_host() -> None:
     emitted = json.loads(result.output)
     assert emitted["code"] == "repo_default_unavailable"
     assert fake_pots.calls == []
+
+
+def test_source_add_json_includes_next_action_for_empty_repo_pot() -> None:
+    fake_pots = _Pots()
+    host = _Host(
+        pots=fake_pots,
+        graph=_Graph(counts_by_pot={"pot-1": {"claims": 0, "entities": 0}}),
+    )
+    _common.set_host(host)
+    _common.set_json(True)
+
+    result = CliRunner().invoke(
+        pots.source_app,
+        ["add", "repo", "owner/repo", "--pot", "pot-1", "--no-default"],
+    )
+
+    assert result.exit_code == 0, result.output
+    emitted = json.loads(result.output)
+    assert emitted["registration_only"] is True
+    assert "recommended_next_action" in emitted
+    assert "pot linked --repo owner/repo" in emitted["recommended_next_action"]
+    assert "switch to a populated pot" in emitted["recommended_next_action"]
+    assert "repo-baseline" in emitted["recommended_next_action"]


### PR DESCRIPTION
## Summary

  Add follow-up guidance after `potpie source add repo` when the target pot is empty.

  `source add repo` remains registration-only and still does not trigger ingestion or scanning. This change improves the success-path UX by showing concrete next actions when the
  selected pot has `0` claims.

  ## What Changed

  - Added empty-pot next-action guidance to `potpie source add repo`
  - Included `recommended_next_action` in JSON output for the empty-pot case
  - Kept populated-pot behavior unchanged
  - Kept source registration registration-only

  ## Behavior

  When `potpie source add repo . --pot <pot-id>` succeeds and the target pot has `0` claims:

  - human output now shows a `next actions:` block
  - JSON output now includes `recommended_next_action`

  Example next actions include:
  - inspect linked pots
  - switch to a populated pot
  - start manual graph mutation flow with `potpie graph mutation-template --kind repo-baseline`

  ## Why

  Previously, users could successfully register a repo into a new empty pot and then stop with no guidance, even though the graph still contained no claims.

  ## Validation

  ```bash
 uv run ruff check adapters/inbound/cli/commands/pots.py tests/unit/test_source_cli_contract.py tests/unit/test_cli_ergonomics.py
  uv run ruff format --check adapters/inbound/cli/commands/pots.py tests/unit/test_source_cli_contract.py tests/unit/test_cli_ergonomics.py
  uv run pytest tests/unit/test_source_cli_contract.py tests/unit/test_cli_ergonomics.py
```
  ## Test Notes

  Manual verification on an empty pot now shows:

  - human output with a next actions: block
  - JSON output with recommended_next_action