### PR TITLE
docs: add DaoXE OpenAI-compatible gateway example

### DIFF
--- a/legacy/.env.template
+++ b/legacy/.env.template
@@ -30,7 +30,8 @@ LLM_TEMPERATURE=0.2
 LLM_MAX_TOKENS=4096
 LLM_TIMEOUT=60
 
-# Optional OpenAI-compatible overrides
+# Optional OpenAI-compatible overrides (e.g. DaoXE multi-model gateway: https://daoxe.com/v1)
+# Model IDs are account-scoped; service not available in mainland China.
 LLM_API_BASE=
 LLM_API_VERSION=
 

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -88,6 +88,19 @@ Core libraries live at the repo root under `potpie/` (`context-engine`, `parsing
    > **`CHAT_MODEL`** and **`INFERENCE_MODEL`** are used for agent reasoning and knowledge graph generation respectively. Model names follow the `provider/model_name` format as expected by [LiteLLM](https://docs.litellm.ai/docs/providers).
    >
    > **💡 Using Ollama instead?** Set `LLM_PROVIDER=ollama` and use `CHAT_MODEL=ollama_chat/qwen2.5-coder:7b` and `INFERENCE_MODEL=ollama_chat/qwen2.5-coder:7b`.
+   >
+   > **Using an OpenAI-compatible gateway (e.g. [DaoXE](https://daoxe.com))?** DaoXE is a multi-model multi-protocol API gateway (`https://daoxe.com/v1`). Point the OpenAI path at it with your DaoXE key and an account-scoped model ID (from authenticated `GET /v1/models` or your dashboard — not a hardcoded public catalog). DaoXE is not available in mainland China.
+   >
+   > ```bash
+   > LLM_PROVIDER=openai
+   > OPENAI_API_KEY=your-daoxe-api-key
+   > # Account-scoped model IDs, e.g. openai/<id-from-GET-/v1/models>
+   > CHAT_MODEL=openai/your-account-model-id
+   > INFERENCE_MODEL=openai/your-account-model-id
+   > LLM_API_BASE=https://daoxe.com/v1
+   > ```
+   >
+   > DaoXE also exposes other protocol routes (for example Anthropic Messages) for clients that speak those APIs; with Potpie's OpenAI/`LLM_API_BASE` path above you use Chat Completions. Starters: [DaoXE-AI](https://github.com/seven7763/DaoXE-AI) · [Pricing](https://daoxe.com/pricing).
 
    See `.env.template` for the full list of optional configuration (logging, feature flags, object storage, email, analytics, etc.).
 


### PR DESCRIPTION
## Summary

- Document using **DaoXE** (multi-model multi-protocol API gateway) with Potpie via the existing OpenAI path: `LLM_PROVIDER=openai` + `LLM_API_BASE=https://daoxe.com/v1` and `OPENAI_API_KEY` set to the DaoXE key.
- Place the example next to the existing Ollama note in `legacy/README.md` (docs-only; no runtime changes).
- Clarify optional `LLM_API_BASE` in `legacy/.env.template`.
- Model IDs are **account-scoped** — placeholders / authenticated `GET /v1/models` only (no hardcoded public catalog).
- Note multi-protocol scope (Chat Completions for this Potpie path; DaoXE also exposes other routes such as Anthropic Messages for clients that speak those APIs).
- Note service availability outside mainland China.
- Links: https://daoxe.com · https://daoxe.com/pricing · https://github.com/seven7763/DaoXE-AI

Potpie already reads `LLM_API_BASE` into provider config (`LLMProviderConfig` / LiteLLM `base_url`) for OpenAI-compatible endpoints.

## Disclosure

I am affiliated with DaoXE.

## Test plan

- [ ] README renders the new note under AI / LLM configuration
- [ ] Example env keys match `legacy/.env.template` (`LLM_PROVIDER`, `OPENAI_API_KEY`, `CHAT_MODEL`, `INFERENCE_MODEL`, `LLM_API_BASE`)
- [ ] Links resolve (`daoxe.com`, DaoXE-AI, pricing)
- [ ] Optional live check with a real `OPENAI_API_KEY` (DaoXE key) and account-scoped model IDs (no credentials in this PR)