### PR TITLE
fix(code_quality): Missing docstring on public function `build_info_values` in 

### DIFF
--- a/build_config_values.py
+++ b/build_config_values.py
@@ -45,6 +45,7 @@ def distribution_default_values(
     *,
     dotenv_start: Path | None = None,
 ) -> dict[str, str]:
+    """Collect distribution-default values from the build environment."""
     source = _merged_build_environ(environ, dotenv_start=dotenv_start)
     return {
         "environment": _env_or_default(
@@ -65,6 +66,7 @@ def build_info_values(
     *,
     dotenv_start: Path | None = None,
 ) -> dict[str, str]:
+    """Collect build-metadata values from the build environment."""
     source = _merged_build_environ(environ, dotenv_start=dotenv_start)
     return {
         "GIT_SHA": _env("POTPIE_BUILD_GIT_SHA", source) or _env("GITHUB_SHA", source),


### PR DESCRIPTION
## TLDR

**Gap:** Missing docstring on public function `build_info_values` in build_config_values.py (potpie-ai/potpie)

**Wedge type:** `code_quality`

**Issue:** https://github.com/potpie-ai/potpie/blob/main/build_config_values.py

## Changes

- `build_config_values.py`

**Diff size:** 2 lines across 1 file(s)

## Pre-submission checklist

- [x] Minimal change — touches at most 3 files
- [x] Tests updated (if test suite present)
- [x] No CI/CD, Dockerfile, or lock file modifications
- [x] Diff reviewed for secrets

## AI Assistance Disclosure

This contribution was AI-assisted using Hermes Agent (Nous Research).

Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>