### PR TITLE
fix(code_quality): Missing docstring on public function `should_validate_distri

### DIFF
--- a/build_config_values.py
+++ b/build_config_values.py
@@ -77,6 +77,7 @@ def should_validate_distribution_defaults(
     *,
     dotenv_start: Path | None = None,
 ) -> bool:
+    """Return True when POTPIE_VALIDATE_DISTRIBUTION_DEFAULTS is set to a truthy value."""
     source = _merged_build_environ(environ, dotenv_start=dotenv_start)
     return _env("POTPIE_VALIDATE_DISTRIBUTION_DEFAULTS", source).lower() in {
         "1",


### PR DESCRIPTION
## TLDR

**Gap:** Missing docstring on public function `should_validate_distribution_defaults` in build_config_values.py (potpie-ai/potpie)

**Wedge type:** `code_quality`

**Issue:** https://github.com/potpie-ai/potpie/blob/main/build_config_values.py

## Changes

- `build_config_values.py`

**Diff size:** 1 lines across 1 file(s)

## Pre-submission checklist

- [x] Minimal change — touches at most 3 files
- [x] Tests updated (if test suite present)
- [x] No CI/CD, Dockerfile, or lock file modifications
- [x] Diff reviewed for secrets

## AI Assistance Disclosure

This contribution was AI-assisted using Hermes Agent (Nous Research).

Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>