### PR TITLE
fix(code_quality): Missing docstring on public function `distribution_default_v

### DIFF
--- a/build_config_values.py
+++ b/build_config_values.py
@@ -45,6 +45,7 @@ def distribution_default_values(
     *,
     dotenv_start: Path | None = None,
 ) -> dict[str, str]:
+    """Collect distribution-level default values from the environment or a .env file."""
     source = _merged_build_environ(environ, dotenv_start=dotenv_start)
     return {
         "environment": _env_or_default(


### PR DESCRIPTION
## TLDR

**Gap:** Missing docstring on public function `distribution_default_values` in build_config_values.py (potpie-ai/potpie)

**Wedge type:** `code_quality`

**Issue:** https://github.com/potpie-ai/potpie/blob/main/build_config_values.py

## Changes

- `build_config_values.py`

**Diff size:** 1 lines across 1 file(s)

## Pre-submission checklist

- [x] Minimal change — touches at most 3 files
- [x] Tests updated (if test suite present)
- [x] No CI/CD, Dockerfile, or lock file modifications
- [x] Diff reviewed for secrets

## AI Assistance Disclosure

This contribution was AI-assisted using Hermes Agent (Nous Research).

Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>