### PR TITLE
docs(cli): point local reinstall at make cli-install and hint uv-tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ python3 -m pip install --user potpie
 > `uv tool install potpie` is recommended for CLI installs because global
 > mutation of Python packages is generally not recommended.
 
+### Developing from this repository
+
+For a source checkout, use the Makefile path (builds the graph explorer, stops
+any old daemon, then installs the editable CLI):
+
+```bash
+make cli-install
+make cli-status
+```
+
+Do not use a bare `uv tool install --editable ./potpie/context-engine` for
+day-to-day local reinstalls — it skips the UI build and daemon stop.
+
 ### Step 2: Run the Potpie setup wizard
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -35,19 +35,6 @@ python3 -m pip install --user potpie
 > `uv tool install potpie` is recommended for CLI installs because global
 > mutation of Python packages is generally not recommended.
 
-### Developing from this repository
-
-For a source checkout, use the Makefile path (builds the graph explorer, stops
-any old daemon, then installs the editable CLI):
-
-```bash
-make cli-install
-make cli-status
-```
-
-Do not use a bare `uv tool install --editable ./potpie/context-engine` for
-day-to-day local reinstalls — it skips the UI build and daemon stop.
-
 ### Step 2: Run the Potpie setup wizard
 
 ```bash

--- a/docs/context-graph/README.md
+++ b/docs/context-graph/README.md
@@ -49,9 +49,23 @@ flowchart TB
 
 ## Target OSS default
 
+**Published package** (PyPI):
+
 ```bash
-pip install potpie
+uv tool install potpie   # recommended
+# or: pip install potpie
 potpie setup        # provisions config, local stores, the default pot, the daemon, and skills
+potpie status
+```
+
+**Repo-local development** (this checkout): use `make cli-install` — it builds the
+graph-explorer UI, stops any old daemon, and installs the editable CLI. Do not use
+raw `uv tool install --editable ./potpie/context-engine` for day-to-day reinstalls.
+
+```bash
+make cli-install
+make cli-status     # confirm PATH / uv-tool install
+potpie setup
 potpie status
 ```
 

--- a/docs/context-graph/cli-flow.md
+++ b/docs/context-graph/cli-flow.md
@@ -303,13 +303,15 @@ usage events.
 facts (uv tool env, PATH, python shebang), and recommended follow-up commands.
 Do not use `python -m pip show potpie-context-engine` for local dev installs —
 the package lives in the uv tool environment. Prefer `uv tool list`,
-`which -a potpie`, and `make cli-status`.
+`which -a potpie`, `make cli-status`, and `make cli-install` for repo-local
+reinstalls (UI build + daemon stop + editable install).
 
 ```bash
 uv tool list
 which -a potpie
 head -n 1 "$(command -v potpie)"
 make cli-status
+make cli-install   # repo-local reinstall only
 potpie doctor
 potpie --json doctor
 ```
@@ -548,8 +550,19 @@ flowchart LR
 Local first run (OSS default — `falkordb_lite`, detached daemon, skills installed
 during setup):
 
+**Published package:**
+
 ```bash
-pip install potpie
+uv tool install potpie   # or: pip install potpie
+potpie setup --repo . --agent claude
+potpie status
+```
+
+**This repo (local development):** prefer `make cli-install` so the graph-explorer
+UI is built and any old daemon is stopped before the editable install.
+
+```bash
+make cli-install
 potpie setup --repo . --agent claude
 potpie status
 

--- a/potpie/cli/README.md
+++ b/potpie/cli/README.md
@@ -42,6 +42,19 @@ The in-progress Graph V1.5 handover plan is
 Run `potpie --help` (or `python -m potpie.cli.main --help`) to list
 the live commands.
 
+## Local install (this repo)
+
+Repo-local development installs the CLI with:
+
+```bash
+make cli-install
+make cli-status
+```
+
+That path builds the graph-explorer UI, stops any old daemon, and installs the
+editable package. Published-package users should use `uv tool install potpie` or
+`pip install potpie` instead.
+
 ## Agent harness install
 
 `potpie skills install [<id>] --agent claude` materializes the packaged skill

--- a/potpie/cli/cli_install_status.py
+++ b/potpie/cli/cli_install_status.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
 import subprocess
 import sys
 from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
 from typing import Any
 
 CLI_TOOL_NAME = "potpie-context-engine"
 CLI_EXECUTABLE = "potpie"
+_UV_TOOL_NAMES = frozenset({"potpie", "potpie-context-engine", "context-engine"})
 
 _DIAGNOSTIC_COMMANDS = (
     "uv tool list",
@@ -21,6 +24,17 @@ _DIAGNOSTIC_COMMANDS = (
     "make cli-install",
 )
 
+_LOCAL_REINSTALL_HINT = (
+    "Check with `make cli-status` or `potpie doctor`. "
+    "Repo-local reinstall: `make cli-install` "
+    "(builds UI, stops old daemon) — not raw `uv tool install`."
+)
+_PUBLISHED_HINT = (
+    "Check with `make cli-status` or `potpie doctor`. "
+    "Published-package reinstall: `uv tool install potpie` "
+    "(or `pip install potpie`)."
+)
+
 
 def collect_cli_install_status() -> dict[str, Any]:
     """Return install facts for ``potpie doctor`` and ``make cli-status``."""
@@ -28,16 +42,29 @@ def collect_cli_install_status() -> dict[str, Any]:
     primary_path = paths_on_path[0] if paths_on_path else None
     python_interpreter = _python_from_script(primary_path) if primary_path else None
     python_version = _python_version(python_interpreter)
-    uv_tool = _uv_tool_status()
-    package_version = _installed_package_version()
-    via_uv_tool = bool(uv_tool.get("installed"))
-    hint = None
+
+    listed_uv = _uv_tool_list_status()
+    active_uv = _active_uv_tool_from_executable(primary_path)
+    via_uv_tool = bool(
+        active_uv and active_uv.get("tool_name") in _UV_TOOL_NAMES
+    )
+    editable = bool(via_uv_tool and _is_editable_uv_tool(active_uv["tool_root"]))
+
+    package_version = _package_version_via_interpreter(python_interpreter)
+    if package_version is None:
+        package_version = _installed_package_version()
+
+    uv_tool_version = None
     if via_uv_tool:
-        hint = (
-            "Check with `make cli-status` or `potpie doctor`. "
-            "Repo-local reinstall: `make cli-install` "
-            "(builds UI, stops old daemon) — not raw `uv tool install`."
-        )
+        uv_tool_version = listed_uv.get("versions", {}).get(
+            str(active_uv["tool_name"])
+        ) or listed_uv.get("version")
+
+    hint = None
+    if via_uv_tool and editable:
+        hint = _LOCAL_REINSTALL_HINT
+    elif via_uv_tool:
+        hint = _PUBLISHED_HINT
 
     return {
         "package_name": CLI_TOOL_NAME,
@@ -50,8 +77,13 @@ def collect_cli_install_status() -> dict[str, Any]:
         "runtime_python": sys.executable,
         "runtime_python_version": ".".join(map(str, sys.version_info[:3])),
         "uv_available": shutil.which("uv") is not None,
-        "uv_tool_installed": uv_tool.get("installed"),
-        "uv_tool_version": uv_tool.get("version"),
+        # True when *some* potpie-related uv tool is listed (may not back PATH).
+        "uv_tool_installed": bool(listed_uv.get("installed")),
+        "uv_tool_version": uv_tool_version or listed_uv.get("version"),
+        "uv_tool_name": active_uv.get("tool_name") if via_uv_tool else None,
+        "uv_tool_root": str(active_uv["tool_root"]) if via_uv_tool else None,
+        "editable": editable if via_uv_tool else None,
+        # Only when the active PATH executable is backed by a uv tools env.
         "install_method": "uv_tool" if via_uv_tool else None,
         "diagnostic_commands": list(_DIAGNOSTIC_COMMANDS),
         "hint": hint,
@@ -75,11 +107,15 @@ def cli_install_human(status: dict[str, Any]) -> str:
     parts = [f"cli: {pkg} {ver}", f"path={path}"]
     if via:
         parts.append(f"via={via}")
+    if status.get("editable"):
+        parts.append("editable=true")
     if py:
         parts.append(f"python={py}")
     line = " ".join(parts)
-    if via == "uv_tool":
+    if status.get("editable"):
         line += " | tip: make cli-status (local reinstall: make cli-install)"
+    elif via == "uv_tool":
+        line += " | tip: make cli-status (published: uv tool install potpie)"
     return line
 
 
@@ -88,6 +124,35 @@ def _installed_package_version() -> str | None:
         return version(CLI_TOOL_NAME)
     except PackageNotFoundError:
         return None
+
+
+def _package_version_via_interpreter(interpreter: str | None) -> str | None:
+    """Read package version from the active CLI interpreter, not this process."""
+    if not interpreter:
+        return None
+    for pkg in (CLI_TOOL_NAME, "potpie"):
+        try:
+            proc = subprocess.run(
+                [
+                    interpreter,
+                    "-c",
+                    (
+                        "from importlib.metadata import version; "
+                        f"print(version({pkg!r}))"
+                    ),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        if proc.returncode == 0:
+            value = (proc.stdout or "").strip()
+            if value:
+                return value
+    return None
 
 
 def _potpie_paths_on_path() -> list[str]:
@@ -138,9 +203,53 @@ def _python_version(interpreter: str | None) -> str | None:
     return match.group(1) if match else output or None
 
 
-def _uv_tool_status() -> dict[str, Any]:
+def _active_uv_tool_from_executable(script_path: str | None) -> dict[str, Any] | None:
+    """Return the uv tools env that backs ``script_path``, if any."""
+    if not script_path:
+        return None
+    try:
+        resolved = Path(script_path).resolve()
+    except OSError:
+        return None
+    parts = resolved.parts
+    for i in range(len(parts) - 2):
+        if parts[i] == "uv" and parts[i + 1] == "tools":
+            tool_name = parts[i + 2]
+            tool_root = Path(*parts[: i + 3])
+            return {"tool_name": tool_name, "tool_root": tool_root}
+    return None
+
+
+def _is_editable_uv_tool(tool_root: Path) -> bool:
+    receipt = tool_root / "uv-receipt.toml"
+    if receipt.is_file():
+        try:
+            text = receipt.read_text(encoding="utf-8")
+        except OSError:
+            text = ""
+        if re.search(r"\beditable\s*=", text):
+            return True
+    lib = tool_root / "lib"
+    if not lib.is_dir():
+        return False
+    try:
+        candidates = lib.rglob("direct_url.json")
+    except OSError:
+        return False
+    for path in candidates:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            continue
+        if isinstance(data, dict) and data.get("dir_info", {}).get("editable"):
+            return True
+    return False
+
+
+def _uv_tool_list_status() -> dict[str, Any]:
+    """Parse ``uv tool list`` for potpie-related tools (may not back PATH)."""
     if shutil.which("uv") is None:
-        return {"installed": False, "version": None}
+        return {"installed": False, "version": None, "versions": {}}
     try:
         proc = subprocess.run(
             ["uv", "tool", "list"],
@@ -150,14 +259,31 @@ def _uv_tool_status() -> dict[str, Any]:
             check=False,
         )
     except (OSError, subprocess.TimeoutExpired):
-        return {"installed": False, "version": None}
+        return {"installed": False, "version": None, "versions": {}}
     if proc.returncode != 0:
-        return {"installed": False, "version": None}
+        return {"installed": False, "version": None, "versions": {}}
+
+    versions: dict[str, str | None] = {}
     for line in proc.stdout.splitlines():
         stripped = line.strip()
         if not stripped or stripped.startswith("-"):
             continue
         name, _, ver = stripped.partition(" ")
-        if name == CLI_TOOL_NAME:
-            return {"installed": True, "version": ver.removeprefix("v") or None}
-    return {"installed": False, "version": None}
+        if name in _UV_TOOL_NAMES:
+            versions[name] = ver.removeprefix("v") or None
+
+    if not versions:
+        return {"installed": False, "version": None, "versions": {}}
+    # Prefer the modern tool name when reporting a single version.
+    preferred = (
+        versions.get("potpie")
+        or versions.get("potpie-context-engine")
+        or versions.get("context-engine")
+    )
+    return {"installed": True, "version": preferred, "versions": versions}
+
+
+def _uv_tool_status() -> dict[str, Any]:
+    """Backward-compatible helper used by older callers/tests."""
+    status = _uv_tool_list_status()
+    return {"installed": status["installed"], "version": status["version"]}

--- a/potpie/cli/cli_install_status.py
+++ b/potpie/cli/cli_install_status.py
@@ -18,6 +18,7 @@ _DIAGNOSTIC_COMMANDS = (
     "which -a potpie",
     'head -n 1 "$(command -v potpie)"',
     "make cli-status",
+    "make cli-install",
 )
 
 
@@ -29,6 +30,14 @@ def collect_cli_install_status() -> dict[str, Any]:
     python_version = _python_version(python_interpreter)
     uv_tool = _uv_tool_status()
     package_version = _installed_package_version()
+    via_uv_tool = bool(uv_tool.get("installed"))
+    hint = None
+    if via_uv_tool:
+        hint = (
+            "Check with `make cli-status` or `potpie doctor`. "
+            "Repo-local reinstall: `make cli-install` "
+            "(builds UI, stops old daemon) — not raw `uv tool install`."
+        )
 
     return {
         "package_name": CLI_TOOL_NAME,
@@ -43,13 +52,14 @@ def collect_cli_install_status() -> dict[str, Any]:
         "uv_available": shutil.which("uv") is not None,
         "uv_tool_installed": uv_tool.get("installed"),
         "uv_tool_version": uv_tool.get("version"),
-        "install_method": "uv_tool" if uv_tool.get("installed") else None,
+        "install_method": "uv_tool" if via_uv_tool else None,
         "diagnostic_commands": list(_DIAGNOSTIC_COMMANDS),
+        "hint": hint,
         "pip_show_note": (
             "Do not use `python -m pip show potpie-context-engine` for local dev "
             "installs: `python` may be absent from PATH and the package lives in "
             "the uv tool environment. Prefer `uv tool list`, `which -a potpie`, "
-            "and `make cli-status`."
+            "`make cli-status`, and `make cli-install` for repo-local reinstalls."
         ),
     }
 
@@ -67,7 +77,10 @@ def cli_install_human(status: dict[str, Any]) -> str:
         parts.append(f"via={via}")
     if py:
         parts.append(f"python={py}")
-    return " ".join(parts)
+    line = " ".join(parts)
+    if via == "uv_tool":
+        line += " | tip: make cli-status (local reinstall: make cli-install)"
+    return line
 
 
 def _installed_package_version() -> str | None:

--- a/potpie/cli/cli_install_status.py
+++ b/potpie/cli/cli_install_status.py
@@ -45,9 +45,7 @@ def collect_cli_install_status() -> dict[str, Any]:
 
     listed_uv = _uv_tool_list_status()
     active_uv = _active_uv_tool_from_executable(primary_path)
-    via_uv_tool = bool(
-        active_uv and active_uv.get("tool_name") in _UV_TOOL_NAMES
-    )
+    via_uv_tool = bool(active_uv and active_uv.get("tool_name") in _UV_TOOL_NAMES)
     editable = bool(via_uv_tool and _is_editable_uv_tool(active_uv["tool_root"]))
 
     package_version = _package_version_via_interpreter(python_interpreter)

--- a/potpie/cli/cli_install_status.py
+++ b/potpie/cli/cli_install_status.py
@@ -46,7 +46,10 @@ def collect_cli_install_status() -> dict[str, Any]:
     listed_uv = _uv_tool_list_status()
     active_uv = _active_uv_tool_from_executable(primary_path)
     via_uv_tool = bool(active_uv and active_uv.get("tool_name") in _UV_TOOL_NAMES)
-    editable = bool(via_uv_tool and _is_editable_uv_tool(active_uv["tool_root"]))
+    editable = bool(
+        via_uv_tool
+        and _is_editable_uv_tool(active_uv["tool_root"], str(active_uv["tool_name"]))
+    )
 
     package_version = _package_version_via_interpreter(python_interpreter)
     if package_version is None:
@@ -218,29 +221,124 @@ def _active_uv_tool_from_executable(script_path: str | None) -> dict[str, Any] |
     return None
 
 
-def _is_editable_uv_tool(tool_root: Path) -> bool:
+def _package_names_for_tool(tool_name: str) -> frozenset[str]:
+    """Distribution / requirement names that identify the tool package itself."""
+    return frozenset(
+        {
+            tool_name,
+            tool_name.replace("-", "_"),
+            tool_name.replace("_", "-"),
+        }
+    )
+
+
+def _is_editable_uv_tool(tool_root: Path, tool_name: str) -> bool:
+    """Return True only when *this* tool package is an editable install."""
+    package_names = _package_names_for_tool(tool_name)
     receipt = tool_root / "uv-receipt.toml"
     if receipt.is_file():
         try:
             text = receipt.read_text(encoding="utf-8")
         except OSError:
             text = ""
-        if re.search(r"\beditable\s*=", text):
+        receipt_editable = _receipt_tool_editable(text, package_names)
+        if receipt_editable is not None:
+            return receipt_editable
+
+    return _direct_url_tool_editable(tool_root, package_names)
+
+
+def _receipt_tool_editable(text: str, package_names: frozenset[str]) -> bool | None:
+    """Parse uv-receipt.toml for the matching tool requirement's editable flag.
+
+    Returns True/False when the tool requirement is found, else None.
+    """
+    requirements: list[Any] = []
+    try:
+        import tomllib
+
+        data = tomllib.loads(text)
+        tool = data.get("tool")
+        if isinstance(tool, dict):
+            raw = tool.get("requirements")
+            if isinstance(raw, list):
+                requirements = raw
+        if not requirements:
+            raw = data.get("requirements")
+            if isinstance(raw, list):
+                requirements = raw
+    except Exception:
+        requirements = []
+
+    if requirements:
+        for req in requirements:
+            if not isinstance(req, dict):
+                continue
+            name = str(req.get("name") or "").strip()
+            if name not in package_names:
+                continue
+            return bool(req.get("editable"))
+        return None
+
+    # Fallback: only treat editable as True when it appears on the matching req.
+    for name in package_names:
+        if re.search(
+            rf'\{{\s*name\s*=\s*"{re.escape(name)}"\s*,[^{{}}]*\beditable\s*=',
+            text,
+        ):
             return True
+        if re.search(rf'\{{\s*name\s*=\s*"{re.escape(name)}"', text):
+            return False
+    return None
+
+
+def _direct_url_tool_editable(tool_root: Path, package_names: frozenset[str]) -> bool:
+    """Check direct_url.json only under this tool's own dist-info directories."""
     lib = tool_root / "lib"
     if not lib.is_dir():
         return False
+
     try:
-        candidates = lib.rglob("direct_url.json")
+        site_package_paths = lib.rglob("site-packages")
     except OSError:
         return False
-    for path in candidates:
+
+    site_packages: list[Path] = []
+    try:
+        for path in site_package_paths:
+            try:
+                if path.is_dir():
+                    site_packages.append(path)
+            except OSError:
+                continue
+    except OSError:
+        # OSError can also arise while the rglob generator walks the tree.
+        return False
+
+    for site in site_packages:
         try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            children = list(site.iterdir())
+        except OSError:
             continue
-        if isinstance(data, dict) and data.get("dir_info", {}).get("editable"):
-            return True
+        for child in children:
+            if not child.name.endswith(".dist-info") or not child.is_dir():
+                continue
+            base = child.name[: -len(".dist-info")]
+            if not any(
+                base.startswith(f"{pkg}-")
+                or base.startswith(f"{pkg.replace('-', '_')}-")
+                for pkg in package_names
+            ):
+                continue
+            direct_url = child / "direct_url.json"
+            try:
+                if not direct_url.is_file():
+                    continue
+                data = json.loads(direct_url.read_text(encoding="utf-8"))
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+                continue
+            if isinstance(data, dict) and data.get("dir_info", {}).get("editable"):
+                return True
     return False
 
 

--- a/potpie/cli/templates/agent_bundle/.agents/skills/potpie-cli/SKILL.md
+++ b/potpie/cli/templates/agent_bundle/.agents/skills/potpie-cli/SKILL.md
@@ -11,6 +11,18 @@ ordinary project-memory context, prefer the relevant use-case skill first.
 
 ## Setup And Scope
 
+For **repo-local** CLI install/reinstall from this checkout, use:
+
+```bash
+make cli-install    # UI build + stop old daemon + editable install
+make cli-status
+potpie doctor
+```
+
+Do not use raw `uv tool install --editable …` or `pip install` for day-to-day
+local reinstalls. Reserve `uv tool install potpie` / `pip install potpie` for
+the **published** package.
+
 ```bash
 potpie doctor
 potpie --json doctor
@@ -79,7 +91,8 @@ deterministic local code scans as the agent ingestion path.
 Do not use scanner-driven graph updates.
 
 For CLI failures, stay in this skill: run `potpie doctor`, `make cli-status`, or
-`uv tool list` for install facts. Do not use `python -m pip show
+`uv tool list` for install facts. For repo-local reinstall use `make cli-install`
+(not raw `uv tool install`). Do not use `python -m pip show
 potpie-context-engine` for local uv-tool installs. Inspect JSON output when
 useful, check API URL/key config, confirm pot scope, and verify source
 registration before changing project code.

--- a/tests/unit/test_cli_install_status.py
+++ b/tests/unit/test_cli_install_status.py
@@ -57,7 +57,11 @@ def test_collect_cli_install_status_from_uv_tool(
     assert status["python_version"] == "3.12.12"
     assert "uv tool list" in status["diagnostic_commands"]
     assert "make cli-status" in status["diagnostic_commands"]
+    assert "make cli-install" in status["diagnostic_commands"]
+    assert status["hint"] is not None
+    assert "make cli-install" in status["hint"]
     assert "pip show" in status["pip_show_note"]
+    assert "make cli-install" in cis.cli_install_human(status)
 
 
 def test_cli_install_human_when_missing_from_path() -> None:
@@ -112,3 +116,35 @@ def test_doctor_includes_cli_install(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result.exit_code == 0, result.stdout
     assert "cli: potpie-context-engine 0.1.0" in result.stdout
     assert "via=uv_tool" in result.stdout
+    assert "make cli-status" in result.stdout
+    assert "make cli-install" in result.stdout
+
+
+def test_cli_install_human_uv_tool_includes_reinstall_hint() -> None:
+    human = cis.cli_install_human(
+        {
+            "on_path": True,
+            "package_name": "potpie-context-engine",
+            "package_version": "0.1.0",
+            "primary_path": "/Users/me/.local/bin/potpie",
+            "install_method": "uv_tool",
+            "python_version": "3.12.12",
+        }
+    )
+    assert "via=uv_tool" in human
+    assert "make cli-status" in human
+    assert "make cli-install" in human
+
+
+def test_collect_cli_install_status_omits_hint_without_uv_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cis.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(cis, "_potpie_paths_on_path", lambda: [])
+    monkeypatch.setattr(cis, "_installed_package_version", lambda: None)
+
+    status = cis.collect_cli_install_status()
+
+    assert status["uv_tool_installed"] is False
+    assert status["hint"] is None
+    assert "make cli-install" in status["diagnostic_commands"]

--- a/tests/unit/test_cli_install_status.py
+++ b/tests/unit/test_cli_install_status.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -17,26 +18,108 @@ pytestmark = pytest.mark.unit
 runner = CliRunner()
 
 
+def _fake_uv_tool_env(
+    tmp_path: Path,
+    *,
+    tool_name: str = "potpie",
+    editable: bool = True,
+) -> tuple[Path, Path]:
+    """Create ``…/uv/tools/<tool>/bin/potpie`` (+ optional editable markers)."""
+    tool_root = tmp_path / "uv" / "tools" / tool_name
+    bin_dir = tool_root / "bin"
+    bin_dir.mkdir(parents=True)
+    script = bin_dir / "potpie"
+    python = bin_dir / "python"
+    python.write_text("#!/bin/sh\n", encoding="utf-8")
+    script.write_text(f"#!{python}\n", encoding="utf-8")
+    script.chmod(0o755)
+    python.chmod(0o755)
+
+    if editable:
+        (tool_root / "uv-receipt.toml").write_text(
+            'requirements = [{ name = "potpie", editable = "/repo/potpie" }]\n',
+            encoding="utf-8",
+        )
+        dist = (
+            tool_root
+            / "lib"
+            / "python3.12"
+            / "site-packages"
+            / "potpie-2.0.0.dist-info"
+        )
+        dist.mkdir(parents=True)
+        (dist / "direct_url.json").write_text(
+            json.dumps(
+                {
+                    "url": "file:///repo/potpie",
+                    "dir_info": {"editable": True},
+                }
+            ),
+            encoding="utf-8",
+        )
+    return tool_root, script
+
+
 def test_collect_cli_install_status_from_uv_tool(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    _tool_root, script = _fake_uv_tool_env(tmp_path, editable=True)
+    link = tmp_path / "bin" / "potpie"
+    link.parent.mkdir(parents=True)
+    link.symlink_to(script)
+
     monkeypatch.setattr(
         cis.shutil, "which", lambda name: "/usr/bin/uv" if name == "uv" else None
     )
+    monkeypatch.setattr(cis, "_potpie_paths_on_path", lambda: [str(link)])
+    monkeypatch.setattr(cis, "_python_version", lambda _path: "3.12.12")
+    monkeypatch.setattr(cis, "_package_version_via_interpreter", lambda _path: "0.1.0")
+    monkeypatch.setattr(cis, "_installed_package_version", lambda: "0.1.0")
     monkeypatch.setattr(
-        cis,
-        "_potpie_paths_on_path",
-        lambda: ["/Users/me/.local/bin/potpie"],
-    )
-    monkeypatch.setattr(
-        cis,
-        "_python_from_script",
-        lambda _path: (
-            "/Users/me/.local/share/uv/tools/potpie-context-engine/bin/python3"
+        cis.subprocess,
+        "run",
+        lambda *args, **kwargs: MagicMock(
+            returncode=0,
+            stdout="potpie v0.1.0\n- potpie\n",
+            stderr="",
         ),
     )
+
+    status = cis.collect_cli_install_status()
+
+    assert status["on_path"] is True
+    assert status["primary_path"] == str(link)
+    assert status["uv_tool_installed"] is True
+    assert status["install_method"] == "uv_tool"
+    assert status["editable"] is True
+    assert status["uv_tool_name"] == "potpie"
+    assert status["python_version"] == "3.12.12"
+    assert "uv tool list" in status["diagnostic_commands"]
+    assert "make cli-status" in status["diagnostic_commands"]
+    assert "make cli-install" in status["diagnostic_commands"]
+    assert status["hint"] is not None
+    assert "make cli-install" in status["hint"]
+    assert "pip show" in status["pip_show_note"]
+    assert "make cli-install" in cis.cli_install_human(status)
+    assert "editable=true" in cis.cli_install_human(status)
+
+
+def test_collect_skips_uv_tool_when_path_executable_is_not_uv_backed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """uv tool list can show potpie while PATH points at a different binary."""
+    other = tmp_path / "elsewhere" / "bin" / "potpie"
+    other.parent.mkdir(parents=True)
+    other.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    other.chmod(0o755)
+
+    monkeypatch.setattr(
+        cis.shutil, "which", lambda name: "/usr/bin/uv" if name == "uv" else None
+    )
+    monkeypatch.setattr(cis, "_potpie_paths_on_path", lambda: [str(other)])
     monkeypatch.setattr(cis, "_python_version", lambda _path: "3.12.12")
-    monkeypatch.setattr(cis, "_installed_package_version", lambda: "0.1.0")
+    monkeypatch.setattr(cis, "_package_version_via_interpreter", lambda _path: "9.9.9")
+    monkeypatch.setattr(cis, "_installed_package_version", lambda: "9.9.9")
     monkeypatch.setattr(
         cis.subprocess,
         "run",
@@ -49,19 +132,51 @@ def test_collect_cli_install_status_from_uv_tool(
 
     status = cis.collect_cli_install_status()
 
-    assert status["on_path"] is True
-    assert status["primary_path"] == "/Users/me/.local/bin/potpie"
-    assert status["uv_tool_installed"] is True
-    assert status["uv_tool_version"] == "0.1.0"
+    assert status["uv_tool_installed"] is True  # listed, but not active
+    assert status["install_method"] is None
+    assert status["editable"] is None
+    assert status["hint"] is None
+    human = cis.cli_install_human(status)
+    assert "via=uv_tool" not in human
+    assert "local reinstall: make cli-install" not in human
+    assert "published: uv tool install potpie" not in human
+
+
+def test_published_uv_tool_hint_omits_make_cli_install(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _tool_root, script = _fake_uv_tool_env(tmp_path, editable=False)
+    link = tmp_path / "bin" / "potpie"
+    link.parent.mkdir(parents=True)
+    link.symlink_to(script)
+
+    monkeypatch.setattr(
+        cis.shutil, "which", lambda name: "/usr/bin/uv" if name == "uv" else None
+    )
+    monkeypatch.setattr(cis, "_potpie_paths_on_path", lambda: [str(link)])
+    monkeypatch.setattr(cis, "_python_version", lambda _path: "3.12.12")
+    monkeypatch.setattr(cis, "_package_version_via_interpreter", lambda _path: "2.0.0")
+    monkeypatch.setattr(
+        cis.subprocess,
+        "run",
+        lambda *args, **kwargs: MagicMock(
+            returncode=0,
+            stdout="potpie v2.0.0\n- potpie\n",
+            stderr="",
+        ),
+    )
+
+    status = cis.collect_cli_install_status()
+
     assert status["install_method"] == "uv_tool"
-    assert status["python_version"] == "3.12.12"
-    assert "uv tool list" in status["diagnostic_commands"]
-    assert "make cli-status" in status["diagnostic_commands"]
-    assert "make cli-install" in status["diagnostic_commands"]
+    assert status["editable"] is False
     assert status["hint"] is not None
-    assert "make cli-install" in status["hint"]
-    assert "pip show" in status["pip_show_note"]
-    assert "make cli-install" in cis.cli_install_human(status)
+    assert "uv tool install potpie" in status["hint"]
+    assert "make cli-install" not in status["hint"]
+    human = cis.cli_install_human(status)
+    assert "via=uv_tool" in human
+    assert "published: uv tool install potpie" in human
+    assert "local reinstall: make cli-install" not in human
 
 
 def test_cli_install_human_when_missing_from_path() -> None:
@@ -102,6 +217,7 @@ def test_doctor_includes_cli_install(monkeypatch: pytest.MonkeyPatch) -> None:
             "primary_path": "/Users/me/.local/bin/potpie",
             "python_version": "3.12.12",
             "install_method": "uv_tool",
+            "editable": True,
         },
     )
 
@@ -114,10 +230,11 @@ def test_doctor_includes_cli_install(monkeypatch: pytest.MonkeyPatch) -> None:
 
     result = runner.invoke(cli_main.app, ["doctor"])
     assert result.exit_code == 0, result.stdout
-    assert "cli: potpie-context-engine 0.1.0" in result.stdout
-    assert "via=uv_tool" in result.stdout
-    assert "make cli-status" in result.stdout
-    assert "make cli-install" in result.stdout
+    human = " ".join(result.stdout.split())
+    assert "cli: potpie-context-engine 0.1.0" in human
+    assert "via=uv_tool" in human
+    assert "make cli-status" in human
+    assert "make cli-install" in human
 
 
 def test_cli_install_human_uv_tool_includes_reinstall_hint() -> None:
@@ -128,6 +245,7 @@ def test_cli_install_human_uv_tool_includes_reinstall_hint() -> None:
             "package_version": "0.1.0",
             "primary_path": "/Users/me/.local/bin/potpie",
             "install_method": "uv_tool",
+            "editable": True,
             "python_version": "3.12.12",
         }
     )

--- a/tests/unit/test_cli_install_status.py
+++ b/tests/unit/test_cli_install_status.py
@@ -57,6 +57,11 @@ def _fake_uv_tool_env(
             ),
             encoding="utf-8",
         )
+    else:
+        (tool_root / "uv-receipt.toml").write_text(
+            'requirements = [{ name = "potpie" }]\n',
+            encoding="utf-8",
+        )
     return tool_root, script
 
 
@@ -140,6 +145,72 @@ def test_collect_skips_uv_tool_when_path_executable_is_not_uv_backed(
     assert "via=uv_tool" not in human
     assert "local reinstall: make cli-install" not in human
     assert "published: uv tool install potpie" not in human
+
+
+def test_sibling_editable_dependency_does_not_mark_tool_editable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Editable sibling deps must not make the potpie tool look editable."""
+    tool_root, script = _fake_uv_tool_env(tmp_path, editable=False)
+    (tool_root / "uv-receipt.toml").write_text(
+        "\n".join(
+            [
+                "requirements = [",
+                '  { name = "potpie" },',
+                '  { name = "helper-lib", editable = "/repo/helper" },',
+                "]",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    site = tool_root / "lib" / "python3.12" / "site-packages"
+    sibling = site / "helper_lib-1.0.0.dist-info"
+    sibling.mkdir(parents=True)
+    (sibling / "direct_url.json").write_text(
+        json.dumps(
+            {
+                "url": "file:///repo/helper",
+                "dir_info": {"editable": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+    # Non-editable potpie dist-info (no editable flag).
+    potpie_dist = site / "potpie-2.0.0.dist-info"
+    potpie_dist.mkdir(parents=True)
+    (potpie_dist / "direct_url.json").write_text(
+        json.dumps({"url": "https://pypi.org/simple/potpie/"}),
+        encoding="utf-8",
+    )
+
+    link = tmp_path / "bin" / "potpie"
+    link.parent.mkdir(parents=True)
+    link.symlink_to(script)
+
+    monkeypatch.setattr(
+        cis.shutil, "which", lambda name: "/usr/bin/uv" if name == "uv" else None
+    )
+    monkeypatch.setattr(cis, "_potpie_paths_on_path", lambda: [str(link)])
+    monkeypatch.setattr(cis, "_python_version", lambda _path: "3.12.12")
+    monkeypatch.setattr(cis, "_package_version_via_interpreter", lambda _path: "2.0.0")
+    monkeypatch.setattr(
+        cis.subprocess,
+        "run",
+        lambda *args, **kwargs: MagicMock(
+            returncode=0,
+            stdout="potpie v2.0.0\n- potpie\n",
+            stderr="",
+        ),
+    )
+
+    status = cis.collect_cli_install_status()
+
+    assert status["install_method"] == "uv_tool"
+    assert status["editable"] is False
+    assert status["hint"] is not None
+    assert "make cli-install" not in status["hint"]
+    assert "uv tool install potpie" in status["hint"]
 
 
 def test_published_uv_tool_hint_omits_make_cli_install(


### PR DESCRIPTION
Closes #1027 
## Summary
- Point repo-local reinstall at `make cli-install` (UI build + daemon stop + editable install)
- Keep `uv tool install potpie` / `pip install potpie` for published package use only
- Add uv-tool `doctor` / `cli-status` hint so agents don’t fall back to raw `uv tool` / `pip show`

## Test plan
- [ ] Docs/skills show `make cli-install` for local checkout vs PyPI install for published
- [ ] `potpie doctor` shows tip with `make cli-status` / `make cli-install` when via uv-tool
- [ ] `pytest tests/unit/test_cli_install_status.py`