### PR TITLE
Fix CLI domain failures exiting with code 0

### DIFF
--- a/potpie/cli/commands/graph.py
+++ b/potpie/cli/commands/graph.py
@@ -404,6 +404,8 @@ def _emit_graph_result(
             or payload.get("recommended_next_action"),
         )
     emit(env.to_dict(), human=_with_graph_warnings(human, merged_warnings))
+    if payload.get("ok", True) is False:
+        raise typer.Exit(code=EXIT_VALIDATION)
 
 
 def _with_graph_warnings(human: str, warnings: tuple[str, ...]) -> str:

--- a/potpie/cli/main.py
+++ b/potpie/cli/main.py
@@ -171,7 +171,7 @@ def run_cli(argv: list[str] | None = None) -> None:
     configure_cli_logging(is_verbose())
 
     try:
-        app(args, standalone_mode=False)
+        exit_code = app(args, standalone_mode=False)
     except (Abort, click.Abort):
         raise typer.Exit(code=1) from None
     except ClickException as exc:
@@ -184,6 +184,9 @@ def run_cli(argv: list[str] | None = None) -> None:
             )
         exc.show(file=sys.stderr)
         sys.exit(exc.exit_code)
+
+    if exit_code:
+        raise typer.Exit(code=int(exit_code))
 
 
 def main() -> None:


### PR DESCRIPTION
Closes #992 
## Summary

- Propagate non-zero exit codes from Typer/Click when `run_cli()` uses `standalone_mode=False`, so `contract()` / `fail()` outcomes (e.g. `CapabilityNotImplemented`, `ambiguous_pot`, validation errors) reach the OS process instead of always exiting 0.
- Exit with code `1` when graph workbench results emit `"ok": false` via `_emit_graph_result()`, closing the gap for in-band failures that never raised an exception (e.g. invalid `graph nudge` events).

## Problem

The CLI printed correct structured errors (JSON or human) but often returned exit code `0`, so scripts, CI, and `cmd && next_step` treated failed commands as successful. Parser/usage errors already exited non-zero; many runtime/domain failures did not.

Root causes:

1. **`host_cli.run_cli()`** discarded the return value from `app(..., standalone_mode=False)`. Click returns command exit codes instead of propagating `typer.Exit` to the process in that mode.
2. **`_emit_graph_result()`** printed graph envelopes with `"ok": false` without raising, so some graph commands exited `0` despite failure payloads.

## Solution

| File | Change |
|------|--------|
| `adapters/inbound/cli/host_cli.py` | Capture `exit_code = app(...)` and `raise typer.Exit(code)` when non-zero |
| `adapters/inbound/cli/commands/graph.py` | After emitting a failed graph envelope, `raise typer.Exit(EXIT_VALIDATION)` when `ok` is false |

Documented exit contract (unchanged): `0` ok / `1` validation / `2` unavailable / `3` degraded / `4` auth.

## Test plan

- [x] `potpie --json cloud status` → exit `2`, `code: not_implemented`
- [x] `potpie --json graph status` (ambiguous pot repo) → exit `1`, `ok: false`
- [x] `potpie --json graph nudge --event bogus --session s1 --pot <id>` → exit `1`, `ok: false`
- [x] `potpie pot create` (missing name) → exit `2` (parser error, unchanged)
- [x] `potpie --json graph catalog --pot <id>` → exit `0`, `ok: true`
- [x] `potpie --json cloud status && echo fail` → chain stops (does not print)
- [x] Unit: `test_graph_cli_contract`, `test_cli_usage_errors`, `test_sentry_daemon`, `test_cli_ergonomics`, `test_cli_bootstrap_status` (145 tests)

Manual verification tip: check Potpie’s exit code without piping (`cmd; echo $?`), since `$?` after `| jq` reflects `jq`, not `potpie`.

