### PR TITLE
Add workflow to build full-repo image and upload to GAR

### DIFF
--- a/.github/workflows/upload-image-gar.yml
+++ b/.github/workflows/upload-image-gar.yml
@@ -1,0 +1,73 @@
+name: Build and Upload image to Artifact Registry
+
+on:
+  workflow_dispatch:
+
+env:
+  PROJECT_ID: ${{ secrets.STAGE_GCLOUD_PROJECT_ID }}
+  IMAGE: potpie-latest
+  GAR_ZONE: us-central1
+  GAR_REPO: potpie
+  DOCKERFILE: legacy/dockerfile
+
+jobs:
+  setup-build-publish:
+    name: Setup, Build, and Publish
+    runs-on: ubuntu-latest
+    environment: staging
+    permissions:
+      contents: "read"
+      id-token: "write"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - id: "auth"
+        uses: "google-github-actions/auth@v2"
+        with:
+          credentials_json: "${{ secrets.STAGE_GKE_SA_KEY }}"
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Create Artifact Registry repository if needed
+        run: |-
+          if ! gcloud artifacts repositories describe "$GAR_REPO" \
+            --location="$GAR_ZONE" \
+            --project="$PROJECT_ID" >/dev/null 2>&1; then
+            echo "Repository $GAR_REPO does not exist. Creating..."
+            gcloud artifacts repositories create "$GAR_REPO" \
+              --repository-format=docker \
+              --location="$GAR_ZONE" \
+              --project="$PROJECT_ID" \
+              --description="Docker repository for potpie full-repo images"
+            echo "Repository $GAR_REPO created successfully"
+          else
+            echo "Repository $GAR_REPO already exists"
+          fi
+
+      - name: Docker configuration
+        run: |-
+          gcloud auth configure-docker "$GAR_ZONE-docker.pkg.dev" --quiet
+
+      - name: Build
+        run: |-
+          SHORT_SHA=$(echo "$GITHUB_SHA" | cut -c1-7)
+          IMAGE_BASE="$GAR_ZONE-docker.pkg.dev/$PROJECT_ID/$GAR_REPO/$IMAGE"
+          IMAGE_TAG_SHA="${IMAGE_BASE}:${SHORT_SHA}"
+          IMAGE_TAG_LATEST="${IMAGE_BASE}:latest"
+          echo "IMAGE_TAG_SHA=$IMAGE_TAG_SHA" >> "$GITHUB_ENV"
+          echo "IMAGE_TAG_LATEST=$IMAGE_TAG_LATEST" >> "$GITHUB_ENV"
+          # Match Jenkins: apply legacy/.dockerignore at the repo-root build context.
+          cp legacy/.dockerignore .dockerignore
+          docker build \
+            --tag "$IMAGE_TAG_SHA" \
+            --tag "$IMAGE_TAG_LATEST" \
+            -f "$DOCKERFILE" \
+            .
+
+      - name: Publish
+        run: |-
+          docker push "$IMAGE_TAG_SHA"
+          docker push "$IMAGE_TAG_LATEST"

--- a/legacy/.dockerignore
+++ b/legacy/.dockerignore
@@ -8,6 +8,10 @@
 # Frontend app (separate Docker build under potpie-ui/)
 potpie-ui
 
+# Removed package path — if present locally it matches workspace members potpie/*
+# and breaks `uv sync` (no pyproject.toml).
+potpie/observability
+
 # Not required at runtime for API / Celery / Convo images
 docs
 seed

--- a/legacy/dockerfile
+++ b/legacy/dockerfile
@@ -17,8 +17,9 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 COPY --from=ghcr.io/astral-sh/uv:0.9.6 /uv /uvx /bin/
 
 # Copy dependency metadata and local path packages (editable deps in uv.lock)
-COPY pyproject.toml uv.lock ./
-COPY legacy/pyproject.toml ./legacy/pyproject.toml
+# README.md + LICENSE are required for hatchling metadata validation during uv sync
+COPY pyproject.toml uv.lock README.md LICENSE ./
+COPY legacy/pyproject.toml legacy/README.md ./legacy/
 COPY potpie/context-engine ./potpie/context-engine
 COPY potpie/integrations ./potpie/integrations
 COPY potpie/parsing ./potpie/parsing


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/upload-image-gar.yml` to build the full-repo Docker image from `legacy/dockerfile` and push it to Google Artifact Registry as `potpie-latest` (tags: short SHA + `latest`).
- Fixes early Dockerfile `COPY` layers so hatchling can resolve `README.md` / `LICENSE` during `uv sync`.
- Ignores stale `potpie/observability` in `.dockerignore` so local leftovers cannot break the workspace glob.

## Test plan
- [x] Locally built image successfully: `docker build --tag potpie-latest -f legacy/dockerfile .`
- [x] Confirmed image exists as `potpie-latest:latest`
- [ ] Ensure GitHub secrets `STAGE_GCLOUD_PROJECT_ID` and `STAGE_GKE_SA_KEY` (and `staging` environment) are configured on this repo
- [ ] Run the workflow via **Actions → Build and Upload image to Artifact Registry → Run workflow**
- [ ] Verify image appears in GAR at `us-central1-docker.pkg.dev/<project>/potpie/potpie-latest:latest`


Made with [Cursor](https://cursor.com)