### PR TITLE
feat: support OrcaRouter as a named reconciliation model provider

### DIFF
--- a/potpie/context-engine/src/potpie_context_engine/adapters/outbound/reconciliation/pydantic_deep_agent.py
+++ b/potpie/context-engine/src/potpie_context_engine/adapters/outbound/reconciliation/pydantic_deep_agent.py
@@ -199,6 +199,42 @@ def _pydantic_deep_version() -> str:
         return "unknown"
 
 
+# OrcaRouter is OpenAI-compatible and exposes a provider/model namespace the
+# same way OpenRouter does, so the reconciliation agent can target it as a
+# named provider instead of an anonymous custom base URL. The model id keeps
+# the ``orcarouter:`` prefix (e.g. ``orcarouter:anthropic/claude-sonnet-4``)
+# while the OpenAI SDK is pointed at the gateway's base URL.
+_ORCAROUTER_MODEL_PREFIX = "orcarouter:"
+_ORCAROUTER_BASE_URL = "https://api.orcarouter.ai/v1"
+
+
+def _resolve_reconciliation_model(model: str) -> str | Any:
+    """Return a pydantic-ai model for the configured reconciliation model id.
+
+    A literal ``model=...`` (e.g. a pydantic-ai ``TestModel`` in tests, or any
+    other ``Model`` instance) is passed through untouched. String ids keep the
+    pydantic-deep string path except for the ``orcarouter:`` prefix, which is
+    built into an ``OpenAIChatModel`` backed by an ``OpenAIProvider`` pointed at
+    the OrcaRouter gateway so users can use it with ``ORCAROUTER_API_KEY`` alone.
+    """
+    if not isinstance(model, str) or not model.startswith(_ORCAROUTER_MODEL_PREFIX):
+        return model
+    try:
+        from pydantic_ai.models.openai import OpenAIChatModel
+        from pydantic_ai.providers.openai import OpenAIProvider
+    except ImportError as exc:  # pragma: no cover - pydantic-ai is a hard dep
+        raise RuntimeError(
+            "pydantic-ai with the openai extra is required to use the "
+            "orcarouter reconciliation model"
+        ) from exc
+    model_name = model[len(_ORCAROUTER_MODEL_PREFIX) :]
+    provider = OpenAIProvider(
+        base_url=_ORCAROUTER_BASE_URL,
+        api_key=os.getenv("ORCAROUTER_API_KEY") or "api-key-not-set",
+    )
+    return OpenAIChatModel(model_name, provider=provider)
+
+
 # Procedure skills shipped beside this adapter. Each is a trusted, in-repo
 # SKILL.md (instructions only — no executable scripts) carrying the *how* for a
 # recurring procedure: the backfill enumerate-then-drain loop, the mutation-plan
@@ -667,9 +703,13 @@ class PydanticDeepReconciliationAgent:
         # gpt-5 family models reject function tools + reasoning_effort on
         # /v1/chat/completions ("openai:" prefix). The Responses endpoint
         # ("openai-responses:" prefix) supports the combination.
-        self._model = model or os.getenv(
+        self._model_id = model or os.getenv(
             "CONTEXT_ENGINE_RECONCILIATION_MODEL", "openai-responses:gpt-5.4-mini"
         )
+        # ``orcarouter:`` ids are resolved to an OpenAI-compatible model backed
+        # by the OrcaRouter gateway; every other id stays a string for
+        # pydantic-deep's own provider inference.
+        self._model = _resolve_reconciliation_model(self._model_id)
         self._instructions = instructions or _RECONCILIATION_INSTRUCTIONS
         self._tools_port: ReconciliationToolsPort | None = tools
         self._context_graph: ContextGraphPort | None = None
@@ -710,7 +750,7 @@ class PydanticDeepReconciliationAgent:
             "agent": "pydantic-deep",
             "version": _pydantic_deep_version(),
             "toolset_version": "batch-tools-v1",
-            "model": self._model,
+            "model": self._model_id,
             "has_context_tools": self._tools_port is not None,
             "has_context_graph": self._context_graph is not None,
         }
@@ -1015,7 +1055,7 @@ class PydanticDeepReconciliationAgent:
                 CostEvent(
                     pot_id=ctx.pot_id,
                     kind="agent",
-                    model=self._model,
+                    model=self._model_id,
                     input_tokens=_int_or_none(usage_payload.get("input_tokens")),
                     output_tokens=_int_or_none(usage_payload.get("output_tokens")),
                     total_tokens=_int_or_none(usage_payload.get("total_tokens")),

--- a/potpie/context-engine/src/potpie_context_engine/benchmarks/README.md
+++ b/potpie/context-engine/src/potpie_context_engine/benchmarks/README.md
@@ -106,7 +106,7 @@ For the **HTTP** path the bench talks to a real engine. Required environment:
 | `OPENAI_API_KEY` | Used by the LLM judge (default model `gpt-5.4`). |
 | `POTPIE_BENCH_JUDGE_MODEL` | Optional. Override the judge model. Default `gpt-5.4`. |
 | `POTPIE_BENCH_REPO` | Optional. `owner/repo` to attach to each ephemeral pot. Default `acme/sandbox`. |
-| `CONTEXT_ENGINE_RECONCILIATION_MODEL` | Optional. Reconciliation-agent model on the engine side. Default `openai-responses:gpt-5.4-mini`. |
+| `CONTEXT_ENGINE_RECONCILIATION_MODEL` | Optional. Reconciliation-agent model on the engine side. Default `openai-responses:gpt-5.4-mini`. Prefix with `orcarouter:` (e.g. `orcarouter:anthropic/claude-sonnet-4`) to run the agent through the OrcaRouter gateway using `ORCAROUTER_API_KEY`. |
 
 ## Running
 

--- a/potpie/context-engine/tests/unit/test_pydantic_deep_agent_batch.py
+++ b/potpie/context-engine/tests/unit/test_pydantic_deep_agent_batch.py
@@ -109,6 +109,74 @@ def test_compose_instructions_dedupes_repeated_event_kinds() -> None:
     assert text.count("github / pull_request / merged") == 1
 
 
+def test_orcarouter_model_prefix_resolves_to_openai_chat_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("pydantic_deep")
+    pytest.importorskip("openai")
+
+    from pydantic_ai.models.openai import OpenAIChatModel
+
+    from potpie_context_engine.adapters.outbound.reconciliation.pydantic_deep_agent import (
+        _resolve_reconciliation_model,
+    )
+
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test-key")
+
+    model = _resolve_reconciliation_model("orcarouter:anthropic/claude-sonnet-4")
+
+    assert isinstance(model, OpenAIChatModel)
+    assert model._model_name == "anthropic/claude-sonnet-4"
+    assert str(model._provider.base_url) == "https://api.orcarouter.ai/v1/"
+    assert model._provider.client.api_key == "sk-orca-test-key"
+
+
+def test_orcarouter_model_prefix_keeps_default_without_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("pydantic_deep")
+    pytest.importorskip("openai")
+
+    from potpie_context_engine.adapters.outbound.reconciliation.pydantic_deep_agent import (
+        _resolve_reconciliation_model,
+    )
+
+    monkeypatch.delenv("ORCAROUTER_API_KEY", raising=False)
+
+    model = _resolve_reconciliation_model("orcarouter:anthropic/claude-sonnet-4")
+    # The OpenAI SDK requires a non-empty key; we fall back to a placeholder so
+    # construction never hard-fails when the env var is absent.
+    assert model._provider.client.api_key == "api-key-not-set"
+
+
+def test_reconciliation_model_string_passthrough() -> None:
+    pytest.importorskip("pydantic_deep")
+
+    from potpie_context_engine.adapters.outbound.reconciliation.pydantic_deep_agent import (
+        _resolve_reconciliation_model,
+    )
+
+    # Non-orcarouter strings keep the pydantic-deep string path untouched.
+    assert (
+        _resolve_reconciliation_model("openai-responses:gpt-5.4-mini")
+        == "openai-responses:gpt-5.4-mini"
+    )
+
+
+def test_reconciliation_model_object_passthrough() -> None:
+    pytest.importorskip("pydantic_deep")
+    pytest.importorskip("openai")
+
+    from pydantic_ai.models.test import TestModel
+
+    from potpie_context_engine.adapters.outbound.reconciliation.pydantic_deep_agent import (
+        _resolve_reconciliation_model,
+    )
+
+    test_model = TestModel()
+    assert _resolve_reconciliation_model(test_model) is test_model
+
+
 def test_run_batch_short_circuits_for_empty_event_list() -> None:
     pytest.importorskip("pydantic_deep")
     agent = PydanticDeepReconciliationAgent()


### PR DESCRIPTION
### Summary

This adds OrcaRouter as a first-class, named provider for Potpie's reconciliation agent, so anyone who runs the context graph through [OrcaRouter](https://www.orcarouter.ai) gets the whole gateway on the same model string they already use for OpenRouter.

Potpie's context engine drives graph reconciliation through `CONTEXT_ENGINE_RECONCILIATION_MODEL` in the `provider/model` format that pydantic-deep resolves — the same convention the repo already documents for OpenRouter (`openrouter/deepseek/deepseek-chat` in `.github/GETTING_STARTED.md`) and recognizes in `tests/integration/conftest.py` (`OPENROUTER_API_KEY` alongside `OPENAI_API_KEY`/`ANTHROPIC_API_KEY`). Until now an OrcaRouter endpoint had to be wired up as a custom base URL, which means no provider name, no discoverability, and a config that isn't portable across Potpie installs.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter:` as a named provider means Potpie users can point the reconciliation agent at it with a single env var (`ORCAROUTER_API_KEY`) and a model string like `orcarouter:anthropic/claude-sonnet-4`, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### What changed

- `pydantic_deep_agent.py` — a `_resolve_reconciliation_model()` helper that turns an `orcarouter:`-prefixed model id into an `OpenAIChatModel` backed by an `OpenAIProvider` pointed at `https://api.orcarouter.ai/v1`. Every other id (including a literal pydantic-ai `Model` such as the `TestModel` the tests use) is passed through untouched, so the default `openai-responses:gpt-5.4-mini` path is unchanged. The raw model id is kept for telemetry/capability metadata so the cost table keeps a stable string.
- `tests/unit/test_pydantic_deep_agent_batch.py` — four tests covering the `orcarouter:` resolution (base URL + API key), the missing-key fallback, and string/object passthrough.
- `benchmarks/README.md` — documented the `orcarouter:` prefix on `CONTEXT_ENGINE_RECONCILIATION_MODEL`.

### Verification

- `ruff check` on the changed files introduces no new findings (error-code set identical to `main`).
- Full context-engine unit suite: 740 passed, 3 skipped; integration `test_pydantic_deep_agent_run_batch.py`: 4 passed.
- Live: a real chat completion and a tool-calling turn both round-tripped through `https://api.orcarouter.ai/v1` using the new `orcarouter:` code path with `ORCAROUTER_API_KEY`.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
