### PR TITLE
Fix/root help command order

### DIFF
--- a/potpie/cli/auth/auth_commands.py
+++ b/potpie/cli/auth/auth_commands.py
@@ -74,8 +74,8 @@ from adapters.outbound.cli_auth.token_exchange import exchange_authorization_cod
 
 auth_app = typer.Typer(
     help=(
-        "Integration auth status and deprecated provider aliases. "
-        "Use `potpie <provider>` for provider login/logout."
+        "Integration auth status (`auth status`). "
+        "Prefer `potpie <provider>` for login — aliases under this group are legacy."
     ),
 )
 linear_app = typer.Typer(help="Linear integration.")
@@ -893,7 +893,13 @@ def register_integration_commands(root: typer.Typer) -> None:
     root.add_typer(jira_app, name="jira")
     root.add_typer(confluence_app, name="confluence")
     root.add_typer(gitbucket_app, name="gitbucket")
-    root.add_typer(auth_app, name="auth")
+    # Keep `auth status` discoverable, but park the group below the happy path.
+    # Provider mirrors under this group are legacy; prefer `potpie <provider>`.
+    root.add_typer(
+        auth_app,
+        name="auth",
+        rich_help_panel="Legacy",
+    )
 
 
 def _print_jira_issue_row(row: dict[str, Any]) -> None:

--- a/potpie/cli/commands/cloud.py
+++ b/potpie/cli/commands/cloud.py
@@ -16,10 +16,12 @@ from potpie.cli.commands._common import contract
 from domain.errors import CapabilityNotImplemented
 
 cloud_app = typer.Typer(
-    help="Managed profile + sync (TODO).", invoke_without_command=True
+    help="Managed Potpie profile and sync (in development).",
+    invoke_without_command=True,
 )
 skills_app = typer.Typer(
-    help="Managed skill catalog sync (TODO).", invoke_without_command=True
+    help="Managed skill catalog sync (in development).",
+    invoke_without_command=True,
 )
 cloud_app.add_typer(skills_app, name="skills")
 
@@ -72,7 +74,7 @@ def cloud_pull(pot: str = typer.Option(None, "--pot")) -> None:
 
 @skills_app.command("sync")
 def cloud_skills_sync(agent: str = typer.Option(None, "--agent")) -> None:
-    """Sync the managed skill catalog into a harness (managed profile; TODO)."""
+    """Sync the managed skill catalog into a harness (in development)."""
     with contract():
         _todo("skills.sync")
 

--- a/potpie/cli/main.py
+++ b/potpie/cli/main.py
@@ -58,10 +58,20 @@ def _version_callback(value: bool) -> None:
     raise typer.Exit()
 
 
+_ROOT_HELP = """\
+Potpie context graph CLI (host-routed: CLI → HostShell → services → ports).
+
+First run:
+  potpie setup --repo . --agent <harness>
+  potpie doctor
+  potpie status
+"""
+
+
 def build_app() -> typer.Typer:
     app = typer.Typer(
         name="potpie",
-        help="Potpie context graph CLI (host-routed: CLI → HostShell → services → ports).",
+        help=_ROOT_HELP,
         no_args_is_help=True,
         add_completion=False,
     )
@@ -120,7 +130,13 @@ def build_app() -> typer.Typer:
     app.add_typer(graph.timeline_app, name="timeline")
     app.add_typer(graph.backend_app, name="backend")
     app.add_typer(skills_cmds.skills_app, name="skills")
-    app.add_typer(cloud.cloud_app, name="cloud")
+    # Keep cloud discoverable but below the local happy path — managed routing
+    # is still in development (see cli-flow.md).
+    app.add_typer(
+        cloud.cloud_app,
+        name="cloud",
+        rich_help_panel="Coming soon",
+    )
     app.add_typer(telemetry.telemetry_app, name="telemetry")
 
     return app

--- a/tests/unit/test_audit32_root_help.py
+++ b/tests/unit/test_audit32_root_help.py
@@ -1,0 +1,68 @@
+"""Tests for CLI audit 32: root help happy path + de-emphasize auth/cloud."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from typer.testing import CliRunner
+
+from potpie.cli import main as host_cli
+
+pytestmark = pytest.mark.unit
+
+
+def _root_help() -> str:
+    result = CliRunner().invoke(host_cli.app, ["--help"])
+    assert result.exit_code == 0, result.output
+    return result.stdout
+
+
+def _panel_body(help_text: str, title: str) -> str:
+    """Return the body of a Rich help panel titled ``title`` (until the next panel)."""
+    pattern = rf"╭─\s*{re.escape(title)}\s*─+╮\n(.*?)(?=\n╭─|\Z)"
+    match = re.search(pattern, help_text, flags=re.DOTALL)
+    assert match is not None, f"panel {title!r} not found in:\n{help_text}"
+    return match.group(1)
+
+
+class TestAudit32RootHelp:
+    def test_root_help_includes_first_run_block(self) -> None:
+        help_text = _root_help()
+
+        assert "First run:" in help_text
+        assert "potpie setup --repo . --agent <harness>" in help_text
+        assert "potpie doctor" in help_text
+        assert "potpie status" in help_text
+
+    def test_auth_and_cloud_are_outside_default_commands_panel(self) -> None:
+        help_text = _root_help()
+        commands = _panel_body(help_text, "Commands")
+
+        assert re.search(r"^\s*│\s*auth\b", commands, flags=re.MULTILINE) is None
+        assert re.search(r"^\s*│\s*cloud\b", commands, flags=re.MULTILINE) is None
+
+    def test_auth_lives_in_legacy_panel(self) -> None:
+        help_text = _root_help()
+        legacy = _panel_body(help_text, "Legacy")
+
+        assert re.search(r"^\s*│\s*auth\b", legacy, flags=re.MULTILINE)
+        assert "auth status" in legacy.lower()
+        assert "legacy" in legacy.lower() or "prefer" in legacy.lower()
+
+    def test_cloud_lives_in_coming_soon_panel(self) -> None:
+        help_text = _root_help()
+        coming_soon = _panel_body(help_text, "Coming soon")
+
+        assert re.search(r"^\s*│\s*cloud\b", coming_soon, flags=re.MULTILINE)
+        assert "in development" in coming_soon.lower()
+        assert "not implemented" not in coming_soon.lower()
+
+    def test_legacy_and_coming_soon_panels_follow_commands(self) -> None:
+        help_text = _root_help()
+
+        commands_idx = help_text.index("╭─ Commands")
+        legacy_idx = help_text.index("╭─ Legacy")
+        coming_soon_idx = help_text.index("╭─ Coming soon")
+
+        assert commands_idx < legacy_idx < coming_soon_idx

--- a/tests/unit/test_audit32_root_help.py
+++ b/tests/unit/test_audit32_root_help.py
@@ -1,4 +1,4 @@
-"""Tests for CLI audit 32: root help happy path + de-emphasize auth/cloud."""
+"""Tests for root help: first-run guidance + de-emphasize auth/cloud."""
 
 from __future__ import annotations
 
@@ -11,11 +11,24 @@ from potpie.cli import main as host_cli
 
 pytestmark = pytest.mark.unit
 
+# Rich help on CI injects ANSI between glyphs (e.g. "╭─" + codes + " Legacy"),
+# so assertions must run on a stripped view of the text.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
 
 def _root_help() -> str:
-    result = CliRunner().invoke(host_cli.app, ["--help"])
+    result = CliRunner().invoke(
+        host_cli.app,
+        ["--help"],
+        color=False,
+        env={"NO_COLOR": "1", "TERM": "dumb"},
+    )
     assert result.exit_code == 0, result.output
-    return result.stdout
+    return _strip_ansi(result.stdout)
 
 
 def _panel_body(help_text: str, title: str) -> str:


### PR DESCRIPTION
 Closes  #1025 
## Summary
- Adds a first-run block to root `potpie --help` (`setup` → `doctor` → `status`)
- Moves `auth` to **Legacy** and `cloud` to **Coming soon**, below the main Commands list
- Softens help copy; command behavior unchanged

## Test plan
- [ ] `potpie --help` shows First run + Legacy / Coming soon panels
- [ ] `potpie auth status --help` and `potpie cloud --help` still work
- [ ] `pytest tests/unit/test_audit32_root_help.py`