### PR TITLE
Clean up graph resolve feature and infra labels

### DIFF
--- a/potpie/context-core/src/potpie_context_core/agent_context_port.py
+++ b/potpie/context-core/src/potpie_context_core/agent_context_port.py
@@ -78,7 +78,14 @@ PLANNED_INCLUDES: frozenset[str] = CONTEXT_INCLUDE_VALUES - READER_BACKED_INCLUD
 FALLBACK_ONLY_INCLUDES: frozenset[str] = PLANNED_INCLUDES
 
 DEFAULT_INTENT_INCLUDES: dict[str, tuple[str, ...]] = {
-    "feature": ("coding_preferences", "infra_topology", "decisions", "owners", "docs"),
+    "feature": (
+        "coding_preferences",
+        "features",
+        "infra_topology",
+        "decisions",
+        "owners",
+        "docs",
+    ),
     "debugging": ("prior_bugs", "infra_topology", "timeline"),
     "review": ("coding_preferences", "decisions", "timeline", "owners"),
     "operations": ("infra_topology", "timeline", "owners"),

--- a/potpie/context-core/src/potpie_context_core/graph_views.py
+++ b/potpie/context-core/src/potpie_context_core/graph_views.py
@@ -161,7 +161,6 @@ _VIEW_LIST: tuple[GraphViewSpec, ...] = (
             "DEFINED_IN",
             "HOSTED_ON",
             "OWNED_BY",
-            "PROVIDES",
             "EXPOSES",
         ),
         traversal=True,

--- a/potpie/context-core/tests/unit/test_graph_views.py
+++ b/potpie/context-core/tests/unit/test_graph_views.py
@@ -70,6 +70,8 @@ def test_traversal_flag_only_on_neighborhood_views() -> None:
 def test_neighborhood_declares_depth_direction_environment() -> None:
     spec = view_spec("infra_topology.service_neighborhood")
     assert {"depth", "direction", "environment"} <= set(spec.inputs)
+    assert "PROVIDES" not in spec.inline_relations
+    assert "EXPOSES" in spec.inline_relations
 
 
 def test_neighborhood_documents_environment_filter_rule() -> None:

--- a/potpie/context-engine/src/potpie_context_engine/application/readers/infra_topology.py
+++ b/potpie/context-engine/src/potpie_context_engine/application/readers/infra_topology.py
@@ -3,7 +3,7 @@
 Inputs: scope (service / env / file). Logic: bounded neighbourhood
 traversal over claim edges with topology predicates (``DEFINED_IN``,
 ``DEPLOYED_TO``, ``DEPENDS_ON``, ``USES``, ``HOSTED_ON``, ``OWNED_BY``,
-``PROVIDES``, ``IMPLEMENTED_IN``),
+``USES_ADAPTER``, ``CONFIGURES``, ``DEPLOYED_WITH``),
 environment-filtered via the ``environment`` edge property. Supports
 blast-radius (incoming ``DEPENDS_ON`` traversal with depth). Supports
 ``as_of`` via the bitemporal predicate.
@@ -55,8 +55,6 @@ _INFRA_PREDICATES: tuple[str, ...] = (
     "DEPLOYED_WITH",
     "HOSTED_ON",
     "OWNED_BY",
-    "PROVIDES",
-    "IMPLEMENTED_IN",
 )
 
 

--- a/potpie/context-engine/tests/unit/test_read_orchestrator.py
+++ b/potpie/context-engine/tests/unit/test_read_orchestrator.py
@@ -90,3 +90,65 @@ def test_intent_expands_to_backed_readers() -> None:
     # readers; empty backed readers return no items, not unsupported includes.
     assert "coding_preferences" in {i.include for i in env.items}
     assert env.unsupported_includes == ()
+
+
+def test_feature_intent_routes_feature_claims_to_features_include() -> None:
+    store = InMemoryClaimQueryStore()
+    store.add(
+        ClaimRow(
+            pot_id="p1",
+            predicate="PROVIDES",
+            subject_key="repo:github.com/acme/widgets",
+            object_key="feature:search",
+            evidence_strength="attested",
+            fact="widgets repo provides search",
+            properties={},
+        )
+    )
+    orch = ReadOrchestrator(claim_query=store)
+
+    env = orch.resolve(
+        pot_id="p1",
+        intent="feature",
+        scope={"anchor_entity_key": "repo:github.com/acme/widgets"},
+    )
+
+    includes = [item.include for item in env.items]
+    assert "features" in includes
+    assert "infra_topology" not in includes
+
+
+def test_infra_topology_excludes_feature_predicates() -> None:
+    store = InMemoryClaimQueryStore()
+    store.add(
+        ClaimRow(
+            pot_id="p1",
+            predicate="DEFINED_IN",
+            subject_key="service:search-api",
+            object_key="repo:github.com/acme/widgets",
+            evidence_strength="attested",
+            fact="search api lives in widgets repo",
+            properties={},
+        )
+    )
+    store.add(
+        ClaimRow(
+            pot_id="p1",
+            predicate="PROVIDES",
+            subject_key="repo:github.com/acme/widgets",
+            object_key="feature:search",
+            evidence_strength="attested",
+            fact="widgets repo provides search",
+            properties={},
+        )
+    )
+    orch = ReadOrchestrator(claim_query=store)
+
+    env = orch.resolve(
+        pot_id="p1",
+        include=["infra_topology"],
+        scope={"anchor_entity_key": "repo:github.com/acme/widgets"},
+    )
+
+    assert [item.include for item in env.items] == ["infra_topology"]
+    assert env.items[0].payload["predicate"] == "DEFINED_IN"


### PR DESCRIPTION
## Summary

  Fix `potpie resolve` so feature-related claims are returned under `features` instead of being surfaced through `infra_topology`. This change keeps the include labels semantically clean for top-level resolve output. Feature predicates such as `PROVIDES` and `IMPLEMENTED_IN` now stay in the feature path, while `infra_topology` remains limited to topology-oriented claims.

Closes #981 

  ## What Changed

  - Added `features` to the default include set for the `feature` intent
  - Removed feature predicates from the `infra_topology` reader
  - Updated the graph view contract so `infra_topology.service_neighborhood` no longer advertises `PROVIDES`
  - Added focused tests for:
    - feature intent expansion
    - infra-topology exclusion of feature predicates
    - graph view contract alignment

  ## Why

  Previously, top-level resolve could return feature claims under `infra_topology`, which made the include labels misleading even when the underlying context was useful.

  This PR corrects that semantic boundary so downstream users and agents can trust the include family more accurately.

  ## Validation

  ```bash
  uv run pytest tests/unit/test_read_orchestrator.py tests/unit/test_graph_views.py tests/unit/test_p9_readers.py tests/unit/test_graph_surface_lite_contract.py
  uv run ruff check domain/agent_context_port.py application/readers/infra_topology.py domain/graph_views.py tests/unit/test_read_orchestrator.py tests/unit/test_graph_views.py
  uv run ruff format --check domain/agent_context_port.py application/readers/infra_topology.py domain/graph_views.py tests/unit/test_read_orchestrator.py tests/unit/
  test_graph_views.py
```
  ## Notes

  Focused automated validation is passing.

  A separate manual local-graph inconsistency was observed while creating ad hoc fixture data for CLI verification: a committed feature claim did not surface in live reads even though the mutation plan recorded it as accepted. 
That behavior appears unrelated to the resolve-labeling change in this PR and is not part of this fix.