### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Listed on TakoAPI](https://takoapi.com/api/badge/potpie-ai-potpie)](https://takoapi.com/agents/potpie-ai-potpie)
+
 <p align="center">
   <a href="https://potpie.ai?utm_source=github">
     <img src="https://raw.githubusercontent.com/potpie-ai/potpie/main/assets/readme_logo_light.svg" alt="Potpie AI logo" />


### PR DESCRIPTION
Hi! 👋 **potpie** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/potpie-ai-potpie

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building potpie! 🙏