### PR TITLE
Use hosted context graph demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [Potpie](https://potpie.ai) turns your codebase and software development lifecycle into a living context graph for AI agents.
 It indexes code, structure, decisions, source history, team knowledge and engineering workflows, so agents can answer questions, plan changes, debug failures, and write code with project-specific context.
 
-![Potpie context graph demo](https://raw.githubusercontent.com/potpie-ai/potpie/main/assets/context_graph.gif)
+![Potpie context graph demo](https://static-images-r2.potpie.ai/context_graph%20(1).gif)
 
 ## Install and setup Potpie
 


### PR DESCRIPTION
## Summary

- Replace the repository-hosted context graph GIF URL with the R2-hosted asset.
- Keep the new high-quality animation out of Git history.
- Preserve an absolute HTTPS image URL for GitHub and PyPI rendering.

## Validation

- Confirmed the hosted asset returns HTTP 200.
- Confirmed `Content-Type: image/gif` and an 8,812,258-byte response.
- Ran `git diff --check -- README.md`.