### PR TITLE
Fix PyPI Core Metadata 2.5 publishing

### DIFF
--- a/.github/workflows/release_potpie_pypi.yml
+++ b/.github/workflows/release_potpie_pypi.yml
@@ -366,7 +366,7 @@ jobs:
           path: release-bundle
 
       - name: Publish potpie-context-engine
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           packages-dir: release-bundle/dist/context-engine/
 
@@ -401,7 +401,7 @@ jobs:
           path: release-bundle
 
       - name: Publish potpie
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           packages-dir: release-bundle/dist/potpie/
 

--- a/potpie/context-engine/pyproject.toml
+++ b/potpie/context-engine/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling==1.32.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.hooks.custom]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.27"]
+requires = ["hatchling==1.32.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.hooks.custom]


### PR DESCRIPTION
## Summary

- update both PyPI publishing jobs to the current reviewed release/v1 action SHA with Twine 7 and packaging 26 support
- pin Hatchling 1.32.0 for the root and Context Engine build backends so release metadata generation is deterministic

## Root cause

Hatchling 1.32.0 now emits Core Metadata 2.5 by default. The release build check used Twine 7 and accepted the wheels, but the separately pinned gh-action-pypi-publish revision still carried Twine 6.1.0 and packaging 25.0, so it rejected the Context Engine wheel before upload. The root Potpie wheel had the same Metadata-Version and would have failed next.

## Validation

- pre-commit run --files .github/workflows/release_potpie_pypi.yml pyproject.toml potpie/context-engine/pyproject.toml
- uv run --frozen pytest --confcutdir=tests/unit tests/unit/test_validate_python_release.py -q: 17 passed
- built potpie-context-engine 0.2.0 and potpie 2.0.1 wheels with the pinned backend
- Twine 7 check passed for both wheels; Context Engine retains its existing missing long-description warnings
- inspected both wheels: Metadata-Version 2.5 and Generator hatchling 1.32.0

## Release follow-up

No package was published by the failed run. After this PR merges, start a new release_scope=all dispatch from the updated main branch; rerunning the old job would reuse its old workflow revision.