### PR TITLE
fix(deps): remediate High Vanta vulns for POT-2264 (stale legacy/uv.lock SBOM)

### DIFF
--- a/legacy/README.md
+++ b/legacy/README.md
@@ -3,12 +3,14 @@
 This directory is **not** the former Potpie demo host.
 
 After `legacy/` was removed in #1034, GitHub’s dependency graph kept a stale
-`potpie-legacy@0.1.0` snapshot that still resolved vulnerable pins
-(`aiohttp==3.14.1`, `gitpython==3.1.54`). That ghost snapshot kept Medium
-Dependabot / Vanta findings open (POT-2236).
+`potpie-legacy@0.1.0` snapshot (and a ghost `legacy/uv.lock`) that still
+resolved vulnerable pins (`aiohttp==3.14.1`, `cryptography==49.0.0`,
+`gitpython==3.1.54`). That ghost snapshot kept Medium and High Dependabot /
+Vanta findings open (POT-2236, POT-2264).
 
-This empty PEP 621 manifest at the same path replaces that snapshot with zero
-dependencies. It is intentionally **not** a uv workspace member.
+This empty PEP 621 manifest and matching `uv.lock` at the same paths replace
+that snapshot with zero third-party dependencies. It is intentionally **not**
+a uv workspace member.
 
 Once Dependabot shows `deps=0` for this path (or the alerts auto-close), a
 follow-up may delete this stub entirely.

--- a/legacy/pyproject.toml
+++ b/legacy/pyproject.toml
@@ -2,14 +2,16 @@
 requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
-# Dependency-graph hygiene stub (POT-2236).
-# GitHub's SBOM still listed a deleted potpie-legacy@0.1.0 snapshot with
-# aiohttp==3.14.1 and gitpython==3.1.54 after legacy/ was removed (#1034).
-# Re-publishing an empty manifest at this path replaces that stale snapshot
-# so Dependabot/Vanta Medium findings can clear. Not a workspace member.
+# Dependency-graph hygiene stub (POT-2236 / POT-2264).
+# GitHub's SBOM still listed a deleted potpie-legacy@0.1.0 snapshot (and a
+# ghost legacy/uv.lock) with aiohttp==3.14.1, cryptography==49.0.0, and
+# gitpython==3.1.54 after legacy/ was removed (#1034). Those pins kept High
+# Dependabot/Vanta findings open (CVE-2026-69244, CVE-2026-69247, GitPython
+# advisories through 3.1.57). Re-publishing an empty manifest + lock at this
+# path replaces that stale snapshot. Not a workspace member.
 [project]
 name = "potpie-legacy"
-version = "0.1.0"
+version = "0.1.1"
 description = "Empty stub replacing the removed legacy demo host (dependency-graph hygiene only)."
 requires-python = ">=3.12,<3.15"
 license = "Apache-2.0"

--- a/legacy/uv.lock
+++ b/legacy/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.12, <3.15"
+
+[[package]]
+name = "potpie-legacy"
+version = "0.1.1"
+source = { editable = "." }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ override-dependencies = [
     # CVE-2026-59881 / CVE-2026-69243 / CVE-2026-69244: floor at 3.14.3.
     "aiohttp>=3.14.3",
     # GitPython: Medium + High advisories through 3.1.57 (incl. GHSA-p538-c434-8v24,
-    # GHSA-539m-9xh6-q6rr, GHSA-wvpp-8hx9-p66j). Floor at 3.1.58.
+    # GHSA-539m-9xh6-q6rr, GHSA-wvpp-8hx9-p66j, and Dependabot #380–#385). Floor at 3.1.58.
     "gitpython>=3.1.58",
     "starlette>=1.3.1",
     "pyjwt>=2.13.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Vulnerability details

Linear: [POT-2264](https://linear.app/potpie/issue/POT-2264)

| # | Package | Vulnerable range | Fixed / status | Advisory |
|---|---------|------------------|----------------|----------|
| 1 | `cryptography` (pip) | `>=44.0.0, <50.0.0` | Workspace locks already `50.0.0` (#1042/#1045); **this PR** replaces stale `legacy/uv.lock` SBOM that still listed `49.0.0` | CVE-2026-69247 / [dependabot/377](https://github.com/potpie-ai/potpie/security/dependabot/377) |
| 2 | `aiohttp` (pip) | `<=3.14.2` | Workspace locks already `3.14.3` (#1038/#1045); **this PR** clears ghost `3.14.1` via empty `legacy/uv.lock` | CVE-2026-69244 / [dependabot/376](https://github.com/potpie-ai/potpie/security/dependabot/376) |
| 3 | `GitPython` (pip) | `<=3.1.56` | Floor already `>=3.1.58` (#1045); ghost `3.1.54` cleared by empty lock | [dependabot/371](https://github.com/potpie-ai/potpie/security/dependabot/371) |
| 4–8 | `GitPython` (pip) | `<=3.1.57` | Same — floor `>=3.1.58`; empty lock removes ghost pin | [dependabot/380](https://github.com/potpie-ai/potpie/security/dependabot/380)–[385](https://github.com/potpie-ai/potpie/security/dependabot/385) |

## Why this PR

#1045 / #1042 already raised workspace floors (`cryptography>=50.0.0`, `aiohttp>=3.14.3`, `gitpython>=3.1.58`). #1046 added an empty `legacy/pyproject.toml` stub for Medium findings. GitHub’s dependency graph still listed a **ghost** `legacy/uv.lock` (file deleted in #1034) whose SBOM resolved `aiohttp==3.14.1`, `cryptography==49.0.0`, and `gitpython==3.1.54` under `potpie-legacy@0.1.0`, so these High Vanta findings stayed open.

## Fix summary

- Add empty `legacy/uv.lock` (only `potpie-legacy` itself; no third-party deps) at the same path as the ghost lock so Dependabot can replace the stale snapshot.
- Bump hygiene stub `potpie-legacy` `0.1.0` → `0.1.1` and refresh README/comments for POT-2264 High advisories.
- Confirm root override floor comment covers Dependabot #380–#385.

## Validation

- `legacy/uv.lock`: only `potpie-legacy==0.1.1` (no `aiohttp` / `cryptography` / `gitpython`)
- Workspace locks unchanged and still patched: `aiohttp==3.14.3`, `cryptography==50.0.0`, `gitpython` floor `>=3.1.58`
- `uv lock --check` passes on root
- OSV: `aiohttp@3.14.3`, `cryptography@50.0.0`, `GitPython@3.1.58` → 0 vulns

## Review

Please review: @yashkrishan  
(Automated review request via GitHub API may return 403 for this integration token.)

Do not mark Linear Done — Vanta poller closes when findings clear.

## Linear note

Linear MCP auth is unavailable in this cloud agent environment (`needsAuth`; interactive auth not available). Please authenticate Linear MCP / add `LINEAR_API_KEY`, move POT-2264 to **In Progress**, and comment with this PR URL.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [POT-2264](https://linear.app/potpie/issue/POT-2264/vanta-potpie-aipotpie-high-vulnerabilities-8)

<div><a href="https://cursor.com/agents/bc-a75f6569-6a45-41ed-9c28-2caf0e179430?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a75f6569-6a45-41ed-9c28-2caf0e179430&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

