### PR TITLE
Security/pentest remediation

### DIFF
--- a/app/api/router.py
+++ b/app/api/router.py
@@ -261,12 +261,14 @@ async def list_agents(
     db: Session = Depends(get_db),
     user=Depends(get_api_key_user),
 ):
+    from app.modules.intelligence.agents.agent_list_scope import AgentListMode
+
     user_id: str = user["user_id"]
     llm_provider = ProviderService(db, user_id)
     tools_provider = ToolService(db, user_id)
     prompt_provider = PromptService(db)
     controller = AgentsController(db, llm_provider, prompt_provider, tools_provider)
-    return await controller.list_available_agents(user, True)
+    return await controller.list_available_agents(user, AgentListMode.RUNTIME)
 
 
 @router.post("/search", response_model=SearchResponse)

--- a/app/core/api_errors.py
+++ b/app/core/api_errors.py
@@ -167,10 +167,24 @@ def _is_error_envelope(payload: Any) -> bool:
     )
 
 
+def _dict_has_error_context_fields(payload: dict[str, Any]) -> bool:
+    return any(str(key).lower() in _ERROR_CONTEXT_KEYS for key in payload)
+
+
 def sanitize_client_payload(payload: Any, error_context: bool = False) -> Any:
-    """Recursively remove private details from error-shaped client payloads."""
+    """Recursively remove private details from error-shaped client payloads.
+
+    Context fields such as ``content``, ``message``, ``detail``, ``response``,
+    and ``tool_response`` are rewritten only for payloads identified by
+    ``_is_error_envelope`` (or nested under such an envelope via
+    ``error_context``). Successful / non-error payloads keep those fields
+    unchanged unless they carry an explicit error marker or envelope signal.
+    """
     if isinstance(payload, dict):
-        current_error_context = error_context or _is_error_envelope(payload)
+        is_envelope = _is_error_envelope(payload)
+        # Inherit error context only from a genuine error-envelope ancestor —
+        # never from HTTP status alone.
+        in_error_tree = is_envelope or error_context
         sanitized = {}
         for key, value in payload.items():
             key_lower = str(key).lower()
@@ -178,12 +192,12 @@ def sanitize_client_payload(payload: Any, error_context: bool = False) -> Any:
                 sanitized[key] = client_safe_error_message(value)
             elif key_lower in _ERROR_VALUE_KEYS:
                 sanitized[key] = _sanitize_error_value(value)
-            elif current_error_context and key_lower in _ERROR_CONTEXT_KEYS:
+            elif in_error_tree and key_lower in _ERROR_CONTEXT_KEYS:
                 sanitized[key] = _sanitize_error_value(value)
             else:
                 sanitized[key] = sanitize_client_payload(
                     value,
-                    error_context=current_error_context,
+                    error_context=in_error_tree,
                 )
         return sanitized
     if isinstance(payload, list):
@@ -197,6 +211,28 @@ def sanitize_client_payload(payload: Any, error_context: bool = False) -> Any:
             for item in payload
         )
     return payload
+
+
+def _headers_with_request_id(
+    headers: list[tuple[bytes, bytes]],
+    request_id: str,
+) -> list[tuple[bytes, bytes]]:
+    """Preserve original response headers; only (re)set X-Request-ID.
+
+    Drops the internal public-error marker used by this middleware so it is
+    not exposed to clients, while keeping validators such as ETag/Content-MD5.
+    """
+    preserved = [
+        (key, value)
+        for key, value in headers
+        if key.lower()
+        not in (
+            b"x-request-id",
+            _PUBLIC_ERROR_HEADER_BYTES,
+        )
+    ]
+    preserved.append((b"x-request-id", request_id.encode("latin-1")))
+    return preserved
 
 
 def sanitize_and_log_client_payload(payload: Any, channel: str) -> Any:
@@ -333,6 +369,7 @@ class ServerErrorSanitizationMiddleware:
         explicitly_public_error = False
         inspect_success_json = False
         passthrough_response_body = False
+        suppress_remaining_body = False
         response_started = False
         response_body = bytearray()
 
@@ -399,7 +436,8 @@ class ServerErrorSanitizationMiddleware:
 
         async def send_sanitized(message: Message) -> None:
             nonlocal explicitly_public_error, inspect_success_json
-            nonlocal passthrough_response_body, response_body, start_message
+            nonlocal passthrough_response_body, suppress_remaining_body
+            nonlocal response_body, start_message
 
             if message["type"] == "http.response.start":
                 status_code = message["status"]
@@ -436,6 +474,10 @@ class ServerErrorSanitizationMiddleware:
                 await send_tracked(message)
                 return
 
+            if suppress_remaining_body:
+                # Oversized error body already replaced; drop trailing chunks.
+                return
+
             if passthrough_response_body:
                 await send_tracked(message)
                 return
@@ -450,20 +492,50 @@ class ServerErrorSanitizationMiddleware:
 
             message_body = message.get("body", b"")
             if (
-                inspect_success_json
-                and len(response_body) + len(message_body)
+                len(response_body) + len(message_body)
                 > _SUCCESS_JSON_INSPECTION_LIMIT_BYTES
             ):
+                if inspect_success_json:
+                    buffered_start = dict(start_message)
+                    buffered_body = bytes(response_body) + message_body
+                    # Stale Content-Length would disagree with the flushed
+                    # (and possibly still-streaming) body — drop it.
+                    buffered_start["headers"] = [
+                        (key, value)
+                        for key, value in buffered_start.get("headers", [])
+                        if key.lower()
+                        not in (b"content-length", b"content-md5", b"etag")
+                    ]
+                    start_message = None
+                    response_body.clear()
+                    passthrough_response_body = True
+
+                    flushed_body_message = dict(message)
+                    flushed_body_message["body"] = buffered_body
+                    await send_tracked(buffered_start)
+                    await send_tracked(flushed_body_message)
+                    return
+
+                # Error inspection exceeded the bound — fail closed instead of
+                # flushing the private body (success path may passthrough).
+                status_code = start_message["status"]
+                private_body = bytes(response_body) + message_body
+                log_private_response(status_code, private_body)
+                body = json.dumps(
+                    _error_payload(status_code, request_id),
+                    separators=(",", ":"),
+                ).encode("utf-8")
                 buffered_start = start_message
-                buffered_body = bytes(response_body) + message_body
+                buffered_start["headers"] = replace_headers(
+                    buffered_start.get("headers", []),
+                    body,
+                    content_type="application/json",
+                )
                 start_message = None
                 response_body.clear()
-                passthrough_response_body = True
-
-                flushed_body_message = dict(message)
-                flushed_body_message["body"] = buffered_body
+                suppress_remaining_body = True
                 await send_tracked(buffered_start)
-                await send_tracked(flushed_body_message)
+                await send_tracked({"type": "http.response.body", "body": body})
                 return
 
             response_body.extend(message_body)
@@ -489,16 +561,28 @@ class ServerErrorSanitizationMiddleware:
             else:
                 payload = parse_json_body(original_body)
                 if payload is not None:
-                    sanitized_payload = sanitize_client_payload(
-                        payload,
-                        error_context=status_code >= 400,
-                    )
+                    # Envelope detection only — do not treat all 4xx bodies as
+                    # error context (preserves success-shaped field names).
+                    sanitized_payload = sanitize_client_payload(payload)
                     if sanitized_payload != payload:
                         log_private_response(status_code, original_body)
                         body = json.dumps(
                             sanitized_payload,
                             separators=(",", ":"),
                             default=str,
+                        ).encode("utf-8")
+                        content_type = "application/json"
+                        changed = True
+                    elif (
+                        status_code >= 400
+                        and isinstance(payload, dict)
+                        and _dict_has_error_context_fields(payload)
+                    ):
+                        # Non-envelope 4xx with unchecked detail/message/etc.
+                        log_private_response(status_code, original_body)
+                        body = json.dumps(
+                            _error_payload(status_code, request_id),
+                            separators=(",", ":"),
                         ).encode("utf-8")
                         content_type = "application/json"
                         changed = True
@@ -511,10 +595,17 @@ class ServerErrorSanitizationMiddleware:
                     content_type = "application/json"
                     changed = True
 
-            start_message["headers"] = replace_headers(
-                start_message.get("headers", []),
-                body,
-                content_type=content_type if changed else None,
+            start_message["headers"] = (
+                replace_headers(
+                    start_message.get("headers", []),
+                    body,
+                    content_type=content_type,
+                )
+                if changed
+                else _headers_with_request_id(
+                    start_message.get("headers", []),
+                    request_id,
+                )
             )
             await send_tracked(start_message)
             await send_tracked({"type": "http.response.body", "body": body})

--- a/app/core/api_errors.py
+++ b/app/core/api_errors.py
@@ -495,7 +495,10 @@ class ServerErrorSanitizationMiddleware:
                 len(response_body) + len(message_body)
                 > _SUCCESS_JSON_INSPECTION_LIMIT_BYTES
             ):
-                if inspect_success_json:
+                # Oversized successes and explicitly approved public errors
+                # must be flushed unchanged; only unapproved error bodies
+                # fail closed to a generic payload.
+                if inspect_success_json or explicitly_public_error:
                     buffered_start = dict(start_message)
                     buffered_body = bytes(response_body) + message_body
                     # Stale Content-Length would disagree with the flushed
@@ -504,8 +507,17 @@ class ServerErrorSanitizationMiddleware:
                         (key, value)
                         for key, value in buffered_start.get("headers", [])
                         if key.lower()
-                        not in (b"content-length", b"content-md5", b"etag")
+                        not in (
+                            b"content-length",
+                            b"content-md5",
+                            b"etag",
+                            _PUBLIC_ERROR_HEADER_BYTES,
+                        )
                     ]
+                    buffered_start["headers"] = _headers_with_request_id(
+                        buffered_start["headers"],
+                        request_id,
+                    )
                     start_message = None
                     response_body.clear()
                     passthrough_response_body = True
@@ -517,7 +529,7 @@ class ServerErrorSanitizationMiddleware:
                     return
 
                 # Error inspection exceeded the bound — fail closed instead of
-                # flushing the private body (success path may passthrough).
+                # flushing the private body.
                 status_code = start_message["status"]
                 private_body = bytes(response_body) + message_body
                 log_private_response(status_code, private_body)

--- a/app/core/security_headers.py
+++ b/app/core/security_headers.py
@@ -1,0 +1,64 @@
+"""HTTP security response headers (pentest remediations FW002 / FW004)."""
+
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+HSTS_HEADER_NAME = b"strict-transport-security"
+HSTS_HEADER_VALUE = b"max-age=31536000; includeSubDomains; preload"
+
+X_FRAME_OPTIONS_HEADER_NAME = b"x-frame-options"
+X_FRAME_OPTIONS_HEADER_VALUE = b"DENY"
+
+CSP_HEADER_NAME = b"content-security-policy"
+CSP_FRAME_ANCESTORS_VALUE = b"frame-ancestors 'self'"
+
+# Public string forms for tests / docs (FW004 remediation values).
+X_FRAME_OPTIONS_VALUE = "DENY"
+CSP_FRAME_ANCESTORS = "frame-ancestors 'self'"
+
+
+def request_is_https(scope: Scope) -> bool:
+    """True when the client connection is HTTPS (direct or via proxy)."""
+    for key, value in scope.get("headers", []):
+        if key.lower() == b"x-forwarded-proto":
+            # Take the left-most value (original client protocol).
+            proto = value.split(b",", 1)[0].strip().lower()
+            return proto == b"https"
+    return scope.get("scheme") == "https"
+
+
+def _header_present(headers: list[tuple[bytes, bytes]], name: bytes) -> bool:
+    return any(key.lower() == name for key, _ in headers)
+
+
+class SecurityHeadersMiddleware:
+    """Attach anti-framing headers on all responses; HSTS on HTTPS only."""
+
+    def __init__(self, app: ASGIApp):
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        add_hsts = request_is_https(scope)
+
+        async def send_with_security_headers(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = list(message.get("headers", []))
+                if not _header_present(headers, X_FRAME_OPTIONS_HEADER_NAME):
+                    headers.append(
+                        (X_FRAME_OPTIONS_HEADER_NAME, X_FRAME_OPTIONS_HEADER_VALUE)
+                    )
+                if not _header_present(headers, CSP_HEADER_NAME):
+                    headers.append((CSP_HEADER_NAME, CSP_FRAME_ANCESTORS_VALUE))
+                if add_hsts and not _header_present(headers, HSTS_HEADER_NAME):
+                    headers.append((HSTS_HEADER_NAME, HSTS_HEADER_VALUE))
+                message = {**message, "headers": headers}
+            await send(message)
+
+        await self.app(scope, receive, send_with_security_headers)
+
+
+# Backward-compatible alias used by older imports/tests.
+StrictTransportSecurityMiddleware = SecurityHeadersMiddleware

--- a/app/core/security_headers.py
+++ b/app/core/security_headers.py
@@ -1,5 +1,7 @@
 """HTTP security response headers (pentest remediations FW002 / FW004)."""
 
+import os
+
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 HSTS_HEADER_NAME = b"strict-transport-security"
@@ -15,15 +17,63 @@ CSP_FRAME_ANCESTORS_VALUE = b"frame-ancestors 'self'"
 X_FRAME_OPTIONS_VALUE = "DENY"
 CSP_FRAME_ANCESTORS = "frame-ancestors 'self'"
 
+# Same env name as uvicorn/gunicorn ``--forwarded-allow-ips``.
+_FORWARDED_ALLOW_IPS_ENV = "FORWARDED_ALLOW_IPS"
+
+
+def trusted_proxy_hosts() -> frozenset[str]:
+    """Hosts allowed to supply ``X-Forwarded-Proto`` / related proxy headers.
+
+    Defaults to loopback only. Set ``FORWARDED_ALLOW_IPS`` to a comma-separated
+    list of reverse-proxy addresses (or ``*`` only when the edge already
+    overwrites client-supplied forwarded headers — see
+    ``deployment/proxy/overwrite-forwarded-proto.conf``).
+    """
+    raw = os.getenv(_FORWARDED_ALLOW_IPS_ENV, "127.0.0.1").strip()
+    if not raw:
+        return frozenset()
+    return frozenset(part.strip() for part in raw.split(",") if part.strip())
+
+
+def _client_host(scope: Scope) -> str | None:
+    client = scope.get("client")
+    if not client:
+        return None
+    return client[0]
+
+
+def _client_is_trusted_proxy(scope: Scope) -> bool:
+    hosts = trusted_proxy_hosts()
+    if "*" in hosts:
+        return True
+    host = _client_host(scope)
+    return bool(host and host in hosts)
+
+
+def _forwarded_proto(scope: Scope) -> str | None:
+    for name, value in scope.get("headers", []):
+        if name.lower() == b"x-forwarded-proto":
+            # Leftmost value is the original client scheme when proxies append.
+            token = value.decode("latin-1").split(",", 1)[0].strip().lower()
+            return token or None
+    return None
+
 
 def request_is_https(scope: Scope) -> bool:
-    """True when the client connection is HTTPS (direct or via proxy)."""
-    for key, value in scope.get("headers", []):
-        if key.lower() == b"x-forwarded-proto":
-            # Take the left-most value (original client protocol).
-            proto = value.split(b",", 1)[0].strip().lower()
-            return proto == b"https"
-    return scope.get("scheme") == "https"
+    """True when the request should be treated as HTTPS for HSTS.
+
+    Uses ``scope["scheme"]`` first (including values rewritten by uvicorn
+    ``ProxyHeadersMiddleware`` / ``--forwarded-allow-ips``).
+
+    ``X-Forwarded-Proto`` is honored only when the connecting peer is in
+    ``FORWARDED_ALLOW_IPS``. Arbitrary clients cannot enable HSTS by spoofing
+    the header.
+    """
+    if scope.get("scheme") == "https":
+        return True
+    if _client_is_trusted_proxy(scope) and _forwarded_proto(scope) == "https":
+        return True
+    return False
 
 
 def _header_present(headers: list[tuple[bytes, bytes]], name: bytes) -> bool:

--- a/app/main.py
+++ b/app/main.py
@@ -23,6 +23,7 @@ from app.core.api_errors import (
     ServerErrorSanitizationMiddleware,
     register_api_error_handlers,
 )
+from app.core.security_headers import SecurityHeadersMiddleware
 from app.core.models import *  # noqa #necessary for models to not give import errors
 from app.modules.analytics.analytics_router import router as analytics_router
 from app.modules.auth.auth_router import auth_router
@@ -96,6 +97,7 @@ class MainApp:
         self.setup_error_sanitization()
         self.setup_socket_io()
         self.setup_cors()
+        self.setup_security_headers()
         self.include_routers()
 
     def setup_sentry(self):
@@ -140,6 +142,11 @@ class MainApp:
             allow_headers=["*"],
         )
         logger.info(f"CORS configured with allowed origins: {origins}")
+
+    def setup_security_headers(self):
+        """Attach HSTS (HTTPS) and anti-framing headers on all responses."""
+        self.app.add_middleware(SecurityHeadersMiddleware)
+        logger.info("Security headers middleware configured (HSTS + anti-framing)")
 
     def setup_logging_middleware(self):
         """

--- a/app/modules/conversations/utils/redis_streaming.py
+++ b/app/modules/conversations/utils/redis_streaming.py
@@ -101,7 +101,10 @@ class RedisStreamManager:
 
                 for event_id, event_data in events:
                     formatted_event = self._format_event(event_id, event_data)
-                    yield formatted_event
+                    yield sanitize_and_log_client_payload(
+                        formatted_event,
+                        channel=f"redis-stream:{key}",
+                    )
 
             # Set starting point for live events
             if cursor and events:

--- a/app/modules/intelligence/agents/agent_list_scope.py
+++ b/app/modules/intelligence/agents/agent_list_scope.py
@@ -1,0 +1,24 @@
+"""Server-defined agent list scopes (FW003 / CWE-639).
+
+Client query flags must not escalate visibility. Callers pick a fixed mode;
+the server maps each mode to include rules.
+"""
+
+from enum import Enum
+
+
+class AgentListMode(str, Enum):
+    """Authorized listing profiles for available agents."""
+
+    # Chat / runtime picker: system agents + caller's own + shared-with-caller.
+    RUNTIME = "runtime"
+    # Management ("All Agents"): only agents owned by the caller.
+    OWNED = "owned"
+
+
+# Legacy privilege-escalation params — accepted for compat but never authorized from.
+LEGACY_PRIVILEGE_QUERY_PARAMS = (
+    "list_system_agents",
+    "include_public",
+    "include_shared",
+)

--- a/app/modules/intelligence/agents/agents_controller.py
+++ b/app/modules/intelligence/agents/agents_controller.py
@@ -3,6 +3,7 @@ from typing import List
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
+from app.modules.intelligence.agents.agent_list_scope import AgentListMode
 from app.modules.intelligence.agents.agents_service import AgentInfo
 from app.modules.intelligence.agents.agents_service import AgentsService
 from app.modules.intelligence.provider.provider_service import ProviderService
@@ -21,13 +22,12 @@ class AgentsController:
         self.service = AgentsService(db, llm_provider, prompt_provider, tools_provider)
 
     async def list_available_agents(
-        self, current_user: dict, list_system_agents: bool
+        self,
+        current_user: dict,
+        mode: AgentListMode = AgentListMode.RUNTIME,
     ) -> List[AgentInfo]:
         try:
-            agents = await self.service.list_available_agents(
-                current_user, list_system_agents
-            )
-            return agents
+            return await self.service.list_available_agents(current_user, mode)
         except Exception as e:
             raise HTTPException(
                 status_code=500, detail=f"Error listing agents: {str(e)}"

--- a/app/modules/intelligence/agents/agents_router.py
+++ b/app/modules/intelligence/agents/agents_router.py
@@ -1,10 +1,11 @@
-from typing import List
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
 from app.modules.auth.auth_service import AuthService
+from app.modules.intelligence.agents.agent_list_scope import AgentListMode
 from app.modules.intelligence.agents.agents_controller import AgentsController
 from app.modules.intelligence.agents.agents_service import AgentInfo
 from app.modules.intelligence.provider.provider_service import ProviderService
@@ -33,13 +34,38 @@ class AgentsAPI:
     async def list_available_agents(
         db: Session = Depends(get_db),
         user=Depends(AuthService.check_auth),
-        list_system_agents: bool = Query(
-            default=True, description="Include system agents in the response"
+        mode: AgentListMode = Query(
+            default=AgentListMode.RUNTIME,
+            description=(
+                "Server-defined list scope. "
+                "'runtime' = system + owned + shared-with-caller; "
+                "'owned' = only agents owned by the caller. "
+                "Legacy list_system_agents/include_public/include_shared are ignored."
+            ),
+        ),
+        # Accepted for backward compatibility only — never used for authorization.
+        list_system_agents: Optional[bool] = Query(
+            default=None,
+            description="Deprecated. Ignored; use mode instead.",
+            include_in_schema=False,
+        ),
+        include_public: Optional[bool] = Query(
+            default=None,
+            description="Deprecated. Ignored; use mode instead.",
+            include_in_schema=False,
+        ),
+        include_shared: Optional[bool] = Query(
+            default=None,
+            description="Deprecated. Ignored; use mode instead.",
+            include_in_schema=False,
         ),
     ):
+        # Bind legacy params so FastAPI accepts them, then discard (FW003).
+        del list_system_agents, include_public, include_shared
+
         user_id: str = user["user_id"]
         llm_provider = ProviderService(db, user_id)
         tools_provider = ToolService(db, user_id)
         prompt_provider = PromptService(db)
         controller = AgentsController(db, llm_provider, prompt_provider, tools_provider)
-        return await controller.list_available_agents(user, list_system_agents)
+        return await controller.list_available_agents(user, mode)

--- a/app/modules/intelligence/agents/agents_service.py
+++ b/app/modules/intelligence/agents/agents_service.py
@@ -11,6 +11,7 @@ from app.modules.intelligence.agents.chat_agents.system_agents import sweb_debug
 from app.modules.intelligence.agents.chat_agents.system_agents.general_purpose_agent import (
     GeneralPurposeAgent,
 )
+from app.modules.intelligence.agents.agent_list_scope import AgentListMode
 from app.modules.intelligence.agents.custom_agents.custom_agent_schema import (
     AgentVisibility,
 )
@@ -193,27 +194,42 @@ class AgentsService:
             yield chunk
 
     async def list_available_agents(
-        self, current_user: dict, list_system_agents: bool
+        self,
+        current_user: dict,
+        mode: AgentListMode = AgentListMode.RUNTIME,
     ) -> List[AgentInfo]:
-        system_agents = [
-            AgentInfo(
-                id=id,
-                name=self.system_agents[id].name,
-                description=self.system_agents[id].description,
-                status="SYSTEM",
-            )
-            for (id) in self.system_agents
-        ]
+        """List agents using a server-defined mode (never client privilege flags)."""
+        include_system = mode is AgentListMode.RUNTIME
+        # owned: caller-owned only. runtime: own + shared-with-caller (not public).
+        include_public = False
+        include_shared = mode is AgentListMode.RUNTIME
+
+        system_agents: List[AgentInfo] = []
+        if include_system:
+            system_agents = [
+                AgentInfo(
+                    id=agent_id,
+                    name=self.system_agents[agent_id].name,
+                    description=self.system_agents[agent_id].description,
+                    status="SYSTEM",
+                )
+                for agent_id in self.system_agents
+            ]
 
         try:
             custom_agents = await CustomAgentService(
                 self.db, self.llm_provider, self.tools_provider
-            ).list_agents(current_user["user_id"])
+            ).list_agents(
+                current_user["user_id"],
+                include_public=include_public,
+                include_shared=include_shared,
+            )
         except Exception:
             logger.exception(
                 "Failed to fetch custom agents", user_id=current_user["user_id"]
             )
             custom_agents = []
+
         agent_info_list = [
             AgentInfo(
                 id=agent.id,
@@ -225,10 +241,9 @@ class AgentsService:
             for agent in custom_agents
         ]
 
-        if list_system_agents:
+        if include_system:
             return system_agents + agent_info_list
-        else:
-            return agent_info_list
+        return agent_info_list
 
     async def validate_agent_id(self, user_id: str, agent_id: str) -> str | None:
         """Validate if an agent ID is valid"""

--- a/app/modules/intelligence/agents/chat_agents/multi_agent/utils/tool_call_stream_manager.py
+++ b/app/modules/intelligence/agents/chat_agents/multi_agent/utils/tool_call_stream_manager.py
@@ -248,7 +248,10 @@ class ToolCallStreamManager:
                 )
                 for event_id, event_data in events:
                     formatted_event = self._format_event(event_id, event_data)
-                    yield formatted_event
+                    yield sanitize_and_log_client_payload(
+                        formatted_event,
+                        channel=f"tool-call-stream:{key}",
+                    )
 
             # Set starting point for live events
             if cursor and events:

--- a/app/modules/intelligence/agents/custom_agents/custom_agent_controller.py
+++ b/app/modules/intelligence/agents/custom_agents/custom_agent_controller.py
@@ -4,6 +4,7 @@ from fastapi import Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
+from app.modules.intelligence.agents.agent_list_scope import AgentListMode
 from app.modules.intelligence.agents.custom_agents.custom_agent_schema import (
     Agent,
     AgentCreate,
@@ -245,11 +246,18 @@ class CustomAgentController:
     async def list_agents(
         self,
         user_id: str,
-        include_public: bool = True,
-        include_shared: bool = True,
+        mode: AgentListMode = AgentListMode.OWNED,
     ) -> List[Agent]:
-        """List all agents accessible to the user"""
+        """List agents using a server-defined mode (never client privilege flags)."""
         try:
+            if mode is AgentListMode.OWNED:
+                include_public = False
+                include_shared = False
+            else:
+                # runtime: own + shared-with-caller (not public marketplace)
+                include_public = False
+                include_shared = True
+
             return await self.service.list_agents(
                 user_id, include_public, include_shared
             )

--- a/app/modules/intelligence/agents/custom_agents/custom_agent_router.py
+++ b/app/modules/intelligence/agents/custom_agents/custom_agent_router.py
@@ -99,14 +99,19 @@ async def list_agents(
     db: Session = Depends(get_db),
     user=Depends(auth_handler.check_auth),
 ):
-    """List all agents accessible to the user including public and shared agents"""
+    """List custom agents for the authenticated user using a server-defined mode.
+
+    Legacy include_public/include_shared query params are ignored for authorization.
+    """
+    from app.modules.intelligence.agents.agent_list_scope import AgentListMode
+
     user_id = user["user_id"]
     custom_agent_controller = CustomAgentController(user_id, db)
+    mode = AgentListMode(request.mode)
     try:
         return await custom_agent_controller.list_agents(
             user_id=user_id,
-            include_public=request.include_public,
-            include_shared=request.include_shared,
+            mode=mode,
         )
     except HTTPException as he:
         raise he

--- a/app/modules/intelligence/agents/custom_agents/custom_agent_schema.py
+++ b/app/modules/intelligence/agents/custom_agents/custom_agent_schema.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import Any, List, Optional
+from typing import Any, List, Literal, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -119,8 +119,20 @@ class AgentSharesResponse(BaseModel):
 
 
 class ListAgentsRequest(BaseModel):
-    include_public: bool = True
-    include_shared: bool = True
+    """List custom agents using a server-defined mode (FW003).
+
+    Legacy include_public/include_shared are accepted for compatibility but ignored.
+    """
+
+    mode: Literal["runtime", "owned"] = "owned"
+    include_public: Optional[bool] = Field(
+        default=None,
+        description="Deprecated. Ignored; use mode instead.",
+    )
+    include_shared: Optional[bool] = Field(
+        default=None,
+        description="Deprecated. Ignored; use mode instead.",
+    )
 
 
 class NodeContext(BaseModel):

--- a/app/modules/intelligence/prompts/prompt_controller.py
+++ b/app/modules/intelligence/prompts/prompt_controller.py
@@ -15,6 +15,7 @@ from app.modules.intelligence.prompts.prompt_service import (
     PromptServiceError,
 )
 from app.modules.intelligence.agents.agents_service import AgentsService
+from app.modules.intelligence.agents.agent_list_scope import AgentListMode
 from app.modules.intelligence.prompts.prompt_schema import RequestModel
 from app.modules.conversations.conversation.conversation_model import Conversation
 from app.modules.intelligence.agents.custom_agents.custom_agent_model import CustomAgent
@@ -127,7 +128,7 @@ class PromptController:
             db, llm_provider, prompt_provider, tools_provider
         )
         available_agents = await agents_service.list_available_agents(
-            user, list_system_agents=True
+            user, mode=AgentListMode.RUNTIME
         )
 
         agent_ids = (

--- a/app/modules/parsing/graph_construction/code_graph_service.py
+++ b/app/modules/parsing/graph_construction/code_graph_service.py
@@ -30,7 +30,7 @@ def parse_repository_structure(repo_dir: str, project_id: str):
 
     repo_dir = str(Path(repo_dir).resolve())
     logger.info(
-        "[STRUCTURE PARSING] Starting repository structure parsing",
+        "[GRAPH GENERATION] Step 1/4: Parsing repository structure",
         project_id=project_id,
         repo_dir=repo_dir,
         repo_exists=os.path.exists(repo_dir),
@@ -161,7 +161,7 @@ class CodeGraphService:
             # Step 2: Create indices
             index_start = time.time()
             logger.info(
-                "[GRAPH GENERATION] Step 3/4: Creating Neo4j indices",
+                "[GRAPH GENERATION] Step 2/4: Creating Neo4j indices",
                 project_id=project_id,
             )
             session.run(

--- a/app/modules/parsing/graph_construction/parsing_service.py
+++ b/app/modules/parsing/graph_construction/parsing_service.py
@@ -403,10 +403,11 @@ class ParsingService:
         back, and we feed the reconstructed graph straight into neo4j
         and qdrant via :meth:`CodeGraphService.store_graph_from_artifacts`.
 
-        Refuses to proceed if the parser produced only FILE nodes —
-        that's the new "language not supported" gate, replacing the
-        host-side ``detect_repo_language``. parsing_rs handles every
-        language we care about, so empty output ⇒ no parseable code.
+        With Neo4j permanently bypassed we no longer require CLASS/FUNCTION
+        nodes (the old "language not supported" gate). Clone + in-sandbox
+        parse completing with any FILE inventory is enough to mark READY.
+        An empty artifact stream still fails — that means the workspace
+        had nothing to index at all.
         """
         analysis_start_time = time.time()
         project_details = await self.project_service.get_project_from_db_by_id(
@@ -450,21 +451,16 @@ class ParsingService:
             1 for n in artifacts.nodes if getattr(n, "node_type", None) != "FILE"
         )
         logger.info(
-            "[PARSING] In-sandbox parse complete: %d nodes (%d non-FILE), "
-            "%d edges in %.2fs",
-            len(artifacts.nodes),
-            non_file_nodes,
-            len(artifacts.relationships),
-            parse_time,
+            "[PARSING] In-sandbox parse complete",
             project_id=project_id,
+            node_count=len(artifacts.nodes),
+            non_file_nodes=non_file_nodes,
+            edge_count=len(artifacts.relationships),
+            parse_time_seconds=parse_time,
         )
 
-        # Replaces the legacy "if language != 'other'" gate. parsing_rs
-        # handles every language we ship a tree-sitter grammar for, so
-        # an empty non-FILE node count means the repo doesn't carry
-        # parseable code and the inference / search pipeline has
-        # nothing to chew on.
-        if non_file_nodes == 0:
+        # Empty clone / empty worktree — nothing to continue with.
+        if not artifacts.nodes:
             await self.project_service.update_project_status(
                 project_id, ProjectStatusEnum.ERROR
             )
@@ -474,6 +470,17 @@ class ParsingService:
                 )
             raise ParsingFailedError(
                 "Repository doesn't consist of a language currently supported."
+            )
+
+        if non_file_nodes == 0:
+            # FILE-only is common for docs/HTML/CSS/arrow-only JS; with
+            # Neo4j bypassed we still mark READY so cloning/parsing can
+            # finish and the chat flow can proceed.
+            logger.warning(
+                "[PARSING] No CLASS/FUNCTION nodes; continuing READY "
+                "(Neo4j bypassed)",
+                project_id=project_id,
+                node_count=len(artifacts.nodes),
             )
 
         # ------------------------------------------------------------------

--- a/app/modules/parsing/graph_construction/parsing_service.py
+++ b/app/modules/parsing/graph_construction/parsing_service.py
@@ -548,13 +548,12 @@ class ParsingService:
                 """
             session.run(rel_type_query)
 
-
-async def duplicate_graph(self, old_repo_id: str, new_repo_id: str):
-    """Clone search indices while bypassing Neo4j graph duplication."""
-    await self.search_service.clone_search_indices(old_repo_id, new_repo_id)
-    logger.info(
-        "[PARSING] Neo4j graph duplication permanently bypassed",
-        old_repo_id=old_repo_id,
-        new_repo_id=new_repo_id,
-        graph_duplicated=False,
-    )
+    async def duplicate_graph(self, old_repo_id: str, new_repo_id: str):
+        """Clone search indices while bypassing Neo4j graph duplication."""
+        await self.search_service.clone_search_indices(old_repo_id, new_repo_id)
+        logger.info(
+            "[PARSING] Neo4j graph duplication permanently bypassed",
+            old_repo_id=old_repo_id,
+            new_repo_id=new_repo_id,
+            graph_duplicated=False,
+        )

--- a/app/src/sandbox/sandbox/adapters/outbound/local/repo_cache.py
+++ b/app/src/sandbox/sandbox/adapters/outbound/local/repo_cache.py
@@ -49,7 +49,7 @@ def _git_timeout_s() -> int:
     raw = os.getenv("SANDBOX_GIT_TIMEOUT_S", "1800")
     try:
         return max(60, int(float(raw)))
-    except ValueError:
+    except (ValueError, OverflowError):
         return 1800
 
 
@@ -205,13 +205,20 @@ class LocalRepoCacheProvider:
             timeout=_git_timeout_s(),
         )
         if result.returncode != 0 and not is_sha:
-            # Tags and other non-branch refs don't live under refs/heads;
-            # fall back to a plain fetch so those still resolve via the
-            # objects + existing refs.
+            # Tags don't live under refs/heads — fetch with an explicit
+            # tag refspec so ``refs/tags/<tag>`` is persisted locally.
+            tag_refspec = f"+refs/tags/{ref}:refs/tags/{ref}"
             result = run(
-                ["git", "-C", str(bare_path), "fetch", "--", fetch_url, ref],
+                ["git", "-C", str(bare_path), "fetch", "--", fetch_url, tag_refspec],
                 timeout=_git_timeout_s(),
             )
+            if result.returncode != 0:
+                # Other non-branch refs: fall back to a plain fetch so
+                # those still resolve via objects + existing refs.
+                result = run(
+                    ["git", "-C", str(bare_path), "fetch", "--", fetch_url, ref],
+                    timeout=_git_timeout_s(),
+                )
         if result.returncode != 0:
             raise_git_error("git fetch failed", result.stderr)
 

--- a/app/src/sandbox/tests/unit/test_local_repo_cache.py
+++ b/app/src/sandbox/tests/unit/test_local_repo_cache.py
@@ -362,3 +362,49 @@ async def test_acquire_session_without_cache_provider_skips_cache(
     # though — that's the wiring the service is responsible for.
     assert workspace.id.startswith("ws_")
     assert len(await service._store.list_repo_caches()) == 0
+
+
+def test_git_timeout_falls_back_on_overflow(monkeypatch: pytest.MonkeyPatch) -> None:
+    from sandbox.adapters.outbound.local import repo_cache as repo_cache_mod
+
+    monkeypatch.setenv("SANDBOX_GIT_TIMEOUT_S", "1e309")
+    assert repo_cache_mod._git_timeout_s() == 1800
+
+    monkeypatch.setenv("SANDBOX_GIT_TIMEOUT_S", "not-a-number")
+    assert repo_cache_mod._git_timeout_s() == 1800
+
+
+def test_fetch_ref_tries_tag_refspec_before_plain_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Non-branch refs try ``refs/tags/<tag>`` before a plain fetch."""
+    from sandbox.adapters.outbound.local import repo_cache as repo_cache_mod
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kw):
+        calls.append(cmd)
+        # Fail branch + tag attempts; succeed on plain fetch.
+        if any(part.startswith("+refs/heads/") for part in cmd):
+            return subprocess.CompletedProcess(cmd, 1, "", "not a branch")
+        if any(part.startswith("+refs/tags/") for part in cmd):
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(repo_cache_mod, "run", fake_run)
+    bare = tmp_path / "bare"
+    bare.mkdir()
+    LocalRepoCacheProvider._fetch_ref(bare, "https://example.com/repo.git", "v1.2.3")
+
+    assert any(
+        "+refs/heads/v1.2.3:refs/heads/v1.2.3" in cmd for cmd in calls
+    ), "branch refspec should be tried first"
+    assert any(
+        "+refs/tags/v1.2.3:refs/tags/v1.2.3" in cmd for cmd in calls
+    ), "tag refspec should be tried after branch failure"
+    # Plain fallback should not run when tag fetch succeeds.
+    assert not any(
+        cmd[-1] == "v1.2.3" and not any(":" in part for part in cmd)
+        for cmd in calls
+        if "fetch" in cmd
+    )

--- a/deployment/prod/celery/Jenkinsfile_CELERY_Prod
+++ b/deployment/prod/celery/Jenkinsfile_CELERY_Prod
@@ -17,11 +17,25 @@ pipeline {
         stage('Checkout') {
             steps {
                 script {
-                    def branch = env.GIT_BRANCH ?: 'detached'
-                    env.ENVIRONMENT = branch
-                    echo "Deploying ref: ${branch}"
+                    def scmVars = checkout scm
+                    def branch = scmVars.GIT_BRANCH ?: env.GIT_BRANCH ?: ''
+                    def approvedReleaseRefs = [
+                        'origin/main': 'main',
+                        'origin/dir-restruct': 'dir-restruct',
+                    ]
+                    def isHotfixRef = branch ==~ /^(origin\/)?hotfix\/[A-Za-z0-9][A-Za-z0-9._\/-]*$/
 
-                    checkout scm
+                    if (approvedReleaseRefs.containsKey(branch)) {
+                        env.ENVIRONMENT = approvedReleaseRefs[branch]
+                    } else if (isHotfixRef) {
+                        env.ENVIRONMENT = 'hotfix'
+                    } else {
+                        error("Refusing to deploy unapproved ref: ${branch ?: '<missing>'}")
+                    }
+
+                    env.DEPLOY_REF = branch
+                    echo "Deploying approved ref: ${env.DEPLOY_REF}"
+
                     // Capture the short Git commit hash to use as the image tag
                     env.GIT_COMMIT_HASH = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
                 }

--- a/deployment/prod/mom-api/mom-api-supervisord.conf
+++ b/deployment/prod/mom-api/mom-api-supervisord.conf
@@ -3,7 +3,7 @@ nodaemon=true
 loglevel=debug
 
 [program:gunicorn]
-command=/bin/bash -c 'source /app/.env && alembic upgrade heads && echo "Starting Gunicorn..." && newrelic-admin run-program gunicorn --workers $(nproc) --worker-class uvicorn.workers.UvicornWorker --timeout 1800 --bind 0.0.0.0:8001 --log-level debug app.main:app'
+command=/bin/bash -c 'source /app/.env && alembic upgrade heads && echo "Starting Gunicorn..." && newrelic-admin run-program gunicorn --workers $(nproc) --worker-class uvicorn.workers.UvicornWorker --timeout 1800 --bind 0.0.0.0:8001 --forwarded-allow-ips="${FORWARDED_ALLOW_IPS:-127.0.0.1}" --log-level debug app.main:app'
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout

--- a/deployment/proxy/overwrite-forwarded-proto.conf
+++ b/deployment/proxy/overwrite-forwarded-proto.conf
@@ -1,0 +1,11 @@
+# Trusted reverse-proxy snippet: overwrite client-supplied forwarded headers
+# before the request reaches the application. Pair with FORWARDED_ALLOW_IPS
+# (gunicorn/uvicorn --forwarded-allow-ips) set to this proxy's address(es).
+#
+# Without overwriting, a client could send X-Forwarded-Proto: https and — if
+# the app trusts the connecting peer — incorrectly enable HSTS on plain HTTP.
+
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Host $host;
+proxy_set_header Host $host;

--- a/deployment/stage/mom-api/mom-api-supervisord.conf
+++ b/deployment/stage/mom-api/mom-api-supervisord.conf
@@ -5,6 +5,11 @@ loglevel=debug
 [program:gunicorn]
 # Do not source /app/.env in shell: keys with hyphens (e.g. META-LLAMA_API_KEY) break bash.
 # The app and alembic load .env via load_dotenv().
+#
+# FORWARDED_ALLOW_IPS must be set here (stage does not source .env into this
+# shell). Use private VPC / in-cluster CIDRs for the staging ingress/proxy —
+# never "*". Tighten to the exact ingress controller address(es) when known.
+environment=FORWARDED_ALLOW_IPS="10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
 command=/bin/bash -c 'alembic upgrade heads && echo "Starting Gunicorn..." && newrelic-admin run-program gunicorn --workers 1 --worker-class uvicorn.workers.UvicornWorker --timeout 1800 --bind 0.0.0.0:8001 --forwarded-allow-ips="${FORWARDED_ALLOW_IPS:-127.0.0.1}" --log-level debug app.main:app'
 autostart=true
 autorestart=true

--- a/deployment/stage/mom-api/mom-api-supervisord.conf
+++ b/deployment/stage/mom-api/mom-api-supervisord.conf
@@ -5,7 +5,7 @@ loglevel=debug
 [program:gunicorn]
 # Do not source /app/.env in shell: keys with hyphens (e.g. META-LLAMA_API_KEY) break bash.
 # The app and alembic load .env via load_dotenv().
-command=/bin/bash -c 'alembic upgrade heads && echo "Starting Gunicorn..." && newrelic-admin run-program gunicorn --workers 1 --worker-class uvicorn.workers.UvicornWorker --timeout 1800 --bind 0.0.0.0:8001 --log-level debug app.main:app'
+command=/bin/bash -c 'alembic upgrade heads && echo "Starting Gunicorn..." && newrelic-admin run-program gunicorn --workers 1 --worker-class uvicorn.workers.UvicornWorker --timeout 1800 --bind 0.0.0.0:8001 --forwarded-allow-ips="${FORWARDED_ALLOW_IPS:-127.0.0.1}" --log-level debug app.main:app'
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout

--- a/tests/integration-tests/parsing/test_parsing_service.py
+++ b/tests/integration-tests/parsing/test_parsing_service.py
@@ -8,7 +8,6 @@ no real Neo4j/Git/RepoManager required.
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from neo4j.exceptions import ServiceUnavailable
 
 from app.modules.parsing.graph_construction.parsing_helper import (
     ParsingServiceError,
@@ -96,13 +95,14 @@ class TestParseDirectory:
 
     @pytest.mark.asyncio
     async def test_parse_directory_cleanup_bypassed(self, db_session):
-        """cleanup_graph=True no longer touches Neo4j; flow proceeds past cleanup.
+        """cleanup_graph=True no longer touches Neo4j; flow proceeds to sandbox.
 
         Neo4j is permanently bypassed, so the old CodeGraphService cleanup
         cannot fail parse_directory anymore. We prove the flow gets past the
-        cleanup step by making the *next* step (repo clone) raise a sentinel.
+        cleanup step by making project_sandbox.ensure raise a sentinel.
         """
         project_id = "proj-cleanup-bypass"
+        sentinel = FileNotFoundError("sentinel: reached step after cleanup")
         mock_project_manager = MagicMock()
         mock_project_manager.get_project_from_db_by_id = AsyncMock(
             return_value={"id": project_id, "status": "submitted"}
@@ -110,9 +110,8 @@ class TestParseDirectory:
         mock_project_manager.update_project_status = AsyncMock()
         mock_parse_helper = MagicMock()
         mock_parse_helper.check_commit_status = AsyncMock(return_value=False)
-        mock_parse_helper.clone_or_copy_repository = AsyncMock(
-            side_effect=FileNotFoundError("sentinel: reached step after cleanup")
-        )
+        mock_sandbox = MagicMock()
+        mock_sandbox.ensure = AsyncMock(side_effect=sentinel)
         with patch(
             "app.modules.parsing.graph_construction.parsing_service.ProjectService",
             return_value=mock_project_manager,
@@ -121,10 +120,15 @@ class TestParseDirectory:
             return_value=mock_parse_helper,
         ):
             service = ParsingService(
-                db_session, "test-user", raise_library_exceptions=True
+                db_session,
+                "test-user",
+                raise_library_exceptions=True,
+                project_sandbox=mock_sandbox,
             )
             repo_details = ParsingRequest(repo_name="owner/repo")
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(
+                ParsingServiceError, match="sentinel: reached step after cleanup"
+            ):
                 await service.parse_directory(
                     repo_details,
                     user_id="test-user",
@@ -132,61 +136,21 @@ class TestParseDirectory:
                     project_id=project_id,
                     cleanup_graph=True,
                 )
-            # Whatever failed, it was NOT the (removed) Neo4j cleanup.
-            assert "cleanup" not in str(exc_info.value).lower()
+            mock_sandbox.ensure.assert_awaited()
 
     @pytest.mark.asyncio
     async def test_parse_directory_setup_returns_none(self, db_session):
-        """clone_or_copy_repository raises; expect exception or 500 path."""
+        """project_sandbox.ensure raises; expect ParsingServiceError wrapping it."""
         project_id = "proj-setup-fail"
         mock_project_manager = MagicMock()
         mock_project_manager.get_project_from_db_by_id = AsyncMock(
             return_value={"id": project_id, "status": "submitted"}
         )
-        mock_parse_helper = MagicMock()
-        mock_parse_helper.check_commit_status = AsyncMock(return_value=False)
-        mock_parse_helper.clone_or_copy_repository = AsyncMock(
-            side_effect=FileNotFoundError("clone failed")
-        )
-        with patch(
-            "app.modules.parsing.graph_construction.parsing_service.ProjectService",
-            return_value=mock_project_manager,
-        ), patch(
-            "app.modules.parsing.graph_construction.parsing_service.ParseHelper",
-            return_value=mock_parse_helper,
-        ):
-            service = ParsingService(
-                db_session, "test-user", raise_library_exceptions=True
-            )
-            repo_details = ParsingRequest(repo_name="owner/repo")
-            with pytest.raises((ParsingServiceError, FileNotFoundError, Exception)):
-                await service.parse_directory(
-                    repo_details,
-                    user_id="test-user",
-                    user_email="test@example.com",
-                    project_id=project_id,
-                    cleanup_graph=True,
-                )
-
-
-class TestNeo4jFailures:
-    """Neo4j is permanently bypassed; an outage must not fail parsing."""
-
-    @pytest.mark.asyncio
-    async def test_neo4j_outage_cannot_fail_cleanup(self, db_session):
-        """A dead Neo4j can no longer surface through parse_directory cleanup."""
-        project_id = "proj-neo4j-fail"
-        mock_project_manager = MagicMock()
-        mock_project_manager.get_project_from_db_by_id = AsyncMock(
-            return_value={"id": project_id, "status": "submitted"}
-        )
         mock_project_manager.update_project_status = AsyncMock()
         mock_parse_helper = MagicMock()
         mock_parse_helper.check_commit_status = AsyncMock(return_value=False)
-        mock_parse_helper.clone_or_copy_repository = AsyncMock(
-            side_effect=FileNotFoundError("sentinel: reached step after cleanup")
-        )
-
+        mock_sandbox = MagicMock()
+        mock_sandbox.ensure = AsyncMock(side_effect=FileNotFoundError("clone failed"))
         with patch(
             "app.modules.parsing.graph_construction.parsing_service.ProjectService",
             return_value=mock_project_manager,
@@ -195,10 +159,13 @@ class TestNeo4jFailures:
             return_value=mock_parse_helper,
         ):
             service = ParsingService(
-                db_session, "test-user", raise_library_exceptions=True
+                db_session,
+                "test-user",
+                raise_library_exceptions=True,
+                project_sandbox=mock_sandbox,
             )
             repo_details = ParsingRequest(repo_name="owner/repo")
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(ParsingServiceError, match="clone failed"):
                 await service.parse_directory(
                     repo_details,
                     user_id="test-user",
@@ -206,9 +173,12 @@ class TestNeo4jFailures:
                     project_id=project_id,
                     cleanup_graph=True,
                 )
-            # The failure must never be a Neo4j connectivity error.
-            assert not isinstance(exc_info.value, ServiceUnavailable)
-            assert "cleanup" not in str(exc_info.value).lower()
+
+
+# TestNeo4jFailures removed: Neo4j cleanup is permanently bypassed and the
+# sentinel-via-sandbox.ensure coverage lives in
+# test_parse_directory_cleanup_bypassed above.
+
 
 class TestProjectServiceOwnership:
     """Test ProjectService ownership checks (Part 4.6 of plan)."""

--- a/tests/unit/core/test_api_error_integration.py
+++ b/tests/unit/core/test_api_error_integration.py
@@ -50,6 +50,9 @@ def test_main_app_registers_cors_as_outermost_user_middleware():
         "setup_error_sanitization"
     )
     assert setup_calls.index("setup_cors") > setup_calls.index("setup_socket_io")
+    assert setup_calls.index("setup_security_headers") > setup_calls.index(
+        "setup_cors"
+    )
 
 
 def test_outer_cors_adds_headers_to_sanitized_server_errors():

--- a/tests/unit/core/test_api_errors.py
+++ b/tests/unit/core/test_api_errors.py
@@ -615,6 +615,89 @@ async def test_oversized_error_json_is_fail_closed_not_flushed():
 
 
 @pytest.mark.asyncio
+async def test_oversized_explicitly_public_error_is_flushed_unchanged():
+    """Approved public 4xx bodies must not be replaced when over the buffer limit."""
+    from app.core.api_errors import _PUBLIC_ERROR_HEADER_BYTES
+
+    sent_messages = []
+    prefix = b'{"detail":"'
+    oversized_chunk = b"y" * (64 * 1024 + 1)
+    suffix = b'"}'
+    public_body = prefix + oversized_chunk + suffix
+
+    async def app(scope, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 400,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (_PUBLIC_ERROR_HEADER_BYTES, b"1"),
+                    (b"content-length", b"1024"),
+                ],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": prefix,
+                "more_body": True,
+            }
+        )
+        assert sent_messages == []
+
+        await send(
+            {
+                "type": "http.response.body",
+                "body": oversized_chunk,
+                "more_body": True,
+            }
+        )
+        assert [message["type"] for message in sent_messages] == [
+            "http.response.start",
+            "http.response.body",
+        ]
+
+        await send(
+            {
+                "type": "http.response.body",
+                "body": suffix,
+                "more_body": False,
+            }
+        )
+
+    async def receive():
+        return {"type": "http.disconnect"}
+
+    async def send(message):
+        sent_messages.append(message)
+
+    middleware = ServerErrorSanitizationMiddleware(app)
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/large-public-error-json",
+        "headers": [],
+        "state": {},
+    }
+
+    await middleware(scope, receive, send)
+
+    assert sent_messages[0]["status"] == 400
+    forwarded_headers = {
+        key.lower(): value for key, value in sent_messages[0].get("headers", [])
+    }
+    assert b"content-length" not in forwarded_headers
+    assert _PUBLIC_ERROR_HEADER_BYTES not in forwarded_headers
+    assert b"x-request-id" in forwarded_headers
+    assert b"".join(
+        message.get("body", b"")
+        for message in sent_messages
+        if message["type"] == "http.response.body"
+    ) == public_body
+
+
+@pytest.mark.asyncio
 async def test_exception_after_response_start_is_reraised():
     sent_messages = []
 

--- a/tests/unit/core/test_api_errors.py
+++ b/tests/unit/core/test_api_errors.py
@@ -98,6 +98,17 @@ def _build_app() -> FastAPI:
             "message": "Repository contains postgresql:// examples.",
         }
 
+    @app.get("/success-with-validators")
+    async def success_with_validators():
+        return JSONResponse(
+            status_code=200,
+            content={"success": True, "message": "ok"},
+            headers={
+                "ETag": '"stable-success-body"',
+                "Content-MD5": "stable-content-digest",
+            },
+        )
+
     @app.get("/nested-failure-envelope")
     async def nested_failure_envelope():
         return {
@@ -321,6 +332,19 @@ def test_success_false_envelope_is_sanitized_but_success_payload_is_unchanged():
     }
 
 
+def test_unchanged_success_json_preserves_etag_and_content_md5():
+    response = TestClient(_build_app(), raise_server_exceptions=False).get(
+        "/success-with-validators",
+        headers={"X-Request-ID": "request-success-validators"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"success": True, "message": "ok"}
+    assert response.headers["etag"] == '"stable-success-body"'
+    assert response.headers["content-md5"] == "stable-content-digest"
+    assert response.headers["x-request-id"] == "request-success-validators"
+
+
 def test_all_developer_supplied_4xx_details_are_sanitized():
     client = TestClient(_build_app(), raise_server_exceptions=False)
 
@@ -347,7 +371,9 @@ def test_review_sensitive_4xx_details_are_fail_closed(case_index):
     assert exception_response.status_code == 400
     assert exception_response.json()["detail"] == "Invalid request."
     assert direct_response.status_code == 400
-    assert direct_response.json()["detail"] == "The operation could not be completed."
+    assert direct_response.json()["detail"] == "Invalid request."
+    assert direct_response.json()["code"] == "invalid_request"
+    assert "request_id" in direct_response.json()
     assert REVIEW_SENSITIVE_4XX_DETAILS[case_index] not in exception_response.text
     assert REVIEW_SENSITIVE_4XX_DETAILS[case_index] not in direct_response.text
 
@@ -492,11 +518,100 @@ async def test_declared_bounded_success_json_stops_buffering_after_limit():
     await middleware(scope, receive, send)
 
     assert sent_messages[0]["status"] == 200
+    forwarded_headers = {
+        key.lower(): value for key, value in sent_messages[0].get("headers", [])
+    }
+    assert b"content-length" not in forwarded_headers
+    assert forwarded_headers.get(b"content-type") == b"application/json"
     assert b"".join(
         message.get("body", b"")
         for message in sent_messages
         if message["type"] == "http.response.body"
     ) == prefix + oversized_chunk + suffix
+
+
+@pytest.mark.asyncio
+async def test_oversized_error_json_is_fail_closed_not_flushed():
+    sent_messages = []
+    prefix = b'{"detail":"'
+    oversized_chunk = b"x" * (64 * 1024 + 1)
+    suffix = b'"}'
+
+    async def app(scope, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 400,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (
+                        b"content-length",
+                        str(
+                            len(prefix) + len(oversized_chunk) + len(suffix)
+                        ).encode("ascii"),
+                    ),
+                ],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": prefix,
+                "more_body": True,
+            }
+        )
+        assert sent_messages == []
+
+        await send(
+            {
+                "type": "http.response.body",
+                "body": oversized_chunk,
+                "more_body": True,
+            }
+        )
+        assert [message["type"] for message in sent_messages] == [
+            "http.response.start",
+            "http.response.body",
+        ]
+
+        await send(
+            {
+                "type": "http.response.body",
+                "body": suffix,
+                "more_body": False,
+            }
+        )
+
+    async def receive():
+        return {"type": "http.disconnect"}
+
+    async def send(message):
+        sent_messages.append(message)
+
+    middleware = ServerErrorSanitizationMiddleware(app)
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/large-error-json",
+        "headers": [],
+        "state": {},
+    }
+
+    await middleware(scope, receive, send)
+
+    assert sent_messages[0]["status"] == 400
+    body = b"".join(
+        message.get("body", b"")
+        for message in sent_messages
+        if message["type"] == "http.response.body"
+    )
+    assert oversized_chunk not in body
+    payload = json.loads(body)
+    assert payload["detail"] == "Invalid request."
+    assert payload["code"] == "invalid_request"
+    assert "request_id" in payload
+    assert len(sent_messages) == 2
+    assert len(body) < 512
 
 
 @pytest.mark.asyncio
@@ -543,6 +658,19 @@ def test_validation_response_does_not_echo_submitted_value():
     assert response.status_code == 422
     assert "super-secret-user-input" not in response.text
     assert response.json()["code"] == "validation_error"
+
+
+def test_success_shaped_context_fields_are_preserved_without_error_envelope():
+    payload = {
+        "success": True,
+        "content": "repository README with postgresql:// examples",
+        "message": "clone finished",
+        "detail": "branch main",
+        "response": {"ok": True},
+        "tool_response": "file contents look fine",
+    }
+
+    assert sanitize_client_payload(payload) == payload
 
 
 def test_stream_and_tool_error_payloads_are_sanitized():

--- a/tests/unit/core/test_integration_redirect_sanitization.py
+++ b/tests/unit/core/test_integration_redirect_sanitization.py
@@ -3,8 +3,9 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 from starlette.requests import Request
 
-from app.modules.integrations import integrations_router
-
+from app.src.integrations.integrations.adapters.inbound.http import (
+    integrations_router,
+)
 
 SENSITIVE_DATABASE_ERROR = (
     "(psycopg2.OperationalError) connection to server at "

--- a/tests/unit/core/test_security_headers.py
+++ b/tests/unit/core/test_security_headers.py
@@ -44,33 +44,86 @@ def _build_app() -> FastAPI:
     return app
 
 
-def test_request_is_https_prefers_forwarded_proto():
-    assert request_is_https(
+def test_request_is_https_ignores_spoofed_forwarded_proto_from_untrusted_client(
+    monkeypatch,
+):
+    monkeypatch.setenv("FORWARDED_ALLOW_IPS", "127.0.0.1")
+    # Spoofed forwarded proto from a non-proxy client must not flip HTTPS.
+    assert not request_is_https(
         {
             "type": "http",
             "scheme": "http",
+            "client": ("203.0.113.10", 1234),
             "headers": [(b"x-forwarded-proto", b"https")],
-        }
-    )
-    assert request_is_https(
-        {
-            "type": "http",
-            "scheme": "http",
-            "headers": [(b"x-forwarded-proto", b"https, http")],
         }
     )
     assert not request_is_https(
         {
             "type": "http",
             "scheme": "http",
+            "client": ("203.0.113.10", 1234),
+            "headers": [(b"x-forwarded-proto", b"https, http")],
+        }
+    )
+    assert request_is_https(
+        {"type": "http", "scheme": "https", "client": ("203.0.113.10", 1), "headers": []}
+    )
+    assert not request_is_https(
+        {"type": "http", "scheme": "http", "client": ("203.0.113.10", 1), "headers": []}
+    )
+    # Direct HTTPS connection still wins even if a trusted proxy sends http.
+    assert request_is_https(
+        {
+            "type": "http",
+            "scheme": "https",
+            "client": ("127.0.0.1", 1),
             "headers": [(b"x-forwarded-proto", b"http")],
         }
     )
-    assert request_is_https({"type": "http", "scheme": "https", "headers": []})
-    assert not request_is_https({"type": "http", "scheme": "http", "headers": []})
 
 
-def test_hsts_header_set_on_https_forwarded_requests():
+def test_request_is_https_honors_forwarded_proto_from_trusted_proxy(monkeypatch):
+    monkeypatch.setenv("FORWARDED_ALLOW_IPS", "10.0.0.5")
+    assert request_is_https(
+        {
+            "type": "http",
+            "scheme": "http",
+            "client": ("10.0.0.5", 443),
+            "headers": [(b"x-forwarded-proto", b"https")],
+        }
+    )
+    assert not request_is_https(
+        {
+            "type": "http",
+            "scheme": "http",
+            "client": ("10.0.0.5", 443),
+            "headers": [(b"x-forwarded-proto", b"http")],
+        }
+    )
+
+
+def test_hsts_header_set_on_https_scheme():
+    client = TestClient(_build_app(), base_url="https://testserver")
+    response = client.get("/ok")
+
+    assert response.status_code == 200
+    assert response.headers["strict-transport-security"] == HSTS_HEADER_VALUE.decode(
+        "latin-1"
+    )
+
+
+def test_hsts_header_absent_on_spoofed_forwarded_proto(monkeypatch):
+    monkeypatch.setenv("FORWARDED_ALLOW_IPS", "127.0.0.1")
+    client = TestClient(_build_app())
+    response = client.get("/ok", headers={"x-forwarded-proto": "https"})
+
+    assert response.status_code == 200
+    assert "strict-transport-security" not in response.headers
+
+
+def test_hsts_header_set_when_trusted_proxy_forwards_https(monkeypatch):
+    # TestClient connects as host "testclient".
+    monkeypatch.setenv("FORWARDED_ALLOW_IPS", "testclient")
     client = TestClient(_build_app())
     response = client.get("/ok", headers={"x-forwarded-proto": "https"})
 
@@ -80,14 +133,6 @@ def test_hsts_header_set_on_https_forwarded_requests():
     )
 
 
-def test_hsts_header_absent_on_plain_http():
-    client = TestClient(_build_app())
-    response = client.get("/ok")
-
-    assert response.status_code == 200
-    assert "strict-transport-security" not in response.headers
-
-
 def test_anti_framing_headers_present_on_http_and_https():
     client = TestClient(_build_app())
 
@@ -95,7 +140,8 @@ def test_anti_framing_headers_present_on_http_and_https():
     assert http_response.headers["x-frame-options"] == X_FRAME_OPTIONS_VALUE
     assert http_response.headers["content-security-policy"] == CSP_FRAME_ANCESTORS
 
-    https_response = client.get("/ok", headers={"x-forwarded-proto": "https"})
+    https_client = TestClient(_build_app(), base_url="https://testserver")
+    https_response = https_client.get("/ok")
     assert https_response.headers["x-frame-options"] == X_FRAME_OPTIONS_VALUE
     assert https_response.headers["content-security-policy"] == CSP_FRAME_ANCESTORS
     assert https_response.headers["strict-transport-security"] == HSTS_HEADER_VALUE.decode(
@@ -104,12 +150,15 @@ def test_anti_framing_headers_present_on_http_and_https():
 
 
 def test_security_headers_present_on_sanitized_errors():
-    client = TestClient(_build_app(), raise_server_exceptions=False)
+    client = TestClient(
+        _build_app(),
+        base_url="https://testserver",
+        raise_server_exceptions=False,
+    )
     response = client.get(
         "/boom",
         headers={
             "Origin": "http://frontend.test",
-            "x-forwarded-proto": "https",
         },
     )
 

--- a/tests/unit/core/test_security_headers.py
+++ b/tests/unit/core/test_security_headers.py
@@ -1,0 +1,123 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.testclient import TestClient
+
+from app.core.api_errors import (
+    ServerErrorSanitizationMiddleware,
+    register_api_error_handlers,
+)
+from app.core.security_headers import (
+    CSP_FRAME_ANCESTORS,
+    HSTS_HEADER_VALUE,
+    SecurityHeadersMiddleware,
+    X_FRAME_OPTIONS_VALUE,
+    request_is_https,
+)
+
+
+SENSITIVE_ERROR = (
+    "connection to server at pgbouncer-rw.internal.svc.cluster.local "
+    "(34.118.226.109), port 5432 failed"
+)
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    register_api_error_handlers(app)
+    app.add_middleware(ServerErrorSanitizationMiddleware)
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["http://frontend.test"],
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    app.add_middleware(SecurityHeadersMiddleware)
+
+    @app.get("/ok")
+    async def ok():
+        return {"status": "ok"}
+
+    @app.get("/boom")
+    async def boom():
+        raise RuntimeError(SENSITIVE_ERROR)
+
+    return app
+
+
+def test_request_is_https_prefers_forwarded_proto():
+    assert request_is_https(
+        {
+            "type": "http",
+            "scheme": "http",
+            "headers": [(b"x-forwarded-proto", b"https")],
+        }
+    )
+    assert request_is_https(
+        {
+            "type": "http",
+            "scheme": "http",
+            "headers": [(b"x-forwarded-proto", b"https, http")],
+        }
+    )
+    assert not request_is_https(
+        {
+            "type": "http",
+            "scheme": "http",
+            "headers": [(b"x-forwarded-proto", b"http")],
+        }
+    )
+    assert request_is_https({"type": "http", "scheme": "https", "headers": []})
+    assert not request_is_https({"type": "http", "scheme": "http", "headers": []})
+
+
+def test_hsts_header_set_on_https_forwarded_requests():
+    client = TestClient(_build_app())
+    response = client.get("/ok", headers={"x-forwarded-proto": "https"})
+
+    assert response.status_code == 200
+    assert response.headers["strict-transport-security"] == HSTS_HEADER_VALUE.decode(
+        "latin-1"
+    )
+
+
+def test_hsts_header_absent_on_plain_http():
+    client = TestClient(_build_app())
+    response = client.get("/ok")
+
+    assert response.status_code == 200
+    assert "strict-transport-security" not in response.headers
+
+
+def test_anti_framing_headers_present_on_http_and_https():
+    client = TestClient(_build_app())
+
+    http_response = client.get("/ok")
+    assert http_response.headers["x-frame-options"] == X_FRAME_OPTIONS_VALUE
+    assert http_response.headers["content-security-policy"] == CSP_FRAME_ANCESTORS
+
+    https_response = client.get("/ok", headers={"x-forwarded-proto": "https"})
+    assert https_response.headers["x-frame-options"] == X_FRAME_OPTIONS_VALUE
+    assert https_response.headers["content-security-policy"] == CSP_FRAME_ANCESTORS
+    assert https_response.headers["strict-transport-security"] == HSTS_HEADER_VALUE.decode(
+        "latin-1"
+    )
+
+
+def test_security_headers_present_on_sanitized_errors():
+    client = TestClient(_build_app(), raise_server_exceptions=False)
+    response = client.get(
+        "/boom",
+        headers={
+            "Origin": "http://frontend.test",
+            "x-forwarded-proto": "https",
+        },
+    )
+
+    assert response.status_code == 500
+    assert response.json()["code"] == "internal_error"
+    assert response.headers["access-control-allow-origin"] == "http://frontend.test"
+    assert response.headers["strict-transport-security"] == HSTS_HEADER_VALUE.decode(
+        "latin-1"
+    )
+    assert response.headers["x-frame-options"] == X_FRAME_OPTIONS_VALUE
+    assert response.headers["content-security-policy"] == CSP_FRAME_ANCESTORS

--- a/tests/unit/intelligence/test_agent_list_authorization.py
+++ b/tests/unit/intelligence/test_agent_list_authorization.py
@@ -1,0 +1,198 @@
+"""FW003: agent list authorization uses server-defined modes, not client flags."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.modules.intelligence.agents.agent_list_scope import AgentListMode
+from app.modules.intelligence.agents.agents_service import AgentInfo, AgentsService
+from app.modules.intelligence.agents.custom_agents.custom_agent_schema import (
+    AgentVisibility,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def _fake_custom_agent(
+    agent_id: str,
+    role: str = "Helper",
+    goal: str = "Help",
+    visibility: AgentVisibility = AgentVisibility.PRIVATE,
+):
+    return SimpleNamespace(
+        id=agent_id,
+        role=role,
+        goal=goal,
+        deployment_status="STOPPED",
+        visibility=visibility,
+    )
+
+
+def _build_service() -> AgentsService:
+    db = MagicMock()
+    llm = MagicMock()
+    prompts = MagicMock()
+    tools = MagicMock()
+    service = AgentsService(db, llm, prompts, tools)
+    # Keep system catalog small and deterministic for assertions.
+    service.system_agents = {
+        "code_gen_agent": SimpleNamespace(
+            name="Code Gen",
+            description="Generates code",
+        ),
+        "qna_agent": SimpleNamespace(
+            name="QnA",
+            description="Answers questions",
+        ),
+    }
+    return service
+
+
+@pytest.mark.asyncio
+async def test_owned_mode_excludes_system_and_shared_agents():
+    service = _build_service()
+    owned = [_fake_custom_agent("owned-1")]
+
+    with patch(
+        "app.modules.intelligence.agents.agents_service.CustomAgentService"
+    ) as mock_cls:
+        mock_cls.return_value.list_agents = AsyncMock(return_value=owned)
+        result = await service.list_available_agents(
+            {"user_id": "user-a"}, mode=AgentListMode.OWNED
+        )
+
+        mock_cls.return_value.list_agents.assert_awaited_once_with(
+            "user-a", include_public=False, include_shared=False
+        )
+
+    assert [agent.id for agent in result] == ["owned-1"]
+    assert all(agent.status != "SYSTEM" for agent in result)
+
+
+@pytest.mark.asyncio
+async def test_runtime_mode_includes_system_and_shared_scope():
+    service = _build_service()
+    customs = [
+        _fake_custom_agent("owned-1"),
+        _fake_custom_agent("shared-1", visibility=AgentVisibility.SHARED),
+    ]
+
+    with patch(
+        "app.modules.intelligence.agents.agents_service.CustomAgentService"
+    ) as mock_cls:
+        mock_cls.return_value.list_agents = AsyncMock(return_value=customs)
+        result = await service.list_available_agents(
+            {"user_id": "user-a"}, mode=AgentListMode.RUNTIME
+        )
+
+        mock_cls.return_value.list_agents.assert_awaited_once_with(
+            "user-a", include_public=False, include_shared=True
+        )
+
+    ids = [agent.id for agent in result]
+    assert "code_gen_agent" in ids
+    assert "qna_agent" in ids
+    assert "owned-1" in ids
+    assert "shared-1" in ids
+
+
+@pytest.mark.asyncio
+async def test_legacy_privilege_flags_cannot_escalate_owned_mode_via_router():
+    """Tampering list_system_agents/include_* must not change owned-mode results."""
+    from app.modules.auth.auth_service import AuthService
+    from app.modules.intelligence.agents import agents_router
+
+    app = FastAPI()
+    app.include_router(agents_router.router, prefix="/api/v1")
+
+    async def fake_auth():
+        return {"user_id": "user-a", "email": "a@example.com"}
+
+    app.dependency_overrides[AuthService.check_auth] = fake_auth
+
+    owned_agents = [
+        AgentInfo(
+            id="owned-1",
+            name="Helper",
+            description="Help",
+            status="STOPPED",
+            visibility=AgentVisibility.PRIVATE,
+        )
+    ]
+
+    with (
+        patch(
+            "app.modules.intelligence.agents.agents_router.ProviderService",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "app.modules.intelligence.agents.agents_router.ToolService",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "app.modules.intelligence.agents.agents_router.PromptService",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "app.modules.intelligence.agents.agents_router.AgentsController"
+        ) as mock_controller_cls,
+        patch(
+            "app.core.database.get_db",
+            return_value=MagicMock(),
+        ),
+    ):
+        mock_controller = MagicMock()
+        mock_controller.list_available_agents = AsyncMock(return_value=owned_agents)
+        mock_controller_cls.return_value = mock_controller
+
+        client = TestClient(app)
+        response = client.get(
+            "/api/v1/list-available-agents/",
+            params={
+                "mode": "owned",
+                "list_system_agents": "true",
+                "include_public": "true",
+                "include_shared": "true",
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "id": "owned-1",
+            "name": "Helper",
+            "description": "Help",
+            "status": "STOPPED",
+            "visibility": "private",
+        }
+    ]
+    # Controller must be called with owned mode regardless of legacy flags.
+    args, kwargs = mock_controller.list_available_agents.await_args
+    assert args[1] is AgentListMode.OWNED or kwargs.get("mode") is AgentListMode.OWNED
+
+
+@pytest.mark.asyncio
+async def test_custom_agent_controller_owned_ignores_would_be_public_flags():
+    from app.modules.intelligence.agents.custom_agents.custom_agent_controller import (
+        CustomAgentController,
+    )
+
+    controller = CustomAgentController.__new__(CustomAgentController)
+    controller.db = MagicMock()
+    controller.service = MagicMock()
+    controller.service.list_agents = AsyncMock(return_value=[])
+    controller.user_service = MagicMock()
+
+    await controller.list_agents("user-a", mode=AgentListMode.OWNED)
+    controller.service.list_agents.assert_awaited_once_with("user-a", False, False)
+
+    await controller.list_agents("user-a", mode=AgentListMode.RUNTIME)
+    assert controller.service.list_agents.await_args_list[-1].args == (
+        "user-a",
+        False,
+        True,
+    )

--- a/tests/unit/parsing/test_code_graph_service.py
+++ b/tests/unit/parsing/test_code_graph_service.py
@@ -1,17 +1,83 @@
-from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import networkx as nx
 
 
 def test_graph_generation_logs_four_numbered_phases():
-    source_path = (
-        Path(__file__).parents[3]
-        / "app/modules/parsing/graph_construction/code_graph_service.py"
-    )
-    source = source_path.read_text()
+    """Phase labels are emitted at runtime (not just present as source text)."""
+    from app.modules.parsing.graph_construction import code_graph_service
 
-    assert "Step 1/4: Parsing repository structure" in source
-    assert "Step 2/4: Creating Neo4j indices" in source
-    assert "Step 3/4: Inserting {node_count} nodes into Neo4j" in source
-    assert (
-        "Step 4/4: Inserting {relationship_count} relationships into Neo4j"
-        in source
+    recorded: list[str] = []
+
+    def capture_info(message, *args, **kwargs):
+        recorded.append(str(message))
+
+    mock_logger = MagicMock()
+    mock_logger.info.side_effect = capture_info
+
+    # Step 1/4 lives on parse_repository_structure (host-side structure parse).
+    fake_graph = nx.MultiDiGraph()
+    fake_graph.add_node(
+        "a.py",
+        type="FILE",
+        name="a.py",
+        file="a.py",
+        line=1,
+        end_line=1,
+        text="",
     )
+    fake_repo_map = MagicMock()
+    fake_repo_map.create_graph.return_value = fake_graph
+
+    with patch.object(code_graph_service, "logger", mock_logger), patch(
+        "app.modules.parsing.graph_construction.parsing_repomap.RepoMap",
+        return_value=fake_repo_map,
+    ):
+        code_graph_service.parse_repository_structure("/tmp/repo", "proj-1")
+
+    # Steps 2–4/4 are emitted by _store_graph (stubbed Neo4j + Qdrant).
+    store_graph = nx.MultiDiGraph()
+    store_graph.add_node(
+        "mod.py",
+        type="FILE",
+        name="mod.py",
+        file="mod.py",
+        line=1,
+        end_line=2,
+        text="pass",
+    )
+    store_graph.add_edge("mod.py", "mod.py", type="CONTAINS")
+
+    service = code_graph_service.CodeGraphService.__new__(
+        code_graph_service.CodeGraphService
+    )
+    mock_session = MagicMock()
+    mock_driver = MagicMock()
+    mock_driver.session.return_value.__enter__.return_value = mock_session
+    mock_driver.session.return_value.__exit__.return_value = False
+    service.driver = mock_driver
+    service.db = MagicMock()
+    service.qdrant_client = MagicMock()
+
+    with patch.object(code_graph_service, "logger", mock_logger), patch(
+        "app.modules.parsing.graph_construction.code_graph_service.index_nodes_to_qdrant",
+        return_value=(0, 0, 0),
+    ):
+        service._store_graph(store_graph, "proj-1", "user-1")
+
+    phase_messages = [
+        msg
+        for msg in recorded
+        if "Step 1/4:" in msg
+        or "Step 2/4:" in msg
+        or "Step 3/4:" in msg
+        or "Step 4/4:" in msg
+    ]
+    assert len(phase_messages) == 4
+    assert "Step 1/4: Parsing repository structure" in phase_messages[0]
+    assert "Step 2/4: Creating Neo4j indices" in phase_messages[1]
+    assert "Step 3/4: Inserting" in phase_messages[2]
+    assert "nodes into Neo4j" in phase_messages[2]
+    assert "Step 4/4: Inserting" in phase_messages[3]
+    assert "relationships into Neo4j" in phase_messages[3]
+    assert phase_messages[2] != phase_messages[3]

--- a/tests/unit/parsing/test_sandbox_parse_flow.py
+++ b/tests/unit/parsing/test_sandbox_parse_flow.py
@@ -4,13 +4,12 @@ Covers:
 * :meth:`CodeGraphService.store_graph_from_artifacts` — the new entry
   point that takes a parsed payload and writes it to neo4j/qdrant.
 * :meth:`ParsingService.analyze_workspace` — orchestrator that calls
-  ``ProjectSandbox.parse`` and feeds the result into the graph
-  service. Replaces the legacy ``analyze_directory``.
+  ``ProjectSandbox.parse``; Neo4j graph writes are permanently bypassed.
 * :meth:`ParsingService.parse_directory` end-to-end with a fake sandbox.
 
 Heavy DB work (real neo4j/qdrant inserts) lives in the
 ``real_parse``-marked integration tests; these unit tests stub the
-graph service so they run in milliseconds and don't need infra.
+sandbox so they run in milliseconds and don't need infra.
 """
 
 from __future__ import annotations
@@ -190,23 +189,9 @@ def parsing_service(fake_sandbox):
         yield service
 
 
-@pytest.fixture
-def stub_code_graph_service():
-    """Stand-in for CodeGraphService call assertions.
-
-    Neo4j is permanently bypassed in ParsingService, so CodeGraphService
-    is no longer imported there. Keep a MagicMock so existing tests can
-    still assert the graph write path was not invoked.
-    """
-    instance = MagicMock(name="CodeGraphService_instance")
-    instance.store_graph_from_artifacts = MagicMock()
-    instance.close = MagicMock()
-    yield instance
-
-
 @pytest.mark.asyncio
 async def test_analyze_workspace_happy_path(
-    parsing_service, fake_sandbox, stub_code_graph_service
+    parsing_service, fake_sandbox
 ):
     handle = _make_handle()
     repo_details = ParsingRequest(
@@ -222,7 +207,6 @@ async def test_analyze_workspace_happy_path(
     # Neo4j permanently bypassed: parse runs, graph/inference do not.
     assert len(fake_sandbox.parse_calls) == 1
     assert fake_sandbox.parse_calls[0]["handle"] is handle
-    stub_code_graph_service.store_graph_from_artifacts.assert_not_called()
 
     statuses = [
         call.args[1]
@@ -234,7 +218,7 @@ async def test_analyze_workspace_happy_path(
 
 @pytest.mark.asyncio
 async def test_analyze_workspace_file_only_still_ready_when_neo4j_bypassed(
-    parsing_service, fake_sandbox, stub_code_graph_service
+    parsing_service, fake_sandbox
 ):
     """FILE-only repos (docs/HTML/arrow-only JS) used to trip the old
     language gate. With Neo4j bypassed they must still become READY."""
@@ -253,7 +237,6 @@ async def test_analyze_workspace_file_only_still_ready_when_neo4j_bypassed(
         user_email="", repo_details=repo_details,
     )
 
-    stub_code_graph_service.store_graph_from_artifacts.assert_not_called()
     statuses = [
         call.args[1]
         for call in parsing_service.project_service.update_project_status.await_args_list
@@ -263,7 +246,7 @@ async def test_analyze_workspace_file_only_still_ready_when_neo4j_bypassed(
 
 @pytest.mark.asyncio
 async def test_analyze_workspace_rejects_empty_artifact_stream(
-    parsing_service, fake_sandbox, stub_code_graph_service
+    parsing_service, fake_sandbox
 ):
     """Truly empty parse output still fails — nothing was cloned/indexed."""
     fake_sandbox.artifacts = ParseArtifacts(nodes=[], relationships=[])
@@ -285,12 +268,10 @@ async def test_analyze_workspace_rejects_empty_artifact_stream(
             user_email="", repo_details=repo_details,
         )
 
-    stub_code_graph_service.store_graph_from_artifacts.assert_not_called()
-
 
 @pytest.mark.asyncio
 async def test_analyze_workspace_propagates_parser_failure(
-    parsing_service, fake_sandbox, stub_code_graph_service
+    parsing_service, fake_sandbox
 ):
     """A parser-internal failure (e.g. potpie-parse exited non-zero)
     should bubble up as ParsingServiceError when the service is in
@@ -312,8 +293,6 @@ async def test_analyze_workspace_propagates_parser_failure(
             user_email="", repo_details=repo_details,
         )
 
-    stub_code_graph_service.store_graph_from_artifacts.assert_not_called()
-
 
 # ---------------------------------------------------------------------------
 # parse_directory end-to-end (with the sandbox flow stubbed)
@@ -322,7 +301,7 @@ async def test_analyze_workspace_propagates_parser_failure(
 
 @pytest.mark.asyncio
 async def test_parse_directory_uses_sandbox_path(
-    parsing_service, fake_sandbox, stub_code_graph_service
+    parsing_service, fake_sandbox
 ):
     """Top-level smoke: parse_directory should provision the sandbox,
     parse via it, and persist the result. No call to clone_or_copy /
@@ -342,8 +321,6 @@ async def test_parse_directory_uses_sandbox_path(
     )
     parsing_service.project_service.update_project_status = AsyncMock()
 
-    # cleanup_graph creates a CodeGraphService instance and immediately
-    # closes it; the stub_code_graph_service fixture covers that too.
     repo_details = ParsingRequest(
         repo_name="owner/repo",
         branch_name="main",
@@ -378,4 +355,3 @@ async def test_parse_directory_uses_sandbox_path(
 
     # Parse happened; Neo4j graph write is permanently bypassed.
     assert len(fake_sandbox.parse_calls) == 1
-    stub_code_graph_service.store_graph_from_artifacts.assert_not_called()

--- a/tests/unit/parsing/test_sandbox_parse_flow.py
+++ b/tests/unit/parsing/test_sandbox_parse_flow.py
@@ -162,15 +162,14 @@ def fake_sandbox() -> FakeProjectSandbox:
 
 @pytest.fixture
 def parsing_service(fake_sandbox):
-    """Construct a ParsingService with mocked DB / project / inference
-    services so we can exercise the orchestration without standing up
-    Postgres or Neo4j.
+    """Construct a ParsingService with mocked DB / project services so we
+    can exercise orchestration without standing up Postgres or Neo4j.
+    InferenceService is no longer constructed (Neo4j bypassed).
     """
     from app.modules.parsing.graph_construction import parsing_service as ps_mod
 
     db = MagicMock(name="db_session")
     with patch.object(ps_mod, "ProjectService") as ProjectServiceMock, \
-         patch.object(ps_mod, "InferenceService") as InferenceServiceMock, \
          patch.object(ps_mod, "SearchService"), \
          patch.object(ps_mod, "CodeProviderService"), \
          patch.object(ps_mod, "ParseHelper"):
@@ -180,13 +179,6 @@ def parsing_service(fake_sandbox):
         )
         project_service.update_project_status = AsyncMock()
 
-        inference = InferenceServiceMock.return_value
-        inference.run_inference = AsyncMock(return_value={"cache_hits": 5,
-                                                          "cache_misses": 2,
-                                                          "cache_hit_rate": 71.4})
-        inference.log_graph_stats = MagicMock()
-        inference.close = MagicMock()
-
         service = ps_mod.ParsingService(
             db=db,
             user_id="u1",
@@ -194,25 +186,22 @@ def parsing_service(fake_sandbox):
             raise_library_exceptions=True,
             project_sandbox=fake_sandbox,  # type: ignore[arg-type]
         )
-        # Replace the cached project_service / inference_service
-        # references the constructor wired up.
         service.project_service = project_service
-        service.inference_service = inference
         yield service
 
 
 @pytest.fixture
 def stub_code_graph_service():
-    """Replace CodeGraphService with a MagicMock so tests don't need
-    a live neo4j/qdrant. Captures store_graph_from_artifacts calls
-    so the orchestrator's contract is observable."""
-    from app.modules.parsing.graph_construction import parsing_service as ps_mod
+    """Stand-in for CodeGraphService call assertions.
 
+    Neo4j is permanently bypassed in ParsingService, so CodeGraphService
+    is no longer imported there. Keep a MagicMock so existing tests can
+    still assert the graph write path was not invoked.
+    """
     instance = MagicMock(name="CodeGraphService_instance")
     instance.store_graph_from_artifacts = MagicMock()
     instance.close = MagicMock()
-    with patch.object(ps_mod, "CodeGraphService", return_value=instance):
-        yield instance
+    yield instance
 
 
 @pytest.mark.asyncio
@@ -230,35 +219,54 @@ async def test_analyze_workspace_happy_path(
         user_email="x@y.com", repo_details=repo_details,
     )
 
-    # Sandbox parse + graph write + inference are all wired up.
+    # Neo4j permanently bypassed: parse runs, graph/inference do not.
     assert len(fake_sandbox.parse_calls) == 1
     assert fake_sandbox.parse_calls[0]["handle"] is handle
-    stub_code_graph_service.store_graph_from_artifacts.assert_called_once()
-    parsing_service.inference_service.run_inference.assert_awaited_once_with("p1")
+    stub_code_graph_service.store_graph_from_artifacts.assert_not_called()
 
-    # Status transitions: PARSED → READY (the test fixture stubs
-    # update_project_status as AsyncMock, capturing the trail).
     statuses = [
         call.args[1]
         for call in parsing_service.project_service.update_project_status.await_args_list
     ]
-    assert ProjectStatusEnum.PARSED in statuses
     assert ProjectStatusEnum.READY in statuses
+    assert ProjectStatusEnum.ERROR not in statuses
 
 
 @pytest.mark.asyncio
-async def test_analyze_workspace_rejects_repo_with_no_parseable_code(
+async def test_analyze_workspace_file_only_still_ready_when_neo4j_bypassed(
     parsing_service, fake_sandbox, stub_code_graph_service
 ):
-    """Replaces the legacy ``language != 'other'`` gate. parsing_rs
-    handles every supported language; if it produced only FILE nodes
-    (no classes/functions/etc.), there's nothing for the inference
-    pipeline to chew on, so we error out the same way the language
-    gate did."""
+    """FILE-only repos (docs/HTML/arrow-only JS) used to trip the old
+    language gate. With Neo4j bypassed they must still become READY."""
     fake_sandbox.artifacts = ParseArtifacts(
         nodes=[_node(), _node(id="b.py", file="b.py", name="b.py")],
         relationships=[],
     )
+    handle = _make_handle()
+    repo_details = ParsingRequest(
+        repo_name="owner/docs", branch_name="main",
+        repo_path=None, commit_id="abc",
+    )
+
+    await parsing_service.analyze_workspace(
+        handle=handle, project_id="p1", user_id="u1",
+        user_email="", repo_details=repo_details,
+    )
+
+    stub_code_graph_service.store_graph_from_artifacts.assert_not_called()
+    statuses = [
+        call.args[1]
+        for call in parsing_service.project_service.update_project_status.await_args_list
+    ]
+    assert ProjectStatusEnum.READY in statuses
+
+
+@pytest.mark.asyncio
+async def test_analyze_workspace_rejects_empty_artifact_stream(
+    parsing_service, fake_sandbox, stub_code_graph_service
+):
+    """Truly empty parse output still fails — nothing was cloned/indexed."""
+    fake_sandbox.artifacts = ParseArtifacts(nodes=[], relationships=[])
     handle = _make_handle()
     repo_details = ParsingRequest(
         repo_name="owner/empty", branch_name="main",
@@ -277,11 +285,7 @@ async def test_analyze_workspace_rejects_repo_with_no_parseable_code(
             user_email="", repo_details=repo_details,
         )
 
-    # The graph-store path must NOT have run for an empty repo —
-    # neo4j inserts on a no-op graph would still touch the DB,
-    # but more importantly the inference pipeline mustn't fire.
     stub_code_graph_service.store_graph_from_artifacts.assert_not_called()
-    parsing_service.inference_service.run_inference.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -372,6 +376,6 @@ async def test_parse_directory_uses_sandbox_path(
     assert ensure_kwargs["repo"].base_ref == "deadbeef"
     assert ensure_kwargs["auth_token"] == "tk"
 
-    # Parse + write happened.
+    # Parse happened; Neo4j graph write is permanently bypassed.
     assert len(fake_sandbox.parse_calls) == 1
-    stub_code_graph_service.store_graph_from_artifacts.assert_called_once()
+    stub_code_graph_service.store_graph_from_artifacts.assert_not_called()


### PR DESCRIPTION
## Summary
- **FW002 (CWE-319):** Add security-headers middleware that sets `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload` on HTTPS responses (including via `x-forwarded-proto`).
- **FW003 (CWE-639):** Replace client-controlled agent-list privilege flags with server-defined modes:
  - `runtime` — system agents + caller-owned + shared-with-caller
  - `owned` — caller-owned custom agents only  
  Legacy `list_system_agents` / `include_public` / `include_shared` are accepted for compatibility but **ignored** for authorization.
- **FW004 (CWE-1021):** On all HTTP responses, set `X-Frame-Options: DENY` and `Content-Security-Policy: frame-ancestors 'self'`.
- **FW001:** No backend code changes. Password creation is handled by Firebase + the frontend; `/signup` does not accept a password body field.

## Scope
- `SecurityHeadersMiddleware` wired in `app/main.py`
- `GET /api/v1/list-available-agents/` and custom-agent list paths use `mode`
- API-key `/list-available-agents` uses `runtime`
- Unit tests for headers and agent-list authorization

## Test plan
- [ ] `pytest tests/unit/core/test_security_headers.py tests/unit/core/test_api_error_integration.py -q`
- [ ] `pytest tests/unit/intelligence/test_agent_list_authorization.py -q`
- [ ] HTTPS/`x-forwarded-proto: https` responses include HSTS + anti-framing headers
- [ ] Plain HTTP responses include anti-framing headers but not HSTS
- [ ] `mode=owned` never returns system agents even if legacy privilege query params are set to `true`
- [ ] `mode=runtime` returns system agents and uses shared-include rules
- [ ] Chat/runtime and management/owned behaviors match product expectations