### PR TITLE
Remove pot-level Jira/Linear ingest commands from CLI

### DIFF
--- a/docs/context-graph/cli-flow.md
+++ b/docs/context-graph/cli-flow.md
@@ -50,7 +50,7 @@ uniformly across the surface.
   (the shipped CLI default host mode is a detached `daemon`). Only
   `CONTEXT_ENGINE_HOST_MODE=in_process` builds an in-process shell via
   `bootstrap/host_wiring.py build_host_shell()`. A handful of commands bypass the
-  HostShell entirely (see notes on `login`, `pot linear-team/jira-project`, `cloud`).
+  HostShell entirely (see notes on `login` and `cloud`).
 - **`contract()`** — the error boundary that maps outcomes to exit codes and emits
   structured JSON errors (`code`, `message`, `detail`, `recommended_next_action`):
 
@@ -189,9 +189,6 @@ potpie pot archive <ref>
 potpie pot linked  [--repo .] [--summary]
 potpie pot default show | set | clear [--repo .]
 
-potpie pot linear-team   ingest | diff-sync <team> [--pot <ref>] [--count <n>] [--since <time>]
-potpie pot jira-project  ingest | diff-sync <key>  [--pot <ref>] [--count <n>] [--since <time>]
-
 potpie source add    <kind> <location> [--name <n>] [--pot <ref>] [--default/--no-default]
 potpie source list   [--pot <ref>]
 potpie source status [<id>] [--pot <ref>]
@@ -207,9 +204,6 @@ potpie source remove <id> [--pot <ref>]
   repo default and the selected pot diverge).
 - **`source status`** with no ID prints a per-pot summary of all sources; with an
   ID it reports that single source.
-- **`pot linear-team` / `pot jira-project`** **bypass HostShell** and POST a single
-  `one_shot_ingest` event to the managed `PotpieContextApiClient.submit_event`; they
-  fail with `api_unreachable` against the embedded local store.
 - **`source add <kind> <location>`** is generic registration only (no scan/ingest);
   registering a repo also sets the repo default. Repo-baseline ingestion is
   harness-led via skills ([skills.md](./skills.md)), not a scanner.

--- a/docs/context-graph/ingestion-nudge.md
+++ b/docs/context-graph/ingestion-nudge.md
@@ -13,8 +13,8 @@ The two things this doc most wants you to internalise:
    internal Postgres event store); the other is a mostly-stubbed external seam
    (the *Event Ledger* product). The old docs conflate them.
 2. **Scanners and most connectors are gone.** Repo/PR/ticket ingestion is now
-   either harness-led (skills authoring semantic mutations) or a CLI one-shot
-   flow — not an in-process scanner library. The canonical write door for
+   either harness-led (skills authoring semantic mutations) or a server-side
+   event flow — not an in-process scanner library. The canonical write door for
    everything that lands as a *fact* is still `graph propose` → `graph commit
    --verify` (see [writing.md](./writing.md)).
 
@@ -59,7 +59,6 @@ flowchart TD
   ing_ep2["POST /api/v1/context/events/reconcile<br/>(agent_reconciliation)"]
   ing_ep3["POST /api/v1/context/record<br/>(context_record)"]
   ing_wh["POST /webhooks/github<br/>(merged PRs)"]
-  ing_cli["CLI one-shot<br/>jira/linear ... ingest<br/>(one_shot_ingest)"]
 
   ing_submit["DefaultIngestionSubmissionService.submit()<br/>_do_submit"]
   ing_record["GraphService.record()<br/>(deterministic, semantic-mutation path)"]
@@ -70,7 +69,6 @@ flowchart TD
   ing_ep2 --> ing_submit
   ing_ep3 --> ing_submit
   ing_wh --> ing_submit
-  ing_cli --> ing_submit
 
   ing_submit -->|"event_type == context_record"| ing_record
   ing_submit -->|"all other events"| ing_admit
@@ -85,7 +83,6 @@ flowchart TD
 | `POST /api/v1/context/events/reconcile` | `agent_reconciliation` | The canonical event-submission path; deduped by scope + `source_system` + `source_id`. |
 | `POST /api/v1/context/record` | `context_record` (`record_durable_context.py`) | **The deterministic exception** — see §3. |
 | `POST /webhooks/github` | `agent_reconciliation` | `GitHubConnector.normalize_webhook()` verifies HMAC (fail-closed unless `CONTEXT_ENGINE_ALLOW_UNSIGNED_WEBHOOKS=1`), emits a `ContextEvent` for merged PRs, maps repo→pot, stamps a server-trusted `webhook` Actor. |
-| CLI one-shot ingest | `one_shot_ingest` (`commands/pots.py`) | `potpie jira project <KEY> ingest` / `potpie linear team <KEY> ingest` POST a single event through the API client into the same agent pipeline. |
 
 For non-record events, `_do_submit` resolves pot/repo/source_id and calls
 `event_admission.admit_event(...)`: persist the event (idempotent on
@@ -130,10 +127,11 @@ This is the biggest ingestion correction versus the old docs.
   `connectors/jira/` and `connectors/linear/` are stale `.pyc` only.
   Connectors implement `kind / capabilities / list_artifacts / normalize_webhook
   / fetch`; `propose_plan` was removed, so **connectors no longer write claims**.
-- **jira/linear are a CLI + agent flow, not connectors.** The `one_shot_ingest`
-  events are processed by the reconciliation agent using event playbooks
-  (`domain/event_playbooks.py`) + the `backfill-enumerate-drain` skill; the
-  actual jira/linear *reads* live in
+- **jira/linear reads are harness-led, not CLI queue-driven.** The old
+  pot-level CLI queue-ingest commands have been removed. Hosted-source
+  hydration should happen through the harness and integration tools, while
+  server-side event ingestion continues to flow through the HTTP endpoints
+  above. The actual jira/linear *reads* live in
   `adapters/outbound/cli_auth/{atlassian_read_client,linear_read_client}.py`.
 
 ---
@@ -313,7 +311,6 @@ taught in the `potpie-graph` skill's "Responding To Nudges" — see
 - [architecture.md](./architecture.md) — the two composition roots / two HTTP
   roots that this doc's ingestion server vs local spine split rests on.
 - [querying.md](./querying.md) — the named views a nudge reads.
-- [cli-flow.md](./cli-flow.md) — full flags for `ledger ...`, `graph nudge`, and
-  the jira/linear one-shot ingest commands.
+- [cli-flow.md](./cli-flow.md) — full flags for `ledger ...` and `graph nudge`.
 - [observability.md](./observability.md) — `batch.process` / `agent.run_batch`
   spans (and the `reconciliation_run` ledger row) and ingestion metrics.

--- a/potpie/context-engine/adapters/inbound/cli/commands/pots.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/pots.py
@@ -705,4 +705,5 @@ def source_remove(source_id: str, pot: str = typer.Option(None, "--pot")) -> Non
         host.pots.remove_source(pot_id=pot_id, source_id=source_id)
         emit({"removed": source_id}, human=f"removed source {source_id}")
 
+
 __all__ = ["pot_app", "source_app"]

--- a/potpie/context-engine/adapters/inbound/cli/commands/pots.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/pots.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-import uuid
-from datetime import datetime, timezone
 from typing import Any
 
-import httpx
 import typer
 
 from adapters.inbound.cli.commands._common import (
@@ -34,14 +31,6 @@ from adapters.inbound.cli.telemetry.onboarding_events import (
     now_ms,
     sanitized_failure_kind,
 )
-from adapters.outbound.cli_auth.potpie_api_config import (
-    resolve_potpie_api_base_url,
-    resolve_potpie_auth_config,
-)
-from adapters.outbound.http.potpie_context_api_client import (
-    PotpieContextApiClient,
-    PotpieContextApiError,
-)
 from adapters.inbound.cli.repo_location import repo_identity_key, resolve_repo_location
 from domain.errors import CapabilityNotImplemented
 
@@ -50,29 +39,7 @@ default_app = typer.Typer(help="Repo-local default pot routing.")
 source_app = typer.Typer(
     help="Source registry for a pot; registration does not ingest or scan."
 )
-linear_team_app = typer.Typer(help="Linear teams attached to a context pot.")
-jira_project_app = typer.Typer(help="Jira projects reachable from a context pot.")
 pot_app.add_typer(default_app, name="default")
-
-
-def _potpie_api_client() -> PotpieContextApiClient:
-    try:
-        return PotpieContextApiClient(
-            resolve_potpie_api_base_url(),
-            auth_headers_provider=lambda: resolve_potpie_auth_config().headers,
-            reauth_provider=lambda: (
-                resolve_potpie_auth_config(force_refresh=True).headers
-            ),
-            client_surface="cli",
-            client_name="potpie-cli",
-        )
-    except ValueError as exc:
-        fail(
-            code="auth_missing",
-            message="Potpie API not configured.",
-            detail=str(exc),
-            next_action="run 'potpie login' or set POTPIE_API_KEY",
-        )
 
 
 @pot_app.command("list")
@@ -129,18 +96,6 @@ def pot_info() -> None:
             {"active_pot": active_payload, "current_repo": routing},
             human="\n".join(lines),
         )
-
-
-def _fail_api_unreachable(*, label: str, exc: httpx.RequestError) -> None:
-    fail(
-        code="api_unreachable",
-        message=f"{label} failed.",
-        detail=str(exc),
-        next_action=(
-            "check POTPIE_API_BASE_URL / POTPIE_API_KEY or run 'potpie login'; "
-            "remote event ingestion is not served by the embedded local graph store"
-        ),
-    )
 
 
 def _repo_key_from_option(repo: str) -> str:
@@ -471,140 +426,6 @@ def pot_reset(
         )
 
 
-@linear_team_app.command("ingest")
-def linear_team_ingest(
-    team: str = typer.Argument(..., help="Linear team id or key, e.g. ENG."),
-    pot: str = typer.Option(None, "--pot", help="Pot id/name (default: active pot)."),
-    count: int = typer.Option(
-        120,
-        "--count",
-        min=1,
-        max=1000,
-        help="Soft per-kind item limit for the one-shot ingestion playbook.",
-    ),
-) -> None:
-    """Queue one-shot ingestion for a Linear team's recent graph history."""
-    with contract():
-        team_key = team.strip()
-        if not team_key:
-            raise ValueError("Linear team id/key is required.")
-
-        pid = resolve_pot_id(get_host(), pot)
-        source_id = f"one_shot_ingest:linear:{team_key.lower()}:{uuid.uuid4()}"
-        try:
-            status_code, data = _potpie_api_client().submit_event(
-                pot_id=pid,
-                source_system="linear",
-                event_type="linear_team",
-                action="one_shot_ingest",
-                source_id=source_id,
-                payload={"team": team_key, "count": count},
-                provider=None,
-                provider_host=None,
-                repo_name=None,
-                occurred_at=datetime.now(timezone.utc),
-            )
-        except PotpieContextApiError as exc:
-            fail(
-                code="api_error",
-                message="Linear ingest failed.",
-                detail=str(exc.detail),
-            )
-        except httpx.RequestError as exc:
-            _fail_api_unreachable(label="Linear ingest", exc=exc)
-
-        out = {
-            "status": "queued" if status_code == 202 else data.get("status", "applied"),
-            "pot_id": pid,
-            "team": team_key,
-            "count": count,
-            "source_id": source_id,
-            "event_id": data.get("event_id"),
-            "batch_id": data.get("batch_id"),
-        }
-        if status_code == 409:
-            out["status"] = "duplicate"
-        emit(
-            out,
-            human=(
-                f"Queued Linear team ingest for {team_key} in pot {pid} "
-                f"(event {out.get('event_id') or 'unknown'})."
-            ),
-        )
-
-
-@linear_team_app.command("diff-sync")
-def linear_team_diff_sync(
-    team: str = typer.Argument(..., help="Linear team id or key, e.g. ENG."),
-    pot: str = typer.Option(None, "--pot", help="Pot id/name (default: active pot)."),
-    since: str = typer.Option(
-        None,
-        "--since",
-        help="ISO-8601 lower bound for source enumeration. Omit to use the "
-        "last graph-audit cursor from history.",
-    ),
-    count: int = typer.Option(
-        120,
-        "--count",
-        min=1,
-        max=1000,
-        help="Soft per-kind item limit for the diff-sync playbook.",
-    ),
-) -> None:
-    """Queue an incremental graph-audit diff-sync for a Linear team."""
-    with contract():
-        team_key = team.strip()
-        if not team_key:
-            raise ValueError("Linear team id/key is required.")
-
-        pid = resolve_pot_id(get_host(), pot)
-        source_id = f"diff_sync:linear:{team_key.lower()}:{uuid.uuid4()}"
-        payload: dict[str, object] = {"team": team_key, "count": count}
-        if since:
-            payload["since"] = since
-        try:
-            status_code, data = _potpie_api_client().submit_event(
-                pot_id=pid,
-                source_system="linear",
-                event_type="linear_team",
-                action="diff_sync",
-                source_id=source_id,
-                payload=payload,
-                provider=None,
-                provider_host=None,
-                repo_name=None,
-                occurred_at=datetime.now(timezone.utc),
-            )
-        except PotpieContextApiError as exc:
-            fail(
-                code="api_error",
-                message="Linear diff-sync failed.",
-                detail=str(exc.detail),
-            )
-        except httpx.RequestError as exc:
-            _fail_api_unreachable(label="Linear diff-sync", exc=exc)
-
-        out = {
-            "status": "queued" if status_code == 202 else data.get("status", "applied"),
-            "pot_id": pid,
-            "team": team_key,
-            "since": since,
-            "count": count,
-            "source_id": source_id,
-            "event_id": data.get("event_id"),
-            "batch_id": data.get("batch_id"),
-        }
-        if status_code == 409:
-            out["status"] = "duplicate"
-        emit(
-            out,
-            human=(
-                f"Queued Linear team diff-sync for {team_key} in pot {pid} "
-                f"(event {out.get('event_id') or 'unknown'})."
-            ),
-        )
-
-
 @pot_app.command("archive")
 def pot_archive(ref: str) -> None:
     with contract():
@@ -883,145 +704,5 @@ def source_remove(source_id: str, pot: str = typer.Option(None, "--pot")) -> Non
         pot_id = resolve_pot_id(host, pot)
         host.pots.remove_source(pot_id=pot_id, source_id=source_id)
         emit({"removed": source_id}, human=f"removed source {source_id}")
-
-
-pot_app.add_typer(linear_team_app, name="linear-team")
-
-
-@jira_project_app.command("ingest")
-def jira_project_ingest(
-    project_key: str = typer.Argument(..., help="Jira project key, e.g. PROJ."),
-    pot: str = typer.Option(None, "--pot", help="Pot id/name (default: active pot)."),
-    count: int = typer.Option(
-        120,
-        "--count",
-        min=1,
-        max=1000,
-        help="Soft per-kind item limit for the one-shot ingestion playbook.",
-    ),
-) -> None:
-    """Queue one-shot ingestion for a Jira project's recent epics and issues."""
-    with contract():
-        key = project_key.strip()
-        if not key:
-            raise ValueError("Jira project key is required.")
-
-        pid = resolve_pot_id(get_host(), pot)
-        source_id = f"one_shot_ingest:jira:{key.lower()}:{uuid.uuid4()}"
-        try:
-            status_code, data = _potpie_api_client().submit_event(
-                pot_id=pid,
-                source_system="jira",
-                event_type="jira_project",
-                action="one_shot_ingest",
-                source_id=source_id,
-                payload={"project_key": key, "count": count},
-                provider=None,
-                provider_host=None,
-                repo_name=None,
-                occurred_at=datetime.now(timezone.utc),
-            )
-        except PotpieContextApiError as exc:
-            fail(
-                code="api_error",
-                message="Jira ingest failed.",
-                detail=str(exc.detail),
-            )
-        except httpx.RequestError as exc:
-            _fail_api_unreachable(label="Jira ingest", exc=exc)
-
-        out = {
-            "status": "queued" if status_code == 202 else data.get("status", "applied"),
-            "pot_id": pid,
-            "project_key": key,
-            "count": count,
-            "source_id": source_id,
-            "event_id": data.get("event_id"),
-            "job_id": data.get("job_id") or data.get("batch_id"),
-        }
-        if status_code == 409:
-            out["status"] = "duplicate"
-        emit(
-            out,
-            human=(
-                f"Queued Jira project ingest for {key} in pot {pid} "
-                f"(event {out.get('event_id') or 'unknown'})."
-            ),
-        )
-
-
-@jira_project_app.command("diff-sync")
-def jira_project_diff_sync(
-    project_key: str = typer.Argument(..., help="Jira project key, e.g. PROJ."),
-    pot: str = typer.Option(None, "--pot", help="Pot id/name (default: active pot)."),
-    since: str = typer.Option(
-        None,
-        "--since",
-        help="ISO-8601 lower bound for source enumeration. Omit to use the "
-        "last graph-audit cursor from history.",
-    ),
-    count: int = typer.Option(
-        120,
-        "--count",
-        min=1,
-        max=1000,
-        help="Soft per-kind item limit for the diff-sync playbook.",
-    ),
-) -> None:
-    """Queue an incremental graph-audit diff-sync for a Jira project."""
-    with contract():
-        key = project_key.strip()
-        if not key:
-            raise ValueError("Jira project key is required.")
-
-        pid = resolve_pot_id(get_host(), pot)
-        source_id = f"diff_sync:jira:{key.lower()}:{uuid.uuid4()}"
-        payload: dict[str, object] = {"project_key": key, "count": count}
-        if since:
-            payload["since"] = since
-        try:
-            status_code, data = _potpie_api_client().submit_event(
-                pot_id=pid,
-                source_system="jira",
-                event_type="jira_project",
-                action="diff_sync",
-                source_id=source_id,
-                payload=payload,
-                provider=None,
-                provider_host=None,
-                repo_name=None,
-                occurred_at=datetime.now(timezone.utc),
-            )
-        except PotpieContextApiError as exc:
-            fail(
-                code="api_error",
-                message="Jira diff-sync failed.",
-                detail=str(exc.detail),
-            )
-        except httpx.RequestError as exc:
-            _fail_api_unreachable(label="Jira diff-sync", exc=exc)
-
-        out = {
-            "status": "queued" if status_code == 202 else data.get("status", "applied"),
-            "pot_id": pid,
-            "project_key": key,
-            "since": since,
-            "count": count,
-            "source_id": source_id,
-            "event_id": data.get("event_id"),
-            "job_id": data.get("job_id") or data.get("batch_id"),
-        }
-        if status_code == 409:
-            out["status"] = "duplicate"
-        emit(
-            out,
-            human=(
-                f"Queued Jira project diff-sync for {key} in pot {pid} "
-                f"(event {out.get('event_id') or 'unknown'})."
-            ),
-        )
-
-
-pot_app.add_typer(jira_project_app, name="jira-project")
 
 __all__ = ["pot_app", "source_app"]

--- a/potpie/context-engine/adapters/inbound/cli/templates/agent_bundle/.agents/skills/potpie-change-timeline/SKILL.md
+++ b/potpie/context-engine/adapters/inbound/cli/templates/agent_bundle/.agents/skills/potpie-change-timeline/SKILL.md
@@ -57,8 +57,8 @@ Timeline reads do not include uncommitted local work unless it was recorded.
 ## Record History
 
 For GitHub, Linear, Jira, docs, and similar sources, hydrate records with the
-agent's integration tools/connectors first. Do not use pot-level connector
-ingestion commands as the source-history path.
+agent's integration tools/connectors first. Do not use Potpie CLI queue
+ingestion as the source-history path.
 
 Use the workbench write flow after reading the source:
 

--- a/potpie/context-engine/adapters/inbound/cli/templates/agent_bundle/.agents/skills/potpie-graph/SKILL.md
+++ b/potpie/context-engine/adapters/inbound/cli/templates/agent_bundle/.agents/skills/potpie-graph/SKILL.md
@@ -200,7 +200,7 @@ worth recording, resolves identity, and writes a semantic mutation.
 
 For GitHub, Linear, Jira, and similar hosted integrations, use the agent's
 integration tools/connectors to pull and hydrate source records first. Do not use
-pot-level connector ingestion commands as the graph update path; after reading
+Potpie CLI queue ingestion as the graph update path; after reading
 the integration data, write durable facts with `graph propose` / `graph commit --verify`
 or capture uncertainty with `graph inbox`.
 

--- a/potpie/context-engine/adapters/inbound/cli/templates/agent_bundle/.agents/skills/potpie-source-ingestion/SKILL.md
+++ b/potpie/context-engine/adapters/inbound/cli/templates/agent_bundle/.agents/skills/potpie-source-ingestion/SKILL.md
@@ -127,8 +127,7 @@ truth, then read the relevant snippets or authored docs.
 
 Use the agent's integration tools/connectors, including GitHub app/MCP/CLI
 tools when available, not Potpie queue ingestion commands. For GitHub-backed
-repo ingestion, gather the items below. Do not use pot-level connector
-ingestion commands.
+repo ingestion, gather the items below. Do not use Potpie CLI queue ingestion.
 
 - Repository metadata: full name, default branch, description, topics,
   visibility, homepage, license, archived/fork status.

--- a/potpie/context-engine/adapters/inbound/cli/templates/agent_bundle/AGENTS.md
+++ b/potpie/context-engine/adapters/inbound/cli/templates/agent_bundle/AGENTS.md
@@ -177,10 +177,9 @@ For explicit repository ingestion, use a todo-driven workflow:
 
 For GitHub, Linear, Jira, and other hosted integrations, pull PRs, issues,
 tickets, comments, labels/status, and linked docs with the agent's integration
-tools/connectors. Do not use pot-level connector ingestion commands such as
-`potpie pot linear-team ingest`, `potpie pot linear-team diff-sync`, or
-Jira/GitHub queue commands as the ingestion path; write the graph updates
-yourself with `graph propose` / `graph commit --verify` or `graph inbox`.
+tools/connectors. Do not use Potpie CLI queue ingestion as the ingestion path;
+write the graph updates yourself with `graph propose` / `graph commit --verify`
+or `graph inbox`.
 
 ## Responding To Nudges
 

--- a/potpie/context-engine/adapters/inbound/cli/templates/claude_bundle/.claude/skills/potpie-graph/SKILL.md
+++ b/potpie/context-engine/adapters/inbound/cli/templates/claude_bundle/.claude/skills/potpie-graph/SKILL.md
@@ -200,7 +200,7 @@ worth recording, resolves identity, and writes a semantic mutation.
 
 For GitHub, Linear, Jira, and similar hosted integrations, use the agent's
 integration tools/connectors to pull and hydrate source records first. Do not use
-pot-level connector ingestion commands as the graph update path; after reading
+Potpie CLI queue ingestion as the graph update path; after reading
 the integration data, write durable facts with `graph propose` / `graph commit --verify`
 or capture uncertainty with `graph inbox`.
 

--- a/potpie/context-engine/adapters/inbound/cli/templates/claude_bundle/CLAUDE.md
+++ b/potpie/context-engine/adapters/inbound/cli/templates/claude_bundle/CLAUDE.md
@@ -104,10 +104,9 @@ the gate warns or fails.
 
 For GitHub, Linear, Jira, and other hosted integrations, pull PRs, issues,
 tickets, comments, labels/status, and linked docs with the agent's integration
-tools/connectors. Do not use pot-level connector ingestion commands such as
-`potpie pot linear-team ingest`, `potpie pot linear-team diff-sync`, or
-Jira/GitHub queue commands as the ingestion path; write the graph updates
-yourself with `graph propose` / `graph commit --verify` or `graph inbox`.
+tools/connectors. Do not use Potpie CLI queue ingestion as the ingestion path;
+write the graph updates yourself with `graph propose` / `graph commit --verify`
+or `graph inbox`.
 
 ## Nudges
 

--- a/potpie/context-engine/adapters/inbound/cli/templates/claude_plugin/skills/potpie-change-timeline/SKILL.md
+++ b/potpie/context-engine/adapters/inbound/cli/templates/claude_plugin/skills/potpie-change-timeline/SKILL.md
@@ -57,8 +57,8 @@ Timeline reads do not include uncommitted local work unless it was recorded.
 ## Record History
 
 For GitHub, Linear, Jira, docs, and similar sources, hydrate records with the
-agent's integration tools/connectors first. Do not use pot-level connector
-ingestion commands as the source-history path.
+agent's integration tools/connectors first. Do not use Potpie CLI queue
+ingestion as the source-history path.
 
 Use the workbench write flow after reading the source:
 

--- a/potpie/context-engine/adapters/inbound/cli/templates/claude_plugin/skills/potpie-graph/SKILL.md
+++ b/potpie/context-engine/adapters/inbound/cli/templates/claude_plugin/skills/potpie-graph/SKILL.md
@@ -200,7 +200,7 @@ worth recording, resolves identity, and writes a semantic mutation.
 
 For GitHub, Linear, Jira, and similar hosted integrations, use the agent's
 integration tools/connectors to pull and hydrate source records first. Do not use
-pot-level connector ingestion commands as the graph update path; after reading
+Potpie CLI queue ingestion as the graph update path; after reading
 the integration data, write durable facts with `graph propose` / `graph commit --verify`
 or capture uncertainty with `graph inbox`.
 

--- a/potpie/context-engine/adapters/inbound/cli/templates/claude_plugin/skills/potpie-source-ingestion/SKILL.md
+++ b/potpie/context-engine/adapters/inbound/cli/templates/claude_plugin/skills/potpie-source-ingestion/SKILL.md
@@ -127,8 +127,7 @@ truth, then read the relevant snippets or authored docs.
 
 Use the agent's integration tools/connectors, including GitHub app/MCP/CLI
 tools when available, not Potpie queue ingestion commands. For GitHub-backed
-repo ingestion, gather the items below. Do not use pot-level connector
-ingestion commands.
+repo ingestion, gather the items below. Do not use Potpie CLI queue ingestion.
 
 - Repository metadata: full name, default branch, description, topics,
   visibility, homepage, license, archived/fork status.

--- a/potpie/context-engine/tests/unit/test_agent_templates_v15.py
+++ b/potpie/context-engine/tests/unit/test_agent_templates_v15.py
@@ -419,30 +419,25 @@ def test_hosted_integration_ingestion_is_agent_led() -> None:
         assert "agent's integration tools/connectors" in text, (
             f"{fragment} does not direct agents to hydrate hosted sources through integrations"
         )
-        assert "do not use pot-level connector ingestion commands" in text, (
-            f"{fragment} does not rule out pot-level connector ingestion commands"
+        assert "do not use potpie cli queue ingestion" in text, (
+            f"{fragment} does not rule out Potpie CLI queue ingestion"
         )
         assert "graph propose" in text and "graph commit" in text, (
             f"{fragment} does not route hosted ingestion back through graph plans"
         )
 
 
-def test_connector_queue_commands_only_appear_as_forbidden_examples() -> None:
-    forbidden_examples = (
+def test_removed_connector_queue_commands_are_not_advertised() -> None:
+    removed_commands = (
         "potpie pot linear-team ingest",
         "potpie pot linear-team diff-sync",
+        "potpie pot jira-project ingest",
+        "potpie pot jira-project diff-sync",
     )
     for path in MD_FILES:
         rel = path.relative_to(TEMPLATES)
         lowered = path.read_text(encoding="utf-8").lower()
-        for token in forbidden_examples:
-            start = 0
-            while True:
-                idx = lowered.find(token, start)
-                if idx == -1:
-                    break
-                window = lowered[max(0, idx - 120) : idx + len(token) + 120]
-                assert "do not use" in window, (
-                    f"{rel} mentions connector queue command `{token}` outside a ban"
-                )
-                start = idx + len(token)
+        for token in removed_commands:
+            assert token not in lowered, (
+                f"{rel} still advertises removed connector queue command `{token}`"
+            )

--- a/potpie/context-engine/tests/unit/test_cli_usage_errors.py
+++ b/potpie/context-engine/tests/unit/test_cli_usage_errors.py
@@ -52,6 +52,35 @@ def test_unknown_subcommand_emits_structured_json_via_run_cli(
     assert payload["recommended_next_action"]
 
 
+@pytest.mark.parametrize(
+    "argv, expected",
+    [
+        (["--json", "pot", "jira-project", "ingest", "ENG"], "jira-project"),
+        (["--json", "pot", "linear-team", "ingest", "ENG"], "linear-team"),
+    ],
+)
+def test_removed_pot_queue_commands_emit_structured_unknown_command(
+    argv: list[str],
+    expected: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(typer.Exit) as exc_info:
+        host_cli.run_cli(argv)
+
+    assert exc_info.value.exit_code == _common.EXIT_VALIDATION
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["code"] == "usage_error"
+    assert expected in payload["message"]
+
+
+def test_pot_help_no_longer_lists_removed_queue_groups() -> None:
+    result = CliRunner().invoke(host_cli.app, ["pot", "--help"])
+    assert result.exit_code == 0
+    assert "linear-team" not in result.output
+    assert "jira-project" not in result.output
+
+
 def test_missing_argument_keeps_typer_text_in_human_mode(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/potpie/context-engine/tests/unit/test_cli_usage_errors.py
+++ b/potpie/context-engine/tests/unit/test_cli_usage_errors.py
@@ -57,6 +57,8 @@ def test_unknown_subcommand_emits_structured_json_via_run_cli(
     [
         (["--json", "pot", "jira-project", "ingest", "ENG"], "jira-project"),
         (["--json", "pot", "linear-team", "ingest", "ENG"], "linear-team"),
+        (["--json", "pot", "jira-project", "diff-sync"], "jira-project"),
+        (["--json", "pot", "linear-team", "diff-sync"], "linear-team"),
     ],
 )
 def test_removed_pot_queue_commands_emit_structured_unknown_command(


### PR DESCRIPTION
## Summary

This removes the pot-level CLI queue-ingest surface:

- `potpie pot jira-project ingest`
- `potpie pot jira-project diff-sync`
- `potpie pot linear-team ingest`
- `potpie pot linear-team diff-sync`

The CLI now stays aligned with the intended architecture:
- setup, source registration, provider auth/read, and graph operations remain in the CLI
- ingestion remains harness-led through integration hydration plus `graph propose` / `graph commit --verify`

## What changed

- Removed the Jira/Linear pot command groups and their queue-ingest handlers from the CLI
- Deleted the now-unused local `_potpie_api_client()` helper and related imports from `pots.py`
- Updated context-graph docs to stop advertising CLI one-shot ingest as part of the supported surface
- Updated bundled harness/templates and plugin skills to use a durable rule:
  - do not use Potpie CLI queue ingestion as the ingestion path
- Updated tests to verify:
  - removed commands are no longer present in `pot --help`
  - removed commands fail as unknown/usage errors
  - bundled templates no longer mention removed command names

## Why

These commands were the last CLI-owned ingestion entry points for Jira/Linear and pulled the `pot` surface back toward queue/API ingestion. Removing them makes the CLI contract cleaner and matches the current Potpie model: hosted-source understanding should happen in the harness, with durable writes going through graph plans rather than queue-style CLI commands.

## Verification

Ran:

- `uv run pytest potpie/context-engine/tests/unit/test_agent_templates_v15.py`
- `uv run pytest potpie/context-engine/tests/unit/test_cli_usage_errors.py`
- `uv run pytest potpie/context-engine/tests/unit/test_pot_create_repo.py`
- `uv run pytest potpie/context-engine/tests/unit/test_source_cli_contract.py`
- `uv run pytest potpie/context-engine/tests/unit/test_cli_ergonomics.py potpie/context-engine/tests/unit/test_cli_format.py potpie/context-engine/tests/unit/test_graph_cli_contract.py`
- `uv run ruff check potpie/context-engine/adapters/inbound/cli/commands/pots.py potpie/context-engine/tests/unit/test_agent_templates_v15.py`

## Test Screenshot
<img width="708" height="478" alt="Screenshot 2026-07-03 at 12 12 32 PM" src="https://github.com/user-attachments/assets/e18f06ba-8e94-43c1-aa18-50e702f67843" />

## Notes

- `potpie login` is intentionally retained for account-backed / managed features.
- Jira and Confluence auth/read commands are unchanged.
- Server/API ingestion paths and `PotpieContextApiClient` remain intact; this change only removes the CLI pot-level queue-ingest surface.