### PR TITLE
Fix embedded-FalkorDB claim read invisibility and default to sentence-transformers

### DIFF
--- a/potpie/context-engine/adapters/inbound/cli/commands/graph.py
+++ b/potpie/context-engine/adapters/inbound/cli/commands/graph.py
@@ -2206,6 +2206,7 @@ def _graph_status_payload(host: Any, pot_id: str, dp) -> dict[str, Any]:
             ),
             "validator_ready": True,
             "match_mode": dp.match_mode,
+            "embedder": dict(dp.embedder),
         },
         backend={
             "profile": dp.backend_profile,
@@ -2728,6 +2729,7 @@ def _data_plane_status_payload(status) -> dict[str, Any]:
         "freshness": dict(status.freshness),
         "quality": dict(status.quality),
         "match_mode": status.match_mode,
+        "embedder": dict(status.embedder),
         "detail": status.detail,
     }
 

--- a/potpie/context-engine/adapters/outbound/graph/backends/claim_query_analytics.py
+++ b/potpie/context-engine/adapters/outbound/graph/backends/claim_query_analytics.py
@@ -20,6 +20,10 @@ from adapters.outbound.graph.entity_summary_repair import (
     ENTITY_SUMMARY_TARGET,
     wants_entity_summary_repair,
 )
+from adapters.outbound.graph.semantic_index_repair import (
+    SEMANTIC_INDEX_TARGET,
+    wants_semantic_index_repair,
+)
 from domain.ports.claim_query import ClaimQueryFilter, ClaimQueryPort, ClaimRow
 from domain.ports.graph.analytics import RepairReport
 
@@ -34,6 +38,7 @@ class ClaimQueryAnalytics:
 
     claim_query: ClaimQueryPort
     entity_summary_repair: Callable[[str], int] | None = None
+    semantic_index_repair: Callable[[str], Mapping[str, Any]] | None = None
 
     def _rows(self, pot_id: str) -> list[ClaimRow]:
         return list(
@@ -72,15 +77,31 @@ class ClaimQueryAnalytics:
         }
 
     def repair(self, pot_id: str, *, targets: Sequence[str] = ()) -> RepairReport:
+        repaired: dict[str, int] = {}
+        details: list[str] = []
+        if self.semantic_index_repair is not None and wants_semantic_index_repair(
+            targets
+        ):
+            report = self.semantic_index_repair(pot_id)
+            repaired[SEMANTIC_INDEX_TARGET] = int(report.get("repaired") or 0)
+            failed = int(report.get("failed") or 0)
+            if failed:
+                repaired[f"{SEMANTIC_INDEX_TARGET}_failed"] = failed
+            detail = report.get("detail")
+            if isinstance(detail, str) and detail:
+                details.append(detail)
         if self.entity_summary_repair is not None and wants_entity_summary_repair(
             targets
         ):
-            repaired = self.entity_summary_repair(pot_id)
+            count = self.entity_summary_repair(pot_id)
+            repaired[ENTITY_SUMMARY_TARGET] = count
+            details.append(f"repaired {count} entity summaries")
+        if repaired or details:
             return RepairReport(
                 pot_id=pot_id,
                 targets=tuple(targets),
-                repaired={ENTITY_SUMMARY_TARGET: repaired},
-                detail=f"repaired {repaired} entity summaries",
+                repaired=repaired,
+                detail="; ".join(details) or None,
             )
         return RepairReport(
             pot_id=pot_id,

--- a/potpie/context-engine/adapters/outbound/graph/backends/falkordb_backend.py
+++ b/potpie/context-engine/adapters/outbound/graph/backends/falkordb_backend.py
@@ -73,9 +73,13 @@ SET r.fact_embedding = vecf32($embedding),
 RETURN count(r) AS updated
 """
 
+# ``source_ref`` is part of the edge identity for FalkorDB writes: a null
+# param must match only edges that themselves have no source_ref, never act
+# as a wildcard across every edge sharing the (predicate, subject, object)
+# tuple.
 _REEMBED_BY_TUPLE_CYPHER = """
 MATCH ()-[r:RELATES_TO {group_id: $gid, name: $predicate, subject_key: $subject_key, object_key: $object_key}]->()
-WHERE ($source_ref IS NULL OR r.source_ref = $source_ref)
+WHERE (($source_ref IS NULL AND r.source_ref IS NULL) OR r.source_ref = $source_ref)
 SET r.fact_embedding = vecf32($embedding),
     r.embedding_model = $embedding_model,
     r.embedding_dim = $embedding_dim
@@ -337,6 +341,7 @@ class FalkorDBGraphBackend:
             )
         ]
         index_recreated = False
+        index_errors: list[str] = []
         if any(
             stored_dim_mismatch(props, embedder_dim=embedder_dim) for props in needs
         ):
@@ -344,6 +349,7 @@ class FalkorDBGraphBackend:
                 graph.query(_DROP_VECTOR_INDEX_CYPHER)
                 index_recreated = True
             except Exception as exc:  # noqa: BLE001
+                index_errors.append(f"index drop failed: {exc}")
                 logger.warning("vector index drop failed (continuing): %s", exc)
         repaired = 0
         failed = 0
@@ -376,12 +382,13 @@ class FalkorDBGraphBackend:
                     exc,
                 )
         # Recreate (or ensure) the vector index after values are rewritten.
+        # The index covers every :RELATES_TO edge in the (shared) graph, so a
+        # dimension migration re-shapes it for all pots in this store.
         assert self.writer is not None
-        try:
-            embedding_dim = int(getattr(self.embedder, "dimensions", 1536))
-            FalkorDBGraphWriter._ensure_indexes_sync(graph, embedding_dim)
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("vector index recreate failed: %s", exc)
+        embedding_dim = int(getattr(self.embedder, "dimensions", 1536))
+        if not FalkorDBGraphWriter._ensure_vector_index_sync(graph, embedding_dim):
+            index_errors.append("index recreate failed — see the daemon/CLI log")
+        index_recreated = index_recreated and not index_errors
         detail = (
             f"re-embedded {repaired} of {len(needs)} stale claim(s) "
             f"(scanned {len(props_list)})"
@@ -390,10 +397,12 @@ class FalkorDBGraphBackend:
             detail += f"; {failed} FAILED — see warnings in the daemon/CLI log"
         if index_recreated:
             detail += "; vector index rebuilt for new embedding dimensions"
+        if index_errors:
+            detail += "; " + "; ".join(index_errors)
         return {
             "scanned": len(props_list),
             "repaired": repaired,
-            "failed": failed,
+            "failed": failed + (1 if index_errors else 0),
             "index_recreated": index_recreated,
             "detail": detail,
         }

--- a/potpie/context-engine/adapters/outbound/graph/backends/falkordb_backend.py
+++ b/potpie/context-engine/adapters/outbound/graph/backends/falkordb_backend.py
@@ -8,6 +8,7 @@ shim details stay in outbound adapters.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import Any, Mapping
 
@@ -26,11 +27,20 @@ from adapters.outbound.graph.falkordb_writer import (
     FalkorDBGraphWriter,
     _records_from_result,
 )
+from adapters.outbound.graph.canonical_claim_query import (
+    card_for_row,
+    row_from_record,
+)
 from adapters.outbound.graph.entity_summary_repair import (
     ENTITY_SUMMARY_REPAIR_LIMIT,
     ENTITY_SUMMARY_SCAN_CYPHER,
     ENTITY_SUMMARY_UPDATE_CYPHER,
     repaired_entity_properties,
+)
+from adapters.outbound.graph.semantic_index_repair import (
+    SEMANTIC_INDEX_REPAIR_LIMIT,
+    claim_needs_reembed,
+    stored_dim_mismatch,
 )
 from adapters.outbound.graph.writer_port import GraphWriterPort
 from domain.errors import CapabilityNotImplemented
@@ -41,8 +51,40 @@ from domain.ports.graph.backend import BackendCapabilities
 from domain.ports.graph.mutation import BackendReadiness
 from domain.reconciliation import MutationBatch, MutationResult
 
+logger = logging.getLogger(__name__)
+
 _PROFILE = "falkordb"
 _LITE_PROFILE = "falkordb_lite"
+
+# All repair Cypher is edge-first with UNBOUND endpoints — anchoring a node
+# is the embedded-FalkorDB plan shape that returns zero rows when the bound
+# node is internal id 0 (see FIND_CLAIMS_CYPHER).
+_SEMANTIC_SCAN_CYPHER = """
+MATCH ()-[r:RELATES_TO {group_id: $gid}]->()
+RETURN r{.*} AS props
+LIMIT $limit
+"""
+
+_REEMBED_BY_CLAIM_KEY_CYPHER = """
+MATCH ()-[r:RELATES_TO {group_id: $gid, claim_key: $claim_key}]->()
+SET r.fact_embedding = vecf32($embedding),
+    r.embedding_model = $embedding_model,
+    r.embedding_dim = $embedding_dim
+RETURN count(r) AS updated
+"""
+
+_REEMBED_BY_TUPLE_CYPHER = """
+MATCH ()-[r:RELATES_TO {group_id: $gid, name: $predicate, subject_key: $subject_key, object_key: $object_key}]->()
+WHERE ($source_ref IS NULL OR r.source_ref = $source_ref)
+SET r.fact_embedding = vecf32($embedding),
+    r.embedding_model = $embedding_model,
+    r.embedding_dim = $embedding_dim
+RETURN count(r) AS updated
+"""
+
+_DROP_VECTOR_INDEX_CYPHER = (
+    "DROP VECTOR INDEX FOR ()-[r:RELATES_TO]-() ON (r.fact_embedding)"
+)
 
 
 class _FalkorDBModeSettings:
@@ -213,6 +255,7 @@ class FalkorDBGraphBackend:
         return ClaimQueryAnalytics(
             self._claim_query,
             entity_summary_repair=self._repair_entity_summaries,
+            semantic_index_repair=self._repair_semantic_index,
         )
 
     @property
@@ -257,6 +300,139 @@ class FalkorDBGraphBackend:
             ),
             metadata={"profile": self.profile_name},
         )
+
+    def _repair_semantic_index(self, pot_id: str) -> dict[str, Any]:
+        """Re-embed claims whose embeddings are missing, stale, or mis-sized.
+
+        This is both the recovery pass for failed embedding attaches and the
+        migration pass for embedder changes (model or dimensions). On a
+        dimension change the vector index is dropped first — re-embedded
+        values at the new size must not stream into an index built for the
+        old one — and recreated after the claims are rewritten.
+        """
+        if self.embedder is None:
+            return {
+                "scanned": 0,
+                "repaired": 0,
+                "failed": 0,
+                "detail": "no embedder configured; nothing to re-embed",
+            }
+        embedder_name = str(getattr(self.embedder, "name", "unknown"))
+        embedder_dim = int(getattr(self.embedder, "dimensions", 0))
+        graph = self.graph_provider()
+        rows = _records_from_result(
+            graph.query(
+                _SEMANTIC_SCAN_CYPHER,
+                params={"gid": pot_id, "limit": SEMANTIC_INDEX_REPAIR_LIMIT},
+            )
+        )
+        props_list = [
+            props for rec in rows if isinstance(props := rec.get("props"), Mapping)
+        ]
+        needs = [
+            props
+            for props in props_list
+            if claim_needs_reembed(
+                props, embedder_name=embedder_name, embedder_dim=embedder_dim
+            )
+        ]
+        index_recreated = False
+        if any(
+            stored_dim_mismatch(props, embedder_dim=embedder_dim) for props in needs
+        ):
+            try:
+                graph.query(_DROP_VECTOR_INDEX_CYPHER)
+                index_recreated = True
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("vector index drop failed (continuing): %s", exc)
+        repaired = 0
+        failed = 0
+        for props in needs:
+            try:
+                row = row_from_record({"props": dict(props)})
+                card = card_for_row(row)
+                if not card:
+                    failed += 1
+                    continue
+                embedding = [float(x) for x in self.embedder.embed(card)]
+                updated = self._set_claim_embedding(
+                    graph,
+                    pot_id=pot_id,
+                    props=props,
+                    embedding=embedding,
+                    embedder_name=embedder_name,
+                    embedder_dim=embedder_dim,
+                )
+                if updated < 1:
+                    raise RuntimeError("re-embed matched no edge")
+                repaired += 1
+            except Exception as exc:  # noqa: BLE001
+                failed += 1
+                logger.warning(
+                    "semantic re-embed failed for %s:%s->%s: %s",
+                    props.get("name"),
+                    props.get("subject_key"),
+                    props.get("object_key"),
+                    exc,
+                )
+        # Recreate (or ensure) the vector index after values are rewritten.
+        assert self.writer is not None
+        try:
+            embedding_dim = int(getattr(self.embedder, "dimensions", 1536))
+            FalkorDBGraphWriter._ensure_indexes_sync(graph, embedding_dim)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("vector index recreate failed: %s", exc)
+        detail = (
+            f"re-embedded {repaired} of {len(needs)} stale claim(s) "
+            f"(scanned {len(props_list)})"
+        )
+        if failed:
+            detail += f"; {failed} FAILED — see warnings in the daemon/CLI log"
+        if index_recreated:
+            detail += "; vector index rebuilt for new embedding dimensions"
+        return {
+            "scanned": len(props_list),
+            "repaired": repaired,
+            "failed": failed,
+            "index_recreated": index_recreated,
+            "detail": detail,
+        }
+
+    @staticmethod
+    def _set_claim_embedding(
+        graph: Any,
+        *,
+        pot_id: str,
+        props: Mapping[str, Any],
+        embedding: list[float],
+        embedder_name: str,
+        embedder_dim: int,
+    ) -> int:
+        claim_key = props.get("claim_key")
+        base_params = {
+            "gid": pot_id,
+            "embedding": embedding,
+            "embedding_model": embedder_name,
+            "embedding_dim": embedder_dim,
+        }
+        if isinstance(claim_key, str) and claim_key:
+            result = graph.query(
+                _REEMBED_BY_CLAIM_KEY_CYPHER,
+                params={**base_params, "claim_key": claim_key},
+            )
+        else:
+            result = graph.query(
+                _REEMBED_BY_TUPLE_CYPHER,
+                params={
+                    **base_params,
+                    "predicate": props.get("name"),
+                    "subject_key": props.get("subject_key"),
+                    "object_key": props.get("object_key"),
+                    "source_ref": props.get("source_ref"),
+                },
+            )
+        records = _records_from_result(result)
+        return int(records[0].get("updated") or 0) if records else 0
 
     def _repair_entity_summaries(self, pot_id: str) -> int:
         graph = self.graph_provider()

--- a/potpie/context-engine/adapters/outbound/graph/backends/in_memory_backend.py
+++ b/potpie/context-engine/adapters/outbound/graph/backends/in_memory_backend.py
@@ -28,6 +28,10 @@ from adapters.outbound.graph.entity_summary_repair import (
     repaired_entity_properties,
     wants_entity_summary_repair,
 )
+from adapters.outbound.graph.semantic_index_repair import (
+    SEMANTIC_INDEX_TARGET,
+    wants_semantic_index_repair,
+)
 from application.services.reconciliation_validation import (
     validate_reconciliation_plan,
 )
@@ -493,15 +497,27 @@ class _Analytics:
         }
 
     def repair(self, pot_id: str, *, targets: Sequence[str] = ()) -> RepairReport:
+        repaired: dict[str, int] = {}
+        details: list[str] = []
+        changed = False
+        if wants_semantic_index_repair(targets) and self.store.embedder is not None:
+            reembedded = self._repair_semantic_index(pot_id)
+            repaired[SEMANTIC_INDEX_TARGET] = reembedded
+            details.append(f"re-embedded {reembedded} stale claim(s)")
+            changed = changed or bool(reembedded)
         if wants_entity_summary_repair(targets):
-            repaired = self._repair_entity_summaries(pot_id)
-            if repaired and self.on_change is not None:
-                self.on_change()
+            count = self._repair_entity_summaries(pot_id)
+            repaired[ENTITY_SUMMARY_TARGET] = count
+            details.append(f"repaired {count} entity summaries")
+            changed = changed or bool(count)
+        if changed and self.on_change is not None:
+            self.on_change()
+        if repaired or details:
             return RepairReport(
                 pot_id=pot_id,
                 targets=tuple(targets),
-                repaired={ENTITY_SUMMARY_TARGET: repaired},
-                detail=f"repaired {repaired} entity summaries",
+                repaired=repaired,
+                detail="; ".join(details) or None,
             )
         return RepairReport(
             pot_id=pot_id,
@@ -509,6 +525,27 @@ class _Analytics:
             repaired={},
             detail="in_memory projections are computed on read; nothing to rebuild",
         )
+
+    def _repair_semantic_index(self, pot_id: str) -> int:
+        """Re-embed rows whose stored vector is missing or mis-sized."""
+        embedder = self.store.embedder
+        assert embedder is not None
+        dims = int(getattr(embedder, "dimensions", 0))
+        repaired = 0
+        for idx, row in enumerate(self.store.rows):
+            if row.pot_id != pot_id:
+                continue
+            if row.fact_embedding is not None and len(row.fact_embedding) == dims:
+                continue
+            try:
+                embedding = tuple(
+                    float(x) for x in embedder.embed(card_for_row(row))
+                )
+            except Exception:  # noqa: BLE001 - repair must not die on one row.
+                continue
+            self.store.rows[idx] = _with_embedding(row, embedding)
+            repaired += 1
+        return repaired
 
     def _repair_entity_summaries(self, pot_id: str) -> int:
         entity_keys = {

--- a/potpie/context-engine/adapters/outbound/graph/backends/in_memory_backend.py
+++ b/potpie/context-engine/adapters/outbound/graph/backends/in_memory_backend.py
@@ -538,9 +538,7 @@ class _Analytics:
             if row.fact_embedding is not None and len(row.fact_embedding) == dims:
                 continue
             try:
-                embedding = tuple(
-                    float(x) for x in embedder.embed(card_for_row(row))
-                )
+                embedding = tuple(float(x) for x in embedder.embed(card_for_row(row)))
             except Exception:  # noqa: BLE001 - repair must not die on one row.
                 continue
             self.store.rows[idx] = _with_embedding(row, embedding)

--- a/potpie/context-engine/adapters/outbound/graph/canonical_claim_query.py
+++ b/potpie/context-engine/adapters/outbound/graph/canonical_claim_query.py
@@ -217,8 +217,75 @@ def stamp_scored_rows(scored: Iterable[tuple[float, ClaimRow]]) -> list[ClaimRow
     return out
 
 
+def claim_identity(row: ClaimRow) -> tuple:
+    """Stable identity for merging the same claim seen via different paths."""
+    if row.claim_key:
+        return ("claim_key", row.claim_key)
+    return ("tuple", row.predicate, row.subject_key, row.object_key, row.source_ref)
+
+
+def merge_vector_scored_rows(
+    lexical_rows: Iterable[ClaimRow],
+    vector_scored: Iterable[tuple[float, ClaimRow]],
+    query: str,
+    *,
+    admit_extra: Any = None,
+) -> list[ClaimRow]:
+    """Overlay native vector scores onto the lexical result superset.
+
+    The lexical rows define membership: a claim must never become invisible
+    because its embedding is missing, stale, or the vector index is unusable —
+    those rows simply fall back to the lexical score. Rows the vector index
+    returned but the lexical query missed are appended as defense in depth
+    (``admit_extra`` lets the caller re-apply filters the vector path cannot
+    express, e.g. entity-label constraints).
+    """
+    scores = {claim_identity(row): score for score, row in vector_scored}
+    seen: set[tuple] = set()
+    out_scored: list[tuple[float, ClaimRow]] = []
+    for row in lexical_rows:
+        ident = claim_identity(row)
+        seen.add(ident)
+        out_scored.append((scores.get(ident, embedding_score(row.fact, query)), row))
+    for score, row in vector_scored:
+        ident = claim_identity(row)
+        if ident in seen:
+            continue
+        if admit_extra is not None and not admit_extra(row):
+            continue
+        seen.add(ident)
+        out_scored.append((score, row))
+    out_scored.sort(key=lambda pair: pair[0], reverse=True)
+    return stamp_scored_rows(out_scored)
+
+
+def card_for_row(row: ClaimRow) -> str:
+    """Build the retrieval card for a stored claim row (read-side / re-embed)."""
+    from domain.retrieval_card import build_retrieval_card
+
+    props = row.properties or {}
+    return build_retrieval_card(
+        description=row.description or props.get("description"),
+        fact=row.fact,
+        subject_key=row.subject_key,
+        predicate=row.predicate,
+        object_key=row.object_key,
+        scope=props.get("code_scope")
+        if isinstance(props.get("code_scope"), Mapping)
+        else None,
+    )
+
+
+# The endpoints stay UNBOUND (no label, no inline property map). Binding them
+# (``(a:Entity {group_id: $gid})``) makes the planner run the edge scan under a
+# bound node scan — the exact plan shape that returns zero rows on embedded
+# FalkorDB when the bound source is internal node id 0 (always the Repository,
+# the first entity a baseline flow creates). Edge-first plans are immune, and
+# ``labels(a)`` / ``labels(b)`` still evaluate on unbound endpoints. The edge's
+# ``group_id`` scopes the pot; endpoints can only be same-pot entities by
+# construction of the writer's MERGE.
 FIND_CLAIMS_CYPHER = """
-MATCH (a:Entity {group_id: $gid})-[r:RELATES_TO {group_id: $gid}]->(b:Entity {group_id: $gid})
+MATCH (a)-[r:RELATES_TO {group_id: $gid}]->(b)
 WHERE ($preds IS NULL OR r.name IN $preds)
   AND ($subjects IS NULL OR r.subject_key IN $subjects)
   AND ($objects IS NULL OR r.object_key IN $objects)
@@ -249,8 +316,11 @@ __all__ = [
     "FIND_CLAIMS_CYPHER",
     "CONTRACT_EDGE_KEYS",
     "RESERVED_EDGE_KEYS",
+    "card_for_row",
+    "claim_identity",
     "embedding_score",
     "iso",
+    "merge_vector_scored_rows",
     "parse_dt",
     "row_from_record",
     "stamp_similarity",

--- a/potpie/context-engine/adapters/outbound/graph/canonical_claim_query.py
+++ b/potpie/context-engine/adapters/outbound/graph/canonical_claim_query.py
@@ -240,6 +240,7 @@ def merge_vector_scored_rows(
     (``admit_extra`` lets the caller re-apply filters the vector path cannot
     express, e.g. entity-label constraints).
     """
+    vector_scored = list(vector_scored)  # iterated twice; accept generators
     scores = {claim_identity(row): score for score, row in vector_scored}
     seen: set[tuple] = set()
     out_scored: list[tuple[float, ClaimRow]] = []
@@ -259,6 +260,39 @@ def merge_vector_scored_rows(
     return stamp_scored_rows(out_scored)
 
 
+def filter_rows_by_labels(
+    rows: Iterable[ClaimRow],
+    filter_: Any,
+    entity_labels: Any,
+) -> list[ClaimRow]:
+    """Apply ``subject_label`` / ``object_label`` filters in Python.
+
+    ``FIND_CLAIMS_CYPHER`` cannot reference the edge endpoints (see the comment
+    on the constant), so label constraints are enforced here via the store's
+    node-only ``entity_labels`` lookup. No-op when neither filter is set — the
+    hot read paths never pay the extra query.
+    """
+    rows = list(rows)
+    if not (filter_.subject_label or filter_.object_label):
+        return rows
+    keys = {key for row in rows for key in (row.subject_key, row.object_key)}
+    labels = (
+        entity_labels(pot_id=filter_.pot_id, entity_keys=sorted(keys)) if keys else {}
+    )
+    out: list[ClaimRow] = []
+    for row in rows:
+        if filter_.subject_label and filter_.subject_label not in labels.get(
+            row.subject_key, ()
+        ):
+            continue
+        if filter_.object_label and filter_.object_label not in labels.get(
+            row.object_key, ()
+        ):
+            continue
+        out.append(row)
+    return out
+
+
 def card_for_row(row: ClaimRow) -> str:
     """Build the retrieval card for a stored claim row (read-side / re-embed)."""
     from domain.retrieval_card import build_retrieval_card
@@ -276,16 +310,18 @@ def card_for_row(row: ClaimRow) -> str:
     )
 
 
-# The endpoints stay UNBOUND (no label, no inline property map). Binding them
-# (``(a:Entity {group_id: $gid})``) makes the planner run the edge scan under a
-# bound node scan — the exact plan shape that returns zero rows on embedded
-# FalkorDB when the bound source is internal node id 0 (always the Repository,
-# the first entity a baseline flow creates). Edge-first plans are immune, and
-# ``labels(a)`` / ``labels(b)`` still evaluate on unbound endpoints. The edge's
-# ``group_id`` scopes the pot; endpoints can only be same-pot entities by
-# construction of the writer's MERGE.
+# The endpoints must not be REFERENCED at all — not bound (``(a:Entity
+# {group_id: $gid})``) and not even read (``labels(a)`` in WHERE). Any endpoint
+# reference makes the planner resolve the nodes under the edge scan, and on
+# embedded FalkorDB that nested node stage silently returns zero rows after the
+# store is persisted and reloaded (every ``potpie`` CLI call is a new process)
+# when internal node id 0 — always the first entity created — is an endpoint.
+# A pure edge scan is immune. The edge's ``group_id`` scopes the pot; endpoints
+# can only be same-pot entities by construction of the writer's MERGE.
+# ``subject_label`` / ``object_label`` filters are applied by the callers in
+# Python via :func:`filter_rows_by_labels` (node-only lookups are safe).
 FIND_CLAIMS_CYPHER = """
-MATCH (a)-[r:RELATES_TO {group_id: $gid}]->(b)
+MATCH ()-[r:RELATES_TO {group_id: $gid}]->()
 WHERE ($preds IS NULL OR r.name IN $preds)
   AND ($subjects IS NULL OR r.subject_key IN $subjects)
   AND ($objects IS NULL OR r.object_key IN $objects)
@@ -298,8 +334,6 @@ WHERE ($preds IS NULL OR r.name IN $preds)
   AND ($as_of IS NULL OR r.valid_at IS NULL OR r.valid_at <= $as_of)
   AND ($va_after IS NULL OR (r.valid_at IS NOT NULL AND r.valid_at >= $va_after))
   AND ($va_before IS NULL OR r.valid_at IS NULL OR r.valid_at <= $va_before)
-  AND ($subject_label IS NULL OR $subject_label IN labels(a))
-  AND ($object_label IS NULL OR $object_label IN labels(b))
 RETURN r{.*} AS props
 """
 
@@ -319,6 +353,7 @@ __all__ = [
     "card_for_row",
     "claim_identity",
     "embedding_score",
+    "filter_rows_by_labels",
     "iso",
     "merge_vector_scored_rows",
     "parse_dt",

--- a/potpie/context-engine/adapters/outbound/graph/falkordb_inspection.py
+++ b/potpie/context-engine/adapters/outbound/graph/falkordb_inspection.py
@@ -37,20 +37,24 @@ RETURN e.entity_key AS key, labels(e) AS labels, properties(e) AS props
 LIMIT $limit
 """
 
+# Edge queries never reference the endpoints: the edge carries
+# ``subject_key``/``object_key``, and endpoint-resolving plans silently return
+# zero rows on embedded FalkorDB after a persistence reload when node id 0 is
+# an endpoint (see FIND_CLAIMS_CYPHER in canonical_claim_query).
 _EDGES_CYPHER = """
-MATCH (a:Entity {group_id: $gid})-[r:RELATES_TO {group_id: $gid}]->(b:Entity {group_id: $gid})
+MATCH ()-[r:RELATES_TO {group_id: $gid}]->()
 WHERE ($include_invalid OR r.invalid_at IS NULL)
   AND ($preds IS NULL OR r.name IN $preds)
-RETURN a.entity_key AS source, b.entity_key AS target, r.name AS predicate, properties(r) AS props
+RETURN r.subject_key AS source, r.object_key AS target, r.name AS predicate, properties(r) AS props
 LIMIT $limit
 """
 
 # Edges incident (either direction) to the current BFS frontier.
 _INCIDENT_CYPHER = """
-MATCH (a:Entity {group_id: $gid})-[r:RELATES_TO {group_id: $gid}]->(b:Entity {group_id: $gid})
-WHERE (a.entity_key IN $frontier OR b.entity_key IN $frontier)
+MATCH ()-[r:RELATES_TO {group_id: $gid}]->()
+WHERE (r.subject_key IN $frontier OR r.object_key IN $frontier)
   AND ($include_invalid OR r.invalid_at IS NULL)
-RETURN a.entity_key AS source, b.entity_key AS target, r.name AS predicate, properties(r) AS props
+RETURN r.subject_key AS source, r.object_key AS target, r.name AS predicate, properties(r) AS props
 """
 
 _HYDRATE_CYPHER = """

--- a/potpie/context-engine/adapters/outbound/graph/falkordb_reader.py
+++ b/potpie/context-engine/adapters/outbound/graph/falkordb_reader.py
@@ -1,12 +1,13 @@
 """FalkorDB :class:`ClaimQueryPort` — read surface for the P9 readers.
 
 Parity with :class:`Neo4jClaimQueryStore`: same canonical ``:RELATES_TO``
-claim shape, same filters, same ``ClaimRow`` output. The Phase-0 spike proved
-the entire ``_FIND_CLAIMS_CYPHER`` (IN lists, IS NULL guards, temporal
-predicates, ``labels()`` filters) runs unchanged on FalkorDB, so this adapter
-**reuses** the Neo4j query constants and row-parsing helpers and only swaps the
-driver call + record normalization (FalkorDB returns ``result_set`` rows, not
-Neo4j ``Record`` maps).
+claim shape, same filters, same ``ClaimRow`` output. This adapter **reuses**
+the Neo4j query constants and row-parsing helpers and only swaps the driver
+call + record normalization (FalkorDB returns ``result_set`` rows, not Neo4j
+``Record`` maps). Claim queries never reference the edge endpoints — entity
+label filters are applied in Python — because embedded FalkorDB silently
+drops rows from endpoint-resolving plans after a persistence reload (see
+``FIND_CLAIMS_CYPHER``).
 
 ``fact_query`` merges two passes: the lexical query defines which claims are
 visible (an unembedded claim must never disappear from reads), and FalkorDB's
@@ -27,6 +28,7 @@ from adapters.outbound.graph.falkordb_writer import (
 from adapters.outbound.graph.canonical_claim_query import (
     ENTITY_LABELS_CYPHER,
     FIND_CLAIMS_CYPHER,
+    filter_rows_by_labels,
     iso,
     merge_vector_scored_rows,
     row_from_record,
@@ -114,6 +116,10 @@ class FalkorDBClaimQueryStore:
         self._graph = None
 
     def find_claims(self, filter_: ClaimQueryFilter) -> list[ClaimRow]:
+        # An explicit zero-row request must win before the vector path (which
+        # coerces limit=0 → 10) or the lexical slice can return anything.
+        if filter_.limit == 0:
+            return []
         params = {
             "gid": filter_.pot_id,
             "preds": list(filter_.predicate_in) or None,
@@ -128,13 +134,13 @@ class FalkorDBClaimQueryStore:
             "as_of": iso(filter_.as_of),
             "va_after": iso(filter_.valid_at_after),
             "va_before": iso(filter_.valid_at_before),
-            "subject_label": filter_.subject_label,
-            "object_label": filter_.object_label,
         }
         # Lexical rows define membership: a claim must stay readable even when
         # its embedding is missing or stale. Vector results only overlay
         # ranking scores (plus defense-in-depth extras) on top.
-        rows = self._find_claims_lexical(params)
+        rows = filter_rows_by_labels(
+            self._find_claims_lexical(params), filter_, self.entity_labels
+        )
 
         if filter_.fact_query:
             vector_scored = (

--- a/potpie/context-engine/adapters/outbound/graph/falkordb_reader.py
+++ b/potpie/context-engine/adapters/outbound/graph/falkordb_reader.py
@@ -8,13 +8,16 @@ predicates, ``labels()`` filters) runs unchanged on FalkorDB, so this adapter
 driver call + record normalization (FalkorDB returns ``result_set`` rows, not
 Neo4j ``Record`` maps).
 
-``fact_query`` uses FalkorDB's native relationship vector index when an embedder
-is wired. If the vector index/procedure is unavailable, the adapter falls back
-to the labeled lexical scorer so local/dev profiles still return useful rows.
+``fact_query`` merges two passes: the lexical query defines which claims are
+visible (an unembedded claim must never disappear from reads), and FalkorDB's
+native relationship vector index — when an embedder is wired — overlays real
+similarity scores on top. A failing vector index degrades ranking, loudly,
+never visibility.
 """
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Callable, Iterable, Mapping
 
 from adapters.outbound.graph.falkordb_writer import (
@@ -25,14 +28,20 @@ from adapters.outbound.graph.canonical_claim_query import (
     ENTITY_LABELS_CYPHER,
     FIND_CLAIMS_CYPHER,
     iso,
+    merge_vector_scored_rows,
     row_from_record,
-    stamp_scored_rows,
-    stamp_similarity,
 )
 from domain.ports.claim_query import ClaimQueryFilter, ClaimRow
 from domain.ports.embedder import EmbedderPort
 from domain.ports.settings import ContextEngineSettingsPort
 
+logger = logging.getLogger(__name__)
+
+# No MATCH after the procedure call: binding endpoint nodes puts the edge scan
+# under a bound node scan — the embedded-FalkorDB plan shape that returns zero
+# rows when the bound node is internal id 0 (see FIND_CLAIMS_CYPHER). Every
+# filter here is an edge property; entity-label filters are re-applied by the
+# caller in Python. ``score`` is a cosine *distance* on FalkorDB.
 _VECTOR_CLAIMS_CYPHER = """
 CALL db.idx.vector.queryRelationships(
     'RELATES_TO',
@@ -41,26 +50,21 @@ CALL db.idx.vector.queryRelationships(
     vecf32($embedding)
 ) YIELD relationship AS r, score
 WITH r, score
-MATCH (a:Entity {group_id: $gid})-[rel:RELATES_TO]->(b:Entity {group_id: $gid})
-WHERE id(rel) = id(r)
-  AND rel.group_id = $gid
-  AND ($preds IS NULL OR rel.name IN $preds)
-  AND ($subjects IS NULL OR rel.subject_key IN $subjects)
-  AND ($objects IS NULL OR rel.object_key IN $objects)
-  AND ($claim_keys IS NULL OR rel.claim_key IN $claim_keys)
-  AND ($subgraphs IS NULL OR rel.subgraph IN $subgraphs)
-  AND ($mutation_ids IS NULL OR rel.mutation_id IN $mutation_ids)
-  AND ($source_refs IS NULL OR rel.source_ref IN $source_refs OR any(ref IN coalesce(rel.source_refs, []) WHERE ref IN $source_refs))
-  AND ($sources IS NULL OR rel.source_system IN $sources)
-  AND ($include_invalid OR rel.invalid_at IS NULL)
-  AND ($as_of IS NULL OR rel.valid_at IS NULL OR rel.valid_at <= $as_of)
-  AND ($va_after IS NULL OR (rel.valid_at IS NOT NULL AND rel.valid_at >= $va_after))
-  AND ($va_before IS NULL OR rel.valid_at IS NULL OR rel.valid_at <= $va_before)
-  AND ($subject_label IS NULL OR $subject_label IN labels(a))
-  AND ($object_label IS NULL OR $object_label IN labels(b))
-RETURN rel{.*} AS props, score
+WHERE r.group_id = $gid
+  AND ($preds IS NULL OR r.name IN $preds)
+  AND ($subjects IS NULL OR r.subject_key IN $subjects)
+  AND ($objects IS NULL OR r.object_key IN $objects)
+  AND ($claim_keys IS NULL OR r.claim_key IN $claim_keys)
+  AND ($subgraphs IS NULL OR r.subgraph IN $subgraphs)
+  AND ($mutation_ids IS NULL OR r.mutation_id IN $mutation_ids)
+  AND ($source_refs IS NULL OR r.source_ref IN $source_refs OR any(ref IN coalesce(r.source_refs, []) WHERE ref IN $source_refs))
+  AND ($sources IS NULL OR r.source_system IN $sources)
+  AND ($include_invalid OR r.invalid_at IS NULL)
+  AND ($as_of IS NULL OR r.valid_at IS NULL OR r.valid_at <= $as_of)
+  AND ($va_after IS NULL OR (r.valid_at IS NOT NULL AND r.valid_at >= $va_after))
+  AND ($va_before IS NULL OR r.valid_at IS NULL OR r.valid_at <= $va_before)
+RETURN r{.*} AS props, score
 ORDER BY score ASC
-LIMIT $limit
 """
 
 _ENTITY_PROPERTIES_CYPHER = """
@@ -91,6 +95,7 @@ class FalkorDBClaimQueryStore:
         self._graph = graph  # injectable for unit tests
         self._graph_provider = graph_provider  # shared handle from the container
         self._embedder = embedder
+        self._vector_query_warned = False
 
     @property
     def match_mode(self) -> str:
@@ -126,15 +131,23 @@ class FalkorDBClaimQueryStore:
             "subject_label": filter_.subject_label,
             "object_label": filter_.object_label,
         }
-        if filter_.fact_query and self._embedder is not None:
-            rows = self._find_claims_vector(filter_, params)
-            if rows:
-                return rows
-
+        # Lexical rows define membership: a claim must stay readable even when
+        # its embedding is missing or stale. Vector results only overlay
+        # ranking scores (plus defense-in-depth extras) on top.
         rows = self._find_claims_lexical(params)
 
         if filter_.fact_query:
-            rows = stamp_similarity(rows, filter_.fact_query)
+            vector_scored = (
+                self._vector_scored(filter_, params)
+                if self._embedder is not None
+                else []
+            )
+            rows = merge_vector_scored_rows(
+                rows,
+                vector_scored,
+                filter_.fact_query,
+                admit_extra=self._label_filter_check(filter_),
+            )
 
         if filter_.limit is not None and filter_.limit >= 0:
             rows = rows[: filter_.limit]
@@ -144,9 +157,9 @@ class FalkorDBClaimQueryStore:
         result = self._get_graph().query(FIND_CLAIMS_CYPHER, params=dict(params))
         return [row_from_record(rec) for rec in _records_from_result(result)]
 
-    def _find_claims_vector(
+    def _vector_scored(
         self, filter_: ClaimQueryFilter, params: Mapping[str, object]
-    ) -> list[ClaimRow]:
+    ) -> list[tuple[float, ClaimRow]]:
         assert filter_.fact_query is not None
         assert self._embedder is not None
         limit = filter_.limit if filter_.limit is not None and filter_.limit > 0 else 10
@@ -157,21 +170,54 @@ class FalkorDBClaimQueryStore:
                     float(x) for x in self._embedder.embed(filter_.fact_query)
                 ],
                 "k": max(limit * 5, 50),
-                "limit": limit,
             }
             result = self._get_graph().query(
                 _VECTOR_CLAIMS_CYPHER, params=vector_params
             )
-        except Exception:
+        except Exception as exc:  # noqa: BLE001
+            # Degrading to lexical scores must not be silent: a broken vector
+            # index (missing, or built for a different embedder dimension)
+            # quietly flattens semantic ranking otherwise.
+            level = logging.DEBUG if self._vector_query_warned else logging.WARNING
+            self._vector_query_warned = True
+            logger.log(
+                level,
+                "falkordb vector query failed (%s); using lexical scores — "
+                "if the embedder changed, run 'potpie graph repair semantic_index'",
+                exc,
+            )
             return []
-        scored = [
+        return [
             (
                 _distance_to_similarity(float(rec.get("score", 1.0))),
                 row_from_record(rec),
             )
             for rec in _records_from_result(result)
         ]
-        return stamp_scored_rows(scored)
+
+    def _label_filter_check(
+        self, filter_: ClaimQueryFilter
+    ) -> Callable[[ClaimRow], bool] | None:
+        """Re-apply entity-label filters to vector-only rows in Python."""
+        if not (filter_.subject_label or filter_.object_label):
+            return None
+
+        def check(row: ClaimRow) -> bool:
+            labels = self.entity_labels(
+                pot_id=filter_.pot_id,
+                entity_keys=[row.subject_key, row.object_key],
+            )
+            if filter_.subject_label and filter_.subject_label not in labels.get(
+                row.subject_key, ()
+            ):
+                return False
+            if filter_.object_label and filter_.object_label not in labels.get(
+                row.object_key, ()
+            ):
+                return False
+            return True
+
+        return check
 
     def entity_labels(
         self, *, pot_id: str, entity_keys: Iterable[str]

--- a/potpie/context-engine/adapters/outbound/graph/falkordb_writer.py
+++ b/potpie/context-engine/adapters/outbound/graph/falkordb_writer.py
@@ -344,9 +344,17 @@ class FalkorDBGraphWriter(GraphWriterPort):
         pot_id: str,
         items: list[EdgeUpsert],
         provenance: ProvenanceRef,
-    ) -> None:
+    ) -> list[dict[str, str]]:
+        """Attach fact embeddings to just-upserted edges.
+
+        Returns one failure record per edge whose embedding could not be
+        attached — a zero-row MATCH counts as a failure, not a no-op: the edge
+        exists (the upsert wrote it), so silence here is how claims used to
+        vanish from vector-only reads.
+        """
         if self._embedder is None:
-            return
+            return []
+        failures: list[dict[str, str]] = []
         for item in items:
             raw_props = dict(item.properties)
             source_ref = _stable_source_ref(
@@ -381,20 +389,24 @@ class FalkorDBGraphWriter(GraphWriterPort):
                 # Keep embedding inside the try: a model error must degrade to
                 # "no vector enrichment", not abort the already-written edge.
                 embedding = [float(x) for x in self._embedder.embed(card)]
-                graph.query(
+                # The edge is matched with UNBOUND endpoints: anchoring the
+                # source node (`(:Entity {entity_key: $from_key})-[r]->`) is
+                # the embedded-FalkorDB plan shape that silently matches zero
+                # rows when the source is internal node id 0 — always the
+                # Repository on a fresh pot. See FIND_CLAIMS_CYPHER.
+                result = graph.query(
                     """
-                    MATCH (:Entity {group_id: $gid, entity_key: $from_key})
-                          -[r:RELATES_TO {
+                    MATCH ()-[r:RELATES_TO {
                               group_id: $gid,
                               name: $predicate,
                               subject_key: $from_key,
                               object_key: $to_key,
                               source_ref: $source_ref
-                          }]->
-                          (:Entity {group_id: $gid, entity_key: $to_key})
+                          }]->()
                     SET r.fact_embedding = vecf32($embedding),
                         r.embedding_model = $embedding_model,
                         r.embedding_dim = $embedding_dim
+                    RETURN count(r) AS updated
                     """,
                     params={
                         "gid": pot_id,
@@ -409,14 +421,38 @@ class FalkorDBGraphWriter(GraphWriterPort):
                         ),
                     },
                 )
+                records = _records_from_result(result)
+                updated = int(records[0]["updated"]) if records else 0
+                if updated < 1:
+                    raise RuntimeError(
+                        "embedding attach matched no edge (upsert wrote it, "
+                        "the attach MATCH could not find it)"
+                    )
             except Exception as exc:  # noqa: BLE001
+                failures.append(
+                    {
+                        "predicate": item.edge_type,
+                        "subject_key": item.from_entity_key,
+                        "object_key": item.to_entity_key,
+                        "error": str(exc),
+                    }
+                )
                 logger.warning(
-                    "falkordb vector write skipped for %s:%s->%s: %s",
+                    "falkordb embedding attach FAILED for %s:%s->%s "
+                    "(claim stays readable, semantic ranking degraded): %s",
                     item.edge_type,
                     item.from_entity_key,
                     item.to_entity_key,
                     exc,
                 )
+        if failures:
+            logger.warning(
+                "falkordb embedding attach failed for %d of %d edge(s) in this "
+                "batch — run 'potpie graph repair semantic_index' to re-embed",
+                len(failures),
+                len(items),
+            )
+        return failures
 
 
 __all__ = ["FalkorDBGraphProvider", "FalkorDBGraphWriter", "build_falkordb_graph"]

--- a/potpie/context-engine/adapters/outbound/graph/falkordb_writer.py
+++ b/potpie/context-engine/adapters/outbound/graph/falkordb_writer.py
@@ -198,6 +198,7 @@ class FalkorDBGraphWriter(GraphWriterPort):
         self._graph = graph  # injectable for unit tests
         self._graph_provider = graph_provider  # shared handle from the container
         self._embedder = embedder
+        self._indexes_ensured = False
 
     @property
     def enabled(self) -> bool:
@@ -354,6 +355,14 @@ class FalkorDBGraphWriter(GraphWriterPort):
         """
         if self._embedder is None:
             return []
+        # Setup's provision step normally creates the vector index, but a
+        # write must not depend on setup having run (fresh homes, tests,
+        # library embedding): ensure indexes once per writer so the vectors
+        # written below are actually queryable.
+        if not self._indexes_ensured:
+            embedding_dim = int(getattr(self._embedder, "dimensions", 1536))
+            self._ensure_indexes_sync(graph, embedding_dim)
+            self._indexes_ensured = True
         failures: list[dict[str, str]] = []
         for item in items:
             raw_props = dict(item.properties)

--- a/potpie/context-engine/adapters/outbound/graph/falkordb_writer.py
+++ b/potpie/context-engine/adapters/outbound/graph/falkordb_writer.py
@@ -65,11 +65,17 @@ _INDEX_STATEMENTS = (
 _RESET_BATCH = 500
 
 
+def _vector_index_statement(embedding_dim: int) -> str:
+    return (
+        "CREATE VECTOR INDEX FOR ()-[r:RELATES_TO]->() ON (r.fact_embedding) "
+        f"OPTIONS {{dimension:{int(embedding_dim)}, similarityFunction:'cosine'}}"
+    )
+
+
 def _index_statements(embedding_dim: int) -> tuple[str, ...]:
     return (
         *_INDEX_STATEMENTS,
-        "CREATE VECTOR INDEX FOR ()-[r:RELATES_TO]->() ON (r.fact_embedding) "
-        f"OPTIONS {{dimension:{int(embedding_dim)}, similarityFunction:'cosine'}}",
+        _vector_index_statement(embedding_dim),
     )
 
 
@@ -244,6 +250,26 @@ class FalkorDBGraphWriter(GraphWriterPort):
                 # Re-running creates an "already indexed" error; best-effort.
                 logger.debug("falkordb index skipped (%s): %s", stmt, exc)
 
+    @staticmethod
+    def _ensure_vector_index_sync(graph: Any, embedding_dim: int) -> bool:
+        """Create just the vector index; report whether it is usable.
+
+        The lazy write-path call must NOT create the range indexes: those
+        change global planner behaviour mid-flight for a store that was never
+        provisioned (embedded FalkorDB plans differently once node indexes
+        exist), and the vector write only needs the vector index. Returns
+        ``False`` on a real failure so the caller retries on the next batch
+        instead of caching a broken state.
+        """
+        try:
+            graph.query(_vector_index_statement(embedding_dim))
+        except Exception as exc:  # noqa: BLE001
+            if "already indexed" in str(exc).lower():
+                return True
+            logger.warning("falkordb vector index creation failed: %s", exc)
+            return False
+        return True
+
     async def upsert_entities(
         self, pot_id: str, items: list[EntityUpsert], provenance: ProvenanceRef
     ) -> int:
@@ -357,12 +383,13 @@ class FalkorDBGraphWriter(GraphWriterPort):
             return []
         # Setup's provision step normally creates the vector index, but a
         # write must not depend on setup having run (fresh homes, tests,
-        # library embedding): ensure indexes once per writer so the vectors
-        # written below are actually queryable.
+        # library embedding): ensure the vector index once per writer so the
+        # vectors written below are actually queryable. Only the vector index
+        # — creating the range indexes here would flip planner behaviour for
+        # every other query on a store that was never provisioned.
         if not self._indexes_ensured:
             embedding_dim = int(getattr(self._embedder, "dimensions", 1536))
-            self._ensure_indexes_sync(graph, embedding_dim)
-            self._indexes_ensured = True
+            self._indexes_ensured = self._ensure_vector_index_sync(graph, embedding_dim)
         failures: list[dict[str, str]] = []
         for item in items:
             raw_props = dict(item.properties)

--- a/potpie/context-engine/adapters/outbound/graph/in_memory_reader.py
+++ b/potpie/context-engine/adapters/outbound/graph/in_memory_reader.py
@@ -19,10 +19,13 @@ import dataclasses
 from dataclasses import dataclass, field
 from typing import Any, Iterable, Mapping
 
-from adapters.outbound.graph.canonical_claim_query import embedding_score
+from adapters.outbound.graph.canonical_claim_query import (
+    card_for_row,
+    embedding_score,
+)
 from domain.ports.claim_query import ClaimQueryFilter, ClaimRow
 from domain.ports.embedder import EmbedderPort
-from domain.retrieval_card import build_retrieval_card, cosine_similarity
+from domain.retrieval_card import cosine_similarity
 
 
 @dataclass(slots=True)
@@ -116,21 +119,6 @@ class InMemoryClaimQueryStore:
         # card on the fly so the row still participates in vector ranking.
         assert self.embedder is not None
         return self.embedder.embed(card_for_row(row))
-
-
-def card_for_row(row: ClaimRow) -> str:
-    """Build the retrieval card for a stored claim row (read-side / on-the-fly embed)."""
-    props = row.properties or {}
-    return build_retrieval_card(
-        description=row.description or props.get("description"),
-        fact=row.fact,
-        subject_key=row.subject_key,
-        predicate=row.predicate,
-        object_key=row.object_key,
-        scope=props.get("code_scope")
-        if isinstance(props.get("code_scope"), Mapping)
-        else None,
-    )
 
 
 def _stamp_similarity(row: ClaimRow, score: float) -> ClaimRow:

--- a/potpie/context-engine/adapters/outbound/graph/neo4j_reader.py
+++ b/potpie/context-engine/adapters/outbound/graph/neo4j_reader.py
@@ -26,6 +26,7 @@ from adapters.outbound.graph.canonical_claim_query import (
     ENTITY_LABELS_CYPHER as _ENTITY_LABELS_CYPHER,
     FIND_CLAIMS_CYPHER as _FIND_CLAIMS_CYPHER,
     embedding_score as _embedding_score,
+    filter_rows_by_labels,
     iso as _iso,
     merge_vector_scored_rows,
     row_from_record as _row_from_record,
@@ -140,13 +141,13 @@ class Neo4jClaimQueryStore:
             "as_of": _iso(filter_.as_of),
             "va_after": _iso(filter_.valid_at_after),
             "va_before": _iso(filter_.valid_at_before),
-            "subject_label": filter_.subject_label,
-            "object_label": filter_.object_label,
         }
         # Lexical rows define membership: a claim must stay readable even when
         # its embedding is missing or stale. Vector results only overlay
         # ranking scores (plus defense-in-depth extras) on top.
-        rows = self._find_claims_lexical(params)
+        rows = filter_rows_by_labels(
+            self._find_claims_lexical(params), filter_, self.entity_labels
+        )
 
         if filter_.fact_query:
             vector_scored = (

--- a/potpie/context-engine/adapters/outbound/graph/neo4j_reader.py
+++ b/potpie/context-engine/adapters/outbound/graph/neo4j_reader.py
@@ -10,34 +10,42 @@ The driver is the plain *synchronous* Neo4j driver (``ClaimQueryPort`` is a
 sync surface; the readers call it inline). It is built lazily from settings
 and cached for reuse.
 
-``fact_query`` uses Neo4j's native relationship vector index when an embedder is
-wired. If the vector procedure is unavailable, the adapter falls back to the
-labeled lexical scorer so old deployments degrade instead of dropping results.
+``fact_query`` merges two passes: the lexical query defines which claims are
+visible (an unembedded claim must never disappear from reads), and Neo4j's
+native relationship vector index — when an embedder is wired — overlays real
+similarity scores on top. A failing vector index degrades ranking, loudly,
+never visibility.
 """
 
 from __future__ import annotations
 
-from typing import Any, Iterable, Mapping
+import logging
+from typing import Any, Callable, Iterable, Mapping
 
 from adapters.outbound.graph.canonical_claim_query import (
     ENTITY_LABELS_CYPHER as _ENTITY_LABELS_CYPHER,
     FIND_CLAIMS_CYPHER as _FIND_CLAIMS_CYPHER,
     embedding_score as _embedding_score,
     iso as _iso,
+    merge_vector_scored_rows,
     row_from_record as _row_from_record,
-    stamp_scored_rows,
-    stamp_similarity,
 )
 from domain.ports.claim_query import ClaimQueryFilter, ClaimRow
 from domain.ports.embedder import EmbedderPort
 from domain.ports.settings import ContextEngineSettingsPort
 
+logger = logging.getLogger(__name__)
+
 _VECTOR_INDEX_NAME = "claim_fact_embeddings"
 
+# Filters on edge properties only (no endpoint MATCH) — same edge-first shape
+# as FIND_CLAIMS_CYPHER, kept structurally identical to the FalkorDB adapter so
+# both backends share one mental model. Entity-label filters are re-applied by
+# the caller in Python. ``score`` is a similarity on Neo4j.
 _VECTOR_CLAIMS_CYPHER = """
 CALL db.index.vector.queryRelationships($index_name, $k, $embedding)
 YIELD relationship AS r, score
-MATCH (a:Entity {group_id: $gid})-[r:RELATES_TO]->(b:Entity {group_id: $gid})
+WITH r, score
 WHERE r.group_id = $gid
   AND ($preds IS NULL OR r.name IN $preds)
   AND ($subjects IS NULL OR r.subject_key IN $subjects)
@@ -51,11 +59,8 @@ WHERE r.group_id = $gid
   AND ($as_of IS NULL OR r.valid_at IS NULL OR r.valid_at <= $as_of)
   AND ($va_after IS NULL OR (r.valid_at IS NOT NULL AND r.valid_at >= $va_after))
   AND ($va_before IS NULL OR r.valid_at IS NULL OR r.valid_at <= $va_before)
-  AND ($subject_label IS NULL OR $subject_label IN labels(a))
-  AND ($object_label IS NULL OR $object_label IN labels(b))
 RETURN r{.*} AS props, score
 ORDER BY score DESC
-LIMIT $limit
 """
 
 _ENTITY_PROPERTIES_CYPHER = """
@@ -79,6 +84,7 @@ class Neo4jClaimQueryStore:
         self._settings = settings
         self._driver = driver
         self._embedder = embedder
+        self._vector_query_warned = False
 
     @property
     def match_mode(self) -> str:
@@ -137,31 +143,37 @@ class Neo4jClaimQueryStore:
             "subject_label": filter_.subject_label,
             "object_label": filter_.object_label,
         }
-        if filter_.fact_query and self._embedder is not None:
-            rows = self._find_claims_vector(filter_, params)
-            if rows:
-                return rows
+        # Lexical rows define membership: a claim must stay readable even when
+        # its embedding is missing or stale. Vector results only overlay
+        # ranking scores (plus defense-in-depth extras) on top.
+        rows = self._find_claims_lexical(params)
 
-        rows = self._find_claims_lexical(filter_, params)
+        if filter_.fact_query:
+            vector_scored = (
+                self._vector_scored(filter_, params)
+                if self._embedder is not None
+                else []
+            )
+            rows = merge_vector_scored_rows(
+                rows,
+                vector_scored,
+                filter_.fact_query,
+                admit_extra=self._label_filter_check(filter_),
+            )
 
         if filter_.limit is not None and filter_.limit >= 0:
             rows = rows[: filter_.limit]
         return rows
 
-    def _find_claims_lexical(
-        self, filter_: ClaimQueryFilter, params: Mapping[str, object]
-    ) -> list[ClaimRow]:
+    def _find_claims_lexical(self, params: Mapping[str, object]) -> list[ClaimRow]:
         driver = self._get_driver()
         with driver.session() as session:
             records = list(session.run(_FIND_CLAIMS_CYPHER, **params))
-        rows = [_row_from_record(rec) for rec in records]
-        if filter_.fact_query:
-            rows = stamp_similarity(rows, filter_.fact_query)
-        return rows
+        return [_row_from_record(rec) for rec in records]
 
-    def _find_claims_vector(
+    def _vector_scored(
         self, filter_: ClaimQueryFilter, params: Mapping[str, object]
-    ) -> list[ClaimRow]:
+    ) -> list[tuple[float, ClaimRow]]:
         assert filter_.fact_query is not None
         assert self._embedder is not None
         limit = filter_.limit if filter_.limit is not None and filter_.limit > 0 else 10
@@ -173,17 +185,50 @@ class Neo4jClaimQueryStore:
                     float(x) for x in self._embedder.embed(filter_.fact_query)
                 ],
                 "k": max(limit * 5, 50),
-                "limit": limit,
             }
             driver = self._get_driver()
             with driver.session() as session:
                 records = list(session.run(_VECTOR_CLAIMS_CYPHER, **vector_params))
-        except Exception:
+        except Exception as exc:  # noqa: BLE001
+            # Degrading to lexical scores must not be silent: a broken vector
+            # index (missing, or built for a different embedder dimension)
+            # quietly flattens semantic ranking otherwise.
+            level = logging.DEBUG if self._vector_query_warned else logging.WARNING
+            self._vector_query_warned = True
+            logger.log(
+                level,
+                "neo4j vector query failed (%s); using lexical scores — "
+                "if the embedder changed, run 'potpie graph repair semantic_index'",
+                exc,
+            )
             return []
-        rows = [
+        return [
             (float(rec.get("score", 0.0)), _row_from_record(rec)) for rec in records
         ]
-        return stamp_scored_rows(rows)
+
+    def _label_filter_check(
+        self, filter_: ClaimQueryFilter
+    ) -> Callable[[ClaimRow], bool] | None:
+        """Re-apply entity-label filters to vector-only rows in Python."""
+        if not (filter_.subject_label or filter_.object_label):
+            return None
+
+        def check(row: ClaimRow) -> bool:
+            labels = self.entity_labels(
+                pot_id=filter_.pot_id,
+                entity_keys=[row.subject_key, row.object_key],
+            )
+            if filter_.subject_label and filter_.subject_label not in labels.get(
+                row.subject_key, ()
+            ):
+                return False
+            if filter_.object_label and filter_.object_label not in labels.get(
+                row.object_key, ()
+            ):
+                return False
+            return True
+
+        return check
 
     def entity_labels(
         self, *, pot_id: str, entity_keys: Iterable[str]

--- a/potpie/context-engine/adapters/outbound/graph/semantic_index_repair.py
+++ b/potpie/context-engine/adapters/outbound/graph/semantic_index_repair.py
@@ -49,9 +49,7 @@ def claim_needs_reembed(
     return stored_dim != int(embedder_dim)
 
 
-def stored_dim_mismatch(
-    props: Mapping[str, Any], *, embedder_dim: int
-) -> bool:
+def stored_dim_mismatch(props: Mapping[str, Any], *, embedder_dim: int) -> bool:
     """True when a stored embedding was written at a different dimension."""
     if props.get("fact_embedding") is None:
         return False

--- a/potpie/context-engine/adapters/outbound/graph/semantic_index_repair.py
+++ b/potpie/context-engine/adapters/outbound/graph/semantic_index_repair.py
@@ -1,0 +1,72 @@
+"""Repair vocabulary + selection for the claim fact-embedding index.
+
+The re-embed pass is the recovery (and migration) path for claims whose
+embeddings are missing (a failed attach), stale (written by a different
+embedder model), or mis-sized (written at different dimensions — e.g. after
+switching from the 256-dim hashing embedder to a sentence-transformers model).
+Backend-specific mechanics (vecf32, index DDL) live with each backend; this
+module owns the shared target vocabulary and the needs-repair predicate.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+SEMANTIC_INDEX_TARGET = "semantic_index"
+SEMANTIC_INDEX_TARGETS = frozenset(
+    {
+        SEMANTIC_INDEX_TARGET,
+        "semantic-index",
+        "semantic",
+        "embeddings",
+        "vectors",
+        "vector_index",
+    }
+)
+
+SEMANTIC_INDEX_REPAIR_LIMIT = 100_000
+
+
+def wants_semantic_index_repair(targets: Sequence[str] = ()) -> bool:
+    """Return true when a repair invocation should re-embed stale claims."""
+    if not targets:
+        return True
+    return any(t.strip().lower() in SEMANTIC_INDEX_TARGETS for t in targets)
+
+
+def claim_needs_reembed(
+    props: Mapping[str, Any], *, embedder_name: str, embedder_dim: int
+) -> bool:
+    """Does a stored claim's embedding disagree with the active embedder?"""
+    if props.get("fact_embedding") is None:
+        return True
+    if str(props.get("embedding_model") or "") != embedder_name:
+        return True
+    try:
+        stored_dim = int(props.get("embedding_dim") or 0)
+    except (TypeError, ValueError):
+        return True
+    return stored_dim != int(embedder_dim)
+
+
+def stored_dim_mismatch(
+    props: Mapping[str, Any], *, embedder_dim: int
+) -> bool:
+    """True when a stored embedding was written at a different dimension."""
+    if props.get("fact_embedding") is None:
+        return False
+    try:
+        stored_dim = int(props.get("embedding_dim") or 0)
+    except (TypeError, ValueError):
+        return False
+    return stored_dim not in (0, int(embedder_dim))
+
+
+__all__ = [
+    "SEMANTIC_INDEX_REPAIR_LIMIT",
+    "SEMANTIC_INDEX_TARGET",
+    "SEMANTIC_INDEX_TARGETS",
+    "claim_needs_reembed",
+    "stored_dim_mismatch",
+    "wants_semantic_index_repair",
+]

--- a/potpie/context-engine/adapters/outbound/intelligence/local_embedder.py
+++ b/potpie/context-engine/adapters/outbound/intelligence/local_embedder.py
@@ -1,27 +1,26 @@
 """Context-graph embedders.
 
 The Trigger Model non-negotiable: retrieval must work with **no API key and no
-external embeddings service**, on the user's machine. This is the default OSS
-embedder. It is a real local embedding model in the feature-hashing family: text
-is tokenized into words *and* character n-grams, each feature is hashed (via a
-stable digest, so embeddings are identical across processes — required for the
-JSON-persisted embedded backend) into a fixed-dimension accumulator with a signed
-contribution, then L2-normalized.
+external embeddings service**, on the user's machine. The default is the
+strongest *local* model available: sentence-transformers (all-MiniLM-L6-v2)
+whenever the package is importable — which it always is for the shipped
+``potpie`` wheel, whose base install carries the ``embeddings`` extra.
 
-Why this beats the old Jaccard stub for V1.5 recall:
+When sentence-transformers is absent (a bare ``potpie-context-engine`` install
+without extras), ``auto`` degrades — with an INFO log — to the bundled
+:class:`HashingEmbedder`: a real feature-hashing embedding model, no
+dependencies. Text is tokenized into words *and* character n-grams, each
+feature is hashed (via a stable digest, so embeddings are identical across
+processes — required for the JSON-persisted embedded backend) into a
+fixed-dimension accumulator with a signed contribution, then L2-normalized.
+It scores in continuous vector space (near-misses rank above noise) and
+catches morphological variants through n-grams — but it measures lexical
+overlap, not meaning; paraphrases don't land near each other.
 
-- It scores in continuous vector space, so near-misses rank above noise instead
-  of collapsing to 0.
-- Character n-grams catch morphological variants (``retry`` / ``retries`` /
-  ``retrying`` share trigrams) and typos — the paraphrase failure mode Jaccard
-  misses entirely.
-
-It is intentionally swappable: ``build_embedder`` reads ``CONTEXT_ENGINE_EMBEDDER``
-first, then Potpie's local setup config. Before setup, the dependency-free hashing
-embedder remains the no-config fallback. ``potpie setup`` can persist
-``sentence-transformers`` so normal ingestion/search uses the stronger local model.
-``CONTEXT_ENGINE_EMBEDDER=none`` disables embeddings and the store falls back to a
-*labeled* lexical match.
+``build_embedder`` reads ``CONTEXT_ENGINE_EMBEDDER`` first, then Potpie's
+local setup config (``potpie setup`` persists ``sentence-transformers`` and
+pre-downloads the model). ``CONTEXT_ENGINE_EMBEDDER=none`` disables embeddings
+and the store falls back to a *labeled* lexical match.
 """
 
 from __future__ import annotations
@@ -280,18 +279,20 @@ def _quiet_transformer_progress() -> Iterator[None]:
 
 
 def build_embedder() -> EmbedderPort | None:
-    """Build the configured embedder (bundled local default, or None to disable).
+    """Build the configured embedder (semantic by default, hashing fallback).
 
     ``CONTEXT_ENGINE_EMBEDDER``:
-      - unset with no setup config / ``local`` / ``hashing`` → :class:`HashingEmbedder`
+      - unset with no setup config / ``auto`` → sentence-transformers when
+        installed (the shipped ``potpie`` wheel always includes it via the
+        ``embeddings`` extra), otherwise the dependency-free hashing embedder
       - ``legacy`` / ``sentence-transformers`` → all-MiniLM-L6-v2 by default
-      - ``auto`` → sentence-transformers when installed, otherwise hashing
+      - ``local`` / ``hashing`` → :class:`HashingEmbedder`
       - ``none`` / ``off`` / ``lexical`` → ``None`` (labeled lexical fallback)
 
     ``CONTEXT_ENGINE_EMBEDDING_MODEL`` overrides the SentenceTransformer model
-    name when the legacy embedder is selected.
+    name when the sentence-transformers embedder is selected.
     """
-    choice = normalize_embedding_mode(configured_embedder_choice() or "local")
+    choice = normalize_embedding_mode(configured_embedder_choice() or "auto")
     if choice in DISABLED_EMBEDDER_ALIASES:
         return None
     if choice in HASHING_EMBEDDER_ALIASES:
@@ -299,6 +300,13 @@ def build_embedder() -> EmbedderPort | None:
     if choice in AUTO_SENTENCE_TRANSFORMER_ALIASES:
         if _sentence_transformers_installed():
             return _sentence_transformer_embedder()
+        # The downgrade changes match quality; say so once instead of leaving
+        # "vector" mode looking semantic when it is only fuzzy-lexical.
+        logger.info(
+            "sentence-transformers is not installed; semantic search uses the "
+            "bundled hashing embedder (install potpie[embeddings] or run "
+            "'potpie setup' for the semantic model)"
+        )
         return HashingEmbedder()
     if choice in EXPLICIT_SENTENCE_TRANSFORMER_ALIASES:
         if not _sentence_transformers_installed():

--- a/potpie/context-engine/application/services/graph_service.py
+++ b/potpie/context-engine/application/services/graph_service.py
@@ -531,6 +531,7 @@ class DefaultGraphService:
             freshness=freshness,
             quality=quality,
             match_mode=self._match_mode(),
+            embedder=self._embedder_identity(),
             detail=readiness.detail,
         )
 
@@ -540,6 +541,25 @@ class DefaultGraphService:
         if mode:
             return mode
         return getattr(self.backend.claim_query, "match_mode", "lexical")
+
+    def _embedder_identity(self) -> dict[str, Any]:
+        """Name + dimensions of the active embedder, or {} in lexical mode.
+
+        "vector" alone hides a real quality difference: the hashing fallback
+        and a sentence-transformers model both report vector mode, but only
+        the latter matches paraphrases.
+        """
+        embedder = getattr(self.backend, "embedder", None)
+        if embedder is None:
+            return {}
+        name = getattr(embedder, "name", None)
+        if not name:
+            return {}
+        out: dict[str, Any] = {"name": str(name)}
+        dimensions = _safe(lambda: int(getattr(embedder, "dimensions", 0)), 0)
+        if dimensions:
+            out["dimensions"] = dimensions
+        return out
 
     def _subgraph_versions(self, pot_id: str) -> dict[str, int]:
         # V1.5 stub: a single monotonic counter (claim count) is enough for V2's

--- a/potpie/context-engine/application/services/graph_workbench.py
+++ b/potpie/context-engine/application/services/graph_workbench.py
@@ -1281,9 +1281,7 @@ def _verification_readback(
     # When the backend runs in vector mode, every committed claim should carry
     # a fact embedding; a claim without one silently drops out of semantic
     # ranking, so the gap must surface here rather than in nobody's logs.
-    vector_mode = (
-        getattr(backend.claim_query, "match_mode", "lexical") == "vector"
-    )
+    vector_mode = getattr(backend.claim_query, "match_mode", "lexical") == "vector"
     unembedded = (
         tuple(
             key

--- a/potpie/context-engine/application/services/graph_workbench.py
+++ b/potpie/context-engine/application/services/graph_workbench.py
@@ -1203,6 +1203,22 @@ def _verify_ingestion_commit(
             "Review graph quality summary before relying on newly committed memory."
         )
 
+    unembedded_claim_keys = tuple(readback.get("unembedded_claim_keys", ()))
+    if unembedded_claim_keys:
+        # The claims read back (Part of the write landed) but carry no fact
+        # embedding, so they fall out of semantic ranking. Not a data-loss
+        # failure — but it must never be a silent one.
+        warnings.append(
+            f"{len(unembedded_claim_keys)} committed claim(s) read back without "
+            "a fact embedding; semantic ranking is degraded for them"
+        )
+        if status == "ok":
+            status = "watch"
+            recommended = (
+                "Run 'potpie graph repair semantic_index' to re-embed claims "
+                "missing vectors."
+            )
+
     return GraphIngestionVerificationResult(
         ok=ok,
         status=status,
@@ -1211,6 +1227,7 @@ def _verify_ingestion_commit(
         claim_keys=claim_keys,
         readback_claim_keys=tuple(readback["readback_claim_keys"]),
         missing_claim_keys=tuple(readback["missing_claim_keys"]),
+        unembedded_claim_keys=unembedded_claim_keys,
         readback_count=int(readback["readback_count"]),
         quality_status=str(after_quality["status"]),
         quality_counts=after_counts,
@@ -1235,6 +1252,7 @@ def _verification_readback(
         return {
             "readback_claim_keys": (),
             "missing_claim_keys": (),
+            "unembedded_claim_keys": (),
             "readback_count": 0,
             "unsupported": (),
         }
@@ -1251,20 +1269,36 @@ def _verification_readback(
         return {
             "readback_claim_keys": (),
             "missing_claim_keys": (),
+            "unembedded_claim_keys": (),
             "readback_count": 0,
             "unsupported": (
                 _unsupported_from_exception(exc, fallback="claim_query.find_claims"),
             ),
         }
-    readback_keys = tuple(
-        dict.fromkeys(_row_claim_key(row) for row in _dedupe_claim_rows(list(rows)))
-    )
+    deduped_rows = _dedupe_claim_rows(list(rows))
+    readback_keys = tuple(dict.fromkeys(_row_claim_key(row) for row in deduped_rows))
     readback_set = set(readback_keys)
+    # When the backend runs in vector mode, every committed claim should carry
+    # a fact embedding; a claim without one silently drops out of semantic
+    # ranking, so the gap must surface here rather than in nobody's logs.
+    vector_mode = (
+        getattr(backend.claim_query, "match_mode", "lexical") == "vector"
+    )
+    unembedded = (
+        tuple(
+            key
+            for row in deduped_rows
+            if (key := _row_claim_key(row)) and row.fact_embedding is None
+        )
+        if vector_mode
+        else ()
+    )
     return {
         "readback_claim_keys": readback_keys,
         "missing_claim_keys": tuple(
             key for key in claim_keys if key not in readback_set
         ),
+        "unembedded_claim_keys": unembedded,
         "readback_count": len(readback_keys),
         "unsupported": (),
     }

--- a/potpie/context-engine/application/services/setup_orchestrator.py
+++ b/potpie/context-engine/application/services/setup_orchestrator.py
@@ -82,12 +82,19 @@ _SEAM_PLAN: tuple[tuple[str, str, str], ...] = (
     ("daemon", "daemon / host", "ensure host running"),
     ("auth", "auth", "init local auth"),
     ("source", "pot management", "register repo '{repo}'"),
+    (
+        "embeddings.reindex",
+        "intelligence / embeddings",
+        "re-embed claims stale for the active embedder",
+    ),
     ("skills", "skill manager", "install skills for '{agent}'"),
 )
 
 # Soft steps never gate the run. Host-gated steps are hard only for a detached
 # daemon host; an in-process host skips them.
-_SOFT_STEPS = frozenset({"auth", "source", "skills", "embeddings.model"})
+_SOFT_STEPS = frozenset(
+    {"auth", "source", "skills", "embeddings.model", "embeddings.reindex"}
+)
 _HOST_GATED = frozenset({"installer", "daemon"})
 
 
@@ -224,6 +231,11 @@ class DefaultSetupOrchestrator:
             self._step("daemon", hard("daemon"), lambda: self.daemon.ensure(plan)),
             self._step("auth", hard("auth"), self.auth.init_local),
             self._step("source", hard("source"), lambda: self._source(plan)),
+            self._step(
+                "embeddings.reindex",
+                hard("embeddings.reindex"),
+                lambda: self._semantic_reindex(plan),
+            ),
             *(
                 [self._step("skills", hard("skills"), lambda: self._skills(plan))]
                 if not plan.defer_skills
@@ -341,6 +353,46 @@ class DefaultSetupOrchestrator:
             detail,
             metadata={**metadata, "mode": plan.embeddings, "model": model},
         )
+
+    def _semantic_reindex(self, plan: SetupPlan) -> StepResult:
+        """Migrate existing claims to the active embedder (idempotent).
+
+        On an upgraded install the pot may hold embeddings written by a
+        different model or dimension count (e.g. hashing-256 before the
+        sentence-transformers default); those claims silently drop out of
+        semantic ranking until re-embedded. A clean pot makes this a fast
+        no-op scan.
+        """
+        step = "embeddings.reindex"
+        embedder = getattr(self.backend, "embedder", None)
+        if embedder is None:
+            return StepResult(
+                step, SKIPPED, f"embedding mode is {plan.embeddings}; lexical only"
+            )
+        active = self.pots.active_pot()
+        if active is None:
+            return StepResult(step, SKIPPED, "no active pot")
+        analytics = getattr(self.backend, "analytics", None)
+        repair = getattr(analytics, "repair", None)
+        if not callable(repair):
+            return StepResult(step, SKIPPED, "backend has no repair surface")
+        report = repair(active.pot_id, targets=("semantic_index",))
+        repaired = dict(report.repaired)
+        reembedded = int(repaired.get("semantic_index") or 0)
+        failed = int(repaired.get("semantic_index_failed") or 0)
+        if failed:
+            return StepResult(
+                step,
+                FAILED,
+                report.detail or f"{failed} claim(s) failed to re-embed",
+                metadata=repaired,
+            )
+        detail = report.detail or (
+            f"re-embedded {reembedded} claim(s)"
+            if reembedded
+            else "claim embeddings match the active embedder"
+        )
+        return StepResult(step, DONE, detail, metadata=repaired)
 
     def _source(self, plan: SetupPlan) -> StepResult:
         if not plan.repo:

--- a/potpie/context-engine/domain/graph_plans.py
+++ b/potpie/context-engine/domain/graph_plans.py
@@ -298,6 +298,7 @@ class GraphIngestionVerificationResult:
     claim_keys: tuple[str, ...] = ()
     readback_claim_keys: tuple[str, ...] = ()
     missing_claim_keys: tuple[str, ...] = ()
+    unembedded_claim_keys: tuple[str, ...] = ()
     readback_count: int = 0
     quality_status: str | None = None
     quality_counts: Mapping[str, int] = field(default_factory=dict)
@@ -319,6 +320,7 @@ class GraphIngestionVerificationResult:
             "claim_keys": list(self.claim_keys),
             "readback_claim_keys": list(self.readback_claim_keys),
             "missing_claim_keys": list(self.missing_claim_keys),
+            "unembedded_claim_keys": list(self.unembedded_claim_keys),
             "readback_count": self.readback_count,
             "quality_status": self.quality_status,
             "quality_counts": dict(self.quality_counts),

--- a/potpie/context-engine/domain/ports/services/graph_service.py
+++ b/potpie/context-engine/domain/ports/services/graph_service.py
@@ -49,6 +49,10 @@ class DataPlaneStatus:
     match_mode: str = "lexical"
     """Active semantic-match mode (``vector`` | ``lexical``) so empty results
     are debuggable, not mysterious (Retrieval Hardening / R1)."""
+    embedder: Mapping[str, Any] = field(default_factory=dict)
+    """Active embedder identity (``name`` + ``dimensions``): "vector" from the
+    hashing fallback and from a semantic model are different quality tiers,
+    and surfaces must not let them look the same."""
     detail: str | None = None
 
 

--- a/potpie/context-engine/tests/conftest.py
+++ b/potpie/context-engine/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 import socket
 import tempfile
@@ -13,6 +14,13 @@ from pathlib import Path
 import pytest
 
 from host.daemon_runtime.context import ServiceEndpoints, ShellContext
+
+# The production default embedder is `auto` → sentence-transformers when
+# installed. Tests must stay deterministic and offline (a real model load
+# downloads weights on a cold cache), so the suite pins the dependency-free
+# hashing embedder; tests that exercise the auto/sentence-transformers paths
+# override this explicitly via monkeypatch.
+os.environ.setdefault("CONTEXT_ENGINE_EMBEDDER", "local")
 
 
 @pytest.fixture()

--- a/potpie/context-engine/tests/integration/test_falkordb_roundtrip.py
+++ b/potpie/context-engine/tests/integration/test_falkordb_roundtrip.py
@@ -207,3 +207,164 @@ def test_vector_search_orders_by_cosine_distance(shared_graph) -> None:
     assert [r.object_key for r in rows] == ["service:auth", "service:db"]
     assert rows[0].properties["semantic_similarity"] == pytest.approx(1.0)
     assert rows[1].properties["semantic_similarity"] == pytest.approx(0.0)
+
+
+def test_claim_read_plan_avoids_bound_node_scan(shared_graph) -> None:
+    """Regression pin for the embedded-FalkorDB id-0 planner defect (POT-1918).
+
+    A source-anchored traversal planned as an edge scan under a bound node
+    scan returns zero rows when the bound node is internal id 0. The claim
+    read must compile to a pure edge-first plan.
+    """
+    from adapters.outbound.graph.canonical_claim_query import FIND_CLAIMS_CYPHER
+
+    settings = _Settings()
+    writer = FalkorDBGraphWriter(settings, graph=shared_graph)
+    pot = "potP"
+    prov = ProvenanceRef(pot_id=pot, source_event_id="e1", source_system="agent")
+
+    async def _seed() -> None:
+        assert await writer.ensure_indexes() is True
+        await writer.upsert_entities(
+            pot, [EntityUpsert("repo:x", ("Entity", "Repository"), {})], prov
+        )
+
+    asyncio.run(_seed())
+
+    literal = FIND_CLAIMS_CYPHER.replace("$gid", f"'{pot}'")
+    for param in (
+        "$preds",
+        "$subjects",
+        "$objects",
+        "$claim_keys",
+        "$subgraphs",
+        "$mutation_ids",
+        "$source_refs",
+        "$sources",
+        "$as_of",
+        "$va_after",
+        "$va_before",
+        "$subject_label",
+        "$object_label",
+    ):
+        literal = literal.replace(param, "NULL")
+    literal = literal.replace("$include_invalid", "false")
+
+    plan = str(shared_graph.explain(literal))
+
+    assert "Edge By Index Scan" in plan
+    assert "Node By Index Scan" not in plan
+    assert "Node By Label Scan" not in plan
+
+
+def test_semantic_index_repair_recovers_and_migrates_embedder_change(
+    shared_graph,
+) -> None:
+    """Repair re-embeds claims that lost their vector AND migrates a model/dim switch."""
+    from adapters.outbound.graph.backends.falkordb_backend import FalkorDBGraphBackend
+
+    settings = _Settings()
+    emb_a = _FakeEmbedder()  # 3-dim "old" model
+    writer = FalkorDBGraphWriter(settings, graph=shared_graph, embedder=emb_a)
+    pot = "potR"
+    prov = ProvenanceRef(pot_id=pot, source_event_id="e1", source_system="agent")
+
+    async def _seed() -> None:
+        assert await writer.ensure_indexes() is True
+        # Repository FIRST — internal node id 0, the id-0 defect's trigger.
+        await writer.upsert_entities(
+            pot, [EntityUpsert("repo:x", ("Entity", "Repository"), {})], prov
+        )
+        await writer.upsert_entities(
+            pot,
+            [
+                EntityUpsert("feature:login", ("Entity", "Feature"), {}),
+                EntityUpsert("feature:storage", ("Entity", "Feature"), {}),
+            ],
+            prov,
+        )
+        await writer.upsert_edges(
+            pot,
+            [
+                EdgeUpsert(
+                    "PROVIDES",
+                    "repo:x",
+                    "feature:login",
+                    {"fact": "repo provides auth login"},
+                ),
+                EdgeUpsert(
+                    "PROVIDES",
+                    "repo:x",
+                    "feature:storage",
+                    {"fact": "repo stores data in database"},
+                ),
+            ],
+            prov,
+        )
+
+    asyncio.run(_seed())
+
+    # Simulate a historical silent attach failure on one claim.
+    shared_graph.query(
+        "MATCH ()-[r:RELATES_TO {group_id: $gid, object_key: $ok}]->() "
+        "SET r.fact_embedding = NULL, r.embedding_model = NULL, "
+        "r.embedding_dim = NULL",
+        params={"gid": pot, "ok": "feature:storage"},
+    )
+
+    class _Embedder4:
+        """The 'new default' model: different name AND dimensions."""
+
+        name = "fake-4"
+        dimensions = 4
+
+        def embed(self, text: str) -> tuple[float, ...]:
+            t = text.lower()
+            if "auth" in t or "login" in t:
+                return (1.0, 0.0, 0.0, 0.0)
+            return (0.0, 1.0, 0.0, 0.0)
+
+        def embed_many(self, texts):
+            return [self.embed(t) for t in texts]
+
+    class _BackendSettings(_Settings):
+        def falkordb_url(self):
+            return None
+
+        def falkordb_mode(self) -> str:
+            return "lite"
+
+        def falkordb_lite_path(self) -> str:
+            return "unused"
+
+    backend = FalkorDBGraphBackend(
+        _BackendSettings(),
+        graph_provider=lambda: shared_graph,
+        embedder=_Embedder4(),
+    )
+
+    report = backend.analytics.repair(pot, targets=["semantic_index"])
+
+    # One claim lost its embedding, the other was written by the old model —
+    # both must be re-embedded at the new dimensions.
+    assert report.repaired["semantic_index"] == 2
+    assert "semantic_index_failed" not in report.repaired
+
+    recs = shared_graph.query(
+        "MATCH ()-[r:RELATES_TO {group_id: $gid}]->() "
+        "RETURN r.embedding_model AS model, r.embedding_dim AS dim, "
+        "r.fact_embedding IS NOT NULL AS has_embedding",
+        params={"gid": pot},
+    )
+    rows = [dict(zip(["model", "dim", "has_embedding"], row)) for row in recs.result_set]
+    assert len(rows) == 2
+    assert all(r["model"] == "fake-4" for r in rows)
+    assert all(r["dim"] == 4 for r in rows)
+    assert all(r["has_embedding"] for r in rows)
+
+    # Vector search works at the new dimensions through the backend's reader.
+    found = backend.claim_query.find_claims(
+        ClaimQueryFilter(pot_id=pot, fact_query="auth login", limit=5)
+    )
+    assert {r.object_key for r in found} == {"feature:login", "feature:storage"}
+    assert found[0].object_key == "feature:login"

--- a/potpie/context-engine/tests/integration/test_falkordb_roundtrip.py
+++ b/potpie/context-engine/tests/integration/test_falkordb_roundtrip.py
@@ -356,7 +356,9 @@ def test_semantic_index_repair_recovers_and_migrates_embedder_change(
         "r.fact_embedding IS NOT NULL AS has_embedding",
         params={"gid": pot},
     )
-    rows = [dict(zip(["model", "dim", "has_embedding"], row)) for row in recs.result_set]
+    rows = [
+        dict(zip(["model", "dim", "has_embedding"], row)) for row in recs.result_set
+    ]
     assert len(rows) == 2
     assert all(r["model"] == "fake-4" for r in rows)
     assert all(r["dim"] == 4 for r in rows)

--- a/potpie/context-engine/tests/integration/test_falkordb_roundtrip.py
+++ b/potpie/context-engine/tests/integration/test_falkordb_roundtrip.py
@@ -244,17 +244,17 @@ def test_claim_read_plan_avoids_bound_node_scan(shared_graph) -> None:
         "$as_of",
         "$va_after",
         "$va_before",
-        "$subject_label",
-        "$object_label",
     ):
         literal = literal.replace(param, "NULL")
     literal = literal.replace("$include_invalid", "false")
 
     plan = str(shared_graph.explain(literal))
 
+    # The plan must not touch the endpoint nodes at all: node scans under the
+    # edge scan (including the `All Node Scan` a labels() reference plans)
+    # silently return zero rows after a persistence reload.
     assert "Edge By Index Scan" in plan
-    assert "Node By Index Scan" not in plan
-    assert "Node By Label Scan" not in plan
+    assert "Node" not in plan
 
 
 def test_semantic_index_repair_recovers_and_migrates_embedder_change(
@@ -370,3 +370,109 @@ def test_semantic_index_repair_recovers_and_migrates_embedder_change(
     )
     assert {r.object_key for r in found} == {"feature:login", "feature:storage"}
     assert found[0].object_key == "feature:login"
+
+
+def test_claim_reads_survive_persistence_reload() -> None:
+    """Regression pin for the embedded-FalkorDB reload defect (the P0-1 bug).
+
+    Every ``potpie`` CLI call is a fresh process: the store is persisted to
+    disk and reloaded between the write and the read. After that reload, any
+    query plan that resolves the edge ENDPOINTS through node scans — a bound
+    node scan, or the ``All Node Scan`` a ``labels(a)`` reference plans under
+    the edge scan — silently returns zero rows when internal node id 0 (the
+    first entity ever created) is an endpoint. In-process reads never hit it,
+    which is exactly why it survived the in-process roundtrip tests above.
+
+    Pins the full journey shape: seed + indexes → close → reopen → read.
+    """
+    import shutil as _shutil
+    import tempfile as _tempfile
+
+    tmp = _tempfile.mkdtemp(prefix="falkordblite_reload_test_")
+    settings = _Settings()
+    pot = "potReload"
+    prov = ProvenanceRef(pot_id=pot, source_event_id="e1", source_system="agent")
+    try:
+        db = falkordb_client.FalkorDB(f"{tmp}/context_graph.db")
+        graph = db.select_graph("context_graph")
+        writer = FalkorDBGraphWriter(settings, graph=graph, embedder=_FakeEmbedder())
+
+        async def _seed() -> None:
+            # Full provision-style indexes: the worst case for the planner.
+            assert await writer.ensure_indexes() is True
+            # The FIRST entity created is internal node id 0 — and the claim
+            # is anchored on it, exactly like the Repository on a fresh pot.
+            await writer.upsert_entities(
+                pot,
+                [
+                    EntityUpsert("service:web", ("Entity", "Service"), {}),
+                    EntityUpsert("service:auth", ("Entity", "Service"), {}),
+                ],
+                prov,
+            )
+            await writer.upsert_edges(
+                pot,
+                [
+                    EdgeUpsert(
+                        "DEPENDS_ON",
+                        "service:web",
+                        "service:auth",
+                        {"fact": "web depends on auth"},
+                    )
+                ],
+                prov,
+            )
+
+        asyncio.run(_seed())
+        db.close()  # persist + stop the embedded redis-server
+
+        # New handle over the persisted file = the next CLI invocation.
+        db = falkordb_client.FalkorDB(f"{tmp}/context_graph.db")
+        graph = db.select_graph("context_graph")
+        try:
+            reader = FalkorDBClaimQueryStore(
+                settings, graph=graph, embedder=_FakeEmbedder()
+            )
+
+            unscoped = reader.find_claims(ClaimQueryFilter(pot_id=pot, limit=10))
+            assert [r.predicate for r in unscoped] == ["DEPENDS_ON"]
+
+            scoped = reader.find_claims(
+                ClaimQueryFilter(pot_id=pot, subject_key_in=("service:web",), limit=10)
+            )
+            assert [r.subject_key for r in scoped] == ["service:web"]
+
+            labelled = reader.find_claims(
+                ClaimQueryFilter(pot_id=pot, subject_label="Service", limit=10)
+            )
+            assert len(labelled) == 1
+            assert (
+                reader.find_claims(
+                    ClaimQueryFilter(pot_id=pot, subject_label="Team", limit=10)
+                )
+                == []
+            )
+
+            # `graph status` counts go through the same claim query.
+            from adapters.outbound.graph.backends.claim_query_analytics import (
+                ClaimQueryAnalytics,
+            )
+
+            counts = ClaimQueryAnalytics(claim_query=reader).counts(pot)
+            assert counts["claims"] == 1
+            assert counts["entities"] == 2
+
+            # The explorer edge queries are edge-only for the same reason.
+            from adapters.outbound.graph.falkordb_inspection import (
+                FalkorDBInspection,
+            )
+
+            inspection = FalkorDBInspection(settings, graph=graph)
+            slice_ = inspection.slice(pot_id=pot, filter_=ClaimQueryFilter(pot_id=pot))
+            assert len(slice_.edges) == 1
+            hood = inspection.neighborhood(pot_id=pot, entity_key="service:web")
+            assert len(hood.edges) == 1
+        finally:
+            db.close()
+    finally:
+        _shutil.rmtree(tmp, ignore_errors=True)

--- a/potpie/context-engine/tests/unit/test_falkordb_inspection.py
+++ b/potpie/context-engine/tests/unit/test_falkordb_inspection.py
@@ -41,7 +41,7 @@ class _FakeGraph:
                     ["person:y", ["Entity", "Person"], {"name": "y"}],
                 ],
             )
-        if "a.entity_key AS source" in cypher:  # slice edges
+        if "r.subject_key AS source" in cypher:  # slice edges (edge-only query)
             return _FakeResult(
                 ["source", "target", "predicate"],
                 [["person:y", "repo:x", "PERFORMED"]],
@@ -82,6 +82,21 @@ def test_neighborhood_bfs_collects_incident_edges_and_hydrates() -> None:
     assert {n.key for n in sl.nodes} == {"repo:x", "person:y"}
     assert len(sl.edges) == 1
     assert sl.edges[0].predicate == "PERFORMED"
+
+
+def test_edge_queries_never_reference_endpoints() -> None:
+    """Same defect class as FIND_CLAIMS_CYPHER: endpoint-resolving plans drop
+    rows on embedded FalkorDB after a persistence reload when node id 0 is an
+    endpoint. The explorer edge queries read source/target off the edge."""
+    from adapters.outbound.graph.falkordb_inspection import (
+        _EDGES_CYPHER,
+        _INCIDENT_CYPHER,
+    )
+
+    for cypher in (_EDGES_CYPHER, _INCIDENT_CYPHER):
+        assert "MATCH ()-[r:RELATES_TO {group_id: $gid}]->()" in cypher
+        assert "a.entity_key" not in cypher
+        assert "labels(" not in cypher
 
 
 def test_neighborhood_clamps_depth() -> None:

--- a/potpie/context-engine/tests/unit/test_falkordb_reader.py
+++ b/potpie/context-engine/tests/unit/test_falkordb_reader.py
@@ -226,18 +226,72 @@ def test_fact_query_overlays_native_vector_scores_when_embedder_present() -> Non
     assert rows[0].properties["semantic_similarity"] == pytest.approx(0.88)
 
 
-def test_lexical_find_claims_keeps_endpoints_unbound() -> None:
-    """Regression pin for the embedded-FalkorDB id-0 planner defect.
+def test_lexical_find_claims_never_references_endpoints() -> None:
+    """Regression pin for the embedded-FalkorDB endpoint-resolution defect.
 
-    Binding endpoints (``(a:Entity {group_id: $gid})``) plans the edge scan
-    under a bound node scan, which returns zero rows when the bound node is
-    internal id 0 — always the Repository on a fresh pot.
+    Any endpoint reference — a binding like ``(a:Entity {group_id: $gid})``
+    or even ``labels(a)`` in WHERE with a null parameter — makes the planner
+    resolve the endpoint nodes under the edge scan, and that plan silently
+    returns zero rows after the store is persisted and reloaded when internal
+    node id 0 (always the first entity created) is an endpoint. The claim
+    query must stay a pure edge scan; label filters are applied in Python.
     """
     from adapters.outbound.graph.canonical_claim_query import FIND_CLAIMS_CYPHER
 
-    assert "MATCH (a)-[r:RELATES_TO {group_id: $gid}]->(b)" in FIND_CLAIMS_CYPHER
-    assert "(a:Entity" not in FIND_CLAIMS_CYPHER
-    assert "(b:Entity" not in FIND_CLAIMS_CYPHER
+    assert "MATCH ()-[r:RELATES_TO {group_id: $gid}]->()" in FIND_CLAIMS_CYPHER
+    assert "labels(" not in FIND_CLAIMS_CYPHER
+    assert "$subject_label" not in FIND_CLAIMS_CYPHER
+    assert "$object_label" not in FIND_CLAIMS_CYPHER
+
+
+def test_label_filters_are_applied_in_python() -> None:
+    """subject_label/object_label constrain results via entity_labels lookups."""
+    claim_row = {
+        "group_id": "p1",
+        "name": "DEPENDS_ON",
+        "subject_key": "service:web",
+        "object_key": "team:platform",
+        "fact": "web is owned by platform",
+    }
+
+    class _LabelsGraph(_FakeGraph):
+        def query(self, cypher, params=None):
+            self.captured.append((cypher, params or {}))
+            if "labels(e)" in cypher:
+                return _FakeResult(
+                    [[1, "key"], [1, "labels"]],
+                    [
+                        ["service:web", ["Entity", "Service"]],
+                        ["team:platform", ["Entity", "Team"]],
+                    ],
+                )
+            return _FakeResult([[1, "props"]], [[claim_row]])
+
+    store = FalkorDBClaimQueryStore(
+        settings=object(),
+        graph=_LabelsGraph(header=[], result_set=[]),
+    )  # type: ignore[arg-type]
+
+    kept = store.find_claims(
+        ClaimQueryFilter(pot_id="p1", subject_label="Service", limit=10)
+    )
+    assert len(kept) == 1
+
+    dropped = store.find_claims(
+        ClaimQueryFilter(pot_id="p1", subject_label="Team", limit=10)
+    )
+    assert dropped == []
+
+
+def test_limit_zero_short_circuits_before_any_query() -> None:
+    graph = _FakeGraph(header=[], result_set=[])
+    store = FalkorDBClaimQueryStore(
+        settings=object(), graph=graph, embedder=_FakeEmbedder()
+    )  # type: ignore[arg-type]
+    assert (
+        store.find_claims(ClaimQueryFilter(pot_id="p1", fact_query="x", limit=0)) == []
+    )
+    assert graph.captured == []
 
 
 def test_unembedded_claims_stay_visible_in_fact_query_results() -> None:

--- a/potpie/context-engine/tests/unit/test_falkordb_reader.py
+++ b/potpie/context-engine/tests/unit/test_falkordb_reader.py
@@ -44,7 +44,9 @@ class _SequencedGraph:
 
     def query(self, cypher, params=None):
         self.captured.append((cypher, params or {}))
-        header, result_set = self._results[min(len(self.captured) - 1, len(self._results) - 1)]
+        header, result_set = self._results[
+            min(len(self.captured) - 1, len(self._results) - 1)
+        ]
         return _FakeResult(header, result_set)
 
 

--- a/potpie/context-engine/tests/unit/test_falkordb_reader.py
+++ b/potpie/context-engine/tests/unit/test_falkordb_reader.py
@@ -35,6 +35,19 @@ class _FakeGraph:
         return _FakeResult(self._header, self._result_set)
 
 
+class _SequencedGraph:
+    """Fake graph returning a different canned result per query, in order."""
+
+    def __init__(self, results: list[tuple[list, list]]):
+        self._results = list(results)
+        self.captured: list[tuple[str, dict]] = []
+
+    def query(self, cypher, params=None):
+        self.captured.append((cypher, params or {}))
+        header, result_set = self._results[min(len(self.captured) - 1, len(self._results) - 1)]
+        return _FakeResult(header, result_set)
+
+
 def _props_graph(*prop_dicts):
     return _FakeGraph(header=[[1, "props"]], result_set=[[p] for p in prop_dicts])
 
@@ -171,9 +184,7 @@ def test_fact_query_stamps_similarity_and_orders() -> None:
     )
 
 
-def test_fact_query_uses_native_relationship_vector_index_when_embedder_present() -> (
-    None
-):
+def test_fact_query_overlays_native_vector_scores_when_embedder_present() -> None:
     graph = _FakeGraph(
         header=[[1, "props"], [1, "score"]],
         result_set=[
@@ -197,15 +208,104 @@ def test_fact_query_uses_native_relationship_vector_index_when_embedder_present(
         ClaimQueryFilter(pot_id="p1", fact_query="connection pool exhausted", limit=3)
     )
 
-    cypher, params = graph.captured[0]
-    assert "db.idx.vector.queryRelationships" in cypher
-    assert "vecf32($embedding)" in cypher
-    assert "id(rel) = id(r)" in cypher
-    assert "ORDER BY score ASC" in cypher
+    # Lexical membership pass first, vector score overlay second.
+    lexical_cypher, _ = graph.captured[0]
+    assert "db.idx.vector" not in lexical_cypher
+    vector_cypher, params = graph.captured[1]
+    assert "db.idx.vector.queryRelationships" in vector_cypher
+    assert "vecf32($embedding)" in vector_cypher
+    # No endpoint binding after the procedure: a bound node scan under the
+    # edge scan is the embedded-FalkorDB id-0 zero-rows plan shape.
+    assert "MATCH" not in vector_cypher
+    assert "ORDER BY score ASC" in vector_cypher
     assert params["embedding"] == [0.1, 0.2, 0.3]
     assert params["k"] == 50
     assert rows[0].subject_key == "a"
     assert rows[0].properties["semantic_similarity"] == pytest.approx(0.88)
+
+
+def test_lexical_find_claims_keeps_endpoints_unbound() -> None:
+    """Regression pin for the embedded-FalkorDB id-0 planner defect.
+
+    Binding endpoints (``(a:Entity {group_id: $gid})``) plans the edge scan
+    under a bound node scan, which returns zero rows when the bound node is
+    internal id 0 — always the Repository on a fresh pot.
+    """
+    from adapters.outbound.graph.canonical_claim_query import FIND_CLAIMS_CYPHER
+
+    assert "MATCH (a)-[r:RELATES_TO {group_id: $gid}]->(b)" in FIND_CLAIMS_CYPHER
+    assert "(a:Entity" not in FIND_CLAIMS_CYPHER
+    assert "(b:Entity" not in FIND_CLAIMS_CYPHER
+
+
+def test_unembedded_claims_stay_visible_in_fact_query_results() -> None:
+    """A claim the vector index cannot see must still appear in search results."""
+    embedded_row = {
+        "group_id": "p1",
+        "name": "X",
+        "subject_key": "a",
+        "object_key": "b",
+        "claim_key": "claim:a",
+        "fact": "connection pool exhausted in checkout",
+    }
+    unembedded_row = {
+        "group_id": "p1",
+        "name": "X",
+        "subject_key": "c",
+        "object_key": "d",
+        "claim_key": "claim:c",
+        "fact": "connection pool tuning notes",
+    }
+    graph = _SequencedGraph(
+        [
+            # Lexical pass sees both claims…
+            ([[1, "props"]], [[embedded_row], [unembedded_row]]),
+            # …the vector index only returns the embedded one.
+            ([[1, "props"], [1, "score"]], [[embedded_row, 0.1]]),
+        ]
+    )
+    store = FalkorDBClaimQueryStore(
+        settings=object(), graph=graph, embedder=_FakeEmbedder()
+    )  # type: ignore[arg-type]
+
+    rows = store.find_claims(
+        ClaimQueryFilter(pot_id="p1", fact_query="connection pool", limit=10)
+    )
+
+    assert {r.claim_key for r in rows} == {"claim:a", "claim:c"}
+    # The embedded claim carries the native vector similarity; the unembedded
+    # one falls back to a lexical score instead of disappearing.
+    by_key = {r.claim_key: r.properties["semantic_similarity"] for r in rows}
+    assert by_key["claim:a"] == pytest.approx(0.9)
+    assert by_key["claim:c"] > 0.0
+
+
+def test_vector_query_failure_degrades_to_lexical_scores() -> None:
+    class _ExplodingOnVectorGraph(_SequencedGraph):
+        def query(self, cypher, params=None):
+            if "db.idx.vector" in cypher:
+                self.captured.append((cypher, params or {}))
+                raise RuntimeError("vector index dimension mismatch")
+            return super().query(cypher, params)
+
+    row = {
+        "group_id": "p1",
+        "name": "X",
+        "subject_key": "a",
+        "object_key": "b",
+        "fact": "connection pool exhausted in checkout",
+    }
+    graph = _ExplodingOnVectorGraph([([[1, "props"]], [[row]])])
+    store = FalkorDBClaimQueryStore(
+        settings=object(), graph=graph, embedder=_FakeEmbedder()
+    )  # type: ignore[arg-type]
+
+    rows = store.find_claims(
+        ClaimQueryFilter(pot_id="p1", fact_query="connection pool exhausted")
+    )
+
+    assert len(rows) == 1
+    assert rows[0].properties["semantic_similarity"] > 0.0
 
 
 def test_fact_query_falls_back_to_lexical_when_embedder_fails() -> None:

--- a/potpie/context-engine/tests/unit/test_falkordb_writer.py
+++ b/potpie/context-engine/tests/unit/test_falkordb_writer.py
@@ -285,6 +285,82 @@ async def test_embedding_attach_zero_match_is_loud_failure(caplog) -> None:
     assert "repair semantic_index" in warning_text
 
 
+async def test_lazy_index_ensure_creates_only_the_vector_index() -> None:
+    """The write-path ensure must not create range indexes.
+
+    Creating node/edge range indexes lazily flips global planner behaviour on
+    a store that was never provisioned — embedded FalkorDB then routes other
+    queries through index-scan plans that silently drop rows after a
+    persistence reload. The vector write only needs the vector index.
+    """
+    graph = _FakeGraph()
+    w = FalkorDBGraphWriter(_FakeSettings(), graph=graph, embedder=_FakeEmbedder())
+    prov = ProvenanceRef(pot_id="p1", source_event_id="e1")
+    await w.upsert_edges(
+        "p1",
+        [EdgeUpsert("DEPENDS_ON", "service:web", "service:auth", {"fact": "x"})],
+        prov,
+    )
+
+    index_qs = [q for q, _ in graph.queries if q.startswith("CREATE")]
+    assert len(index_qs) == 1
+    assert index_qs[0].startswith("CREATE VECTOR INDEX")
+
+
+def test_lazy_vector_index_failure_is_retried_next_batch() -> None:
+    """A failed index creation must not be cached as ensured."""
+
+    class _FlakyIndexGraph(_FakeGraph):
+        def __init__(self):
+            super().__init__()
+            self.vector_index_attempts = 0
+
+        def query(self, cypher: str, params=None):
+            if "CREATE VECTOR INDEX" in cypher:
+                self.queries.append((cypher, params or {}))
+                self.vector_index_attempts += 1
+                if self.vector_index_attempts == 1:
+                    raise RuntimeError("connection reset")
+                return _FakeResult()
+            return super().query(cypher, params)
+
+    graph = _FlakyIndexGraph()
+    w = FalkorDBGraphWriter(_FakeSettings(), graph=graph, embedder=_FakeEmbedder())
+    prov = ProvenanceRef(pot_id="p1", source_event_id="e1")
+    edge = [EdgeUpsert("DEPENDS_ON", "service:web", "service:auth", {"fact": "x"})]
+
+    w._write_edge_vectors_sync(graph, "p1", edge, prov)
+    w._write_edge_vectors_sync(graph, "p1", edge, prov)
+    w._write_edge_vectors_sync(graph, "p1", edge, prov)
+
+    # Attempted again after the failure, then cached once it succeeded.
+    assert graph.vector_index_attempts == 2
+
+
+def test_lazy_vector_index_already_indexed_counts_as_success() -> None:
+    class _AlreadyIndexedGraph(_FakeGraph):
+        def __init__(self):
+            super().__init__()
+            self.vector_index_attempts = 0
+
+        def query(self, cypher: str, params=None):
+            if "CREATE VECTOR INDEX" in cypher:
+                self.queries.append((cypher, params or {}))
+                self.vector_index_attempts += 1
+                raise RuntimeError("Attribute 'fact_embedding' is already indexed")
+            return super().query(cypher, params)
+
+    graph = _AlreadyIndexedGraph()
+    w = FalkorDBGraphWriter(_FakeSettings(), graph=graph, embedder=_FakeEmbedder())
+    prov = ProvenanceRef(pot_id="p1", source_event_id="e1")
+    edge = [EdgeUpsert("DEPENDS_ON", "service:web", "service:auth", {"fact": "x"})]
+
+    w._write_edge_vectors_sync(graph, "p1", edge, prov)
+    w._write_edge_vectors_sync(graph, "p1", edge, prov)
+
+    assert graph.vector_index_attempts == 1
+
+
 def test_build_falkordb_graph_server_mode_requires_url() -> None:
     # Server mode with no URL must fail loudly, not silently fall back to Lite.
     with pytest.raises(RuntimeError, match="server mode requires a URL"):

--- a/potpie/context-engine/tests/unit/test_falkordb_writer.py
+++ b/potpie/context-engine/tests/unit/test_falkordb_writer.py
@@ -30,11 +30,18 @@ class _FakeResult:
 class _FakeGraph:
     """Captures queries; answers count() and absorbs DETACH DELETE."""
 
-    def __init__(self, count: int = 0, *, raise_on_index: bool = False):
+    def __init__(
+        self,
+        count: int = 0,
+        *,
+        raise_on_index: bool = False,
+        attach_updated: int = 1,
+    ):
         self.queries: list[tuple[str, dict]] = []
         self._count = count
         self._deleted = False
         self._raise_on_index = raise_on_index
+        self._attach_updated = attach_updated
 
     def query(self, cypher: str, params=None):
         self.queries.append((cypher, params or {}))
@@ -46,6 +53,10 @@ class _FakeGraph:
         if "count(n) AS cnt" in cypher:
             val = 0 if self._deleted else self._count
             return _FakeResult(header=[[1, "cnt"]], result_set=[[val]])
+        if "count(r) AS updated" in cypher:
+            return _FakeResult(
+                header=[[1, "updated"]], result_set=[[self._attach_updated]]
+            )
         return _FakeResult()
 
 
@@ -227,6 +238,51 @@ async def test_upsert_edges_writes_falkordb_vecf32_embedding() -> None:
     assert params["embedding"] == [0.1, 0.2, 0.3]
     assert params["embedding_model"] == "fake-embedder"
     assert params["embedding_dim"] == 3
+
+
+async def test_embedding_attach_uses_unbound_endpoints_and_verifies_count() -> None:
+    """Regression pin for the embedded-FalkorDB id-0 planner defect.
+
+    Anchoring the source node in the attach MATCH silently matched zero rows
+    when the source was internal node id 0 (always the Repository). The edge
+    must be matched by its own properties, and the SET must prove it landed.
+    """
+    graph = _FakeGraph()
+    w = FalkorDBGraphWriter(_FakeSettings(), graph=graph, embedder=_FakeEmbedder())
+    prov = ProvenanceRef(pot_id="p1", source_event_id="e1")
+    await w.upsert_edges(
+        "p1",
+        [EdgeUpsert("DEPENDS_ON", "service:web", "service:auth", {"fact": "x"})],
+        prov,
+    )
+
+    attach_cypher = next(q for q, _ in graph.queries if "vecf32($embedding)" in q)
+    assert "MATCH ()-[r:RELATES_TO" in attach_cypher
+    assert "(:Entity" not in attach_cypher
+    assert "RETURN count(r) AS updated" in attach_cypher
+
+
+async def test_embedding_attach_zero_match_is_loud_failure(caplog) -> None:
+    graph = _FakeGraph(attach_updated=0)
+    w = FalkorDBGraphWriter(_FakeSettings(), graph=graph, embedder=_FakeEmbedder())
+    prov = ProvenanceRef(pot_id="p1", source_event_id="e1")
+
+    failures = w._write_edge_vectors_sync(
+        graph,
+        "p1",
+        [EdgeUpsert("DEPENDS_ON", "service:web", "service:auth", {"fact": "x"})],
+        prov,
+    )
+
+    assert len(failures) == 1
+    assert failures[0]["predicate"] == "DEPENDS_ON"
+    assert failures[0]["subject_key"] == "service:web"
+    assert "matched no edge" in failures[0]["error"]
+    warning_text = " ".join(
+        rec.getMessage() for rec in caplog.records if rec.levelname == "WARNING"
+    )
+    assert "embedding attach FAILED" in warning_text
+    assert "repair semantic_index" in warning_text
 
 
 def test_build_falkordb_graph_server_mode_requires_url() -> None:

--- a/potpie/context-engine/tests/unit/test_graph_workbench_plans.py
+++ b/potpie/context-engine/tests/unit/test_graph_workbench_plans.py
@@ -222,6 +222,58 @@ def test_commit_verify_reads_back_claim_and_quality_summary() -> None:
     assert result.to_dict()["verification"]["readback_count"] == 1
 
 
+def test_commit_verify_flags_unembedded_claims() -> None:
+    """A committed claim without a fact embedding must surface in verification."""
+    import dataclasses
+
+    from application.services.graph_workbench import (
+        _verification_quality_snapshot,
+        _verify_ingestion_commit,
+    )
+
+    class _StubEmbedder:
+        name = "stub-embedder"
+        dimensions = 3
+
+        def embed(self, text: str) -> tuple[float, ...]:
+            return (0.1, 0.2, 0.3)
+
+        def embed_many(self, texts):
+            return [self.embed(t) for t in texts]
+
+    backend = InMemoryGraphBackend(embedder=_StubEmbedder())
+    store = _MemoryPlanStore()
+    workbench = GraphWorkbenchService(backend=backend, plan_store=store)
+    proposal = workbench.propose(_link_payload(), pot_id=POT)
+    result = workbench.commit(proposal.plan_id, pot_id=POT, verify=True)
+
+    # Healthy path: the embedder attached a vector at write time.
+    assert result.verification is not None
+    assert result.verification.unembedded_claim_keys == ()
+
+    # Simulate a failed embedding attach, then re-run verification.
+    claim_store = backend.claim_query
+    claim_store.rows[:] = [
+        dataclasses.replace(row, fact_embedding=None) for row in claim_store.rows
+    ]
+    record = store.get(pot_id=POT, plan_id=proposal.plan_id)
+    assert record is not None
+    verification = _verify_ingestion_commit(
+        backend,
+        pot_id=POT,
+        record=record,
+        before_quality=_verification_quality_snapshot(backend, pot_id=POT),
+    )
+
+    assert verification.unembedded_claim_keys == proposal.claim_keys
+    assert verification.status == "watch"
+    assert any("without a fact embedding" in w for w in verification.warnings)
+    assert "repair semantic_index" in (verification.recommended_next_action or "")
+    assert verification.to_dict()["unembedded_claim_keys"] == list(
+        proposal.claim_keys
+    )
+
+
 def test_commit_verify_flags_quality_regression() -> None:
     workbench, _backend, _store = _service()
     first = workbench.propose(_owner_payload("team:platform"), pot_id=POT)

--- a/potpie/context-engine/tests/unit/test_graph_workbench_plans.py
+++ b/potpie/context-engine/tests/unit/test_graph_workbench_plans.py
@@ -269,9 +269,7 @@ def test_commit_verify_flags_unembedded_claims() -> None:
     assert verification.status == "watch"
     assert any("without a fact embedding" in w for w in verification.warnings)
     assert "repair semantic_index" in (verification.recommended_next_action or "")
-    assert verification.to_dict()["unembedded_claim_keys"] == list(
-        proposal.claim_keys
-    )
+    assert verification.to_dict()["unembedded_claim_keys"] == list(proposal.claim_keys)
 
 
 def test_commit_verify_flags_quality_regression() -> None:

--- a/potpie/context-engine/tests/unit/test_local_embedder_setup.py
+++ b/potpie/context-engine/tests/unit/test_local_embedder_setup.py
@@ -34,16 +34,38 @@ def _clear_embedding_env(monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv(name, raising=False)
 
 
-def test_no_config_defaults_to_bundled_hashing_embedder(
+def test_no_config_defaults_to_sentence_transformers_when_installed(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """The shipped wheel carries the embeddings extra: semantic by default."""
     monkeypatch.setenv("CONTEXT_ENGINE_HOME", str(tmp_path))
     _clear_embedding_env(monkeypatch)
+    monkeypatch.setattr(
+        local_embedder, "_sentence_transformers_installed", lambda: True
+    )
 
     embedder = local_embedder.build_embedder()
 
+    assert isinstance(embedder, SentenceTransformerEmbedder)
+    assert embedder.model_name == "all-MiniLM-L6-v2"
+
+
+def test_no_config_falls_back_to_hashing_without_sentence_transformers(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, caplog
+) -> None:
+    monkeypatch.setenv("CONTEXT_ENGINE_HOME", str(tmp_path))
+    _clear_embedding_env(monkeypatch)
+    monkeypatch.setattr(
+        local_embedder, "_sentence_transformers_installed", lambda: False
+    )
+
+    with caplog.at_level(logging.INFO, logger=local_embedder.__name__):
+        embedder = local_embedder.build_embedder()
+
     assert isinstance(embedder, HashingEmbedder)
     assert embedder.name == "local-hashing-v1"
+    # The quality downgrade must announce itself.
+    assert any("hashing embedder" in rec.getMessage() for rec in caplog.records)
 
 
 def test_build_embedder_reads_setup_sentence_transformer_config(

--- a/potpie/context-engine/tests/unit/test_neo4j_claim_query.py
+++ b/potpie/context-engine/tests/unit/test_neo4j_claim_query.py
@@ -227,9 +227,7 @@ def test_fact_query_stamps_similarity_and_orders() -> None:
     )
 
 
-def test_fact_query_uses_native_relationship_vector_index_when_embedder_present() -> (
-    None
-):
+def test_fact_query_overlays_native_vector_scores_when_embedder_present() -> None:
     driver = _FakeDriver(
         [
             {
@@ -252,8 +250,14 @@ def test_fact_query_uses_native_relationship_vector_index_when_embedder_present(
         ClaimQueryFilter(pot_id="p1", fact_query="connection pool exhausted", limit=3)
     )
 
-    cypher, params = driver.captured[0]
-    assert "db.index.vector.queryRelationships" in cypher
+    # Lexical membership pass first, vector score overlay second.
+    lexical_cypher, _ = driver.captured[0]
+    assert "db.index.vector" not in lexical_cypher
+    vector_cypher, params = driver.captured[1]
+    assert "db.index.vector.queryRelationships" in vector_cypher
+    # No endpoint binding after the procedure (same edge-first shape as the
+    # FalkorDB adapter): filters run on edge properties only.
+    assert "MATCH" not in vector_cypher
     assert params["embedding"] == [0.1, 0.2, 0.3]
     assert params["k"] == 50
     assert rows[0].subject_key == "a"

--- a/potpie/context-engine/tests/unit/test_neo4j_claim_query.py
+++ b/potpie/context-engine/tests/unit/test_neo4j_claim_query.py
@@ -264,6 +264,46 @@ def test_fact_query_overlays_native_vector_scores_when_embedder_present() -> Non
     assert rows[0].properties["semantic_similarity"] == pytest.approx(0.91)
 
 
+def test_label_filters_are_applied_in_python() -> None:
+    """The shared claim query has no labels() clause; filters use entity_labels."""
+    from adapters.outbound.graph.canonical_claim_query import FIND_CLAIMS_CYPHER
+
+    assert "labels(" not in FIND_CLAIMS_CYPHER
+
+    claim = _rec(
+        group_id="p1",
+        name="OWNED_BY",
+        subject_key="service:web",
+        object_key="team:platform",
+        fact="web is owned by platform",
+    )
+
+    class _DispatchingSession(_FakeSession):
+        def run(self, cypher, **params):
+            self._captured.append((cypher, params))
+            if "labels(e)" in cypher:
+                return [
+                    {"key": "service:web", "labels": ["Entity", "Service"]},
+                    {"key": "team:platform", "labels": ["Entity", "Team"]},
+                ]
+            return [claim]
+
+    class _DispatchingDriver(_FakeDriver):
+        def session(self):
+            return _DispatchingSession(self._records, self.captured)
+
+    store = Neo4jClaimQueryStore(settings=object(), driver=_DispatchingDriver([]))  # type: ignore[arg-type]
+
+    kept = store.find_claims(
+        ClaimQueryFilter(pot_id="p1", subject_label="Service", limit=10)
+    )
+    assert len(kept) == 1
+    dropped = store.find_claims(
+        ClaimQueryFilter(pot_id="p1", object_label="Service", limit=10)
+    )
+    assert dropped == []
+
+
 def test_fact_query_falls_back_to_lexical_when_embedder_fails() -> None:
     driver = _FakeDriver(
         [

--- a/potpie/context-engine/tests/unit/test_semantic_index_repair.py
+++ b/potpie/context-engine/tests/unit/test_semantic_index_repair.py
@@ -48,8 +48,7 @@ def test_claim_needs_reembed_predicate() -> None:
         "embedding_dim": 4,
     }
     assert (
-        claim_needs_reembed(healthy, embedder_name="new-model", embedder_dim=4)
-        is False
+        claim_needs_reembed(healthy, embedder_name="new-model", embedder_dim=4) is False
     )
     assert claim_needs_reembed({}, embedder_name="new-model", embedder_dim=4) is True
     assert (

--- a/potpie/context-engine/tests/unit/test_semantic_index_repair.py
+++ b/potpie/context-engine/tests/unit/test_semantic_index_repair.py
@@ -1,0 +1,253 @@
+"""Tests for the semantic-index re-embed repair (POT-1918 / P0-1).
+
+The repair is both the recovery pass for silently-failed embedding attaches
+and the migration pass for embedder changes (model or dimensions) — e.g. the
+switch from the 256-dim hashing embedder to sentence-transformers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from adapters.outbound.graph.backends.falkordb_backend import FalkorDBGraphBackend
+from adapters.outbound.graph.backends.in_memory_backend import InMemoryGraphBackend
+from adapters.outbound.graph.semantic_index_repair import (
+    claim_needs_reembed,
+    wants_semantic_index_repair,
+)
+from domain.ports.claim_query import ClaimRow
+
+pytestmark = pytest.mark.unit
+
+POT = "p1"
+
+
+class _Embedder:
+    def __init__(self, name: str = "new-model", dimensions: int = 4) -> None:
+        self.name = name
+        self.dimensions = dimensions
+
+    def embed(self, text: str) -> tuple[float, ...]:
+        return tuple(1.0 if i == 0 else 0.0 for i in range(self.dimensions))
+
+    def embed_many(self, texts):
+        return [self.embed(t) for t in texts]
+
+
+def test_wants_semantic_index_repair_target_vocabulary() -> None:
+    assert wants_semantic_index_repair(()) is True  # no targets = repair all
+    assert wants_semantic_index_repair(("semantic_index",)) is True
+    assert wants_semantic_index_repair(("embeddings",)) is True
+    assert wants_semantic_index_repair(("entity_summaries",)) is False
+
+
+def test_claim_needs_reembed_predicate() -> None:
+    healthy = {
+        "fact_embedding": [1.0, 0.0, 0.0, 0.0],
+        "embedding_model": "new-model",
+        "embedding_dim": 4,
+    }
+    assert (
+        claim_needs_reembed(healthy, embedder_name="new-model", embedder_dim=4)
+        is False
+    )
+    assert claim_needs_reembed({}, embedder_name="new-model", embedder_dim=4) is True
+    assert (
+        claim_needs_reembed(
+            {**healthy, "embedding_model": "old-model"},
+            embedder_name="new-model",
+            embedder_dim=4,
+        )
+        is True
+    )
+    assert (
+        claim_needs_reembed(
+            {**healthy, "embedding_dim": 3},
+            embedder_name="new-model",
+            embedder_dim=4,
+        )
+        is True
+    )
+
+
+# ---------------------------------------------------------------------------
+# FalkorDB backend repair (fake graph)
+# ---------------------------------------------------------------------------
+
+
+class _FakeResult:
+    def __init__(self, names, rows):
+        self.header = [[1, name] for name in names]
+        self.result_set = rows
+
+
+def _claim_props(
+    claim_key: str | None,
+    *,
+    embedding=None,
+    model: str | None = None,
+    dim: int | None = None,
+) -> dict:
+    props = {
+        "group_id": POT,
+        "name": "PROVIDES",
+        "subject_key": "repo:x",
+        "object_key": f"feature:{claim_key or 'anon'}",
+        "fact": "repo provides a feature",
+    }
+    if claim_key:
+        props["claim_key"] = claim_key
+    if embedding is not None:
+        props["fact_embedding"] = embedding
+        props["embedding_model"] = model
+        props["embedding_dim"] = dim
+    return props
+
+
+class _SemanticRepairGraph:
+    """Fake graph: canned claim scan + records index DDL and re-embed SETs."""
+
+    def __init__(self, scan_rows):
+        self._scan_rows = scan_rows
+        self.reembeds: list[dict] = []
+        self.index_statements: list[str] = []
+
+    def query(self, cypher: str, params: dict | None = None) -> _FakeResult:
+        params = params or {}
+        if "RETURN r{.*} AS props" in cypher and "LIMIT" in cypher:
+            return _FakeResult(["props"], [[row] for row in self._scan_rows])
+        if "DROP VECTOR INDEX" in cypher or "CREATE" in cypher:
+            self.index_statements.append(cypher)
+            return _FakeResult([], [])
+        if "SET r.fact_embedding" in cypher:
+            self.reembeds.append(params)
+            return _FakeResult(["updated"], [[1]])
+        return _FakeResult([], [])
+
+
+def test_falkordb_semantic_repair_reembeds_stale_claims_and_migrates_index() -> None:
+    healthy = _claim_props(
+        "claim:healthy", embedding=[1.0, 0.0, 0.0, 0.0], model="new-model", dim=4
+    )
+    missing = _claim_props("claim:missing")
+    stale_model = _claim_props(
+        "claim:stale-model", embedding=[0.0, 1.0, 0.0, 0.0], model="old-model", dim=4
+    )
+    stale_dim = _claim_props(
+        "claim:stale-dim", embedding=[0.0, 1.0, 0.0], model="new-model", dim=3
+    )
+    graph = _SemanticRepairGraph([healthy, missing, stale_model, stale_dim])
+
+    class _Settings:
+        def is_enabled(self):
+            return True
+
+        def falkordb_url(self):
+            return None
+
+        def falkordb_graph_name(self):
+            return "context_graph"
+
+        def falkordb_mode(self):
+            return "lite"
+
+        def falkordb_lite_path(self):
+            return ".potpie/test/falkordb.db"
+
+    backend = FalkorDBGraphBackend(
+        _Settings(), graph_provider=lambda: graph, embedder=_Embedder()
+    )
+
+    report = backend.analytics.repair(POT, targets=["semantic_index"])
+
+    assert report.repaired["semantic_index"] == 3
+    assert "semantic_index_failed" not in report.repaired
+    reembedded_keys = {p.get("claim_key") for p in graph.reembeds}
+    assert reembedded_keys == {"claim:missing", "claim:stale-model", "claim:stale-dim"}
+    # Every re-embed carries the active embedder's identity at its dimensions.
+    for params in graph.reembeds:
+        assert params["embedding_model"] == "new-model"
+        assert params["embedding_dim"] == 4
+        assert len(params["embedding"]) == 4
+    # The 3-dim stale claim forces an index drop + recreate at 4 dims.
+    assert any("DROP VECTOR INDEX" in s for s in graph.index_statements)
+    assert any(
+        "CREATE VECTOR INDEX" in s and "dimension:4" in s
+        for s in graph.index_statements
+    )
+    assert "vector index rebuilt" in (report.detail or "")
+
+
+def test_falkordb_semantic_repair_counts_failures() -> None:
+    class _ZeroMatchGraph(_SemanticRepairGraph):
+        def query(self, cypher: str, params: dict | None = None) -> _FakeResult:
+            if "SET r.fact_embedding" in cypher:
+                return _FakeResult(["updated"], [[0]])
+            return super().query(cypher, params)
+
+    graph = _ZeroMatchGraph([_claim_props("claim:missing")])
+
+    class _Settings:
+        def is_enabled(self):
+            return True
+
+        def falkordb_url(self):
+            return None
+
+        def falkordb_graph_name(self):
+            return "context_graph"
+
+        def falkordb_mode(self):
+            return "lite"
+
+        def falkordb_lite_path(self):
+            return ".potpie/test/falkordb.db"
+
+    backend = FalkorDBGraphBackend(
+        _Settings(), graph_provider=lambda: graph, embedder=_Embedder()
+    )
+
+    report = backend.analytics.repair(POT, targets=["semantic_index"])
+
+    assert report.repaired["semantic_index"] == 0
+    assert report.repaired["semantic_index_failed"] == 1
+    assert "FAILED" in (report.detail or "")
+
+
+# ---------------------------------------------------------------------------
+# In-memory backend repair
+# ---------------------------------------------------------------------------
+
+
+def _row(claim_key: str, *, fact_embedding=None) -> ClaimRow:
+    return ClaimRow(
+        pot_id=POT,
+        predicate="PROVIDES",
+        subject_key="repo:x",
+        object_key=f"feature:{claim_key}",
+        valid_at=None,
+        invalid_at=None,
+        evidence_strength="attested",
+        source_system="agent",
+        source_ref="repo:x:README",
+        fact="repo provides a feature",
+        properties={},
+        fact_embedding=fact_embedding,
+        claim_key=claim_key,
+    )
+
+
+def test_in_memory_semantic_repair_reembeds_missing_and_mis_sized() -> None:
+    backend = InMemoryGraphBackend(embedder=_Embedder(dimensions=4))
+    store = backend.claim_query
+    store.add(_row("claim:missing"))
+    store.add(_row("claim:short", fact_embedding=(1.0, 0.0, 0.0)))
+    store.add(_row("claim:healthy", fact_embedding=(1.0, 0.0, 0.0, 0.0)))
+
+    report = backend.analytics.repair(POT, targets=["semantic_index"])
+
+    assert report.repaired["semantic_index"] == 2
+    assert all(
+        row.fact_embedding is not None and len(row.fact_embedding) == 4
+        for row in store.rows
+    )


### PR DESCRIPTION
## Summary

On the default `falkordb_lite` backend, claims anchored on a pot's first-created entity (internal node id 0 — always the Repository in the standard flow) were invisible to every read surface while `commit` reported success. The embedded engine returns zero rows for a source-anchored traversal when the bound source node is id 0; both claim read paths and the embedding-attach query used exactly that shape, and every miss was silent. This PR fixes the query shapes, makes the remaining failure modes loud, adds a real re-embed repair, and switches the default embedder to sentence-transformers.

### 1. Edge-first claim reads
- `FIND_CLAIMS_CYPHER` and both vector queries drop endpoint-node bindings — unbound endpoints keep `labels()` filters working and compile to a pure `Edge By Index Scan` (pinned with an EXPLAIN-based regression test).
- `fact_query` is now **lexical membership + vector score overlay**: a claim whose embedding is missing, stale, or unreachable degrades to a lexical score instead of disappearing from reads (verify readback, views, search, UI). Vector-query failures log a warning naming the repair command instead of silently returning `[]`.

### 2. Loud, verifiable embedding attach
- The attach MATCH is edge-first and count-verified; zero matches raise and are reported per edge, with a batch summary warning.
- `commit --verify` readback reports `unembedded_claim_keys` when the backend runs in vector mode, escalating verification status to `watch` with a repair recommendation.

### 3. Real `semantic_index` repair + index migration
- `graph repair --semantic-index` (previously a no-op) re-embeds claims whose embeddings are missing, written by a different model, or written at different dimensions; on a dimension change it drops and recreates the vector index.
- `potpie setup` gains a soft `embeddings.reindex` step, so upgraded installs are migrated by the standard onboarding command.

### 4. sentence-transformers by default
- `build_embedder()` unset default: `local` → `auto`. The shipped `potpie` wheel already carries sentence-transformers, and setup already selects and persists it — this closes the gap for processes that never ran setup (fresh daemon, MCP, CI), which silently used the 256-dim hashing embedder.
- `graph status` now surfaces the active embedder `{name, dimensions}` beside `match_mode` — hashing-vector and semantic-vector are different quality tiers and no longer look identical.
- The test suite pins `CONTEXT_ENGINE_EMBEDDER=local` in conftest for offline determinism; default-path tests monkeypatch installation state.
- Safe for existing pots: the repair pass in (3) migrates hashing-256 stores in place.

### 5. Lazy vector-index creation
Only setup's provision step created the vector index, so a home where setup never ran wrote embeddings no vector query could reach. The writer now ensures indexes once before its first vector write.

## Test plan

- [x] Unit + conformance: 2,102 passed (2 pre-existing environmental failures in daemon subprocess tests — bare `python` not on PATH — fail identically on `main`)
- [x] Integration on real falkordblite: EXPLAIN plan-shape regression pin; full recover-and-migrate cycle (strip an embedding + switch embedder model/dims → repair re-embeds all, rebuilds the index, search works at the new dimensions)
- [x] Live scratch-home end-to-end: fresh install → `vector` mode with `sentence-transformers/all-MiniLM-L6-v2` (384 dims) and zero config; `commit --verify` reads back with no missing/unembedded claims; semantic search returns scored results; repair is a no-op on healthy pots; a claim committed under the hashing embedder is migrated in place by repair

🤖 Generated with [Claude Code](https://claude.com/claude-code)