### PR TITLE
fix: normalize naive timestamps in read path

### DIFF
--- a/potpie/context-core/src/potpie_context_core/ports/claim_query.py
+++ b/potpie/context-core/src/potpie_context_core/ports/claim_query.py
@@ -15,7 +15,7 @@ computed read annotations.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Iterable, Mapping, Protocol, runtime_checkable
 
 
@@ -85,6 +85,19 @@ class ClaimQueryFilter:
     # candidates ordered by similarity. Cosine distance scores are
     # stamped onto ``ClaimRow.properties["semantic_similarity"]``.
     fact_query: str | None = None
+
+    def __post_init__(self) -> None:
+        # A naive temporal bound is interpreted as UTC (consistent with how
+        # naive valid_at values are already treated by readers/ranking). Every
+        # backend read consumes these bounds directly from this filter — some
+        # callers (e.g. graph search-entities, inspection) build it without
+        # going through ReadRequest — so normalizing here guarantees the bounds
+        # are aware before any Python-side datetime comparison (potpie issue
+        # #1008).
+        for field_name in ("as_of", "valid_at_after", "valid_at_before"):
+            value = getattr(self, field_name)
+            if value is not None and value.tzinfo is None:
+                object.__setattr__(self, field_name, value.replace(tzinfo=timezone.utc))
 
 
 @runtime_checkable

--- a/potpie/context-engine/src/potpie_context_engine/adapters/outbound/graph/in_memory_reader.py
+++ b/potpie/context-engine/src/potpie_context_engine/adapters/outbound/graph/in_memory_reader.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import dataclasses
 from dataclasses import dataclass, field
+from datetime import timezone
 from typing import Any, Iterable, Mapping
 
 from potpie_context_engine.adapters.outbound.graph.canonical_claim_query import (
@@ -167,15 +168,22 @@ def _matches_filter(
         return False
     if not filter_.include_invalidated and row.invalid_at is not None:
         return False
+    # A naive row timestamp is interpreted as UTC, matching how naive filter
+    # bounds are normalized at the read boundary (potpie issue #1008). Without
+    # this, a naive valid_at compared against an aware bound raises
+    # ``TypeError: can't compare offset-naive and offset-aware datetimes``.
+    row_valid_at = row.valid_at
+    if row_valid_at is not None and row_valid_at.tzinfo is None:
+        row_valid_at = row_valid_at.replace(tzinfo=timezone.utc)
     if filter_.valid_at_after and (
-        row.valid_at is None or row.valid_at < filter_.valid_at_after
+        row_valid_at is None or row_valid_at < filter_.valid_at_after
     ):
         return False
     if filter_.valid_at_before and (
-        row.valid_at is not None and row.valid_at > filter_.valid_at_before
+        row_valid_at is not None and row_valid_at > filter_.valid_at_before
     ):
         return False
-    if filter_.as_of and row.valid_at is not None and row.valid_at > filter_.as_of:
+    if filter_.as_of and row_valid_at is not None and row_valid_at > filter_.as_of:
         return False
     if filter_.subject_label:
         labels = store.entity_label_index.get((row.pot_id, row.subject_key), ())

--- a/potpie/context-engine/src/potpie_context_engine/application/readers/_common.py
+++ b/potpie/context-engine/src/potpie_context_engine/application/readers/_common.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 import re
 from typing import Any
 
@@ -37,6 +37,16 @@ class ReadRequest:
     # these; other readers ignore them.
     depth: int | None = None
     direction: str | None = None  # "out" | "in" | "both"
+
+    def __post_init__(self) -> None:
+        # A naive temporal bound is interpreted as UTC (consistent with how
+        # naive valid_at values are already treated). Without this, a naive
+        # ``as_of`` crashes ranking with ``TypeError: can't subtract
+        # offset-naive and offset-aware datetimes`` (potpie issue #1008).
+        for field_name in ("as_of", "since", "until"):
+            value = getattr(self, field_name)
+            if value is not None and value.tzinfo is None:
+                object.__setattr__(self, field_name, value.replace(tzinfo=timezone.utc))
 
 
 @dataclass(frozen=True, slots=True)

--- a/potpie/context-engine/src/potpie_context_engine/application/readers/timeline_reader.py
+++ b/potpie/context-engine/src/potpie_context_engine/application/readers/timeline_reader.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import dataclasses
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Iterable, Mapping
 
 from potpie_context_engine.application.readers._common import (
@@ -491,12 +491,20 @@ def _representative_activity_row(
 
 def _event_datetime(row: ClaimRow) -> datetime | None:
     raw = row.properties.get("occurred_at")
+    event_time: datetime | None = None
     if isinstance(raw, str) and raw.strip():
         try:
-            return datetime.fromisoformat(raw.strip().replace("Z", "+00:00"))
+            event_time = datetime.fromisoformat(raw.strip().replace("Z", "+00:00"))
         except ValueError:
             pass
-    return row.valid_at
+    if event_time is None:
+        event_time = row.valid_at
+    # A naive event time is interpreted as UTC: the window bounds
+    # (since/until) are normalized to UTC at the read boundary, so comparing
+    # against a naive event time would raise (potpie issue #1008).
+    if event_time is not None and event_time.tzinfo is None:
+        event_time = event_time.replace(tzinfo=timezone.utc)
+    return event_time
 
 
 def _event_time_iso(row: ClaimRow) -> str | None:

--- a/potpie/context-engine/src/potpie_context_engine/domain/ranking.py
+++ b/potpie/context-engine/src/potpie_context_engine/domain/ranking.py
@@ -117,7 +117,9 @@ class RankingService:
         ``breakdown`` so readers can surface "why this ranked high" if
         the agent asks.
         """
-        now = context.now or datetime.now(tz=timezone.utc)
+        now = _as_utc(context.now)
+        if now is None:
+            now = datetime.now(tz=timezone.utc)
         ranked: list[RankedItem] = []
         for cand in candidates:
             breakdown = self._score_one(cand, now=now, context=context)
@@ -188,6 +190,18 @@ def _strength_score(strength: str | None, mapping: Mapping[str, float]) -> float
     return mapping.get(strength, 0.5)
 
 
+def _as_utc(value: datetime | None) -> datetime | None:
+    """Interpret a naive datetime as UTC (matches how ``valid_at`` is treated).
+
+    A caller-supplied clock (``TaskContext.now``) without an explicit tzinfo is
+    ambiguous; defaulting to UTC keeps ``now - valid_at`` from mixing naive and
+    aware datetimes (potpie issue #1008).
+    """
+    if value is None or value.tzinfo is not None:
+        return value
+    return value.replace(tzinfo=timezone.utc)
+
+
 def _recency_score(
     valid_at: datetime | None,
     *,
@@ -200,6 +214,8 @@ def _recency_score(
         return 0.5
     if valid_at.tzinfo is None:
         valid_at = valid_at.replace(tzinfo=timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
     age = max(now - valid_at, timedelta(0))
 
     effective_half_life = half_life

--- a/potpie/context-engine/tests/unit/test_graph_surface_lite_contract.py
+++ b/potpie/context-engine/tests/unit/test_graph_surface_lite_contract.py
@@ -6,6 +6,7 @@ graph surface.
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any
 
 import pytest
@@ -460,6 +461,41 @@ def test_timeline_read_filters_by_exact_source_ref(service) -> None:
         item["source_refs"] == ["github:potpie-ai/potpie#issue/881"]
         for item in env.items
     )
+
+
+def test_entity_search_accepts_naive_since_until_window(service) -> None:
+    """potpie issue #1008: search-entities builds ClaimQueryFilter directly
+    (bypassing ReadRequest), so a naive since/until must still be interpreted
+    as UTC and never crash the in-memory filter's datetime comparison."""
+    store = service.backend.claim_query
+    store.add(
+        ClaimRow(
+            pot_id="p",
+            predicate="TOUCHED",
+            subject_key="activity:github:pr-1",
+            object_key="service:auth-svc",
+            claim_key="claim:pr-1",
+            truth="timeline_event",
+            source_refs=("github:potpie-ai/potpie#pr/1",),
+            fact="PR 1 touched auth service.",
+            valid_at=datetime(2024, 5, 1, tzinfo=timezone.utc),
+        )
+    )
+
+    result = service.search_entities(
+        GraphEntitySearchRequest(
+            pot_id="p",
+            query="touched auth",
+            since=datetime(2024, 4, 1),  # naive → interpreted as UTC
+            until=datetime(2024, 6, 1),  # naive → interpreted as UTC
+            limit=10,
+        )
+    )
+
+    assert {entity.key for entity in result.entities} == {
+        "activity:github:pr-1",
+        "service:auth-svc",
+    }
 
 
 def test_entity_search_filters_by_exact_source_ref(service) -> None:

--- a/potpie/context-engine/tests/unit/test_p9_readers.py
+++ b/potpie/context-engine/tests/unit/test_p9_readers.py
@@ -113,6 +113,35 @@ def test_claim_semantic_similarity_ignores_booleans() -> None:
     assert not row_matches_query(row, "unrelated query")
 
 
+def test_naive_as_of_is_interpreted_as_utc_and_does_not_crash() -> None:
+    """potpie issue #1008: a date-only/naive as_of must not crash the read.
+
+    ``as_of="2024-06-01"`` used to reach recency scoring as a naive datetime
+    and raise ``TypeError: can't subtract offset-naive and offset-aware
+    datetimes`` against aware valid_at claims.
+    """
+    store = InMemoryClaimQueryStore()
+    store.add(
+        _row(
+            predicate="TOUCHED",
+            subject_key="activity:github:pr:1042",
+            object_key="service:auth-svc",
+            fact="PR 1042 touched auth service",
+            valid_at=datetime(2024, 5, 1, tzinfo=timezone.utc),
+        )
+    )
+    reader = TimelineReader(claim_query=store, ranker=RankingService())
+
+    request = ReadRequest(
+        pot_id="pot-1", scope={"service": "auth-svc"}, as_of=datetime(2024, 6, 1)
+    )
+
+    response = reader.read(request)
+    assert response.items  # normal envelope, no TypeError
+    # The naive bound is normalized to UTC at the read boundary.
+    assert request.as_of == datetime(2024, 6, 1, tzinfo=timezone.utc)
+
+
 # ---------------------------------------------------------------------------
 # CodingPreferencesReader
 # ---------------------------------------------------------------------------

--- a/potpie/context-engine/tests/unit/test_p9_readers.py
+++ b/potpie/context-engine/tests/unit/test_p9_readers.py
@@ -31,7 +31,7 @@ from potpie_context_engine.application.readers._common import (
     dedupe_claim_rows,
     row_matches_query,
 )
-from potpie_context_core.ports.claim_query import ClaimRow
+from potpie_context_core.ports.claim_query import ClaimQueryFilter, ClaimRow
 from potpie_context_engine.domain.ranking import RankingService
 
 
@@ -140,6 +140,98 @@ def test_naive_as_of_is_interpreted_as_utc_and_does_not_crash() -> None:
     assert response.items  # normal envelope, no TypeError
     # The naive bound is normalized to UTC at the read boundary.
     assert request.as_of == datetime(2024, 6, 1, tzinfo=timezone.utc)
+
+
+def test_naive_valid_at_row_and_naive_as_of_do_not_crash() -> None:
+    """potpie issue #1008: a claim stored with a naive valid_at must not crash
+    the read once the naive as_of is normalized to aware at the boundary.
+
+    The in-memory claim filter compares ``row.valid_at > filter_.as_of`` in
+    Python, so a naive row value against an aware bound raised the same
+    ``TypeError`` the issue reports for the ranker.
+    """
+    store = InMemoryClaimQueryStore()
+    store.add(
+        _row(
+            predicate="TOUCHED",
+            subject_key="activity:github:pr:1043",
+            object_key="service:auth-svc",
+            fact="PR 1043 touched auth service",
+            valid_at=datetime(2024, 5, 1),  # naive stored valid_at
+        )
+    )
+    reader = TimelineReader(claim_query=store, ranker=RankingService())
+
+    response = reader.read(
+        ReadRequest(
+            pot_id="pot-1", scope={"service": "auth-svc"}, as_of=datetime(2024, 6, 1)
+        )
+    )
+
+    assert response.items  # normal envelope, no TypeError
+
+
+def test_naive_event_time_with_naive_window_bounds_do_not_crash() -> None:
+    """potpie issue #1008: a naive occurred_at (no offset) against naive
+    since/until window bounds must not crash the timeline window filter.
+
+    ``since``/``until`` are normalized to aware UTC at the read boundary, so a
+    naive event time compared against them previously raised ``TypeError``.
+    The naive event time is interpreted as UTC and the window still filters.
+    """
+    store = InMemoryClaimQueryStore()
+    store.add(
+        _row(
+            predicate="TOUCHED",
+            subject_key="activity:github:pr:1044",
+            object_key="service:auth-svc",
+            fact="PR 1044 touched auth service",
+            valid_at=datetime(2024, 5, 1, tzinfo=timezone.utc),
+            properties={"occurred_at": "2024-05-01T10:00:00"},  # naive
+        )
+    )
+    store.add(
+        _row(
+            predicate="TOUCHED",
+            subject_key="activity:github:pr:1045",
+            object_key="service:auth-svc",
+            fact="PR 1045 touched auth service",
+            valid_at=datetime(2024, 6, 10, tzinfo=timezone.utc),
+            properties={"occurred_at": "2024-06-10T10:00:00"},  # naive, outside window
+        )
+    )
+    reader = TimelineReader(claim_query=store, ranker=RankingService())
+
+    response = reader.read(
+        ReadRequest(
+            pot_id="pot-1",
+            scope={"service": "auth-svc"},
+            since=datetime(2024, 5, 1),
+            until=datetime(2024, 5, 31),
+        )
+    )
+
+    keys = {r.candidate.payload["subject_key"] for r in response.items}
+    assert keys == {"activity:github:pr:1044"}  # window filtering still applies
+
+
+def test_claim_query_filter_normalizes_naive_bounds_to_utc() -> None:
+    """potpie issue #1008: backends receive aware bounds even when the filter
+    is built directly (search-entities / inspection bypass ReadRequest)."""
+    flt = ClaimQueryFilter(
+        pot_id="pot-1",
+        as_of=datetime(2024, 6, 1),
+        valid_at_after=datetime(2024, 4, 1),
+        valid_at_before=datetime(2024, 6, 30),
+    )
+    assert flt.as_of == datetime(2024, 6, 1, tzinfo=timezone.utc)
+    assert flt.valid_at_after == datetime(2024, 4, 1, tzinfo=timezone.utc)
+    assert flt.valid_at_before == datetime(2024, 6, 30, tzinfo=timezone.utc)
+
+    # Aware inputs pass through untouched.
+    aware = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    assert ClaimQueryFilter(pot_id="pot-1", as_of=aware).as_of == aware
+    assert ClaimQueryFilter(pot_id="pot-1").as_of is None
 
 
 # ---------------------------------------------------------------------------

--- a/potpie/context-engine/tests/unit/test_ranking.py
+++ b/potpie/context-engine/tests/unit/test_ranking.py
@@ -101,6 +101,41 @@ class TestRecencyMatters:
         assert fresh_gap >= balanced_gap
 
 
+class TestNaiveNowNormalizedToUtc:
+    """potpie issue #1008: a naive clock must not crash recency scoring.
+
+    A naive ``now`` (e.g. ``as_of="2024-06-01"`` parsed without a tzinfo)
+    used to raise ``TypeError: can't subtract offset-naive and offset-aware
+    datetimes`` against an aware ``valid_at``. It is now interpreted as UTC,
+    the same instant as the explicit ``...T00:00:00Z`` spelling.
+    """
+
+    def test_naive_now_does_not_crash_and_matches_aware_clock(self) -> None:
+        service = RankingService()
+        candidate = _make_candidate(
+            key="k", valid_at=datetime(2024, 5, 1, tzinfo=timezone.utc)
+        )
+
+        naive_ctx = TaskContext(pot_id="p", now=datetime(2024, 6, 1))
+        aware_ctx = TaskContext(
+            pot_id="p", now=datetime(2024, 6, 1, tzinfo=timezone.utc)
+        )
+
+        naive = service.rank([candidate], naive_ctx)[0]
+        aware = service.rank([candidate], aware_ctx)[0]
+        # Same instant → identical recency score, no exception.
+        assert naive.breakdown["recency"] == aware.breakdown["recency"]
+        assert naive.breakdown["recency"] > 0.0
+
+    def test_naive_valid_at_and_naive_now_both_default_to_utc(self) -> None:
+        service = RankingService()
+        candidate = _make_candidate(key="k", valid_at=datetime(2024, 5, 1))
+        ranked = service.rank(
+            [candidate], TaskContext(pot_id="p", now=datetime(2024, 6, 1))
+        )
+        assert ranked[0].breakdown["recency"] > 0.0
+
+
 class TestScopeOverlap:
     def test_scope_overlap_dominates_when_only_factor_differs(self) -> None:
         service = RankingService()


### PR DESCRIPTION
## Summary

Fixes #1008.

- Normalize naive temporal bounds to UTC in the read path.
- Normalize timestamps before recency calculations.
- Prevent naive/aware datetime arithmetic errors.
- Add regression tests for naive and timezone-aware timestamps.

## Root Cause

A naive `as_of` timestamp could reach the ranking layer while `valid_at` was timezone-aware, causing subtraction between offset-naive and offset-aware datetimes.

## Fix

Naive timestamps are interpreted as UTC at the read/domain boundary so datetime comparisons and arithmetic operate consistently.

## Testing

- Verified the issue reproduction.
- Added regression coverage for the ranking and reader paths.
- Full context-engine unit suite: 906 passed, 1 skipped.
- Conformance suite: 72 passed.
- Ruff checks passed on changed files.