### PR TITLE
Use GitHub App token for Hub docs dispatch

### DIFF
--- a/.github/workflows/docs-dispatch.yml
+++ b/.github/workflows/docs-dispatch.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Explain Hub token mint failure
         if: ${{ failure() && steps.docs_change.outputs.should_dispatch == 'true' && steps.hub_token.conclusion == 'failure' }}
         run: |
-          echo "::error::GitHub App token was not minted. Confirm the App is installed on potpie-ai/potpie and the Actions Client ID/private key are configured."
+          echo "::error::GitHub App token was not minted. Confirm the App is installed on potpie-ai/docs and the Actions Client ID/private key are configured for this workflow."
 
       - name: Send repository_dispatch to Hub
         if: steps.docs_change.outputs.should_dispatch == 'true'
@@ -78,7 +78,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${HUB_DISPATCH_TOKEN:-}" ]; then
-            echo "::error::GitHub App token was not minted. Confirm the App is installed on potpie-ai/potpie and the Actions Client ID/private key are configured."
+            echo "::error::GitHub App token was not minted. Confirm the App is installed on potpie-ai/docs and the Actions Client ID/private key are configured for this workflow."
             exit 1
           fi
           if [ -z "${HUB_REPO:-}" ]; then
@@ -88,9 +88,23 @@ jobs:
             echo "::error::DOCS_HUB_REPO must be $DEFAULT_HUB_REPO when using the documentation GitHub App"
             exit 1
           fi
-          SPOKE_ID="$(node -e 'const fs=require("fs"); const c=JSON.parse(fs.readFileSync("docs/config.json","utf8")); if (!c.spokeId) process.exit(1); process.stdout.write(String(c.spokeId))')"
-          payload=$(printf '{"event_type":"spoke-docs-updated","client_payload":{"repository":"%s","branch":"%s","sha":"%s","spoke_id":"%s"}}' \
-            "$SPOKE_REPO" "$BRANCH" "$SHA" "$SPOKE_ID")
+          payload="$(node -e '
+            const fs = require("fs");
+            const config = JSON.parse(fs.readFileSync("docs/config.json", "utf8"));
+            if (typeof config.spokeId !== "string" || !config.spokeId.trim()) {
+              console.error("::error::docs/config.json spokeId must be a non-empty string");
+              process.exit(1);
+            }
+            process.stdout.write(JSON.stringify({
+              event_type: "spoke-docs-updated",
+              client_payload: {
+                repository: process.env.SPOKE_REPO,
+                branch: process.env.BRANCH,
+                sha: process.env.SHA,
+                spoke_id: config.spokeId,
+              },
+            }));
+          ')"
           code=$(curl -sS -o /tmp/dispatch-response.json -w "%{http_code}" \
             -X POST \
             -H "Accept: application/vnd.github+json" \
@@ -105,4 +119,4 @@ jobs:
             echo
             exit 1
           fi
-          echo "Dispatched spoke-docs-updated to $HUB_REPO for $SPOKE_REPO@$SHA (spoke_id=$SPOKE_ID)"
+          echo "Dispatched spoke-docs-updated to $HUB_REPO for $SPOKE_REPO@$SHA"

--- a/.github/workflows/docs-dispatch.yml
+++ b/.github/workflows/docs-dispatch.yml
@@ -70,8 +70,7 @@ jobs:
         if: steps.docs_change.outputs.should_dispatch == 'true'
         env:
           HUB_DISPATCH_TOKEN: ${{ steps.hub_token.outputs.token }}
-          HUB_REPO: ${{ vars.DOCS_HUB_REPO }}
-          DEFAULT_HUB_REPO: potpie-ai/docs
+          HUB_REPO: potpie-ai/docs
           SPOKE_REPO: ${{ github.repository }}
           BRANCH: ${{ github.ref_name }}
           SHA: ${{ github.sha }}
@@ -79,13 +78,6 @@ jobs:
           set -euo pipefail
           if [ -z "${HUB_DISPATCH_TOKEN:-}" ]; then
             echo "::error::GitHub App token was not minted. Confirm the App is installed on potpie-ai/docs and the Actions Client ID/private key are configured for this workflow."
-            exit 1
-          fi
-          if [ -z "${HUB_REPO:-}" ]; then
-            HUB_REPO="$DEFAULT_HUB_REPO"
-          fi
-          if [ "$HUB_REPO" != "$DEFAULT_HUB_REPO" ]; then
-            echo "::error::DOCS_HUB_REPO must be $DEFAULT_HUB_REPO when using the documentation GitHub App"
             exit 1
           fi
           payload="$(node -e '

--- a/.github/workflows/docs-dispatch.yml
+++ b/.github/workflows/docs-dispatch.yml
@@ -50,10 +50,26 @@ jobs:
           echo "should_dispatch=$should_dispatch" >> "$GITHUB_OUTPUT"
           echo "Dispatch Hub rebuild: $should_dispatch"
 
+      - name: Mint Hub dispatch token
+        id: hub_token
+        if: steps.docs_change.outputs.should_dispatch == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ vars.DOCS_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.DOCS_GITHUB_APP_PRIVATE_KEY }}
+          owner: potpie-ai
+          repositories: docs
+          permission-contents: write
+
+      - name: Explain Hub token mint failure
+        if: ${{ failure() && steps.docs_change.outputs.should_dispatch == 'true' && steps.hub_token.conclusion == 'failure' }}
+        run: |
+          echo "::error::GitHub App token was not minted. Confirm the App is installed on potpie-ai/potpie and the Actions Client ID/private key are configured."
+
       - name: Send repository_dispatch to Hub
         if: steps.docs_change.outputs.should_dispatch == 'true'
         env:
-          DOCS_HUB_DISPATCH_TOKEN: ${{ secrets.DOCS_HUB_DISPATCH_TOKEN }}
+          HUB_DISPATCH_TOKEN: ${{ steps.hub_token.outputs.token }}
           HUB_REPO: ${{ vars.DOCS_HUB_REPO }}
           DEFAULT_HUB_REPO: potpie-ai/docs
           SPOKE_REPO: ${{ github.repository }}
@@ -61,12 +77,16 @@ jobs:
           SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          if [ -z "${DOCS_HUB_DISPATCH_TOKEN:-}" ]; then
-            echo "::error::DOCS_HUB_DISPATCH_TOKEN secret is not set on this Spoke"
+          if [ -z "${HUB_DISPATCH_TOKEN:-}" ]; then
+            echo "::error::GitHub App token was not minted. Confirm the App is installed on potpie-ai/potpie and the Actions Client ID/private key are configured."
             exit 1
           fi
           if [ -z "${HUB_REPO:-}" ]; then
             HUB_REPO="$DEFAULT_HUB_REPO"
+          fi
+          if [ "$HUB_REPO" != "$DEFAULT_HUB_REPO" ]; then
+            echo "::error::DOCS_HUB_REPO must be $DEFAULT_HUB_REPO when using the documentation GitHub App"
+            exit 1
           fi
           SPOKE_ID="$(node -e 'const fs=require("fs"); const c=JSON.parse(fs.readFileSync("docs/config.json","utf8")); if (!c.spokeId) process.exit(1); process.stdout.write(String(c.spokeId))')"
           payload=$(printf '{"event_type":"spoke-docs-updated","client_payload":{"repository":"%s","branch":"%s","sha":"%s","spoke_id":"%s"}}' \
@@ -74,7 +94,7 @@ jobs:
           code=$(curl -sS -o /tmp/dispatch-response.json -w "%{http_code}" \
             -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${DOCS_HUB_DISPATCH_TOKEN}" \
+            -H "Authorization: Bearer ${HUB_DISPATCH_TOKEN}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${HUB_REPO}/dispatches" \
             -d "$payload")

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,11 @@ repos:
       - id: detect-private-key
       - id: debug-statements
 
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.3
     hooks:

--- a/tests/docs/docs-dispatch-check.test.mjs
+++ b/tests/docs/docs-dispatch-check.test.mjs
@@ -6,12 +6,12 @@ import { describe, test } from 'node:test';
 import { shouldDispatchDocs } from './docs-dispatch-check.mjs';
 import { DOCS_CONFIG_REPO_PATH } from './lib/docs-changed.mjs';
 
-function makeInputs(changedPaths, docsPath = 'docs') {
+function makeInputs(changedPaths, docsPath = 'docs', spokeId = 'demo') {
   const root = mkdtempSync(join(tmpdir(), 'docs-dispatch-'));
   const configPath = join(root, 'docs/config.json');
   const changedFilesPath = join(root, 'changed.txt');
   mkdirSync(join(root, 'docs'), { recursive: true });
-  writeFileSync(configPath, JSON.stringify({ spokeId: 'demo', docsPath }));
+  writeFileSync(configPath, JSON.stringify({ spokeId, docsPath }));
   writeFileSync(changedFilesPath, `${changedPaths.join('\n')}\n`);
   return { configPath, changedFilesPath };
 }
@@ -30,5 +30,14 @@ describe('shouldDispatchDocs', () => {
 
   test('skips code-only changes', () => {
     assert.equal(shouldDispatchDocs(makeInputs(['potpie/cli/main.py'], 'website/docs')), false);
+  });
+
+  test('rejects blank and invalid spokeId values before deciding to dispatch', () => {
+    for (const spokeId of ['', 'Not Valid']) {
+      assert.throws(
+        () => shouldDispatchDocs(makeInputs(['website/docs/index.md'], 'website/docs', spokeId)),
+        /spokeId/,
+      );
+    }
   });
 });

--- a/tests/docs/docs-dispatch-workflow.test.mjs
+++ b/tests/docs/docs-dispatch-workflow.test.mjs
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, test } from 'node:test';
+import { parse } from 'yaml';
+
+const workflowPath = fileURLToPath(
+  new URL('../../.github/workflows/docs-dispatch.yml', import.meta.url),
+);
+
+function loadDispatchSteps() {
+  const workflow = parse(readFileSync(workflowPath, 'utf8'));
+  return workflow.jobs.dispatch.steps;
+}
+
+describe('docs dispatch workflow', () => {
+  test('checks whether docs changed before minting a GitHub App token', () => {
+    const steps = loadDispatchSteps();
+    const docsChangeIndex = steps.findIndex((step) => step.id === 'docs_change');
+    const tokenIndex = steps.findIndex((step) => step.id === 'hub_token');
+
+    assert.notEqual(docsChangeIndex, -1);
+    assert.notEqual(tokenIndex, -1);
+    assert.ok(docsChangeIndex < tokenIndex);
+    assert.equal(
+      steps[tokenIndex].if,
+      "steps.docs_change.outputs.should_dispatch == 'true'",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Replace the long-lived Hub dispatch PAT with a short-lived GitHub App installation token.
- Mint the token only when documentation changed.
- Restrict it to potpie-ai/docs with Contents write, then use it only for repository_dispatch.
- Pin the token action to its reviewed v3 commit.

## Prerequisites before merge
- Install the documentation GitHub App on potpie-ai/potpie and potpie-ai/docs.
- Configure DOCS_GITHUB_APP_CLIENT_ID as an Actions variable and DOCS_GITHUB_APP_PRIVATE_KEY as an Actions secret in Potpie.
- Merge the Hub App-auth change before removing the existing Hub PAT secret.

## Verification
- npm test --prefix tests/docs (89 passing)
- Workflow YAML parses
- git diff --check