### PR TITLE
Release: bump Potpie to 2.0.1 and Context Engine to 0.2.0

### DIFF
--- a/potpie/context-engine/pyproject.toml
+++ b/potpie/context-engine/pyproject.toml
@@ -7,7 +7,7 @@ path = "sentry_defaults_hook.py"
 
 [project]
 name = "potpie-context-engine"
-version = "0.1.0"
+version = "0.2.0"
 description = "Context graph API and webhooks."
 requires-python = ">=3.12,<3.15"
 classifiers = ["Typing :: Typed"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ path = "scripts/distribution_defaults_hook.py"
 
 [project]
 name = "potpie"
-version = "2.0.0"
+version = "2.0.1"
 description = "Potpie product distribution"
 readme = "README.md"
 requires-python = ">=3.12,<3.15"
@@ -35,7 +35,7 @@ dependencies = [
     "httpx>=0.28.0",
     "keyring>=25.0.0",
     "pillow>=12.3.0",
-    "potpie-context-engine[all]==0.1.0",
+    "potpie-context-engine[all]==0.2.0",
     "pydantic-ai-slim>=1.106.0",
     "pydantic-settings>=2.14.2",
     "pyjwt>=2.13.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2433,7 +2433,7 @@ wheels = [
 
 [[package]]
 name = "potpie"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -2498,7 +2498,7 @@ dev = [
 
 [[package]]
 name = "potpie-context-engine"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "potpie/context-engine" }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- bump `potpie-context-engine` from 0.1.0 to 0.2.0
- bump `potpie` from 2.0.0 to 2.0.1
- pin Potpie to Context Engine 0.2.0 and refresh the workspace lock

## Validation

- `uv run --offline pytest tests/unit/test_validate_python_release.py --confcutdir=tests/unit` (17 passed)
- GitHub Actions-equivalent release metadata validation for scope `all`
- built and inspected both wheels; confirmed package versions and Potpie exact Context Engine requirement