### PR TITLE
fix(deps): remediate Medium Vanta vulns for POT-2266 (stale legacy/uv.lock + h2)

### DIFF
--- a/legacy/README.md
+++ b/legacy/README.md
@@ -3,12 +3,14 @@
 This directory is **not** the former Potpie demo host.
 
 After `legacy/` was removed in #1034, GitHub’s dependency graph kept a stale
-`potpie-legacy@0.1.0` snapshot that still resolved vulnerable pins
-(`aiohttp==3.14.1`, `gitpython==3.1.54`). That ghost snapshot kept Medium
-Dependabot / Vanta findings open (POT-2236).
+`potpie-legacy@0.1.0` / `legacy/uv.lock` snapshot that still resolved
+vulnerable pins (`aiohttp==3.14.1`, `gitpython==3.1.54`, and
+`httpx[http2]` → `h2==4.3.0`). That ghost snapshot kept Medium Dependabot /
+Vanta findings open (POT-2236, POT-2266).
 
-This empty PEP 621 manifest at the same path replaces that snapshot with zero
-dependencies. It is intentionally **not** a uv workspace member.
+This empty PEP 621 manifest plus empty `uv.lock` at the same path (version
+`0.2.0`) replaces that snapshot with zero dependencies. It is intentionally
+**not** a uv workspace member.
 
 Once Dependabot shows `deps=0` for this path (or the alerts auto-close), a
 follow-up may delete this stub entirely.

--- a/legacy/pyproject.toml
+++ b/legacy/pyproject.toml
@@ -2,14 +2,15 @@
 requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
-# Dependency-graph hygiene stub (POT-2236).
-# GitHub's SBOM still listed a deleted potpie-legacy@0.1.0 snapshot with
-# aiohttp==3.14.1 and gitpython==3.1.54 after legacy/ was removed (#1034).
-# Re-publishing an empty manifest at this path replaces that stale snapshot
-# so Dependabot/Vanta Medium findings can clear. Not a workspace member.
+# Dependency-graph hygiene stub (POT-2236 / POT-2266).
+# GitHub's SBOM kept a deleted potpie-legacy@0.1.0 + legacy/uv.lock snapshot
+# with aiohttp==3.14.1, gitpython==3.1.54, and httpx[http2] -> h2==4.3.0 after
+# legacy/ was removed (#1034). Re-publishing an empty manifest + empty uv.lock
+# at this path (version bump to 0.2.0) replaces that stale snapshot so
+# Dependabot/Vanta Medium findings can clear. Not a workspace member.
 [project]
 name = "potpie-legacy"
-version = "0.1.0"
+version = "0.2.0"
 description = "Empty stub replacing the removed legacy demo host (dependency-graph hygiene only)."
 requires-python = ">=3.12,<3.15"
 license = "Apache-2.0"

--- a/legacy/uv.lock
+++ b/legacy/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.12, <3.15"
+
+[[package]]
+name = "potpie-legacy"
+version = "0.2.0"
+source = { editable = "." }

--- a/potpie/context-engine/pyproject.toml
+++ b/potpie/context-engine/pyproject.toml
@@ -137,6 +137,7 @@ constraint-dependencies = [
     "aiohttp>=3.14.3",
     "cryptography>=50.0.0",
     "gitpython>=3.1.58",
+    "h2>=4.4.1",
     "idna>=3.15",
     "pyjwt>=2.13.0",
     "pydantic-ai-slim>=1.102.0",

--- a/potpie/context-engine/uv.lock
+++ b/potpie/context-engine/uv.lock
@@ -15,6 +15,7 @@ constraints = [
     { name = "aiohttp", specifier = ">=3.14.3" },
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "gitpython", specifier = ">=3.1.58" },
+    { name = "h2", specifier = ">=4.4.1" },
     { name = "idna", specifier = ">=3.15" },
     { name = "pydantic-ai-slim", specifier = ">=1.102.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },

--- a/potpie/sandbox/pyproject.toml
+++ b/potpie/sandbox/pyproject.toml
@@ -42,6 +42,7 @@ constraint-dependencies = [
     "aiohttp>=3.14.3",
     "cryptography>=50.0.0",
     "gitpython>=3.1.58",
+    "h2>=4.4.1",
     "idna>=3.15",
     "pyjwt>=2.13.0",
     "pydantic-ai-slim>=1.102.0",

--- a/potpie/sandbox/uv.lock
+++ b/potpie/sandbox/uv.lock
@@ -7,6 +7,7 @@ constraints = [
     { name = "aiohttp", specifier = ">=3.14.3" },
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "gitpython", specifier = ">=3.1.58" },
+    { name = "h2", specifier = ">=4.4.1" },
     { name = "idna", specifier = ">=3.15" },
     { name = "pydantic-ai-slim", specifier = ">=1.102.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,8 @@ override-dependencies = [
     # GitPython: Medium + High advisories through 3.1.57 (incl. GHSA-p538-c434-8v24,
     # GHSA-539m-9xh6-q6rr, GHSA-wvpp-8hx9-p66j). Floor at 3.1.58.
     "gitpython>=3.1.58",
+    # CVE-2026-71554 / GHSA-6hr6-w5qg-qmwg: h2 <=4.4.0; floor at 4.4.1.
+    "h2>=4.4.1",
     "starlette>=1.3.1",
     "pyjwt>=2.13.0",
     "pydantic-settings>=2.14.2",

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,7 @@ overrides = [
     { name = "aiohttp", specifier = ">=3.14.3" },
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "gitpython", specifier = ">=3.1.58" },
+    { name = "h2", specifier = ">=4.4.1" },
     { name = "idna", specifier = ">=3.15" },
     { name = "openai", specifier = ">=2.7.1" },
     { name = "pydantic-ai-slim", specifier = ">=1.102.0" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Vulnerability details

Linear: [POT-2266](https://linear.app/potpie/issue/POT-2266)

| # | Package | Vulnerable range | Fixed / status | Advisory |
|---|---------|------------------|----------------|----------|
| 1 | `aiohttp` (pip) | `<= 3.14.1` | Workspace locks already `3.14.3`; **this PR** replaces stale `legacy/uv.lock` that still listed `3.14.1` | CVE-2026-59881 / [dependabot/374](https://github.com/potpie-ai/potpie/security/dependabot/374) |
| 2 | `GitPython` (pip) | `<= 3.1.55` | Ghost `gitpython==3.1.54` via stale `legacy/uv.lock`; **this PR** empty lock + stub `0.2.0` | [dependabot/373](https://github.com/potpie-ai/potpie/security/dependabot/373) |
| 3 | `GitPython` (pip) | `<= 3.1.56` | Same as above | [dependabot/372](https://github.com/potpie-ai/potpie/security/dependabot/372) |
| 4 | `aiohttp` (pip) | `<= 3.14.1` | Same as #1 | CVE-2026-69243 / [dependabot/375](https://github.com/potpie-ai/potpie/security/dependabot/375) |
| 5 | `GitPython` (pip) | `<= 3.1.57` | Floors already `>=3.1.58`; ghost lock cleared here | [dependabot/382](https://github.com/potpie-ai/potpie/security/dependabot/382) |
| 6 | `h2` (pip) | `<= 4.4.0` | Stale lock had `httpx[http2]` → `h2==4.3.0`; empty lock + floor `h2>=4.4.1` (CVE-2026-71554) | [dependabot/379](https://github.com/potpie-ai/potpie/security/dependabot/379) |

## Fix summary

- After #1034 removed `legacy/`, GitHub’s dependency graph kept a **stale `legacy/uv.lock`** snapshot (aiohttp 3.14.1, gitpython 3.1.54, httpx[http2]→h2 4.3.0). #1046 added an empty `legacy/pyproject.toml` stub, but the ghost lockfile manifest remained.
- Added empty `legacy/uv.lock` (only `potpie-legacy@0.2.0`, no deps) and bumped the stub version so Dependabot replaces that snapshot.
- Added `h2>=4.4.1` override/constraint floors in root, context-engine, and sandbox manifests + lock metadata.

## Validation

- `uv lock --check` passed for root, `legacy/`, and `sandbox/`
- Manifest scan: no resolved `aiohttp<=3.14.1`, `gitpython<=3.1.57`, or `h2<=4.4.0` in any `uv.lock`
- `legacy/uv.lock` contains only `potpie-legacy==0.2.0`

## Review

Please review: @yashkrishan  
(Automated `requested_reviewers` API returned 403 for this integration token.)

Do not mark Linear Done — Vanta poller closes when findings clear.

## Linear note

Linear MCP auth is unavailable in this cloud agent environment, so POT-2266 could not be moved to In Progress or commented on automatically. After authenticating Linear MCP / adding `LINEAR_API_KEY`, please comment with this PR URL: https://github.com/potpie-ai/potpie/pull/1048

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [POT-2266](https://linear.app/potpie/issue/POT-2266/vanta-potpie-aipotpie-medium-vulnerabilities-6)

<div><a href="https://cursor.com/agents/bc-ca2861a7-893b-4494-ac08-b8c4cab1d07e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca2861a7-893b-4494-ac08-b8c4cab1d07e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

