### PR TITLE
CI: remove Windows from release smoke matrix

### DIFF
--- a/.github/workflows/release_potpie_pypi.yml
+++ b/.github/workflows/release_potpie_pypi.yml
@@ -179,7 +179,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.12", "3.13", "3.14"]
     env:
       RELEASE_SCOPE: ${{ needs.preflight.outputs.release_scope }}


### PR DESCRIPTION
Removes windows-latest from the PyPI release smoke-install matrix because the context engine local extra installs FalkorDBLite, whose redislite dependency does not support win32. Linux and macOS coverage remains across Python 3.12, 3.13, and 3.14. Validation: pre-commit check-yaml and actionlint both pass; git diff --check passes.