### PR TITLE
Release potpie 2.0.0

### DIFF
--- a/potpie/context-engine/pyproject.toml
+++ b/potpie/context-engine/pyproject.toml
@@ -7,7 +7,7 @@ path = "distribution_defaults_hook.py"
 
 [project]
 name = "potpie-context-engine"
-version = "0.1.0b3"
+version = "0.1.0"
 description = "Context graph API, webhooks, CLI, and MCP."
 requires-python = ">=3.12,<3.15"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "potpie"
-version = "2.0.0b3"
+version = "2.0.0"
 description = "Potpie context engine"
 readme = "README.md"
 requires-python = ">=3.12,<3.15"
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Software Development",
 ]
 dependencies = [
-    "potpie-context-engine[all]==0.1.0b3",
+    "potpie-context-engine[all]==0.1.0",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -2464,7 +2464,7 @@ wheels = [
 
 [[package]]
 name = "potpie"
-version = "2.0.0b3"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "potpie-context-engine", extra = ["all"] },
@@ -2499,7 +2499,7 @@ dev = [
 
 [[package]]
 name = "potpie-context-engine"
-version = "0.1.0b3"
+version = "0.1.0"
 source = { editable = "potpie/context-engine" }
 dependencies = [
     { name = "falkordblite" },


### PR DESCRIPTION
## Summary
- update the root `potpie` package version to `2.0.0`
- update the root dependency pin to `potpie-context-engine[all]==0.1.0`
- update `potpie-context-engine` package metadata and `uv.lock` package records to `0.1.0`

## Validation
- `uv lock --check`

## Notes
- Kept the change surgical to release metadata only.