### PR TITLE
Fix graph explorer npm install warnings

### DIFF
--- a/potpie/context-engine/adapters/inbound/http/ui/frontend/package.json
+++ b/potpie/context-engine/adapters/inbound/http/ui/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "node scripts/dev.mjs",
     "test": "npm run test:dev-port",
     "test:dev-port": "node --test scripts/dev-port.test.mjs",
+    "audit": "npm audit --audit-level=moderate",
     "build": "npm run test:dev-port && tsc -b && vite build",
     "preview": "vite preview"
   },
@@ -21,5 +22,9 @@
     "@vitejs/plugin-react": "^4.3.4",
     "typescript": "^5.6.3",
     "vite": "^6.4.3"
+  },
+  "allowScripts": {
+    "esbuild": true,
+    "fsevents": true
   }
 }


### PR DESCRIPTION
## Summary
- Add a graph explorer `npm run audit` command for an explicit frontend audit check.
- Record npm 11 install-script approvals for the known Vite installer dependencies: `esbuild` and `fsevents`.

## Context
POT-1783 tracked noise from `make cli-install`: npm audit output and pending install-script approvals. `main` already resolves Vite to the patched 6.4.3 line, so the remaining problem is npm 11 asking for install-script review on every install.

The approval is package-level instead of version-pinned. That keeps the CLI install path stable across normal transitive patch updates without committing generated npm state or revisiting this issue every time esbuild publishes a patch. Future audit findings will still surface through `npm run audit` and the install output.

## Validation
- `npm install`
- `npm run audit`
- `npm approve-scripts --allow-scripts-pending`
- `make ui-build`
- `make cli-install`