### PR TITLE
fix(deps): remediate Medium Vanta vulns for POT-2223 (postcss CVE-2026-69153)

### DIFF
--- a/potpie/daemon/http/ui/frontend/package-lock.json
+++ b/potpie/daemon/http/ui/frontend/package-lock.json
@@ -839,9 +839,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -856,9 +853,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -873,9 +867,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -890,9 +881,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -907,9 +895,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -924,9 +909,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -941,9 +923,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -958,9 +937,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -975,9 +951,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -992,9 +965,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1009,9 +979,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1026,9 +993,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1043,9 +1007,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1727,7 +1688,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -1775,7 +1738,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -1793,7 +1758,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/potpie/daemon/http/ui/frontend/package.json
+++ b/potpie/daemon/http/ui/frontend/package.json
@@ -20,5 +20,8 @@
     "@vitejs/plugin-react": "^4.3.4",
     "typescript": "^5.6.3",
     "vite": "^6.4.3"
+  },
+  "overrides": {
+    "postcss": ">=8.5.23"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Vulnerability details

Linear: [POT-2223](https://linear.app/potpie/issue/POT-2223)

| # | Package | Vulnerable range | Fixed / status | Advisory |
|---|---------|------------------|----------------|----------|
| 1 | `aiohttp` (pip) | `<= 3.14.1` | Already `>=3.14.3` on main (#1039, #1040) | CVE-2026-59881 / [dependabot/374](https://github.com/potpie-ai/potpie/security/dependabot/374) |
| 2 | `GitPython` (pip) | `<= 3.1.55` | Removed with `legacy/` (#1034); was last at 3.1.54 | [dependabot/373](https://github.com/potpie-ai/potpie/security/dependabot/373) |
| 3 | `GitPython` (pip) | `<= 3.1.56` | Same — package no longer in tree (need `>=3.1.57` if reintroduced) | [dependabot/372](https://github.com/potpie-ai/potpie/security/dependabot/372) |
| 4 | `postcss` (npm) | `<= 8.5.22` | **This PR:** lock `8.5.26` + override `>=8.5.23` | CVE-2026-69153 / [dependabot/378](https://github.com/potpie-ai/potpie/security/dependabot/378) |
| 5 | `aiohttp` (pip) | `<= 3.14.1` | Already `>=3.14.3` on main (#1039, #1040) | CVE-2026-69243 / [dependabot/375](https://github.com/potpie-ai/potpie/security/dependabot/375) |

## Fix summary

- Bumped `potpie/daemon/http/ui/frontend` `postcss` from `8.5.19` → `8.5.26` via `npm audit fix`.
- Added `overrides.postcss: ">=8.5.23"` in `package.json` to prevent transitive regression.
- Confirmed root + nested `uv.lock` files resolve `aiohttp==3.14.3` (no `3.14.0`/`3.14.1`).
- Confirmed `GitPython` is not present in any current manifest (only mentioned in docs). GitHub’s dependency-graph SBOM still lists a ghost `potpie-legacy@0.1.0` → `gitpython@3.1.54`; if Dependabot alerts 372/373 do not auto-close after merge, please dismiss them as not present in the default branch.

## Validation

- `npm audit` in `potpie/daemon/http/ui/frontend`: **0 vulnerabilities**
- `npm ls postcss`: `postcss@8.5.26` (overridden)
- `npm run build`: succeeded
- Manifest scan: no `aiohttp` `<=3.14.1` and no `GitPython` in current locks/toml

## Review

Please review: @yashkrishan  
(Automated review request via GitHub API may return 403 for this integration token.)

Do not mark Linear Done — Vanta poller closes when findings clear.

## Linear note

Linear MCP auth is unavailable in this cloud agent environment, so POT-2223 could not be moved to In Progress or commented on automatically. After authenticating Linear MCP / adding `LINEAR_API_KEY`, please comment with this PR URL.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [POT-2223](https://linear.app/potpie/issue/POT-2223/vanta-potpie-aipotpie-medium-vulnerabilities-5)

<div><a href="https://cursor.com/agents/bc-a934878a-a499-411a-a972-2a6d91a72b84?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a934878a-a499-411a-a972-2a6d91a72b84&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

