### PR TITLE
Fix graph read filters and make text presentation honor format, detail, and relations

### DIFF
--- a/docs/context-graph/cli-flow.md
+++ b/docs/context-graph/cli-flow.md
@@ -324,7 +324,7 @@ potpie graph catalog [--task <text>] [--subgraph <s>] [--profile full|read] [--f
 potpie graph describe [<subgraph>] [--view <v>] [--examples] [--pot <ref>]
 
 potpie graph read --subgraph <s> --view <v> \
-  [--query <text>] [--scope <k:v,...>] [--repo <r>] \
+  [--query <text>] [--query-threshold 0.70] [--scope <k:v,...>] [--repo <r>] \
   [--since <t>] [--until <t>] [--time-window/--window <dur>] \
   [--environment <env>] [--source-ref <ref> ...] \
   [--depth <n>] [--direction out|in|both] [--limit 12] \
@@ -333,7 +333,7 @@ potpie graph read --subgraph <s> --view <v> \
   [--current] [--pot <ref>]
 
 potpie timeline recent \
-  [--query <text>] [--since <t>] [--until <t>] [--time-window/--window <dur>] \
+  [--query <text>] [--query-threshold 0.70] [--since <t>] [--until <t>] [--time-window/--window <dur>] \
   [--service <svc>] [--limit 12] [--format ...] [--detail ...] [--relations ...] [--pot <ref>]
 
 potpie graph search-entities [<query> | --query <text>] \

--- a/docs/context-graph/cli-flow.md
+++ b/docs/context-graph/cli-flow.md
@@ -359,6 +359,35 @@ potpie graph search-entities [<query> | --query <text>] \
   answer synthesis**. `timeline recent` is the same path as
   `graph read --subgraph recent_changes --view timeline`. Reader/ranking/view detail
   lives in [querying.md](./querying.md).
+
+  **Text-mode presentation** (default human output, no `--json`): `--format`,
+  `--detail`, and `--relations` shape the layout and depth independently.
+
+  | Flag | Text effect |
+  |------|-------------|
+  | `--format events` (timeline default) | Bullet list of deduped timeline events |
+  | `--format table` | Markdown pipe table (`occurred_at \| source_ref \| …`) |
+  | `--format raw` (non-timeline default) | Bullet list of ranked items |
+  | `--detail compact` | Core fields only (fact, score, summary) |
+  | `--detail full` | Adds truth, coverage, claim/breakdown metadata |
+  | `--relations summary` | Inline relation counts and predicate names |
+  | `--relations full` | Indented relation sub-lines (or secondary table with `--format table`) |
+
+  ```bash
+  # Human markdown table for recent changes
+  potpie graph read --subgraph recent_changes --view timeline --format table --limit 10
+
+  # Deeper relation detail in text mode
+  potpie graph read --subgraph recent_changes --view timeline \
+    --format events --detail full --relations full --limit 5
+
+  # Non-timeline entity table
+  potpie graph read --subgraph decisions --view preferences_for_scope \
+    --scope language:python --format table --limit 5
+  ```
+
+  `--json` uses the same item shaping (`detail` / `relations`) but emits structured
+  JSON instead of human tables/bullets.
 - **`graph search-entities`** is the **Filter** axis (identity resolution before a
   write) — structured per-entity lookup, **not** through the read trunk.
 

--- a/docs/context-graph/querying.md
+++ b/docs/context-graph/querying.md
@@ -378,7 +378,7 @@ Full flag lists live in [`cli-flow.md`](./cli-flow.md); this is the read-side or
 | `graph status` | data-plane status for the active pot |
 | `graph catalog [--subgraph] [--profile full\|read]` | **contract discovery** — returns `GraphCatalogResult`: versions, commands, truth classes, mutation ops (+ empty review/deferred), source authorities, `match_mode`, views, public entity types & predicates. Derived entirely from the ontology + view map + constants ("no docs needed"). `--task` is **accepted but ignored in V1.5**. |
 | `graph describe [subgraph] [--view] [--examples]` | in-process `describe_contract()` (not a host call); returns a subgraph and optionally one view. |
-| `graph read --subgraph <s> --view <v>` | **Retrieve** axis (§7/§8); `--detail compact\|full`, `--relations summary\|full`, `--query`, `--scope k:v`, `--since/--until`, `--depth/--direction`, `--limit`, `--sort`, `--format`. |
+| `graph read --subgraph <s> --view <v>` | **Retrieve** axis (§7/§8); `--detail compact\|full`, `--relations summary\|full`, `--query`, `--query-threshold` (default `0.70`; lower is looser), `--scope k:v`, `--since/--until`, `--depth/--direction`, `--limit`, `--sort`, `--format`. |
 | `timeline recent` | sugar for `graph read --subgraph recent_changes --view timeline`. |
 | `graph search-entities` | **Filter** axis (§7); structured typed lookup for identity resolution. |
 | `graph neighborhood --entity <key>` | **Traverse** axis (§7); `graph inspect <key>` is a legacy alias. |

--- a/docs/context-graph/querying.md
+++ b/docs/context-graph/querying.md
@@ -378,7 +378,7 @@ Full flag lists live in [`cli-flow.md`](./cli-flow.md); this is the read-side or
 | `graph status` | data-plane status for the active pot |
 | `graph catalog [--subgraph] [--profile full\|read]` | **contract discovery** — returns `GraphCatalogResult`: versions, commands, truth classes, mutation ops (+ empty review/deferred), source authorities, `match_mode`, views, public entity types & predicates. Derived entirely from the ontology + view map + constants ("no docs needed"). `--task` is **accepted but ignored in V1.5**. |
 | `graph describe [subgraph] [--view] [--examples]` | in-process `describe_contract()` (not a host call); returns a subgraph and optionally one view. |
-| `graph read --subgraph <s> --view <v>` | **Retrieve** axis (§7/§8); `--detail compact\|full`, `--relations summary\|full`, `--query`, `--query-threshold` (default `0.70`; lower is looser), `--scope k:v`, `--since/--until`, `--depth/--direction`, `--limit`, `--sort`, `--format`. |
+| `graph read --subgraph <s> --view <v>` | **Retrieve** axis (§7/§8); `--detail compact\|full`, `--relations summary\|full`, `--query`, `--query-threshold` (default `0.70`; lower is looser), `--scope k:v`, `--since/--until`, `--depth/--direction`, `--limit`, `--sort`, `--format`. `--detail` and `--relations` affect **both** `--json` and default human output. `--format table` renders markdown pipe tables in human mode; timeline views default to `--format events` (bullets). |
 | `timeline recent` | sugar for `graph read --subgraph recent_changes --view timeline`. |
 | `graph search-entities` | **Filter** axis (§7); structured typed lookup for identity resolution. |
 | `graph neighborhood --entity <key>` | **Traverse** axis (§7); `graph inspect <key>` is a legacy alias. |

--- a/potpie/context-engine/adapters/inbound/cli/commands/graph.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/graph.py
@@ -504,6 +504,11 @@ def graph_read(
         None, "--view", help="View name within --subgraph, e.g. prior_occurrences"
     ),
     query: str = typer.Option(None, "--query"),
+    query_threshold: float = typer.Option(
+        0.70,
+        "--query-threshold",
+        help="Minimum semantic similarity for --query matches (0.0-1.0).",
+    ),
     scope: str = typer.Option(None, "--scope", help="key:value[,key:value]"),
     current: bool = typer.Option(
         False,
@@ -579,6 +584,7 @@ def graph_read(
         since_dt, until_dt = _resolve_time_bounds(
             since=since, until=until, window=time_window
         )
+        query_threshold = _normalize_query_threshold(query_threshold)
         parsed_scope = _parse_scope(scope)
         if repo:
             parsed_scope["repo"] = _resolve_repo_scope(repo)
@@ -607,6 +613,7 @@ def graph_read(
                 limit=read_limit,
                 detail=detail,
                 relations=relations,
+                query_threshold=query_threshold,
                 freshness_preference=(
                     "fresh"
                     if _is_timeline_view(f"{subgraph}.{view}") and not query
@@ -629,6 +636,11 @@ def graph_read(
 @timeline_app.command("recent")
 def timeline_recent(
     query: str = typer.Option(None, "--query"),
+    query_threshold: float = typer.Option(
+        0.70,
+        "--query-threshold",
+        help="Minimum semantic similarity for --query matches (0.0-1.0).",
+    ),
     since: str = typer.Option(None, "--since", help="ISO instant lower bound."),
     until: str = typer.Option(None, "--until", help="ISO instant upper bound."),
     time_window: str = typer.Option(
@@ -667,6 +679,7 @@ def timeline_recent(
         since_dt, until_dt = _resolve_time_bounds(
             since=since, until=until, window=time_window
         )
+        query_threshold = _normalize_query_threshold(query_threshold)
         scope = {"service": service} if service else {}
         read_limit = _service_limit_for_read(
             subgraph="recent_changes",
@@ -686,6 +699,7 @@ def timeline_recent(
                 limit=read_limit,
                 detail=detail,
                 relations=relations,
+                query_threshold=query_threshold,
                 freshness_preference="fresh" if not query else "balanced",
             )
         )
@@ -3062,10 +3076,19 @@ def _read_human(
         )
     payload = result.to_dict()
     items = payload.get("items", [])
+    quality = payload.get("quality", {})
     lines = [
         f"view={payload.get('view')} backed={payload.get('backed')} "
-        f"items={len(items)} quality={payload.get('quality', {}).get('status')}"
+        f"items={len(items)} quality={quality.get('status')}"
     ]
+    if quality.get("status") == "unsupported":
+        reason = quality.get("reason") or "unsupported_filter"
+        names = ", ".join(
+            str(item.get("name"))
+            for item in payload.get("unsupported", ())
+            if item.get("name")
+        )
+        lines.append(f"unsupported_filter={names or reason}")
     for item in items[:10]:
         fact = item.get("summary") or item.get("entity_key") or ""
         lines.append(f"  • [{item.get('entity_type') or '?'}] {fact}")
@@ -3316,11 +3339,20 @@ def _timeline_human(
 ) -> str:
     events = _timeline_events(result, sort=sort, dedupe=dedupe, limit=event_limit)
     payload = result.to_dict()
+    quality = payload.get("quality", {})
     lines = [
         f"view={payload.get('view')} events={len(events)} "
-        f"quality={payload.get('quality', {}).get('status')}",
+        f"quality={quality.get('status')}",
         "scope=project-wide pot timeline across registered repo sources; local uncommitted worktree is not included",
     ]
+    if quality.get("status") == "unsupported":
+        reason = quality.get("reason") or "unsupported_filter"
+        names = ", ".join(
+            str(item.get("name"))
+            for item in payload.get("unsupported", ())
+            if item.get("name")
+        )
+        lines.append(f"unsupported_filter={names or reason}")
     for event in events[:20]:
         refs = ", ".join(_string_list(event.get("source_refs"))) or "no-source-ref"
         when = event.get("occurred_at") or "unknown-date"
@@ -3340,6 +3372,13 @@ def _resolve_time_bounds(
         end = until_dt or datetime.now(timezone.utc)
         return end - _parse_duration(window), until_dt
     return None, until_dt
+
+
+def _normalize_query_threshold(value: float) -> float:
+    threshold = float(value)
+    if threshold < 0.0 or threshold > 1.0:
+        raise ValueError("--query-threshold must be between 0.0 and 1.0")
+    return threshold
 
 
 def _parse_instant(value: str) -> datetime:

--- a/potpie/context-engine/adapters/inbound/cli/commands/graph.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/graph.py
@@ -41,6 +41,14 @@ from adapters.inbound.cli.commands._common import (
     pot_scope_info,
     resolve_pot_id,
 )
+from adapters.inbound.cli.read_presenter import (
+    build_presentation_context,
+    prepare_items,
+    render_items_bullets,
+    render_items_table,
+    render_timeline_events,
+    render_timeline_table,
+)
 from adapters.inbound.cli.telemetry.product_analytics import AnalyticsValue
 from adapters.inbound.cli.telemetry.usage_events import (
     capture_usage_command_succeeded,
@@ -3070,29 +3078,23 @@ def _read_human(
     dedupe: str = "auto",
     event_limit: int | None = None,
 ) -> str:
-    if format_ in ("events", "table"):
-        return _timeline_human(
-            result, sort=sort, dedupe=dedupe, event_limit=event_limit
-        )
-    payload = result.to_dict()
-    items = payload.get("items", [])
-    quality = payload.get("quality", {})
-    lines = [
-        f"view={payload.get('view')} backed={payload.get('backed')} "
-        f"items={len(items)} quality={quality.get('status')}"
-    ]
-    if quality.get("status") == "unsupported":
-        reason = quality.get("reason") or "unsupported_filter"
-        names = ", ".join(
-            str(item.get("name"))
-            for item in payload.get("unsupported", ())
-            if item.get("name")
-        )
-        lines.append(f"unsupported_filter={names or reason}")
-    for item in items[:10]:
-        fact = item.get("summary") or item.get("entity_key") or ""
-        lines.append(f"  • [{item.get('entity_type') or '?'}] {fact}")
-    return "\n".join(lines)
+    ctx = build_presentation_context(
+        result,
+        format_=format_,
+        sort=sort,
+        dedupe=dedupe,
+        event_limit=event_limit,
+    )
+    shaped_items = prepare_items(result)
+    if _is_timeline_view(ctx.view):
+        events = _timeline_events(result, sort=sort, dedupe=dedupe, limit=event_limit)
+        if format_ == "table":
+            return render_timeline_table(result, events, shaped_items, ctx)
+        if format_ == "events":
+            return render_timeline_events(result, events, shaped_items, ctx)
+    if format_ == "table":
+        return render_items_table(shaped_items, ctx, result=result)
+    return render_items_bullets(result, shaped_items, ctx)
 
 
 def _raw_item_rows(result) -> list[dict[str, Any]]:
@@ -3332,33 +3334,6 @@ def _timeline_freshness(events: list[Mapping[str, Any]]) -> dict[str, Any]:
         "local_worktree_included": False,
         "note": "Timeline reads recorded graph events for the whole pot/project across repo sources; uncommitted local changes are not included unless recorded.",
     }
-
-
-def _timeline_human(
-    result, *, sort: str, dedupe: str, event_limit: int | None = None
-) -> str:
-    events = _timeline_events(result, sort=sort, dedupe=dedupe, limit=event_limit)
-    payload = result.to_dict()
-    quality = payload.get("quality", {})
-    lines = [
-        f"view={payload.get('view')} events={len(events)} "
-        f"quality={quality.get('status')}",
-        "scope=project-wide pot timeline across registered repo sources; local uncommitted worktree is not included",
-    ]
-    if quality.get("status") == "unsupported":
-        reason = quality.get("reason") or "unsupported_filter"
-        names = ", ".join(
-            str(item.get("name"))
-            for item in payload.get("unsupported", ())
-            if item.get("name")
-        )
-        lines.append(f"unsupported_filter={names or reason}")
-    for event in events[:20]:
-        refs = ", ".join(_string_list(event.get("source_refs"))) or "no-source-ref"
-        when = event.get("occurred_at") or "unknown-date"
-        fact = event.get("fact") or event.get("activity_key") or "(no fact)"
-        lines.append(f"  • {when} [{refs}] {fact}")
-    return "\n".join(lines)
 
 
 def _resolve_time_bounds(

--- a/potpie/context-engine/adapters/inbound/cli/read_presenter.py
+++ b/potpie/context-engine/adapters/inbound/cli/read_presenter.py
@@ -53,9 +53,8 @@ def build_presentation_context(
     dedupe: str,
     event_limit: int | None,
 ) -> ReadPresentationContext:
-    payload = result.to_dict()
     return ReadPresentationContext(
-        view=_str(payload.get("view")),
+        view=_str(getattr(result, "view", None)),
         detail=_normalize_read_detail(getattr(result, "detail", None)),
         relations=_normalize_read_relations(getattr(result, "relations", None)),
         format_mode=format_,
@@ -71,8 +70,11 @@ def render_timeline_events(
     shaped_items: list[dict[str, Any]],
     ctx: ReadPresentationContext,
 ) -> str:
-    payload = result.to_dict()
-    quality = payload.get("quality", {})
+    payload = {
+        "view": getattr(result, "view", None),
+        "unsupported": getattr(result, "unsupported", ()),
+    }
+    quality = getattr(result, "quality", {}) or {}
     lines = _timeline_header_lines(payload, len(events), quality)
     if not events:
         lines.append("(no events)")
@@ -93,8 +95,11 @@ def render_timeline_table(
     shaped_items: list[dict[str, Any]],
     ctx: ReadPresentationContext,
 ) -> str:
-    payload = result.to_dict()
-    quality = payload.get("quality", {})
+    payload = {
+        "view": getattr(result, "view", None),
+        "unsupported": getattr(result, "unsupported", ()),
+    }
+    quality = getattr(result, "quality", {}) or {}
     lines = _timeline_header_lines(payload, len(events), quality)
     if not events:
         lines.append("(no events)")
@@ -190,8 +195,12 @@ def render_items_bullets(
     items: list[dict[str, Any]],
     ctx: ReadPresentationContext,
 ) -> str:
-    payload = result.to_dict()
-    quality = payload.get("quality", {})
+    payload = {
+        "view": getattr(result, "view", None),
+        "backed": getattr(result, "backed", None),
+        "unsupported": getattr(result, "unsupported", ()),
+    }
+    quality = getattr(result, "quality", {}) or {}
     lines = _items_header_lines(payload, len(items), quality)
     if not items:
         lines.append("(no rows)")

--- a/potpie/context-engine/adapters/inbound/cli/read_presenter.py
+++ b/potpie/context-engine/adapters/inbound/cli/read_presenter.py
@@ -6,9 +6,9 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 from domain.ports.services.graph_service import (
-    _normalize_read_detail,
-    _normalize_read_relations,
-    _read_item_for_detail,
+    normalize_read_detail,
+    normalize_read_relations,
+    read_item_for_detail,
 )
 
 _FACT_TRUNCATE_LEN = 120
@@ -27,11 +27,11 @@ class ReadPresentationContext:
 
 
 def prepare_items(result) -> list[dict[str, Any]]:
-    detail = _normalize_read_detail(getattr(result, "detail", None))
-    relations = _normalize_read_relations(getattr(result, "relations", None))
+    detail = normalize_read_detail(getattr(result, "detail", None))
+    relations = normalize_read_relations(getattr(result, "relations", None))
     raw_items = getattr(result, "items", None) or ()
     return [
-        _read_item_for_detail(item, detail=detail, relations=relations)
+        read_item_for_detail(item, detail=detail, relations=relations)
         for item in raw_items
     ]
 
@@ -55,8 +55,8 @@ def build_presentation_context(
 ) -> ReadPresentationContext:
     return ReadPresentationContext(
         view=_str(getattr(result, "view", None)),
-        detail=_normalize_read_detail(getattr(result, "detail", None)),
-        relations=_normalize_read_relations(getattr(result, "relations", None)),
+        detail=normalize_read_detail(getattr(result, "detail", None)),
+        relations=normalize_read_relations(getattr(result, "relations", None)),
         format_mode=format_,
         sort=sort,
         dedupe=dedupe,

--- a/potpie/context-engine/adapters/inbound/cli/read_presenter.py
+++ b/potpie/context-engine/adapters/inbound/cli/read_presenter.py
@@ -1,0 +1,541 @@
+"""Human-readable presentation for ``graph read`` and ``timeline recent``."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from domain.ports.services.graph_service import (
+    _normalize_read_detail,
+    _normalize_read_relations,
+    _read_item_for_detail,
+)
+
+_FACT_TRUNCATE_LEN = 120
+_DEFAULT_ITEM_LIMIT = 10
+
+
+@dataclass(frozen=True, slots=True)
+class ReadPresentationContext:
+    view: str
+    detail: str
+    relations: str
+    format_mode: str
+    sort: str
+    dedupe: str
+    event_limit: int | None
+
+
+def prepare_items(result) -> list[dict[str, Any]]:
+    detail = _normalize_read_detail(getattr(result, "detail", None))
+    relations = _normalize_read_relations(getattr(result, "relations", None))
+    raw_items = getattr(result, "items", None) or ()
+    return [
+        _read_item_for_detail(item, detail=detail, relations=relations)
+        for item in raw_items
+    ]
+
+
+def items_by_key(items: list[Mapping[str, Any]]) -> dict[str, dict[str, Any]]:
+    indexed: dict[str, dict[str, Any]] = {}
+    for item in items:
+        key = _str(item.get("entity_key"))
+        if key:
+            indexed[key] = dict(item)
+    return indexed
+
+
+def build_presentation_context(
+    result,
+    *,
+    format_: str,
+    sort: str,
+    dedupe: str,
+    event_limit: int | None,
+) -> ReadPresentationContext:
+    payload = result.to_dict()
+    return ReadPresentationContext(
+        view=_str(payload.get("view")),
+        detail=_normalize_read_detail(getattr(result, "detail", None)),
+        relations=_normalize_read_relations(getattr(result, "relations", None)),
+        format_mode=format_,
+        sort=sort,
+        dedupe=dedupe,
+        event_limit=event_limit,
+    )
+
+
+def render_timeline_events(
+    result,
+    events: list[Mapping[str, Any]],
+    shaped_items: list[dict[str, Any]],
+    ctx: ReadPresentationContext,
+) -> str:
+    payload = result.to_dict()
+    quality = payload.get("quality", {})
+    lines = _timeline_header_lines(payload, len(events), quality)
+    if not events:
+        lines.append("(no events)")
+        return "\n".join(lines)
+
+    item_index = items_by_key(shaped_items)
+    limit = _effective_limit(ctx.event_limit, default=20)
+    for event in events[:limit]:
+        lines.extend(
+            _timeline_event_bullet_lines(event, item_index=item_index, ctx=ctx)
+        )
+    return "\n".join(lines)
+
+
+def render_timeline_table(
+    result,
+    events: list[Mapping[str, Any]],
+    shaped_items: list[dict[str, Any]],
+    ctx: ReadPresentationContext,
+) -> str:
+    payload = result.to_dict()
+    quality = payload.get("quality", {})
+    lines = _timeline_header_lines(payload, len(events), quality)
+    if not events:
+        lines.append("(no events)")
+        return "\n".join(lines)
+
+    item_index = items_by_key(shaped_items)
+    limit = _effective_limit(ctx.event_limit, default=20)
+    display_events = events[:limit]
+
+    if ctx.detail == "full":
+        headers = [
+            "occurred_at",
+            "source_ref",
+            "activity",
+            "fact",
+            "score",
+            "truth",
+            "predicate",
+            "target_key",
+            "actor_key",
+            "relations",
+        ]
+    else:
+        headers = [
+            "occurred_at",
+            "source_ref",
+            "activity",
+            "fact",
+            "score",
+            "relations",
+        ]
+    lines.append(" | ".join(headers))
+    lines.append(" | ".join("---" for _ in headers))
+
+    for event in display_events:
+        parent = _parent_item_for_event(event, item_index)
+        relations_cell = _relations_cell(parent, ctx)
+        fact = _display_fact(event.get("fact") or event.get("activity_key"), ctx)
+        row = [
+            _escape_table_cell(event.get("occurred_at") or "unknown-date"),
+            _escape_table_cell(
+                ", ".join(_string_list(event.get("source_refs"))) or "-"
+            ),
+            _escape_table_cell(event.get("activity_key") or "-"),
+            _escape_table_cell(fact),
+            _escape_table_cell(event.get("score")),
+        ]
+        if ctx.detail == "full":
+            row.extend(
+                [
+                    _escape_table_cell(event.get("truth") or "-"),
+                    _escape_table_cell(event.get("predicate") or "-"),
+                    _escape_table_cell(event.get("target_key") or "-"),
+                    _escape_table_cell(event.get("actor_key") or "-"),
+                ]
+            )
+        row.append(_escape_table_cell(relations_cell))
+        lines.append(" | ".join(str(cell) for cell in row))
+
+    if ctx.relations == "full":
+        seen_activities: set[str] = set()
+        for event in display_events:
+            activity_key = _str(event.get("activity_key"))
+            if not activity_key or activity_key in seen_activities:
+                continue
+            seen_activities.add(activity_key)
+            parent = _parent_item_for_event(event, item_index)
+            if parent and parent.get("relations"):
+                lines.append("")
+                lines.append(f"relations for {activity_key}")
+                lines.append("predicate | from | to | fact | truth")
+                lines.append("--- | --- | --- | --- | ---")
+                for rel in parent.get("relations", ()):
+                    if not isinstance(rel, Mapping):
+                        continue
+                    lines.append(
+                        " | ".join(
+                            _escape_table_cell(value)
+                            for value in (
+                                rel.get("predicate") or "-",
+                                rel.get("from_key") or "-",
+                                rel.get("to_key") or "-",
+                                _display_fact(rel.get("fact"), ctx),
+                                rel.get("truth") or "-",
+                            )
+                        )
+                    )
+    return "\n".join(lines)
+
+
+def render_items_bullets(
+    result,
+    items: list[dict[str, Any]],
+    ctx: ReadPresentationContext,
+) -> str:
+    payload = result.to_dict()
+    quality = payload.get("quality", {})
+    lines = _items_header_lines(payload, len(items), quality)
+    if not items:
+        lines.append("(no rows)")
+        return "\n".join(lines)
+
+    limit = _effective_limit(ctx.event_limit, default=_DEFAULT_ITEM_LIMIT)
+    for item in items[:limit]:
+        lines.extend(_item_bullet_lines(item, ctx))
+    return "\n".join(lines)
+
+
+def render_items_table(
+    items: list[dict[str, Any]],
+    ctx: ReadPresentationContext,
+    *,
+    result=None,
+) -> str:
+    lines: list[str] = []
+    if result is not None:
+        payload = result.to_dict()
+        quality = payload.get("quality", {})
+        lines.extend(_items_header_lines(payload, len(items), quality))
+
+    if ctx.detail == "full":
+        headers = [
+            "score",
+            "type",
+            "entity_key",
+            "summary",
+            "truth",
+            "coverage",
+            "relations",
+        ]
+    else:
+        headers = ["score", "type", "entity_key", "summary", "relations"]
+    lines.append(" | ".join(headers))
+    lines.append(" | ".join("---" for _ in headers))
+
+    if not items:
+        lines.append("(no rows)")
+        return "\n".join(lines)
+
+    limit = _effective_limit(ctx.event_limit, default=_DEFAULT_ITEM_LIMIT)
+    for item in items[:limit]:
+        entity_key = _item_entity_key(item)
+        row = [
+            _escape_table_cell(item.get("score")),
+            _escape_table_cell(item.get("entity_type") or "-"),
+            _escape_table_cell(entity_key or "-"),
+            _escape_table_cell(_display_fact(item.get("summary") or entity_key, ctx)),
+        ]
+        if ctx.detail == "full":
+            row.extend(
+                [
+                    _escape_table_cell(item.get("truth") or "-"),
+                    _escape_table_cell(item.get("coverage_status") or "-"),
+                ]
+            )
+        row.append(_escape_table_cell(_relations_cell(item, ctx)))
+        lines.append(" | ".join(str(cell) for cell in row))
+
+    if ctx.relations == "full":
+        for item in items[:limit]:
+            relation_lines = _format_relations_full_lines(item, indent="  ")
+            if relation_lines:
+                entity_key = _item_entity_key(item) or "item"
+                lines.append("")
+                lines.append(f"relations for {entity_key}")
+                lines.extend(relation_lines)
+    return "\n".join(lines)
+
+
+def _timeline_header_lines(
+    payload: Mapping[str, Any],
+    event_count: int,
+    quality: Mapping[str, Any],
+) -> list[str]:
+    lines = [
+        f"view={payload.get('view')} events={event_count} "
+        f"quality={quality.get('status')}",
+        "scope=project-wide pot timeline across registered repo sources; "
+        "local uncommitted worktree is not included",
+    ]
+    if quality.get("status") == "unsupported":
+        reason = quality.get("reason") or "unsupported_filter"
+        names = ", ".join(
+            str(item.get("name"))
+            for item in payload.get("unsupported", ())
+            if item.get("name")
+        )
+        lines.append(f"unsupported_filter={names or reason}")
+    return lines
+
+
+def _items_header_lines(
+    payload: Mapping[str, Any],
+    item_count: int,
+    quality: Mapping[str, Any],
+) -> list[str]:
+    lines = [
+        f"view={payload.get('view')} backed={payload.get('backed')} "
+        f"items={item_count} quality={quality.get('status')}"
+    ]
+    if quality.get("status") == "unsupported":
+        reason = quality.get("reason") or "unsupported_filter"
+        names = ", ".join(
+            str(item.get("name"))
+            for item in payload.get("unsupported", ())
+            if item.get("name")
+        )
+        lines.append(f"unsupported_filter={names or reason}")
+    return lines
+
+
+def _timeline_event_bullet_lines(
+    event: Mapping[str, Any],
+    *,
+    item_index: dict[str, dict[str, Any]],
+    ctx: ReadPresentationContext,
+) -> list[str]:
+    refs = ", ".join(_string_list(event.get("source_refs"))) or "no-source-ref"
+    when = event.get("occurred_at") or "unknown-date"
+    fact = _display_fact(
+        event.get("fact") or event.get("activity_key") or "(no fact)", ctx
+    )
+    score = event.get("score")
+    suffix_parts: list[str] = []
+    if score is not None:
+        suffix_parts.append(f"score={score}")
+    if ctx.detail == "full":
+        for key in (
+            "truth",
+            "predicate",
+            "actor_key",
+            "target_key",
+            "evidence_strength",
+        ):
+            value = event.get(key)
+            if value:
+                suffix_parts.append(f"{key}={value}")
+    suffix = f"  {'  '.join(suffix_parts)}" if suffix_parts else ""
+    lines = [f"  • {when} [{refs}] {fact}{suffix}"]
+
+    parent = _parent_item_for_event(event, item_index)
+    if ctx.relations == "summary" and parent:
+        summary = _format_relations_summary(parent)
+        if summary:
+            lines.append(f"    relations: {summary}")
+    elif ctx.relations == "full" and parent:
+        lines.extend(_format_relations_full_lines(parent, indent="    "))
+    return lines
+
+
+def _item_bullet_lines(
+    item: Mapping[str, Any], ctx: ReadPresentationContext
+) -> list[str]:
+    entity_type = item.get("entity_type") or "?"
+    entity_key = _item_entity_key(item)
+    summary = _display_fact(item.get("summary") or entity_key or "", ctx)
+    meta_parts: list[str] = []
+    if item.get("score") is not None:
+        meta_parts.append(f"score={item.get('score')}")
+    if ctx.detail == "full":
+        for key in ("truth", "coverage_status"):
+            value = item.get(key)
+            if value:
+                meta_parts.append(f"{key}={value}")
+    meta = f"  {'  '.join(meta_parts)}" if meta_parts else ""
+    lines = [f"  • [{entity_type}] {entity_key or summary}{meta}"]
+    if entity_key and summary and summary != entity_key:
+        lines.append(f"    {summary}")
+    refs = _string_list(item.get("source_refs"))
+    if refs:
+        lines.append(f"    refs: {', '.join(refs)}")
+    claim = item.get("claim")
+    if ctx.detail == "full" and isinstance(claim, Mapping):
+        claim_parts = [
+            f"{key}={claim.get(key)}"
+            for key in ("predicate", "subject_key", "object_key", "claim_key")
+            if claim.get(key) is not None
+        ]
+        if claim_parts:
+            lines.append(f"    claim: {' '.join(claim_parts)}")
+    breakdown = item.get("breakdown")
+    if ctx.detail == "full" and isinstance(breakdown, Mapping) and breakdown:
+        breakdown_text = " ".join(
+            f"{key}={value}" for key, value in sorted(breakdown.items())
+        )
+        lines.append(f"    breakdown: {breakdown_text}")
+    if ctx.relations == "summary":
+        summary_line = _format_relations_summary(item)
+        if summary_line:
+            lines.append(f"    relations: {summary_line}")
+    elif ctx.relations == "full":
+        lines.extend(_format_relations_full_lines(item, indent="    "))
+    return lines
+
+
+def _parent_item_for_event(
+    event: Mapping[str, Any],
+    item_index: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    activity_key = _str(event.get("activity_key"))
+    if activity_key and activity_key in item_index:
+        return item_index[activity_key]
+    return None
+
+
+def _relations_cell(
+    item: Mapping[str, Any] | None, ctx: ReadPresentationContext
+) -> str:
+    if item is None:
+        return "-"
+    if ctx.relations == "full" and item.get("relations"):
+        count = len(item.get("relations", ()))
+        predicates = sorted(
+            {
+                _str(rel.get("predicate"))
+                for rel in item.get("relations", ())
+                if isinstance(rel, Mapping) and rel.get("predicate")
+            }
+        )
+        if predicates:
+            return f"{count} [{', '.join(predicates)}]"
+        return str(count) if count else "-"
+    return _format_relations_summary(item) or "-"
+
+
+def _format_relations_summary(item: Mapping[str, Any]) -> str:
+    count = item.get("relation_count")
+    if count is None and item.get("relations"):
+        count = len(item.get("relations", ()))
+    if not count:
+        return ""
+    predicates = item.get("relation_predicates")
+    if predicates is None and item.get("relations"):
+        predicates = sorted(
+            {
+                _str(rel.get("predicate"))
+                for rel in item.get("relations", ())
+                if isinstance(rel, Mapping) and rel.get("predicate")
+            }
+        )
+    predicate_text = ""
+    if predicates:
+        predicate_text = f" [{', '.join(str(p) for p in predicates)}]"
+    related = item.get("related_keys")
+    if related is None and item.get("relations"):
+        related = _related_keys_from_relations(item.get("relations", ()))
+    related_text = ""
+    if related:
+        related_text = f" → {', '.join(str(key) for key in related[:5])}"
+    return f"{count}{predicate_text}{related_text}"
+
+
+def _format_relations_full_lines(item: Mapping[str, Any], *, indent: str) -> list[str]:
+    relations = item.get("relations")
+    if not isinstance(relations, list) or not relations:
+        return []
+    lines: list[str] = []
+    for rel in relations:
+        if not isinstance(rel, Mapping):
+            continue
+        predicate = _str(rel.get("predicate")) or "RELATED"
+        from_key = _str(rel.get("from_key"))
+        to_key = _str(rel.get("to_key"))
+        direction = f"{from_key} → {to_key}" if from_key or to_key else ""
+        lines.append(f"{indent}↳ {predicate} {direction}".rstrip())
+        fact = rel.get("fact")
+        if fact:
+            lines.append(f"{indent}  fact: {fact}")
+        refs = _string_list(rel.get("source_refs"))
+        if refs:
+            lines.append(f"{indent}  refs: {', '.join(refs)}")
+        truth = rel.get("truth")
+        if truth:
+            lines.append(f"{indent}  truth: {truth}")
+    return lines
+
+
+def _related_keys_from_relations(
+    relations: list[Mapping[str, Any]],
+) -> list[str]:
+    keys: list[str] = []
+    seen: set[str] = set()
+    for rel in relations:
+        for candidate in (
+            rel.get("related_key"),
+            rel.get("to_key"),
+            rel.get("from_key"),
+        ):
+            key = _str(candidate)
+            if key and key not in seen:
+                keys.append(key)
+                seen.add(key)
+            if len(keys) >= 10:
+                return keys
+    return keys
+
+
+def _item_entity_key(item: Mapping[str, Any]) -> str:
+    key = _str(item.get("entity_key"))
+    if key:
+        return key
+    claim = item.get("claim")
+    if isinstance(claim, Mapping):
+        return _str(claim.get("subject_key") or claim.get("object_key"))
+    return ""
+
+
+def _display_fact(value: Any, ctx: ReadPresentationContext) -> str:
+    text = _str(value) if value is not None else ""
+    if ctx.detail == "compact":
+        return _truncate(text, _FACT_TRUNCATE_LEN)
+    return text
+
+
+def _escape_table_cell(value: Any) -> str:
+    if value is None:
+        return "-"
+    text = str(value)
+    text = text.replace("\n", " ").replace("\r", " ")
+    return text.replace("|", "\\|")
+
+
+def _truncate(text: str, max_len: int) -> str:
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3] + "..."
+
+
+def _effective_limit(limit: int | None, *, default: int) -> int:
+    if limit is None or limit < 0:
+        return default
+    return limit
+
+
+def _str(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _string_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value] if value else []
+    if isinstance(value, (list, tuple)):
+        return [v for v in value if isinstance(v, str) and v]
+    return []

--- a/potpie/context-engine/adapters/inbound/cli/read_presenter.py
+++ b/potpie/context-engine/adapters/inbound/cli/read_presenter.py
@@ -281,7 +281,7 @@ def _timeline_header_lines(
     lines = [
         f"view={payload.get('view')} events={event_count} "
         f"quality={quality.get('status')}",
-        "scope=project-wide pot timeline across registered repo sources; "
+        "scope=applied graph-read scope across registered repo sources; "
         "local uncommitted worktree is not included",
     ]
     if quality.get("status") == "unsupported":

--- a/potpie/context-engine/adapters/inbound/cli/templates/agent_bundle/.agents/skills/potpie-graph/SKILL.md
+++ b/potpie/context-engine/adapters/inbound/cli/templates/agent_bundle/.agents/skills/potpie-graph/SKILL.md
@@ -39,6 +39,7 @@ potpie graph describe debugging --view prior_occurrences --examples
 
 ```bash
 potpie graph read --subgraph debugging --view prior_occurrences --query "refund race timeout" --limit 8
+potpie graph read --subgraph debugging --view prior_occurrences --query "refund race timeout" --query-threshold 0.55 --limit 8
 potpie graph read --subgraph decisions --view preferences_for_scope --scope repo:acme/x,path:src/payments/client.py
 potpie graph read --subgraph recent_changes --view timeline --time-window 7d --limit 20 --format table
 potpie graph read --subgraph recent_changes --view timeline --source-ref <github-pr-or-issue-ref> --format table

--- a/potpie/context-engine/adapters/inbound/cli/templates/claude_bundle/.claude/skills/potpie-graph/SKILL.md
+++ b/potpie/context-engine/adapters/inbound/cli/templates/claude_bundle/.claude/skills/potpie-graph/SKILL.md
@@ -39,6 +39,7 @@ potpie graph describe debugging --view prior_occurrences --examples
 
 ```bash
 potpie graph read --subgraph debugging --view prior_occurrences --query "refund race timeout" --limit 8
+potpie graph read --subgraph debugging --view prior_occurrences --query "refund race timeout" --query-threshold 0.55 --limit 8
 potpie graph read --subgraph decisions --view preferences_for_scope --scope repo:acme/x,path:src/payments/client.py
 potpie graph read --subgraph recent_changes --view timeline --time-window 7d --limit 20 --format table
 potpie graph read --subgraph recent_changes --view timeline --source-ref <github-pr-or-issue-ref> --format table

--- a/potpie/context-engine/adapters/inbound/cli/templates/claude_plugin/skills/potpie-graph/SKILL.md
+++ b/potpie/context-engine/adapters/inbound/cli/templates/claude_plugin/skills/potpie-graph/SKILL.md
@@ -39,6 +39,7 @@ potpie graph describe debugging --view prior_occurrences --examples
 
 ```bash
 potpie graph read --subgraph debugging --view prior_occurrences --query "refund race timeout" --limit 8
+potpie graph read --subgraph debugging --view prior_occurrences --query "refund race timeout" --query-threshold 0.55 --limit 8
 potpie graph read --subgraph decisions --view preferences_for_scope --scope repo:acme/x,path:src/payments/client.py
 potpie graph read --subgraph recent_changes --view timeline --time-window 7d --limit 20 --format table
 potpie graph read --subgraph recent_changes --view timeline --source-ref <github-pr-or-issue-ref> --format table

--- a/potpie/context-engine/application/readers/_common.py
+++ b/potpie/context-engine/application/readers/_common.py
@@ -310,8 +310,8 @@ def row_matches_query(
         return True
     if _query_text_matches(row, clean_query):
         return True
-    similarity = row.properties.get("semantic_similarity")
-    return isinstance(similarity, (int, float)) and float(similarity) >= threshold
+    similarity = claim_semantic_similarity(row)
+    return similarity is not None and similarity >= threshold
 
 
 def _endpoints(row: ClaimRow) -> tuple[str, str]:

--- a/potpie/context-engine/application/readers/_common.py
+++ b/potpie/context-engine/application/readers/_common.py
@@ -238,11 +238,7 @@ def graph_read_scope(scope: Mapping[str, Any]) -> dict[str, str]:
         value = scope.get(key) or scope.get(f"{key}s")
         if isinstance(value, Iterable) and not isinstance(value, (str, Mapping)):
             value = next(
-                (
-                    item
-                    for item in value
-                    if isinstance(item, str) and item.strip()
-                ),
+                (item for item in value if isinstance(item, str) and item.strip()),
                 None,
             )
         if isinstance(value, str) and value.strip():
@@ -253,7 +249,9 @@ def graph_read_scope(scope: Mapping[str, Any]) -> dict[str, str]:
 def scope_ref_matches(row: ClaimRow, scope: Mapping[str, str], key: str) -> bool:
     """Whether either endpoint of a claim row matches one requested scope key."""
     if key == "repo":
-        return any(_repo_key_matches(endpoint, scope["repo"]) for endpoint in _endpoints(row))
+        return any(
+            _repo_key_matches(endpoint, scope["repo"]) for endpoint in _endpoints(row)
+        )
     if key == "service":
         return any(
             _scope_entity_key_matches(endpoint, scope["service"], prefix="service")
@@ -262,7 +260,8 @@ def scope_ref_matches(row: ClaimRow, scope: Mapping[str, str], key: str) -> bool
     if key in _PATH_SCOPE_KEYS:
         requested = _scope_path(scope)
         return bool(requested) and any(
-            _code_asset_key_matches_path(endpoint, requested) for endpoint in _endpoints(row)
+            _code_asset_key_matches_path(endpoint, requested)
+            for endpoint in _endpoints(row)
         )
     return False
 
@@ -280,12 +279,16 @@ def code_scope_conflicts(
     for key in ("language", "framework", "audience", "environment"):
         if key in requested and key in rule and requested[key] != rule[key]:
             return True
-    if "repo" in requested and "repo" in rule and not _repo_values_match(
-        requested["repo"], rule["repo"]
+    if (
+        "repo" in requested
+        and "repo" in rule
+        and not _repo_values_match(requested["repo"], rule["repo"])
     ):
         return True
-    if "service" in requested and "service" in rule and not _service_values_match(
-        requested["service"], rule["service"]
+    if (
+        "service" in requested
+        and "service" in rule
+        and not _service_values_match(requested["service"], rule["service"])
     ):
         return True
     requested_path = _scope_path(requested)

--- a/potpie/context-engine/application/readers/_common.py
+++ b/potpie/context-engine/application/readers/_common.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from datetime import datetime
+import re
 from typing import Any
 
 from domain.ports.claim_query import ClaimRow
@@ -26,6 +27,7 @@ class ReadRequest:
     freshness_preference: str = "balanced"
     include_invalidated: bool = False
     source_refs: tuple[str, ...] = ()
+    query_threshold: float = 0.70
     # Traverse-axis controls (Query Surface). Only the neighborhood reader uses
     # these; other readers ignore them.
     depth: int | None = None
@@ -216,6 +218,228 @@ def row_in_anchor_set(row: ClaimRow, anchor_keys: Iterable[str]) -> bool:
     return row.subject_key in anchors or row.object_key in anchors
 
 
+_PATH_SCOPE_KEYS = ("file_path", "path")
+QUERY_SIMILARITY_THRESHOLD = 0.70
+
+
+def graph_read_scope(scope: Mapping[str, Any]) -> dict[str, str]:
+    """Normalize scope keys used as hard filters by graph-read readers."""
+    out: dict[str, str] = {}
+    for key in (
+        "repo",
+        "service",
+        "file_path",
+        "path",
+        "language",
+        "framework",
+        "audience",
+        "environment",
+    ):
+        value = scope.get(key) or scope.get(f"{key}s")
+        if isinstance(value, Iterable) and not isinstance(value, (str, Mapping)):
+            value = next(
+                (
+                    item
+                    for item in value
+                    if isinstance(item, str) and item.strip()
+                ),
+                None,
+            )
+        if isinstance(value, str) and value.strip():
+            out[key] = value.strip().lower()
+    return out
+
+
+def scope_ref_matches(row: ClaimRow, scope: Mapping[str, str], key: str) -> bool:
+    """Whether either endpoint of a claim row matches one requested scope key."""
+    if key == "repo":
+        return any(_repo_key_matches(endpoint, scope["repo"]) for endpoint in _endpoints(row))
+    if key == "service":
+        return any(
+            _scope_entity_key_matches(endpoint, scope["service"], prefix="service")
+            for endpoint in _endpoints(row)
+        )
+    if key in _PATH_SCOPE_KEYS:
+        requested = _scope_path(scope)
+        return bool(requested) and any(
+            _code_asset_key_matches_path(endpoint, requested) for endpoint in _endpoints(row)
+        )
+    return False
+
+
+def code_scope_conflicts(
+    requested_scope: Mapping[str, str], rule_scope: Mapping[str, Any]
+) -> bool:
+    """True when a stored rule scope cannot apply to the requested task scope."""
+    requested = dict(requested_scope)
+    rule = {
+        str(k): v.strip().lower()
+        for k, v in rule_scope.items()
+        if isinstance(v, str) and v.strip()
+    }
+    for key in ("language", "framework", "audience", "environment"):
+        if key in requested and key in rule and requested[key] != rule[key]:
+            return True
+    if "repo" in requested and "repo" in rule and not _repo_values_match(
+        requested["repo"], rule["repo"]
+    ):
+        return True
+    if "service" in requested and "service" in rule and not _service_values_match(
+        requested["service"], rule["service"]
+    ):
+        return True
+    requested_path = _scope_path(requested)
+    rule_path = _scope_path(rule)
+    if requested_path and rule_path and not _paths_overlap(rule_path, requested_path):
+        return True
+    return False
+
+
+def row_matches_query(
+    row: ClaimRow,
+    query: str | None,
+    *,
+    threshold: float = QUERY_SIMILARITY_THRESHOLD,
+) -> bool:
+    """Return whether a row is relevant enough for an explicit graph-read query."""
+    clean_query = _clean_query(query)
+    if clean_query is None:
+        return True
+    if _query_text_matches(row, clean_query):
+        return True
+    similarity = row.properties.get("semantic_similarity")
+    return isinstance(similarity, (int, float)) and float(similarity) >= threshold
+
+
+def _endpoints(row: ClaimRow) -> tuple[str, str]:
+    return row.subject_key, row.object_key
+
+
+def _clean_query(query: str | None) -> str | None:
+    if not isinstance(query, str):
+        return None
+    clean = query.strip().lower()
+    return clean or None
+
+
+def _query_text_matches(row: ClaimRow, query: str) -> bool:
+    haystack = _query_haystack(row)
+    if query in haystack:
+        return True
+    query_tokens = _query_tokens(query)
+    if not query_tokens:
+        return False
+    haystack_tokens = set(_query_tokens(haystack))
+    return all(token in haystack_tokens for token in query_tokens)
+
+
+def _query_haystack(row: ClaimRow) -> str:
+    parts: list[str] = [
+        row.fact or "",
+        row.description or "",
+        row.subject_key,
+        row.object_key,
+        row.claim_key or "",
+        row.source_ref or "",
+        " ".join(row.source_refs),
+    ]
+    for value in row.properties.values():
+        if isinstance(value, str):
+            parts.append(value)
+    return " ".join(part for part in parts if part).lower()
+
+
+def _query_tokens(value: str) -> tuple[str, ...]:
+    return tuple(
+        token
+        for token in re.findall(r"[a-z0-9_./:-]+", value.lower())
+        if len(token) >= 3
+    )
+
+
+def _scope_entity_key_matches(endpoint: str, value: str, *, prefix: str) -> bool:
+    expected = value if value.startswith(f"{prefix}:") else f"{prefix}:{value}"
+    return endpoint.lower() == expected
+
+
+def _repo_key_matches(endpoint: str, value: str) -> bool:
+    expected = _repo_key_value(value)
+    return endpoint.lower() == expected
+
+
+def _repo_values_match(left: str, right: str) -> bool:
+    return _repo_key_value(left) == _repo_key_value(right)
+
+
+def _service_values_match(left: str, right: str) -> bool:
+    return _service_key_value(left) == _service_key_value(right)
+
+
+def _repo_key_value(value: str) -> str:
+    clean = value.strip().lower()
+    return clean if clean.startswith("repo:") else f"repo:{clean}"
+
+
+def _service_key_value(value: str) -> str:
+    clean = value.strip().lower()
+    return clean if clean.startswith("service:") else f"service:{clean}"
+
+
+def _code_asset_key_matches_path(endpoint: str, requested_path: str) -> bool:
+    path = _path_from_code_asset_key(endpoint)
+    return path is not None and _paths_overlap(path, requested_path)
+
+
+def _path_from_code_asset_key(endpoint: str) -> str | None:
+    if not endpoint.lower().startswith("code:"):
+        return None
+    # CodeAsset identity is code:<repo-or-service>:<path-or-symbol>. The
+    # repo/service anchor may itself carry a key prefix.
+    body = endpoint[5:]
+    if body.lower().startswith("service:"):
+        parts = body.split(":", 2)
+        if len(parts) != 3:
+            return None
+        path = parts[2].strip().lower()
+        return path or None
+    if body.lower().startswith("repo:"):
+        body = body[5:]
+    if ":" not in body:
+        return None
+    _, path = body.split(":", 1)
+    path = path.strip().lower()
+    return path or None
+
+
+def _scope_path(scope: Mapping[str, str]) -> str | None:
+    value = scope.get("file_path") or scope.get("path")
+    return _clean_path(value) if isinstance(value, str) else None
+
+
+def _clean_path(value: str) -> str:
+    return value.strip().lower().strip("/")
+
+
+def _paths_overlap(left: str, right: str) -> bool:
+    left_clean = _strip_glob(_clean_path(left))
+    right_clean = _strip_glob(_clean_path(right))
+    if not left_clean or not right_clean:
+        return True
+    return (
+        left_clean == right_clean
+        or left_clean.startswith(right_clean + "/")
+        or right_clean.startswith(left_clean + "/")
+    )
+
+
+def _strip_glob(path: str) -> str:
+    out = path.rstrip("/")
+    for suffix in ("/**", "/*", "**", "*"):
+        if out.endswith(suffix):
+            out = out[: -len(suffix)].rstrip("/")
+    return out
+
+
 __all__ = [
     "ReadRequest",
     "ReadResponse",
@@ -224,11 +448,15 @@ __all__ = [
     "claim_environment",
     "claim_payload",
     "claim_semantic_similarity",
+    "code_scope_conflicts",
     "coverage_status_from_count",
     "dedupe_claim_rows",
+    "graph_read_scope",
     "make_task_context",
     "rank_candidates",
     "row_in_anchor_set",
+    "row_matches_query",
+    "scope_ref_matches",
     "scoped_entity_keys",
     "service_anchor_keys",
 ]

--- a/potpie/context-engine/application/readers/coding_preferences.py
+++ b/potpie/context-engine/application/readers/coding_preferences.py
@@ -24,9 +24,12 @@ from application.readers._common import (
     claim_corroboration,
     claim_payload,
     claim_semantic_similarity,
+    code_scope_conflicts,
     coverage_status_from_count,
     dedupe_claim_rows,
+    graph_read_scope,
     rank_candidates,
+    row_matches_query,
 )
 from domain.ports.claim_query import ClaimQueryFilter, ClaimQueryPort, ClaimRow
 from domain.ranking import Candidate, RankingService
@@ -58,8 +61,13 @@ class CodingPreferencesReader:
         )
 
         scope_keys = _normalise_scope_for_overlap(req.scope)
+        hard_scope = graph_read_scope(req.scope)
         candidates: list[Candidate] = []
         for row in rows:
+            if not row_matches_query(row, req.query, threshold=req.query_threshold):
+                continue
+            if _scope_conflicts(row, hard_scope):
+                continue
             overlap = _scope_overlap(row, scope_keys)
             if overlap == 0.0 and scope_keys:
                 # Hard zero on overlap: skip — readers should not surface
@@ -132,6 +140,15 @@ def _scope_overlap(row: ClaimRow, task_scope: Mapping[str, str]) -> float:
     if not rule_scope:
         return 0.5
     return hierarchical_scope_overlap(task_scope, rule_scope)
+
+
+def _scope_conflicts(row: ClaimRow, task_scope: Mapping[str, str]) -> bool:
+    if not task_scope:
+        return False
+    rule_scope_raw = row.properties.get("code_scope")
+    if not isinstance(rule_scope_raw, Mapping):
+        return False
+    return code_scope_conflicts(task_scope, rule_scope_raw)
 
 
 def _payload_from_row(row: ClaimRow) -> dict[str, Any]:

--- a/potpie/context-engine/application/readers/timeline_reader.py
+++ b/potpie/context-engine/application/readers/timeline_reader.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import dataclasses
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping
 
 from application.readers._common import (
     ReadRequest,
@@ -27,9 +27,11 @@ from application.readers._common import (
     claim_semantic_similarity,
     coverage_status_from_count,
     dedupe_claim_rows,
+    graph_read_scope,
     rank_candidates,
     row_in_anchor_set,
-    service_anchor_keys,
+    row_matches_query,
+    scope_ref_matches,
 )
 from domain.ports.claim_query import ClaimQueryFilter, ClaimQueryPort, ClaimRow
 from domain.ranking import Candidate, RankingService
@@ -50,12 +52,13 @@ class TimelineReader:
     family: str = "timeline"
 
     def read(self, req: ReadRequest) -> ReadResponse:
-        anchor_keys = service_anchor_keys(req.scope)
+        scope_filters = _timeline_scope_filters(req.scope)
+        anchor_keys = _timeline_anchor_keys(scope_filters)
         window_after, window_before = _resolve_window(req)
 
         rows = self._activities_for_scope(
             req=req,
-            anchor_keys=anchor_keys,
+            scope_filters=scope_filters,
             window_after=window_after,
             window_before=window_before,
         )
@@ -66,7 +69,9 @@ class TimelineReader:
         for row in grouped_rows:
             event_time = _event_datetime(row)
             overlap = (
-                1.0 if (not anchor_keys) or row_in_anchor_set(row, anchor_keys) else 0.4
+                1.0
+                if (not scope_filters) or row_in_anchor_set(row, anchor_keys)
+                else 0.8
             )
             candidates.append(
                 Candidate(
@@ -94,6 +99,7 @@ class TimelineReader:
             ),
             meta={
                 "anchor_keys": list(anchor_keys),
+                "scope_filters": dict(scope_filters),
                 "window_after": window_after.isoformat() if window_after else None,
                 "window_before": window_before.isoformat() if window_before else None,
                 "candidate_pool": len(rows),
@@ -105,59 +111,76 @@ class TimelineReader:
         self,
         *,
         req: ReadRequest,
-        anchor_keys: Iterable[str],
+        scope_filters: Mapping[str, str],
         window_after: datetime | None,
         window_before: datetime | None,
     ) -> list[ClaimRow]:
-        anchors = tuple(anchor_keys)
-        base = ClaimQueryFilter(
-            pot_id=req.pot_id,
-            predicate_in=_TIMELINE_PREDICATES,
-            include_invalidated=req.include_invalidated,
-            as_of=req.as_of,
-            source_ref_in=req.source_refs,
-            # Timeline windows are source-event windows. Older rows may have
-            # occurred_at only in properties with valid_at set to ingestion time,
-            # so filter after hydration with _event_datetime().
-            limit=max(req.max_items * 20, 200),
-            fact_query=req.query,
-        )
-        if not anchors:
-            return _filter_window(
-                dedupe_claim_rows(self.claim_query.find_claims(base)),
-                window_after=window_after,
-                window_before=window_before,
+        query_limit = max(req.max_items * 20, 200)
+        anchor_keys = tuple(_timeline_anchor_keys(scope_filters))
+
+        if anchor_keys:
+            # Push repo/service scope into the claim query so scoped reads are
+            # not truncated by unrelated timeline edges in large pots.
+            rows = _fetch_anchor_scoped_rows(
+                self.claim_query,
+                req=req,
+                anchor_keys=anchor_keys,
+                limit=query_limit,
+            )
+            if _scope_needs_full_activity_groups(scope_filters):
+                rows = _expand_activity_group_edges(
+                    self.claim_query,
+                    req=req,
+                    seed_rows=rows,
+                    limit=query_limit,
+                )
+        elif scope_filters:
+            # Path-only scope cannot be indexed as a simple anchor key; fetch
+            # provenance edges and post-filter activity groups by path overlap.
+            rows = dedupe_claim_rows(
+                self.claim_query.find_claims(
+                    ClaimQueryFilter(
+                        pot_id=req.pot_id,
+                        predicate_in=("MENTIONS", "TOUCHED"),
+                        include_invalidated=req.include_invalidated,
+                        as_of=req.as_of,
+                        source_ref_in=req.source_refs,
+                        limit=query_limit,
+                        fact_query=req.query,
+                    )
+                )
+            )
+        else:
+            rows = dedupe_claim_rows(
+                self.claim_query.find_claims(
+                    ClaimQueryFilter(
+                        pot_id=req.pot_id,
+                        predicate_in=_TIMELINE_PREDICATES,
+                        include_invalidated=req.include_invalidated,
+                        as_of=req.as_of,
+                        source_ref_in=req.source_refs,
+                        # Timeline windows are source-event windows. Older rows may
+                        # have occurred_at only in properties with valid_at set to
+                        # ingestion time, so filter after hydration with
+                        # _event_datetime().
+                        limit=query_limit,
+                        fact_query=req.query,
+                    )
+                )
             )
 
-        # Activity → anchor (MENTIONS) plus anchor → activity (PERFORMED etc).
-        mentioning = self.claim_query.find_claims(
-            ClaimQueryFilter(
-                pot_id=base.pot_id,
-                predicate_in=("MENTIONS", "TOUCHED"),
-                object_key_in=anchors,
-                include_invalidated=base.include_invalidated,
-                as_of=base.as_of,
-                source_ref_in=base.source_ref_in,
-                limit=base.limit,
-                fact_query=req.query,
+        rows = _filter_window(
+            rows,
+            window_after=window_after,
+            window_before=window_before,
+        )
+        if req.query:
+            rows = _filter_query_activity_groups(
+                rows, query=req.query, threshold=req.query_threshold
             )
-        )
-        authored = self.claim_query.find_claims(
-            ClaimQueryFilter(
-                pot_id=base.pot_id,
-                predicate_in=("PERFORMED", "AUTHORED"),
-                subject_key_in=anchors,
-                include_invalidated=base.include_invalidated,
-                as_of=base.as_of,
-                source_ref_in=base.source_ref_in,
-                limit=base.limit,
-                fact_query=req.query,
-            )
-        )
-        out = dedupe_claim_rows((*mentioning, *authored))
-        return _filter_window(
-            out, window_after=window_after, window_before=window_before
-        )
+        if scope_filters:
+            rows = _filter_activity_groups(rows, scope_filters=scope_filters)
+        return rows
 
 
 # ---------------------------------------------------------------------------
@@ -176,6 +199,167 @@ def _resolve_window(req: ReadRequest) -> tuple[datetime | None, datetime | None]
         # Caller asked only for "before this"; pass through.
         return None, until
     return None, None
+
+
+def _timeline_scope_filters(scope: Mapping[str, Any]) -> dict[str, str]:
+    normalized = graph_read_scope(scope)
+    return {
+        key: value
+        for key, value in normalized.items()
+        if key in {"repo", "service", "path", "file_path"}
+    }
+
+
+def _fetch_anchor_scoped_rows(
+    claim_query: ClaimQueryPort,
+    *,
+    req: ReadRequest,
+    anchor_keys: tuple[str, ...],
+    limit: int,
+) -> list[ClaimRow]:
+    """Fetch timeline edges tied to repo/service anchors via the graph index."""
+    common = {
+        "pot_id": req.pot_id,
+        "include_invalidated": req.include_invalidated,
+        "as_of": req.as_of,
+        "source_ref_in": req.source_refs,
+        "limit": limit,
+        "fact_query": req.query,
+    }
+    mentioning = claim_query.find_claims(
+        ClaimQueryFilter(
+            predicate_in=("MENTIONS", "TOUCHED"),
+            object_key_in=anchor_keys,
+            **common,
+        )
+    )
+    authored = claim_query.find_claims(
+        ClaimQueryFilter(
+            predicate_in=("PERFORMED", "AUTHORED"),
+            subject_key_in=anchor_keys,
+            **common,
+        )
+    )
+    return dedupe_claim_rows((*mentioning, *authored))
+
+
+def _scope_needs_full_activity_groups(scope_filters: Mapping[str, str]) -> bool:
+    return "file_path" in scope_filters or "path" in scope_filters
+
+
+def _expand_activity_group_edges(
+    claim_query: ClaimQueryPort,
+    *,
+    req: ReadRequest,
+    seed_rows: Iterable[ClaimRow],
+    limit: int,
+) -> list[ClaimRow]:
+    """Hydrate all timeline edges for activities matched by anchor-scoped seeds."""
+    activity_keys = tuple({_activity_key(row) for row in seed_rows})
+    if not activity_keys:
+        return []
+    common = {
+        "pot_id": req.pot_id,
+        "include_invalidated": req.include_invalidated,
+        "as_of": req.as_of,
+        "source_ref_in": req.source_refs,
+        "limit": limit,
+        "fact_query": req.query,
+    }
+    as_subject = claim_query.find_claims(
+        ClaimQueryFilter(
+            predicate_in=_TIMELINE_PREDICATES,
+            subject_key_in=activity_keys,
+            **common,
+        )
+    )
+    as_object = claim_query.find_claims(
+        ClaimQueryFilter(
+            predicate_in=("PERFORMED", "AUTHORED"),
+            object_key_in=activity_keys,
+            **common,
+        )
+    )
+    return dedupe_claim_rows((*as_subject, *as_object))
+
+
+def _timeline_anchor_keys(scope: Mapping[str, str]) -> list[str]:
+    keys: list[str] = []
+    repo = scope.get("repo")
+    if repo:
+        keys.append(repo if repo.startswith("repo:") else f"repo:{repo}")
+    service = scope.get("service")
+    if service:
+        keys.append(
+            service if service.startswith("service:") else f"service:{service}"
+        )
+    return keys
+
+
+def _filter_activity_groups(
+    rows: Iterable[ClaimRow], *, scope_filters: Mapping[str, str]
+) -> list[ClaimRow]:
+    grouped: dict[str, list[ClaimRow]] = {}
+    order: list[str] = []
+    for row in rows:
+        activity_key = _activity_key(row)
+        if activity_key not in grouped:
+            order.append(activity_key)
+        grouped.setdefault(activity_key, []).append(row)
+
+    out: list[ClaimRow] = []
+    for activity_key in order:
+        group = grouped[activity_key]
+        if _activity_group_matches_scope(group, scope_filters=scope_filters):
+            out.extend(group)
+    return out
+
+
+def _filter_query_activity_groups(
+    rows: Iterable[ClaimRow], *, query: str, threshold: float
+) -> list[ClaimRow]:
+    grouped, order = _group_activity_rows(rows)
+    out: list[ClaimRow] = []
+    for activity_key in order:
+        group = grouped[activity_key]
+        if any(row_matches_query(row, query, threshold=threshold) for row in group):
+            out.extend(group)
+    return out
+
+
+def _group_activity_rows(
+    rows: Iterable[ClaimRow],
+) -> tuple[dict[str, list[ClaimRow]], list[str]]:
+    grouped: dict[str, list[ClaimRow]] = {}
+    order: list[str] = []
+    for row in rows:
+        activity_key = _activity_key(row)
+        if activity_key not in grouped:
+            order.append(activity_key)
+        grouped.setdefault(activity_key, []).append(row)
+    return grouped, order
+
+
+def _activity_group_matches_scope(
+    rows: Iterable[ClaimRow], *, scope_filters: Mapping[str, str]
+) -> bool:
+    scoped_edges = [
+        row for row in rows if row.predicate.upper() in {"TOUCHED", "MENTIONS"}
+    ]
+    for key in _scope_filter_keys(scope_filters):
+        if not any(scope_ref_matches(row, scope_filters, key) for row in scoped_edges):
+            return False
+    return True
+
+
+def _scope_filter_keys(scope_filters: Mapping[str, str]) -> tuple[str, ...]:
+    keys: list[str] = []
+    for key in ("repo", "service"):
+        if key in scope_filters:
+            keys.append(key)
+    if "file_path" in scope_filters or "path" in scope_filters:
+        keys.append("file_path" if "file_path" in scope_filters else "path")
+    return tuple(keys)
 
 
 def _payload_from_row(row: ClaimRow) -> dict[str, Any]:
@@ -208,6 +392,7 @@ def _with_freshness(req: ReadRequest, preference: str) -> ReadRequest:
         freshness_preference=preference,
         include_invalidated=req.include_invalidated,
         source_refs=req.source_refs,
+        query_threshold=req.query_threshold,
     )
 
 

--- a/potpie/context-engine/application/readers/timeline_reader.py
+++ b/potpie/context-engine/application/readers/timeline_reader.py
@@ -290,9 +290,7 @@ def _timeline_anchor_keys(scope: Mapping[str, str]) -> list[str]:
         keys.append(repo if repo.startswith("repo:") else f"repo:{repo}")
     service = scope.get("service")
     if service:
-        keys.append(
-            service if service.startswith("service:") else f"service:{service}"
-        )
+        keys.append(service if service.startswith("service:") else f"service:{service}")
     return keys
 
 

--- a/potpie/context-engine/application/readers/timeline_reader.py
+++ b/potpie/context-engine/application/readers/timeline_reader.py
@@ -342,7 +342,7 @@ def _activity_group_matches_scope(
     rows: Iterable[ClaimRow], *, scope_filters: Mapping[str, str]
 ) -> bool:
     scoped_edges = [
-        row for row in rows if row.predicate.upper() in {"TOUCHED", "MENTIONS"}
+        row for row in rows if row.predicate.upper() in _TIMELINE_PREDICATES
     ]
     for key in _scope_filter_keys(scope_filters):
         if not any(scope_ref_matches(row, scope_filters, key) for row in scoped_edges):

--- a/potpie/context-engine/application/services/graph_service.py
+++ b/potpie/context-engine/application/services/graph_service.py
@@ -300,6 +300,7 @@ class DefaultGraphService:
             freshness_preference=request.freshness_preference,
             include_invalidated=request.include_invalidated,
             source_refs=request.source_refs,
+            query_threshold=request.query_threshold,
             depth=request.depth,
             direction=request.direction,
         )

--- a/potpie/context-engine/application/services/graph_service.py
+++ b/potpie/context-engine/application/services/graph_service.py
@@ -77,8 +77,8 @@ from domain.ports.services.graph_service import (
     GraphEntitySearchResult,
     GraphReadRequest,
     GraphReadResult,
-    _normalize_read_detail,
-    _normalize_read_relations,
+    normalize_read_detail,
+    normalize_read_relations,
 )
 from domain.semantic_mutations import (
     SemanticMutationRequest,
@@ -223,8 +223,8 @@ class DefaultGraphService:
         )
 
     def read(self, request: GraphReadRequest) -> GraphReadResult:
-        detail = _normalize_read_detail(request.detail)
-        relations = _normalize_read_relations(request.relations)
+        detail = normalize_read_detail(request.detail)
+        relations = normalize_read_relations(request.relations)
         view_name = _qualified_view_name(request.subgraph, request.view)
         contract = ontology_contract().view(view_name)
         spec = view_spec(view_name)

--- a/potpie/context-engine/application/services/read_orchestrator.py
+++ b/potpie/context-engine/application/services/read_orchestrator.py
@@ -92,6 +92,7 @@ class ReadOrchestrator:
         freshness_preference: str = "balanced",
         include_invalidated: bool = False,
         source_refs: tuple[str, ...] = (),
+        query_threshold: float = 0.70,
         depth: int | None = None,
         direction: str | None = None,
         metadata: Mapping[str, Any] | None = None,
@@ -110,6 +111,7 @@ class ReadOrchestrator:
             freshness_preference=freshness_preference,
             include_invalidated=include_invalidated,
             source_refs=tuple(source_refs),
+            query_threshold=query_threshold,
             depth=depth,
             direction=direction,
         )

--- a/potpie/context-engine/domain/ports/services/graph_service.py
+++ b/potpie/context-engine/domain/ports/services/graph_service.py
@@ -137,6 +137,7 @@ class GraphReadRequest:
     source_refs: tuple[str, ...] = ()
     detail: str = "compact"
     relations: str = "summary"
+    query_threshold: float = 0.70
 
 
 @dataclass(frozen=True, slots=True)

--- a/potpie/context-engine/domain/ports/services/graph_service.py
+++ b/potpie/context-engine/domain/ports/services/graph_service.py
@@ -173,8 +173,8 @@ class GraphReadResult:
     relations: str = "summary"
 
     def to_dict(self) -> dict[str, Any]:
-        detail = _normalize_read_detail(self.detail)
-        relations = _normalize_read_relations(self.relations)
+        detail = normalize_read_detail(self.detail)
+        relations = normalize_read_relations(self.relations)
         out = {
             "ok": self.ok,
             "graph_contract_version": self.graph_contract_version,
@@ -189,7 +189,7 @@ class GraphReadResult:
             "detail": detail,
             "relations_detail": relations,
             "items": [
-                _read_item_for_detail(item, detail=detail, relations=relations)
+                read_item_for_detail(item, detail=detail, relations=relations)
                 for item in self.items
             ],
             "coverage": [dict(report) for report in self.coverage],
@@ -317,21 +317,21 @@ class GraphService(Protocol):
         ...
 
 
-def _normalize_read_detail(value: str | None) -> str:
+def normalize_read_detail(value: str | None) -> str:
     detail = (value or "compact").strip().lower()
     if detail not in {"compact", "full"}:
         raise ValueError("detail must be one of: compact, full")
     return detail
 
 
-def _normalize_read_relations(value: str | None) -> str:
+def normalize_read_relations(value: str | None) -> str:
     relations = (value or "summary").strip().lower()
     if relations not in {"summary", "full"}:
         raise ValueError("relations must be one of: summary, full")
     return relations
 
 
-def _read_item_for_detail(
+def read_item_for_detail(
     item: Mapping[str, Any], *, detail: str, relations: str
 ) -> dict[str, Any]:
     payload = dict(item)
@@ -418,4 +418,7 @@ __all__ = [
     "GraphReadRequest",
     "GraphReadResult",
     "GraphService",
+    "normalize_read_detail",
+    "normalize_read_relations",
+    "read_item_for_detail",
 ]

--- a/potpie/context-engine/tests/unit/test_graph_cli_contract.py
+++ b/potpie/context-engine/tests/unit/test_graph_cli_contract.py
@@ -2281,3 +2281,94 @@ def test_timeline_recent_passes_project_scope_and_time_window() -> None:
     assert req.since is not None
     emitted = json.loads(result.output)
     assert emitted["event_count"] == 2
+
+
+def _invoke_timeline_read_text(*args: str) -> str:
+    _common.set_json(False)
+    graph_service = _Graph(read_result=_timeline_env())
+    _common.set_host(_Host(graph_service))
+    result = CliRunner().invoke(
+        graph.graph_app,
+        ["read", "--subgraph", "recent_changes", "--view", "timeline", *args],
+    )
+    assert result.exit_code == 0
+    return _plain_cli_output(result.output)
+
+
+def test_graph_read_table_format_renders_pipe_table() -> None:
+    output = _invoke_timeline_read_text("--format", "table", "--limit", "2")
+    assert "occurred_at |" in output
+    assert "--- | ---" in output
+    data_lines = [
+        line
+        for line in output.splitlines()
+        if line.strip()
+        and not line.startswith("view=")
+        and not line.startswith("scope=")
+        and not line.startswith("occurred_at |")
+        and not line.startswith("--- |")
+    ]
+    assert data_lines
+    assert not any(line.lstrip().startswith("•") for line in data_lines)
+
+
+def test_graph_read_events_format_uses_bullets_not_table() -> None:
+    output = _invoke_timeline_read_text("--format", "events", "--limit", "2")
+    assert "  • " in output
+    assert "--- | ---" not in output
+
+
+def test_graph_read_table_vs_events_produce_different_output() -> None:
+    events_output = _invoke_timeline_read_text("--format", "events", "--limit", "2")
+    table_output = _invoke_timeline_read_text("--format", "table", "--limit", "2")
+    assert events_output != table_output
+
+
+def test_graph_read_text_detail_full_shows_claim_or_breakdown() -> None:
+    compact_output = _invoke_timeline_read_text(
+        "--format", "events", "--detail", "compact", "--limit", "1"
+    )
+    full_output = _invoke_timeline_read_text(
+        "--format", "events", "--detail", "full", "--limit", "1"
+    )
+    assert "truth=" in full_output
+    assert "truth=" not in compact_output
+
+
+def test_graph_read_text_relations_summary_shows_counts() -> None:
+    output = _invoke_timeline_read_text(
+        "--format", "events", "--relations", "summary", "--limit", "1"
+    )
+    assert "relations:" in output
+    assert "TOUCHED" in output
+
+
+def test_graph_read_text_relations_full_lists_edges() -> None:
+    output = _invoke_timeline_read_text(
+        "--format",
+        "events",
+        "--relations",
+        "full",
+        "--detail",
+        "full",
+        "--limit",
+        "1",
+    )
+    assert "↳ TOUCHED" in output
+    assert "↳ PERFORMED" in output
+
+
+def test_timeline_recent_table_format() -> None:
+    _common.set_json(False)
+    graph_service = _Graph(read_result=_timeline_env())
+    _common.set_host(_Host(graph_service))
+
+    result = CliRunner().invoke(
+        graph.timeline_app,
+        ["--format", "table", "--limit", "2"],
+    )
+
+    assert result.exit_code == 0
+    output = _plain_cli_output(result.output)
+    assert "occurred_at |" in output
+    assert "--- | ---" in output

--- a/potpie/context-engine/tests/unit/test_p9_readers.py
+++ b/potpie/context-engine/tests/unit/test_p9_readers.py
@@ -860,9 +860,7 @@ class TestTimelineReader:
         }
 
         by_service = reader.read(
-            ReadRequest(
-                pot_id="pot-1", scope={"service": "checkout-api"}, max_items=10
-            )
+            ReadRequest(pot_id="pot-1", scope={"service": "checkout-api"}, max_items=10)
         )
         assert _timeline_activity_keys(by_service) == {"activity:github:pr:alpha"}
 
@@ -890,9 +888,7 @@ class TestTimelineReader:
                 max_items=10,
             )
         )
-        assert _timeline_activity_keys(by_repo_and_path) == {
-            "activity:github:pr:alpha"
-        }
+        assert _timeline_activity_keys(by_repo_and_path) == {"activity:github:pr:alpha"}
 
         beta = reader.read(
             ReadRequest(

--- a/potpie/context-engine/tests/unit/test_p9_readers.py
+++ b/potpie/context-engine/tests/unit/test_p9_readers.py
@@ -27,6 +27,7 @@ from application.readers._common import (
     ReadRequest,
     claim_semantic_similarity,
     dedupe_claim_rows,
+    row_matches_query,
 )
 from domain.ports.claim_query import ClaimRow
 from domain.ranking import RankingService
@@ -107,6 +108,7 @@ def test_claim_semantic_similarity_ignores_booleans() -> None:
         properties={"semantic_similarity": True},
     )
     assert claim_semantic_similarity(row) is None
+    assert not row_matches_query(row, "unrelated query")
 
 
 # ---------------------------------------------------------------------------

--- a/potpie/context-engine/tests/unit/test_p9_readers.py
+++ b/potpie/context-engine/tests/unit/test_p9_readers.py
@@ -935,6 +935,28 @@ class TestTimelineReader:
 
         assert _timeline_activity_keys(response) == {"activity:github:pr:alpha"}
 
+    def test_timeline_scope_includes_performed_edges(self) -> None:
+        store = InMemoryClaimQueryStore()
+        store.add(
+            _row(
+                predicate="PERFORMED",
+                subject_key="repo:github.com/mock/alpha-checkout",
+                object_key="activity:github:pr:alpha",
+                fact="alpha checkout team performed the activity",
+            )
+        )
+        reader = TimelineReader(claim_query=store, ranker=RankingService())
+
+        response = reader.read(
+            ReadRequest(
+                pot_id="pot-1",
+                scope={"repo": "github.com/mock/alpha-checkout"},
+                max_items=10,
+            )
+        )
+
+        assert _timeline_activity_keys(response) == {"activity:github:pr:alpha"}
+
     def test_timeline_source_ref_filter_still_narrows_events(self) -> None:
         store = _timeline_scope_store()
         reader = TimelineReader(claim_query=store, ranker=RankingService())

--- a/potpie/context-engine/tests/unit/test_p9_readers.py
+++ b/potpie/context-engine/tests/unit/test_p9_readers.py
@@ -171,6 +171,46 @@ class TestCodingPreferencesReader:
         assert response.items
         assert "httpx" in (response.items[0].candidate.payload["fact"] or "")
 
+    def test_query_filters_out_non_matching_preferences(self) -> None:
+        store = self._setup_store()
+        reader = CodingPreferencesReader(claim_query=store, ranker=RankingService())
+        response = reader.read(
+            ReadRequest(
+                pot_id="pot-1",
+                scope={"language": "python"},
+                query="does-not-exist-12345",
+                max_items=5,
+            )
+        )
+        assert response.items == ()
+        assert response.coverage_status == "empty"
+
+    def test_query_threshold_can_be_relaxed(self) -> None:
+        store = self._setup_store()
+        reader = CodingPreferencesReader(claim_query=store, ranker=RankingService())
+
+        strict = reader.read(
+            ReadRequest(
+                pot_id="pot-1",
+                scope={"language": "python"},
+                query="httpx absent",
+                max_items=5,
+            )
+        )
+        relaxed = reader.read(
+            ReadRequest(
+                pot_id="pot-1",
+                scope={"language": "python"},
+                query="httpx absent",
+                query_threshold=0.30,
+                max_items=5,
+            )
+        )
+
+        assert strict.items == ()
+        assert relaxed.items
+        assert relaxed.items[0].candidate.payload["subject_key"] == "policy:use-httpx"
+
     def test_empty_pool_reports_empty_coverage(self) -> None:
         reader = CodingPreferencesReader(
             claim_query=InMemoryClaimQueryStore(), ranker=RankingService()
@@ -178,6 +218,161 @@ class TestCodingPreferencesReader:
         response = reader.read(ReadRequest(pot_id="pot-1", scope={"language": "rust"}))
         assert response.items == ()
         assert response.coverage_status == "empty"
+
+    def test_repo_path_scope_excludes_conflicting_preferences(self) -> None:
+        store = InMemoryClaimQueryStore()
+        store.add(
+            _row(
+                predicate="POLICY_APPLIES_TO",
+                subject_key="preference:alpha-pytest",
+                object_key="code:github.com/mock/alpha-checkout:src/checkout",
+                fact="add pytest tests for checkout changes",
+                properties={
+                    "code_scope": {
+                        "repo": "github.com/mock/alpha-checkout",
+                        "service": "checkout-api",
+                        "file_path": "src/checkout",
+                        "language": "python",
+                    }
+                },
+            )
+        )
+        store.add(
+            _row(
+                predicate="POLICY_APPLIES_TO",
+                subject_key="preference:beta-logging",
+                object_key="code:github.com/mock/beta-billing:src/billing",
+                fact="add structured logging for billing changes",
+                properties={
+                    "code_scope": {
+                        "repo": "github.com/mock/beta-billing",
+                        "service": "billing-worker",
+                        "file_path": "src/billing",
+                        "language": "python",
+                    }
+                },
+            )
+        )
+        store.add(
+            _row(
+                predicate="POLICY_APPLIES_TO",
+                subject_key="preference:global-python",
+                object_key="scope:any",
+                fact="prefer small focused python tests",
+            )
+        )
+        reader = CodingPreferencesReader(claim_query=store, ranker=RankingService())
+
+        response = reader.read(
+            ReadRequest(
+                pot_id="pot-1",
+                scope={
+                    "repo": "github.com/mock/alpha-checkout",
+                    "path": "src/checkout/cache.py",
+                    "language": "python",
+                },
+                max_items=10,
+            )
+        )
+
+        keys = {r.candidate.payload["subject_key"] for r in response.items}
+        assert "preference:alpha-pytest" in keys
+        assert "preference:global-python" in keys
+        assert "preference:beta-logging" not in keys
+
+    def test_beta_scope_excludes_alpha_preference(self) -> None:
+        store = InMemoryClaimQueryStore()
+        store.add(
+            _row(
+                predicate="POLICY_APPLIES_TO",
+                subject_key="preference:alpha-pytest",
+                object_key="code:github.com/mock/alpha-checkout:src/checkout",
+                fact="add pytest tests for checkout changes",
+                properties={
+                    "code_scope": {
+                        "repo": "github.com/mock/alpha-checkout",
+                        "file_path": "src/checkout",
+                    }
+                },
+            )
+        )
+        store.add(
+            _row(
+                predicate="POLICY_APPLIES_TO",
+                subject_key="preference:beta-logging",
+                object_key="code:github.com/mock/beta-billing:src/billing",
+                fact="add structured logging for billing changes",
+                properties={
+                    "code_scope": {
+                        "repo": "github.com/mock/beta-billing",
+                        "file_path": "src/billing",
+                    }
+                },
+            )
+        )
+        reader = CodingPreferencesReader(claim_query=store, ranker=RankingService())
+
+        response = reader.read(
+            ReadRequest(
+                pot_id="pot-1",
+                scope={"repo": "github.com/mock/beta-billing", "path": "src/billing"},
+                max_items=10,
+            )
+        )
+
+        keys = {r.candidate.payload["subject_key"] for r in response.items}
+        assert keys == {"preference:beta-logging"}
+
+    def test_conflicting_language_framework_and_service_preferences_are_excluded(
+        self,
+    ) -> None:
+        store = InMemoryClaimQueryStore()
+        store.add(
+            _row(
+                predicate="POLICY_APPLIES_TO",
+                subject_key="preference:python-fastapi",
+                object_key="service:checkout-api",
+                fact="python fastapi checkout preference",
+                properties={
+                    "code_scope": {
+                        "service": "checkout-api",
+                        "language": "python",
+                        "framework": "fastapi",
+                    }
+                },
+            )
+        )
+        store.add(
+            _row(
+                predicate="POLICY_APPLIES_TO",
+                subject_key="preference:go-chi",
+                object_key="service:billing-worker",
+                fact="go chi billing preference",
+                properties={
+                    "code_scope": {
+                        "service": "billing-worker",
+                        "language": "go",
+                        "framework": "chi",
+                    }
+                },
+            )
+        )
+        reader = CodingPreferencesReader(claim_query=store, ranker=RankingService())
+
+        response = reader.read(
+            ReadRequest(
+                pot_id="pot-1",
+                scope={
+                    "service": "checkout-api",
+                    "language": "python",
+                    "framework": "fastapi",
+                },
+                max_items=10,
+            )
+        )
+
+        keys = {r.candidate.payload["subject_key"] for r in response.items}
+        assert keys == {"preference:python-fastapi"}
 
 
 # ---------------------------------------------------------------------------
@@ -653,6 +848,200 @@ class TestTimelineReader:
         payload = response.items[0].candidate.payload
         assert payload["activity_key"] == "activity:github:pr:dupe"
         assert payload["properties"]["activity_edge_count"] == 2
+
+    def test_timeline_scope_filters_by_repo_service_and_path(self) -> None:
+        store = _timeline_scope_store()
+        reader = TimelineReader(claim_query=store, ranker=RankingService())
+
+        unscoped = reader.read(ReadRequest(pot_id="pot-1", max_items=10))
+        assert _timeline_activity_keys(unscoped) == {
+            "activity:github:pr:alpha",
+            "activity:github:pr:beta",
+        }
+
+        by_service = reader.read(
+            ReadRequest(
+                pot_id="pot-1", scope={"service": "checkout-api"}, max_items=10
+            )
+        )
+        assert _timeline_activity_keys(by_service) == {"activity:github:pr:alpha"}
+
+        by_repo = reader.read(
+            ReadRequest(
+                pot_id="pot-1",
+                scope={"repo": "github.com/mock/alpha-checkout"},
+                max_items=10,
+            )
+        )
+        assert _timeline_activity_keys(by_repo) == {"activity:github:pr:alpha"}
+
+        by_path = reader.read(
+            ReadRequest(pot_id="pot-1", scope={"path": "src/checkout"}, max_items=10)
+        )
+        assert _timeline_activity_keys(by_path) == {"activity:github:pr:alpha"}
+
+        by_repo_and_path = reader.read(
+            ReadRequest(
+                pot_id="pot-1",
+                scope={
+                    "repo": "github.com/mock/alpha-checkout",
+                    "path": "src/checkout",
+                },
+                max_items=10,
+            )
+        )
+        assert _timeline_activity_keys(by_repo_and_path) == {
+            "activity:github:pr:alpha"
+        }
+
+        beta = reader.read(
+            ReadRequest(
+                pot_id="pot-1",
+                scope={"repo": "github.com/mock/beta-billing", "path": "src/billing"},
+                max_items=10,
+            )
+        )
+        assert _timeline_activity_keys(beta) == {"activity:github:pr:beta"}
+
+    def test_timeline_anchor_scope_survives_unrelated_activity_cap(self) -> None:
+        """Scoped repo reads must not drop matches when unrelated rows fill the cap."""
+        store = InMemoryClaimQueryStore()
+        for index in range(250):
+            store.add(
+                _row(
+                    predicate="TOUCHED",
+                    subject_key=f"activity:github:pr:filler-{index}",
+                    object_key="repo:github.com/mock/unrelated-repo",
+                    fact=f"filler activity {index}",
+                    valid_at=_NOW - timedelta(hours=1),
+                    properties={"occurred_at": "2026-07-03T12:00:00+00:00"},
+                )
+            )
+        store.add(
+            _row(
+                predicate="TOUCHED",
+                subject_key="activity:github:pr:alpha",
+                object_key="repo:github.com/mock/alpha-checkout",
+                fact="alpha checkout latency change",
+                valid_at=_NOW - timedelta(hours=3),
+                properties={"occurred_at": "2026-07-01T10:00:00+00:00"},
+            )
+        )
+        reader = TimelineReader(claim_query=store, ranker=RankingService())
+
+        response = reader.read(
+            ReadRequest(
+                pot_id="pot-1",
+                scope={"repo": "github.com/mock/alpha-checkout"},
+                max_items=10,
+            )
+        )
+
+        assert _timeline_activity_keys(response) == {"activity:github:pr:alpha"}
+
+    def test_timeline_source_ref_filter_still_narrows_events(self) -> None:
+        store = _timeline_scope_store()
+        reader = TimelineReader(claim_query=store, ranker=RankingService())
+
+        response = reader.read(
+            ReadRequest(
+                pot_id="pot-1",
+                source_refs=("mock:github:mock/alpha-checkout#pr/101",),
+                max_items=10,
+            )
+        )
+
+        assert _timeline_activity_keys(response) == {"activity:github:pr:alpha"}
+
+    def test_timeline_query_filters_activity_groups(self) -> None:
+        store = _timeline_scope_store()
+        reader = TimelineReader(claim_query=store, ranker=RankingService())
+
+        alpha = reader.read(
+            ReadRequest(pot_id="pot-1", query="ALPHA_SENTINEL", max_items=10)
+        )
+        assert _timeline_activity_keys(alpha) == {"activity:github:pr:alpha"}
+
+        nonsense = reader.read(
+            ReadRequest(pot_id="pot-1", query="does-not-exist-12345", max_items=10)
+        )
+        assert nonsense.items == ()
+        assert nonsense.coverage_status == "empty"
+
+
+def _timeline_scope_store() -> InMemoryClaimQueryStore:
+    store = InMemoryClaimQueryStore()
+    store.add(
+        _row(
+            predicate="TOUCHED",
+            subject_key="activity:github:pr:alpha",
+            object_key="repo:github.com/mock/alpha-checkout",
+            fact="ALPHA_SENTINEL checkout latency change",
+            valid_at=_NOW - timedelta(hours=3),
+            source_ref="mock:github:mock/alpha-checkout#pr/101",
+            properties={"occurred_at": "2026-07-01T10:00:00+00:00"},
+        )
+    )
+    store.add(
+        _row(
+            predicate="TOUCHED",
+            subject_key="activity:github:pr:alpha",
+            object_key="service:checkout-api",
+            fact="ALPHA_SENTINEL touched checkout service",
+            valid_at=_NOW - timedelta(hours=3),
+            source_ref="mock:github:mock/alpha-checkout#pr/101",
+            properties={"occurred_at": "2026-07-01T10:00:00+00:00"},
+        )
+    )
+    store.add(
+        _row(
+            predicate="TOUCHED",
+            subject_key="activity:github:pr:alpha",
+            object_key="code:github.com/mock/alpha-checkout:src/checkout/cache.py",
+            fact="ALPHA_SENTINEL touched checkout cache",
+            valid_at=_NOW - timedelta(hours=3),
+            source_ref="mock:github:mock/alpha-checkout#pr/101",
+            properties={"occurred_at": "2026-07-01T10:00:00+00:00"},
+        )
+    )
+    store.add(
+        _row(
+            predicate="TOUCHED",
+            subject_key="activity:github:pr:beta",
+            object_key="repo:github.com/mock/beta-billing",
+            fact="BETA_SENTINEL invoice retry change",
+            valid_at=_NOW - timedelta(hours=2),
+            source_ref="mock:github:mock/beta-billing#pr/202",
+            properties={"occurred_at": "2026-07-02T11:00:00+00:00"},
+        )
+    )
+    store.add(
+        _row(
+            predicate="TOUCHED",
+            subject_key="activity:github:pr:beta",
+            object_key="service:billing-worker",
+            fact="BETA_SENTINEL touched billing service",
+            valid_at=_NOW - timedelta(hours=2),
+            source_ref="mock:github:mock/beta-billing#pr/202",
+            properties={"occurred_at": "2026-07-02T11:00:00+00:00"},
+        )
+    )
+    store.add(
+        _row(
+            predicate="TOUCHED",
+            subject_key="activity:github:pr:beta",
+            object_key="code:github.com/mock/beta-billing:src/billing/retry.py",
+            fact="BETA_SENTINEL touched billing retry",
+            valid_at=_NOW - timedelta(hours=2),
+            source_ref="mock:github:mock/beta-billing#pr/202",
+            properties={"occurred_at": "2026-07-02T11:00:00+00:00"},
+        )
+    )
+    return store
+
+
+def _timeline_activity_keys(response) -> set[str]:
+    return {item.candidate.payload["activity_key"] for item in response.items}
 
 
 # ---------------------------------------------------------------------------

--- a/potpie/context-engine/tests/unit/test_read_presenter.py
+++ b/potpie/context-engine/tests/unit/test_read_presenter.py
@@ -110,6 +110,8 @@ def test_render_timeline_table_includes_headers_and_relations_column() -> None:
     output = render_timeline_table(result, events, shaped, ctx)
     assert "occurred_at | source_ref | activity | fact | score | relations" in output
     assert "TOUCHED" in output
+    assert "scope=applied graph-read scope" in output
+    assert "project-wide" not in output
 
 
 def test_render_items_table_handles_empty_rows() -> None:

--- a/potpie/context-engine/tests/unit/test_read_presenter.py
+++ b/potpie/context-engine/tests/unit/test_read_presenter.py
@@ -1,0 +1,127 @@
+"""Unit tests for graph read human presentation."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from adapters.inbound.cli.read_presenter import (
+    ReadPresentationContext,
+    _escape_table_cell,
+    _format_relations_summary,
+    prepare_items,
+    render_items_table,
+    render_timeline_table,
+)
+from domain.ports.services.graph_service import GraphReadResult
+
+pytestmark = pytest.mark.unit
+
+
+def _timeline_result() -> GraphReadResult:
+    return GraphReadResult(
+        graph_contract_version="v1.5",
+        ontology_version="2026-06-graph",
+        view="recent_changes.timeline",
+        subgraph="recent_changes",
+        read_shape="entity_relations",
+        quality={"status": "ok"},
+        items=(
+            {
+                "entity_key": "activity:github:pr-2",
+                "entity_type": "Activity",
+                "score": 0.9,
+                "summary": 'PR #2 "newer" was merged into acme/widgets.',
+                "source_refs": ["github:pr:2"],
+                "truth": "timeline_event",
+                "relations": [
+                    {
+                        "predicate": "TOUCHED",
+                        "from_key": "activity:github:pr-2",
+                        "to_key": "repo:github.com/acme/widgets",
+                        "fact": "PR #2 merged",
+                        "source_refs": ["github:pr:2"],
+                        "truth": "timeline_event",
+                    },
+                    {
+                        "predicate": "PERFORMED",
+                        "from_key": "person:bob",
+                        "to_key": "activity:github:pr-2",
+                        "fact": "PR #2 merged",
+                        "source_refs": ["github:pr:2"],
+                        "truth": "timeline_event",
+                    },
+                ],
+            },
+        ),
+    )
+
+
+def test_escape_table_cell_replaces_pipes_and_newlines() -> None:
+    assert _escape_table_cell("a|b\nc") == "a\\|b c"
+
+
+def test_format_relations_summary_includes_count_predicates_and_keys() -> None:
+    item = {
+        "relation_count": 2,
+        "relation_predicates": ["PERFORMED", "TOUCHED"],
+        "related_keys": ["repo:github.com/acme/widgets", "person:bob"],
+    }
+    summary = _format_relations_summary(item)
+    assert summary.startswith("2 [")
+    assert "TOUCHED" in summary
+    assert "repo:github.com/acme/widgets" in summary
+
+
+def test_prepare_items_applies_detail_and_relations_shaping() -> None:
+    result = replace(
+        _timeline_result(),
+        detail="compact",
+        relations="summary",
+    )
+    items = prepare_items(result)
+    assert items[0]["relation_count"] == 2
+    assert "relations" not in items[0]
+
+
+def test_render_timeline_table_includes_headers_and_relations_column() -> None:
+    result = _timeline_result()
+    shaped = prepare_items(result)
+    ctx = ReadPresentationContext(
+        view="recent_changes.timeline",
+        detail="compact",
+        relations="summary",
+        format_mode="table",
+        sort="occurred_at",
+        dedupe="source_ref",
+        event_limit=5,
+    )
+    events = [
+        {
+            "activity_key": "activity:github:pr-2",
+            "occurred_at": "2026-06-08",
+            "source_refs": ["github:pr:2"],
+            "fact": "PR #2 merged",
+            "score": 0.9,
+            "predicate": "TOUCHED",
+        }
+    ]
+    output = render_timeline_table(result, events, shaped, ctx)
+    assert "occurred_at | source_ref | activity | fact | score | relations" in output
+    assert "TOUCHED" in output
+
+
+def test_render_items_table_handles_empty_rows() -> None:
+    ctx = ReadPresentationContext(
+        view="decisions.preferences_for_scope",
+        detail="compact",
+        relations="summary",
+        format_mode="table",
+        sort="auto",
+        dedupe="auto",
+        event_limit=10,
+    )
+    output = render_items_table([], ctx)
+    assert "score | type | entity_key | summary | relations" in output
+    assert "(no rows)" in output


### PR DESCRIPTION
Fixes https://github.com/potpie-ai/potpie/issues/994

## Summary
- **Read path:** Timeline and coding-preferences readers now honor scope and query filters; add `--query-threshold` (default `0.70`) for tunable semantic cutoff.
- **Timeline scoping:** Restore anchor-scoped claim queries for repo/service reads and expand activity groups when path scope is combined with anchors, so large pots do not truncate scoped matches behind a global row cap.
- **Presentation:** Extract `read_presenter.py` so text-mode `graph read` / `timeline recent` respect `--format` (events vs table), `--detail` (compact vs full), and `--relations` (summary vs full).
- **CLI feedback:** Surface `unsupported_filter` in human headers; reject malformed `--scope` entries before the service call.

## Changes

### Read filters
- `application/readers/_common.py` — shared scope normalization, path overlap, query matching, `code_scope` conflict checks
- `timeline_reader.py` — repo/service scope pushed into claim queries; path post-filter; query filtering at activity-group level
- `coding_preferences.py` — hard scope exclusion + query threshold filtering
- CLI/service — `--query-threshold` on `graph read` and `timeline recent`

### Text presentation
- `adapters/inbound/cli/read_presenter.py` — timeline bullets/tables, non-timeline item bullets/tables, detail/relations shaping
- `graph.py` — delegate human output to presenter; slimmed `_read_human` / `_emit_graph_read`

### Tests & docs
- `test_p9_readers.py` — scope, query, threshold, anchor-cap regression
- `test_read_presenter.py` — table escaping, relations summary, detail shaping
- `test_graph_cli_contract.py` — format table vs events, detail full, relations summary/full, malformed scope
- `cli-flow.md`, `querying.md`, `potpie-graph` skill updated

## Follow-up
- Timeline header still uses generic project-wide scope copy when filters are active (banner wording only)

## Test plan

<img width="1116" height="435" alt="image" src="https://github.com/user-attachments/assets/a297eadd-e097-4279-b6f8-b637f382c3ae" />

- [x] Reader unit tests
- [x] Presenter unit tests
- [x] CLI contract tests (format/detail/relations/scope validation)
- [x] `pre-commit run --all-files --show-diff-on-failure`
- [x] Manual scoped timeline + preferences reads on a real pot
- [x] Manual `--format table --detail full --relations full` on timeline and preferences views