### PR TITLE
fix: close the 2.0.1 release-test findings

### DIFF
--- a/potpie/cli/cli_install_status.py
+++ b/potpie/cli/cli_install_status.py
@@ -16,32 +16,51 @@ CLI_TOOL_NAME = "potpie-context-engine"
 CLI_EXECUTABLE = "potpie"
 _UV_TOOL_NAMES = frozenset({"potpie", "potpie-context-engine", "context-engine"})
 
+# Diagnostics that ship with the wheel must only name commands the wheel
+# provides. `make` targets exist in the source checkout, never in an install,
+# so they are added only when the running CLI is an editable repo install.
 _DIAGNOSTIC_COMMANDS = (
+    "potpie doctor",
     "uv tool list",
     "which -a potpie",
-    'head -n 1 "$(command -v potpie)"',
-    "make cli-status",
-    "make cli-install",
 )
+_EDITABLE_DIAGNOSTIC_COMMANDS = ("make cli-status", "make cli-install")
 
 _LOCAL_REINSTALL_HINT = (
-    "Check with `make cli-status` or `potpie doctor`. "
-    "Repo-local reinstall: `make cli-install` "
+    "Check with `potpie doctor`. Repo-local reinstall: `make cli-install` "
     "(builds UI, stops old daemon) — not raw `uv tool install`."
 )
 _PUBLISHED_HINT = (
-    "Check with `make cli-status` or `potpie doctor`. "
-    "Published-package reinstall: `uv tool install potpie` "
-    "(or `pip install potpie`)."
+    "Check with `potpie doctor`. Published-package reinstall: "
+    "`uv tool install --force potpie` (or `pip install --upgrade potpie`)."
 )
 
 
 def collect_cli_install_status() -> dict[str, Any]:
-    """Return install facts for ``potpie doctor`` and ``make cli-status``."""
+    """Return install facts about **the running** ``potpie``.
+
+    Resolution starts at this process (``sys.argv[0]`` / ``sys.executable``)
+    rather than at ``$PATH``: scanning ``$PATH`` first made ``doctor`` report a
+    *different* install's version, and made the running binary declare itself
+    "NOT on PATH" whenever ``$PATH`` did not happen to contain it.
+    """
     paths_on_path = _potpie_paths_on_path()
-    primary_path = paths_on_path[0] if paths_on_path else None
-    python_interpreter = _python_from_script(primary_path) if primary_path else None
-    python_version = _python_version(python_interpreter)
+    running_path = _running_cli_path()
+    # The running entry point is authoritative; PATH entries are context.
+    primary_path = running_path or (paths_on_path[0] if paths_on_path else None)
+    resolved_primary = _realpath(primary_path)
+    other_paths = [
+        path for path in paths_on_path if _realpath(path) != resolved_primary
+    ]
+    is_running = bool(running_path) and primary_path == running_path
+
+    if is_running:
+        # We are the process being diagnosed: ask ourselves, never a shebang.
+        python_interpreter = sys.executable
+        python_version = ".".join(map(str, sys.version_info[:3]))
+    else:
+        python_interpreter = _python_from_script(primary_path)
+        python_version = _python_version(python_interpreter)
 
     listed_uv = _uv_tool_list_status()
     active_uv = _active_uv_tool_from_executable(primary_path)
@@ -51,7 +70,11 @@ def collect_cli_install_status() -> dict[str, Any]:
         and _is_editable_uv_tool(active_uv["tool_root"], str(active_uv["tool_name"]))
     )
 
-    package_version = _package_version_via_interpreter(python_interpreter)
+    package_version = (
+        _installed_package_version()
+        if is_running
+        else _package_version_via_interpreter(python_interpreter)
+    )
     if package_version is None:
         package_version = _installed_package_version()
 
@@ -67,12 +90,24 @@ def collect_cli_install_status() -> dict[str, Any]:
     elif via_uv_tool:
         hint = _PUBLISHED_HINT
 
+    diagnostics = list(_DIAGNOSTIC_COMMANDS)
+    if editable:
+        diagnostics.extend(_EDITABLE_DIAGNOSTIC_COMMANDS)
+
     return {
         "package_name": CLI_TOOL_NAME,
         "package_version": package_version,
+        "product_version": _product_version(),
         "on_path": bool(paths_on_path),
         "paths": paths_on_path,
         "primary_path": primary_path,
+        "running_path": running_path,
+        # The running CLI is on PATH only if some PATH entry resolves to it.
+        "running_on_path": bool(
+            resolved_primary
+            and any(_realpath(path) == resolved_primary for path in paths_on_path)
+        ),
+        "other_paths": other_paths,
         "python_interpreter": python_interpreter,
         "python_version": python_version,
         "runtime_python": sys.executable,
@@ -86,38 +121,90 @@ def collect_cli_install_status() -> dict[str, Any]:
         "editable": editable if via_uv_tool else None,
         # Only when the active PATH executable is backed by a uv tools env.
         "install_method": "uv_tool" if via_uv_tool else None,
-        "diagnostic_commands": list(_DIAGNOSTIC_COMMANDS),
+        "diagnostic_commands": diagnostics,
         "hint": hint,
         "pip_show_note": (
-            "Do not use `python -m pip show potpie-context-engine` for local dev "
-            "installs: `python` may be absent from PATH and the package lives in "
-            "the uv tool environment. Prefer `uv tool list`, `which -a potpie`, "
-            "`make cli-status`, and `make cli-install` for repo-local reinstalls."
+            "Do not use `python -m pip show potpie-context-engine`: `python` may "
+            "be absent from PATH and the package lives in the uv tool "
+            "environment. Prefer `potpie doctor`, `uv tool list`, and "
+            "`which -a potpie`."
         ),
     }
 
 
+def _realpath(path: str | None) -> str | None:
+    if not path:
+        return None
+    try:
+        return os.path.realpath(path)
+    except OSError:
+        return path
+
+
+def _product_version() -> str | None:
+    try:
+        return version("potpie")
+    except PackageNotFoundError:
+        return None
+
+
+def _running_cli_path() -> str | None:
+    """Path of the console script that started this process, if it is one.
+
+    ``python -m potpie.cli.main`` and test harnesses do not run a console
+    script, so this returns ``None`` there and PATH scanning takes over.
+    """
+    argv0 = (sys.argv[0] if sys.argv else "") or ""
+    if not argv0:
+        return None
+    name = os.path.basename(argv0)
+    if name not in {CLI_EXECUTABLE, f"{CLI_EXECUTABLE}.exe"}:
+        return None
+    candidate = argv0
+    if os.path.sep not in argv0:
+        found = shutil.which(argv0)
+        if not found:
+            return None
+        candidate = found
+    if not os.path.isfile(candidate):
+        return None
+    return os.path.abspath(candidate)
+
+
 def cli_install_human(status: dict[str, Any]) -> str:
-    if not status.get("on_path"):
-        return "cli: potpie NOT on PATH (run: make cli-install)"
+    path = status.get("primary_path")
+    if not path:
+        return (
+            "cli: potpie entry point not resolvable "
+            "(install with: uv tool install potpie)"
+        )
     pkg = str(status.get("package_name") or CLI_TOOL_NAME)
     ver = status.get("package_version") or status.get("uv_tool_version") or "unknown"
-    path = status.get("primary_path") or "unknown"
+    product = status.get("product_version")
     py = status.get("python_version")
     via = status.get("install_method")
-    parts = [f"cli: {pkg} {ver}", f"path={path}"]
+    parts = [f"cli: potpie {product}" if product else "cli: potpie", f"({pkg} {ver})"]
+    parts.append(f"path={path}")
     if via:
         parts.append(f"via={via}")
     if status.get("editable"):
         parts.append("editable=true")
     if py:
         parts.append(f"python={py}")
-    line = " ".join(parts)
+    lines = [" ".join(parts)]
+    if not status.get("running_on_path"):
+        lines.append(
+            "  note: this potpie is not the one on $PATH "
+            "(run `uv tool update-shell`, or restart your shell)"
+        )
+    others = status.get("other_paths") or []
+    if others:
+        lines.append(f"  other installs on $PATH: {', '.join(others)}")
     if status.get("editable"):
-        line += " | tip: make cli-status (local reinstall: make cli-install)"
+        lines.append("  tip: local reinstall with `make cli-install`")
     elif via == "uv_tool":
-        line += " | tip: make cli-status (published: uv tool install potpie)"
-    return line
+        lines.append("  tip: reinstall with `uv tool install --force potpie`")
+    return "\n".join(lines)
 
 
 def _installed_package_version() -> str | None:
@@ -174,6 +261,12 @@ def _potpie_paths_on_path() -> list[str]:
 
 
 def _python_from_script(script_path: str | None) -> str | None:
+    """Interpreter named by a script's shebang, only if it *is* a Python.
+
+    uv's tool-env entry points are ``#!/bin/sh`` wrappers. Running
+    ``/bin/sh --version`` and scraping a number reported macOS bash's 3.2.57 as
+    the CLI's Python version, so a non-Python shebang yields nothing here.
+    """
     if not script_path:
         return None
     try:
@@ -181,13 +274,28 @@ def _python_from_script(script_path: str | None) -> str | None:
             first = handle.readline().strip()
     except (OSError, UnicodeDecodeError):
         return None
-    if first.startswith("#!"):
-        return first[2:].strip() or None
-    return None
+    if not first.startswith("#!"):
+        return None
+    shebang = first[2:].strip()
+    if not shebang:
+        return None
+    interpreter = shebang.split()[0]
+    # `#!/usr/bin/env python3.12` names the interpreter in the second word.
+    if os.path.basename(interpreter) == "env":
+        parts = shebang.split()
+        interpreter = parts[1] if len(parts) > 1 else ""
+    return interpreter if _is_python_interpreter(interpreter) else None
+
+
+def _is_python_interpreter(interpreter: str) -> bool:
+    return os.path.basename(interpreter or "").lower().startswith("python")
+
+
+_PYTHON_VERSION_RE = re.compile(r"^Python (\d+\.\d+(?:\.\d+)?)", re.MULTILINE)
 
 
 def _python_version(interpreter: str | None) -> str | None:
-    if not interpreter:
+    if not interpreter or not _is_python_interpreter(interpreter):
         return None
     try:
         proc = subprocess.run(
@@ -200,8 +308,9 @@ def _python_version(interpreter: str | None) -> str | None:
     except (OSError, subprocess.TimeoutExpired):
         return None
     output = (proc.stdout or proc.stderr or "").strip()
-    match = re.search(r"(\d+\.\d+(?:\.\d+)?)", output)
-    return match.group(1) if match else output or None
+    # Anchored on Python's own banner so no other tool's version can match.
+    match = _PYTHON_VERSION_RE.search(output)
+    return match.group(1) if match else None
 
 
 def _active_uv_tool_from_executable(script_path: str | None) -> dict[str, Any] | None:

--- a/potpie/cli/commands/_common.py
+++ b/potpie/cli/commands/_common.py
@@ -20,6 +20,7 @@ import json
 import os
 import sys
 import time
+import traceback
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable, Final, Iterator, Mapping, NoReturn, Sequence
@@ -271,11 +272,17 @@ def get_engine_client(explicit_pot: str | None = None, *, runtime: Any | None = 
         try:
             connection = load_daemon_connection(home)
         except DaemonDiscoveryError as exc:
+            # Say *why* discovery failed and point at a recovery that can
+            # actually run: "start" when there is no record at all, "restart"
+            # when a pre-upgrade daemon left one this build cannot read.
             raise EngineClientError(
                 ProtocolTransportError(
-                    code="daemon_discovery_unavailable",
-                    message="canonical daemon discovery is unavailable",
-                    recommended_next_action="run 'potpie daemon restart'",
+                    code=getattr(exc, "code", "daemon_discovery_unavailable"),
+                    message=f"cannot reach the potpie daemon: {exc}",
+                    recommended_next_action=(
+                        getattr(exc, "recommended_next_action", None)
+                        or "run 'potpie daemon restart'"
+                    ),
                     retry_posture="safe",
                 )
             ) from exc
@@ -351,8 +358,14 @@ def confirm_destructive_operation(
     confirmed_by_flag: bool,
     prompt: str,
     rerun_command: str,
+    target: str | None = None,
 ):
-    """Bind explicit confirmation before dispatching a destructive operation."""
+    """Bind explicit confirmation before dispatching a destructive operation.
+
+    ``target`` names what is about to be destroyed. It rides on the
+    non-interactive refusal too, so a scripted or ``--json`` caller sees the
+    resolved target rather than only a rerun command.
+    """
 
     from potpie.runtime import DestructiveConfirmation
 
@@ -361,7 +374,11 @@ def confirm_destructive_operation(
     if is_json() or not sys.stdin.isatty():
         fail(
             code="destructive_confirmation_required",
-            message="Destructive operation requires explicit confirmation.",
+            message=(
+                "Destructive operation requires explicit confirmation."
+                + (f" Target: {target}" if target else "")
+            ),
+            detail={"target": target} if target else None,
             next_action=f"review the target, then rerun '{rerun_command}'",
             exit_code=EXIT_VALIDATION,
         )
@@ -612,9 +629,24 @@ def contract() -> Iterator[None]:
             error_code="unexpected_cli_error",
             error_kind="unexpected",
         )
+        # `--verbose` promises verbose tracebacks on errors; the catch-all used
+        # to swallow the only case where one is genuinely needed. The default
+        # message stays generic on purpose — exception text can carry local
+        # paths — so detail is disclosed only when the user asks for it.
+        verbose = is_verbose()
+        if verbose:
+            traceback.print_exception(exc, file=sys.stderr)
         fail(
             code="unexpected_cli_error",
-            message="Unexpected internal error.",
+            message=(
+                f"Unexpected internal error: {type(exc).__name__}: {exc}"
+                if verbose
+                else "Unexpected internal error."
+            ),
+            detail=(
+                {"traceback": traceback.format_exception(exc)} if verbose else None
+            ),
+            next_action=(None if verbose else "re-run with --verbose for a traceback"),
             exit_code=EXIT_VALIDATION,
         )
     finally:

--- a/potpie/cli/commands/bootstrap.py
+++ b/potpie/cli/commands/bootstrap.py
@@ -35,7 +35,7 @@ from potpie.cli.commands._common import (
     is_json,
     repo_default_pot_id,
     repo_effective_pot_info,
-    resolve_pot_id,
+    resolve_pot_scope,
     run_engine_operation,
     use_pot_selection,
 )
@@ -360,9 +360,12 @@ def register(root: typer.Typer) -> None:
 
         with contract():
             shell = get_root_runtime()
-            pot_id = resolve_pot_id(shell, pot)
+            pot_id, resolved_via = resolve_pot_scope(shell, pot)
+            # Resolve once and target that pot explicitly. Passing the raw
+            # ``--pot`` here let the engine re-resolve on its own and report a
+            # different pot's counts under the active pot's name.
             data_plane = run_engine_operation(
-                get_engine_client(pot).data_plane_status(DataPlaneStatusRequest())
+                get_engine_client(pot_id).data_plane_status(DataPlaneStatusRequest())
             )
             report = _build_context_status_report(
                 shell,
@@ -370,13 +373,21 @@ def register(root: typer.Typer) -> None:
                 intent=intent,
                 harness=harness,
                 data_plane=data_plane,
+                resolved_via=resolved_via,
             )
             _capture_host_status_activation()
             emit(
                 {
                     "profile": report.profile,
                     "daemon_up": report.daemon_up,
+                    "pot": {
+                        "id": report.pot_id,
+                        "name": report.pot_name,
+                        "resolved_via": report.resolved_via,
+                    },
+                    "pot_id": report.pot_id,
                     "active_pot": report.active_pot,
+                    "active_pot_id": report.active_pot_id,
                     "backend_ready": report.backend_ready,
                     "data_plane": dict(report.data_plane),
                     "pot_summary": dict(report.pot_summary),
@@ -550,6 +561,14 @@ def register(root: typer.Typer) -> None:
     root.add_typer(config_app, name="config")
 
 
+_RESOLUTION_LABELS = {
+    "explicit": "via --pot",
+    "repo_default": "via this repo's default pot binding",
+    "linked_repo": "via the pot this repo is registered in",
+    "active_pot": "via the active pot",
+}
+
+
 def _build_context_status_report(
     shell,
     *,
@@ -557,10 +576,12 @@ def _build_context_status_report(
     intent: str,
     harness: str,
     data_plane,
+    resolved_via: str | None = None,
 ) -> StatusReport:
     """Join root-owned status surfaces with the engine-owned data plane."""
     aggregate = get_pot_service(shell).aggregate_status(pot_id=pot_id)
     active = aggregate.active_pot
+    target = getattr(aggregate, "target_pot", None)
     nudge = get_skill_service(shell).nudge(agent=harness) if harness else None
     backend_ready = bool(data_plane.backend_ready)
     if active is None:
@@ -571,6 +592,9 @@ def _build_context_status_report(
         next_action = "Run 'potpie resolve \"<task>\"' to pull context for your work."
     return StatusReport(
         pot_id=pot_id,
+        pot_name=(target.name if target is not None else pot_id),
+        resolved_via=resolved_via,
+        active_pot_id=(active.pot_id if active else None),
         profile=shell.profile,
         daemon_up=True,
         active_pot=active.name if active else None,
@@ -635,10 +659,22 @@ def _setup_human(report, *, include_steps: bool = True) -> str:
 
 
 def _status_human(report) -> str:
+    pot_label = report.pot_name or report.active_pot
     lines = [
         f"profile={report.profile} daemon={'up' if report.daemon_up else 'down'} "
-        f"pot={report.active_pot} backend_ready={report.backend_ready}",
+        f"pot={pot_label} ({report.pot_id}) backend_ready={report.backend_ready}",
     ]
+    if report.resolved_via:
+        lines.append(
+            f"  resolved: {_RESOLUTION_LABELS.get(report.resolved_via, report.resolved_via)}"
+        )
+    # The active-pot pointer and the pot this directory resolves to are
+    # different things; say so rather than labelling one with the other's name.
+    if report.active_pot_id and report.active_pot_id != report.pot_id:
+        lines.append(
+            f"  note: active pot is {report.active_pot} ({report.active_pot_id}); "
+            f"commands here use {pot_label} — pass --pot to override"
+        )
     counts = dict(report.data_plane).get("counts") or {}
     if counts:
         lines.append(f"  graph: {counts}")

--- a/potpie/cli/commands/daemon.py
+++ b/potpie/cli/commands/daemon.py
@@ -25,13 +25,20 @@ def _start(daemon: Daemon) -> dict[str, int | str]:
     try:
         return daemon.start()
     except DaemonStartError as exc:
-        fail(
-            code="daemon_start_failed",
-            message=str(exc),
-            detail=(str(exc.log_path) if exc.log_path else None),
-            next_action="inspect the daemon log with 'potpie daemon logs'",
-            exit_code=EXIT_UNAVAILABLE,
-        )
+        _fail_start(exc)
+
+
+def _fail_start(exc: DaemonStartError) -> NoReturn:
+    fail(
+        code="daemon_start_failed",
+        message=str(exc),
+        detail=(str(exc.log_path) if exc.log_path else None),
+        next_action=(
+            getattr(exc, "recommended_next_action", None)
+            or "inspect the daemon log with 'potpie daemon logs'"
+        ),
+        exit_code=EXIT_UNAVAILABLE,
+    )
 
 
 def _restart(daemon: Daemon) -> dict[str, int | str]:
@@ -41,13 +48,7 @@ def _restart(daemon: Daemon) -> dict[str, int | str]:
         _stop(daemon)
         return _start(daemon)
     except DaemonStartError as exc:
-        fail(
-            code="daemon_start_failed",
-            message=str(exc),
-            detail=(str(exc.log_path) if exc.log_path else None),
-            next_action="inspect the daemon log with 'potpie daemon logs'",
-            exit_code=EXIT_UNAVAILABLE,
-        )
+        _fail_start(exc)
     except DaemonStopError as exc:
         _fail_stop(exc)
 
@@ -63,9 +64,11 @@ def _fail_stop(exc: DaemonStopError) -> NoReturn:
     )
 
 
-def _stop(daemon: Daemon) -> dict[str, Any]:
+def _stop(daemon: Daemon, *, force: bool = False) -> dict[str, Any]:
     try:
-        return daemon.stop()
+        # Only ask for the forced path when forcing, so any Daemon-shaped
+        # collaborator keeps working with the plain signature.
+        return daemon.stop(force=True) if force else daemon.stop()
     except DaemonStopError as exc:
         _fail_stop(exc)
 
@@ -81,7 +84,19 @@ def daemon_start() -> None:
 def daemon_status() -> None:
     with contract():
         st = _detached_daemon().status()
-        emit(st, human=f"daemon: {st['mode']} (up={st['up']})")
+        emit(st, human=_status_human(st))
+
+
+def _status_human(st: dict[str, Any]) -> str:
+    lines = [f"daemon: {st['mode']} (up={st['up']})"]
+    # A running daemon this build cannot authenticate is the single state that
+    # wedges every other command, so name it here instead of reporting a bare
+    # "up=True" that contradicts `potpie status`.
+    if st.get("identity") == "unauthenticated":
+        lines.append(f"  identity: unauthenticated — {st.get('detail')}")
+        if st.get("recovery"):
+            lines.append(f"  recovery: {st['recovery']}")
+    return "\n".join(lines)
 
 
 @daemon_app.command("logs")
@@ -100,9 +115,18 @@ def daemon_restart() -> None:
 
 
 @daemon_app.command("stop")
-def daemon_stop() -> None:
+def daemon_stop(
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help=(
+            "Replace a daemon whose runtime record cannot be authenticated "
+            "(verifies the recorded process is a potpie daemon first)."
+        ),
+    ),
+) -> None:
     with contract():
-        result = _stop(_detached_daemon())
+        result = _stop(_detached_daemon(), force=force)
         emit(result, human=result.get("detail", "stopped"))
 
 

--- a/potpie/cli/commands/graph.py
+++ b/potpie/cli/commands/graph.py
@@ -13,6 +13,7 @@ import shlex
 import sys
 import time
 from contextlib import contextmanager
+from contextvars import ContextVar
 from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -100,6 +101,27 @@ from potpie_context_engine.domain.nudge import NUDGE_EVENT_HELP
 
 graph_app = typer.Typer(help="Graph reads/admin via capability ports.")
 inbox_app = typer.Typer(help="Pending graph-work inbox.")
+
+# `--pot` is accepted by every other graph leaf, so a caller naturally reaches
+# for `graph inbox --pot X list`. Typer puts group options on the group, so
+# accept it there too and let the leaves inherit it.
+_INBOX_GROUP_POT: ContextVar[str | None] = ContextVar("_INBOX_GROUP_POT", default=None)
+
+
+@inbox_app.callback()
+def _inbox_group(
+    pot: str = typer.Option(
+        None, "--pot", help="Pot id/name for every inbox subcommand."
+    ),
+) -> None:
+    _INBOX_GROUP_POT.set(pot or None)
+
+
+def _inbox_pot(pot: str | None) -> str | None:
+    """Leaf ``--pot`` wins; otherwise inherit the group's."""
+    return pot or _INBOX_GROUP_POT.get()
+
+
 quality_app = typer.Typer(help="Read-only graph quality reports.")
 bulk_app = typer.Typer(help="Chunked semantic graph mutation application.")
 backend_app = typer.Typer(help="GraphBackend profile selection + health.")
@@ -530,7 +552,7 @@ def graph_catalog(
         pot_id = resolve_pot_id(host, pot)
         ctx.set_pot_id(pot_id)
         result = run_engine_operation(
-            get_engine_client(pot).catalog(
+            get_engine_client(pot_id).catalog(
                 EngineCatalogRequest(task=task, subgraph=subgraph)
             )
         )
@@ -540,13 +562,52 @@ def graph_catalog(
         _emit_graph_result(ctx, payload, human=human)
 
 
+def _split_qualified_view(
+    subgraph: str | None, view: str | None
+) -> tuple[str | None, str | None]:
+    """Accept a fully-qualified ``<subgraph>.<view>`` in ``--view``.
+
+    Returns ``(subgraph, view)``. A dotted ``--view`` supplies the subgraph;
+    a conflicting ``--subgraph`` is an error rather than a silent override.
+    """
+    value = (view or "").strip()
+    if "." not in value:
+        return subgraph, view
+    qualified_subgraph, _, qualified_view = value.partition(".")
+    if "." in qualified_view:
+        raise ValueError(
+            f"view {view!r} is not a valid <subgraph>.<view> name; "
+            "run 'potpie graph catalog' for the qualified names"
+        )
+    existing = (subgraph or "").strip()
+    if existing and existing != qualified_subgraph:
+        raise ValueError(
+            f"--subgraph {existing!r} conflicts with --view {view!r}; "
+            "pass the subgraph once"
+        )
+    return qualified_subgraph, qualified_view
+
+
 @graph_app.command("read")
 def graph_read(
+    view_ref: str = typer.Argument(
+        None,
+        metavar="[SUBGRAPH.VIEW]",
+        help=(
+            "Qualified view name exactly as 'potpie graph catalog' prints it, "
+            "e.g. debugging.prior_occurrences. Alternative to --subgraph/--view."
+        ),
+    ),
     subgraph: str = typer.Option(
         None, "--subgraph", help="Canonical graph subgraph, e.g. debugging"
     ),
     view: str = typer.Option(
-        None, "--view", help="View name within --subgraph, e.g. prior_occurrences"
+        None,
+        "--view",
+        help=(
+            "View name within --subgraph, e.g. prior_occurrences. Also accepts "
+            "the qualified 'subgraph.view' form."
+        ),
     ),
     query: str = typer.Option(None, "--query"),
     query_threshold: float = typer.Option(
@@ -611,14 +672,27 @@ def graph_read(
 ) -> None:
     """V2-style read over a named view (routes through the read trunk)."""
     with _graph_command("graph.read") as ctx:
-        if not subgraph:
-            raise ValueError("--subgraph is required")
+        # `graph catalog` advertises views as `<subgraph>.<view>`; accept that
+        # exact string, positionally or via --view, so catalog output is
+        # copy-pasteable instead of always needing a manual split.
+        if view_ref:
+            if view:
+                raise ValueError(
+                    f"pass the view once: got positional {view_ref!r} and "
+                    f"--view {view!r}"
+                )
+            view = view_ref
+        subgraph, view = _split_qualified_view(subgraph, view)
         if not view:
-            raise ValueError("--view is required")
-        if "." in view:
             raise ValueError(
-                "graph read now requires --subgraph <name> --view <view>; "
-                f"got fully-qualified view {view!r}"
+                "--view is required (e.g. --subgraph debugging "
+                "--view prior_occurrences, or --view debugging.prior_occurrences)"
+            )
+        if not subgraph:
+            raise ValueError(
+                f"--subgraph is required for view {view!r} "
+                f"(e.g. --subgraph <name> --view {view}); "
+                "run 'potpie graph catalog' for the qualified names"
             )
         host = get_root_runtime()
         pot_id = resolve_pot_id(host, pot)
@@ -641,7 +715,7 @@ def graph_read(
             requested_limit=limit,
         )
         result = run_engine_operation(
-            get_engine_client(pot).read(
+            get_engine_client(pot_id).read(
                 EngineReadRequest(
                     subgraph=subgraph,
                     view=view,
@@ -730,7 +804,7 @@ def timeline_recent(
             requested_limit=limit,
         )
         result = run_engine_operation(
-            get_engine_client(pot).read(
+            get_engine_client(pot_id).read(
                 EngineReadRequest(
                     subgraph="recent_changes",
                     view="timeline",
@@ -799,7 +873,7 @@ def graph_search_entities(
         ctx.set_pot_id(pot_id)
         since_dt, until_dt = _resolve_time_bounds(since=since, until=until, window=None)
         result = run_engine_operation(
-            get_engine_client(pot).search_entities(
+            get_engine_client(pot_id).search_entities(
                 EngineSearchEntitiesRequest(
                     query=effective_query,
                     type=type_,
@@ -859,7 +933,7 @@ def graph_mutate(
         pot_id = resolve_pot_id(host, pot)
         ctx.set_pot_id(pot_id)
         payload = _load_json(file)
-        client = get_engine_client(pot)
+        client = get_engine_client(pot_id)
         proposal = run_engine_operation(
             client.propose(
                 EngineProposeRequest(mutation=_context_bound_mutation(payload))
@@ -1330,7 +1404,7 @@ def graph_nudge(
         pot_id = resolve_pot_id(host, pot)
         ctx.set_pot_id(pot_id)
         result = run_engine_operation(
-            get_engine_client(pot).nudge(
+            get_engine_client(pot_id).nudge(
                 EngineNudgeRequest(
                     event=event,
                     session_id=session,
@@ -1359,7 +1433,7 @@ def graph_status(pot: str = typer.Option(None, "--pot")) -> None:
         pot_id = resolve_pot_id(host, pot)
         ctx.set_pot_id(pot_id)
         dp = run_engine_operation(
-            get_engine_client(pot).data_plane_status(EngineDataPlaneStatusRequest())
+            get_engine_client(pot_id).data_plane_status(EngineDataPlaneStatusRequest())
         )
         versions = {"_global": int(dict(dp.counts).get("claims", 0))}
         ctx.set_subgraph_versions(versions)
@@ -1452,7 +1526,7 @@ def graph_neighborhood(
         ctx.set_pot_id(pot_id)
         predicates = _parse_predicates(predicate)
         sl = run_engine_operation(
-            get_engine_client(pot).neighborhood(
+            get_engine_client(pot_id).neighborhood(
                 EngineNeighborhoodRequest(
                     entity_key=entity,
                     depth=depth,
@@ -1513,7 +1587,7 @@ def graph_propose(
         ctx.set_pot_id(pot_id)
         payload = _load_json(file)
         result = run_engine_operation(
-            get_engine_client(pot).propose(
+            get_engine_client(pot_id).propose(
                 EngineProposeRequest(
                     mutation=_context_bound_mutation(payload),
                     ttl_seconds=_parse_ttl_seconds(ttl),
@@ -1549,7 +1623,7 @@ def graph_commit(
         pot_id = resolve_pot_id(host, pot)
         ctx.set_pot_id(pot_id)
         result = run_engine_operation(
-            get_engine_client(pot).commit(
+            get_engine_client(pot_id).commit(
                 EngineCommitRequest(
                     plan_id=plan_id,
                     approved_by=approved_by,
@@ -1652,7 +1726,7 @@ def graph_bulk_apply(
             start_chunk=start_chunk,
             manifest=manifest,
         )
-        client = get_engine_client(pot)
+        client = get_engine_client(pot_id)
         ok = True
 
         for chunk in chunks:
@@ -1784,7 +1858,7 @@ def graph_history(
         ctx.set_pot_id(pot_id)
         since_dt, until_dt = _resolve_time_bounds(since=since, until=until, window=None)
         result = run_engine_operation(
-            get_engine_client(pot).history(
+            get_engine_client(pot_id).history(
                 EngineHistoryRequest(
                     entity_key=entity,
                     claim_key=claim,
@@ -1816,10 +1890,10 @@ def graph_inbox_add(
 ) -> None:
     with _graph_command("graph.inbox.add") as ctx:
         host = get_root_runtime()
-        pot_id = resolve_pot_id(host, pot)
+        pot_id = resolve_pot_id(host, _inbox_pot(pot))
         ctx.set_pot_id(pot_id)
         result = run_engine_operation(
-            get_engine_client(pot).inbox_add(
+            get_engine_client(pot_id).inbox_add(
                 EngineInboxAddRequest(
                     summary=summary,
                     details=details,
@@ -1846,11 +1920,11 @@ def graph_inbox_list(
 ) -> None:
     with _graph_command("graph.inbox.list") as ctx:
         host = get_root_runtime()
-        pot_id = resolve_pot_id(host, pot)
+        pot_id = resolve_pot_id(host, _inbox_pot(pot))
         ctx.set_pot_id(pot_id)
         since_dt, until_dt = _resolve_time_bounds(since=since, until=until, window=None)
         result = run_engine_operation(
-            get_engine_client(pot).inbox_list(
+            get_engine_client(pot_id).inbox_list(
                 EngineInboxListRequest(
                     status=tuple(status or ()),
                     claimed_by=claimed_by,
@@ -1874,10 +1948,12 @@ def graph_inbox_show(
         if not item_id:
             raise ValueError("item_id is required")
         host = get_root_runtime()
-        pot_id = resolve_pot_id(host, pot)
+        pot_id = resolve_pot_id(host, _inbox_pot(pot))
         ctx.set_pot_id(pot_id)
         result = run_engine_operation(
-            get_engine_client(pot).inbox_show(EngineInboxShowRequest(item_id=item_id))
+            get_engine_client(pot_id).inbox_show(
+                EngineInboxShowRequest(item_id=item_id)
+            )
         )
         _emit_inbox_result(ctx, result)
 
@@ -1892,10 +1968,10 @@ def graph_inbox_claim(
         if not item_id:
             raise ValueError("item_id is required")
         host = get_root_runtime()
-        pot_id = resolve_pot_id(host, pot)
+        pot_id = resolve_pot_id(host, _inbox_pot(pot))
         ctx.set_pot_id(pot_id)
         result = run_engine_operation(
-            get_engine_client(pot).inbox_claim(
+            get_engine_client(pot_id).inbox_claim(
                 EngineInboxClaimRequest(item_id=item_id, claimed_by=claimed_by)
             )
         )
@@ -1914,10 +1990,10 @@ def graph_inbox_mark_applied(
         if not item_id:
             raise ValueError("item_id is required")
         host = get_root_runtime()
-        pot_id = resolve_pot_id(host, pot)
+        pot_id = resolve_pot_id(host, _inbox_pot(pot))
         ctx.set_pot_id(pot_id)
         result = run_engine_operation(
-            get_engine_client(pot).inbox_mark_applied(
+            get_engine_client(pot_id).inbox_mark_applied(
                 EngineInboxMarkAppliedRequest(
                     item_id=item_id,
                     closed_by=closed_by,
@@ -1940,10 +2016,10 @@ def graph_inbox_mark_rejected(
         if not item_id:
             raise ValueError("item_id is required")
         host = get_root_runtime()
-        pot_id = resolve_pot_id(host, pot)
+        pot_id = resolve_pot_id(host, _inbox_pot(pot))
         ctx.set_pot_id(pot_id)
         result = run_engine_operation(
-            get_engine_client(pot).inbox_mark_rejected(
+            get_engine_client(pot_id).inbox_mark_rejected(
                 EngineInboxMarkRejectedRequest(
                     item_id=item_id,
                     closed_by=closed_by,
@@ -1967,10 +2043,10 @@ def graph_inbox_close(
         if not item_id:
             raise ValueError("item_id is required")
         host = get_root_runtime()
-        pot_id = resolve_pot_id(host, pot)
+        pot_id = resolve_pot_id(host, _inbox_pot(pot))
         ctx.set_pot_id(pot_id)
         result = run_engine_operation(
-            get_engine_client(pot).inbox_close(
+            get_engine_client(pot_id).inbox_close(
                 EngineInboxCloseRequest(
                     item_id=item_id,
                     closed_by=closed_by,
@@ -2111,7 +2187,7 @@ def _run_quality_report(
         pot_id = resolve_pot_id(host, pot)
         ctx.set_pot_id(pot_id)
         result = run_engine_operation(
-            get_engine_client(pot).quality(
+            get_engine_client(pot_id).quality(
                 EngineQualityRequest(
                     report=report,
                     subgraph=subgraph,
@@ -2134,7 +2210,7 @@ def graph_inspect(
         pot_id = resolve_pot_id(host, pot)
         ctx.set_pot_id(pot_id)
         sl = run_engine_operation(
-            get_engine_client(pot).inspect(
+            get_engine_client(pot_id).inspect(
                 EngineInspectRequest(entity_key=entity_key, depth=depth)
             )
         )

--- a/potpie/cli/commands/pots.py
+++ b/potpie/cli/commands/pots.py
@@ -477,15 +477,18 @@ def pot_reset(
 ) -> None:
     """Clear a pot's graph state. Sources and the pot itself survive."""
     with contract():
-        if ref and pot and ref != pot:
+        host = get_root_runtime()
+        # An id and a name can name the *same* pot, so compare what they
+        # resolve to rather than the strings the caller happened to type.
+        if ref and pot and resolve_pot_id(host, ref) != resolve_pot_id(host, pot):
             fail(
                 code="validation_error",
                 message=(
-                    f"conflicting pot selection: positional {ref!r} vs --pot {pot!r}"
+                    f"conflicting pot selection: positional {ref!r} and "
+                    f"--pot {pot!r} name different pots"
                 ),
                 next_action="pass the pot once, either positionally or via --pot",
             )
-        host = get_root_runtime()
         selected = ref or pot
         pot_id, resolved_via = resolve_pot_scope(host, selected)
         target = pot_scope_info(host, pot_id)

--- a/potpie/cli/commands/pots.py
+++ b/potpie/cli/commands/pots.py
@@ -65,15 +65,39 @@ def pot_list(
                 detail="managed pot listing is not implemented",
                 recommended_next_action="run 'potpie login'; managed routing lands in HU3",
             )
-        pots = get_pot_service().list_pots()
+        host = get_root_runtime()
+        pots = get_pot_service(host).list_pots()
+        routing = repo_effective_pot_info(host)
+        effective = routing.get("effective_pot") or {}
+        effective_id = effective.get("id")
+        repo = routing.get("repo")
         payload: dict[str, object] = {
             "pots": [
-                {"id": p.pot_id, "name": p.name, "active": p.active, "origin": "local"}
+                {
+                    "id": p.pot_id,
+                    "name": p.name,
+                    "active": p.active,
+                    "origin": "local",
+                    # '*' alone hid the split the destructive ops actually use:
+                    # mark the pot this working directory resolves to as well.
+                    "effective_for_current_repo": bool(
+                        effective_id and p.pot_id == effective_id
+                    ),
+                }
                 for p in pots
             ],
+            "current_repo": routing,
         }
-        pot_rows = [f"{'*' if p.active else ' '} {p.name} ({p.pot_id})" for p in pots]
+        pot_rows = [
+            f"{'*' if p.active else ' '}{'>' if p.pot_id == effective_id else ' '} "
+            f"{p.name} ({p.pot_id})"
+            for p in pots
+        ]
         human_lines = ["Local", *(pot_rows or ["(no pots)"])]
+        if effective_id:
+            human_lines.append(
+                f"  (* = active pot; > = pot commands use in {repo or 'this directory'})"
+            )
         if all_:
             payload["managed_pending"] = True
             human_lines.append("  (managed pots require 'potpie login' — HU3)")
@@ -81,7 +105,11 @@ def pot_list(
 
 
 @pot_app.command("info")
-def pot_info() -> None:
+def pot_info(
+    pot: str = typer.Option(
+        None, "--pot", help="Report this pot instead of the resolved one."
+    ),
+) -> None:
     with contract():
         host = get_root_runtime()
         active = get_pot_service(host).active_pot()
@@ -89,16 +117,26 @@ def pot_info() -> None:
         active_payload = (
             {"id": active.pot_id, "name": active.name} if active is not None else None
         )
+        pot_id, resolved_via = resolve_pot_scope(host, pot)
+        selected = pot_scope_info(host, pot_id)
+        repo = current_repo_identity_for_cli()
         lines = [
+            f"pot: {selected['name']} ({pot_id}) "
+            f"{pot_scope_resolution_human(resolved_via, repo=repo)}",
+            f"  sources={selected.get('source_count', 0)} counts={selected.get('counts')}",
             f"active: {active.name} ({active.pot_id})"
             if active is not None
-            else "(no active pot)"
+            else "active: (no active pot)",
         ]
         routing_line = repo_effective_pot_human(routing)
         if routing_line:
             lines.append(routing_line)
         emit(
-            {"active_pot": active_payload, "current_repo": routing},
+            {
+                "pot": {**selected, "resolved_via": resolved_via},
+                "active_pot": active_payload,
+                "current_repo": routing,
+            },
             human="\n".join(lines),
         )
 
@@ -177,8 +215,17 @@ def register_repo_source(
         resolved_location=resolved_location,
         repo_key=repo_key,
     )
+    reused = existing is not None
+    stored_location = resolved_location
     if existing is not None:
+        # Re-registration keeps the original row. Say so, and report the
+        # location actually on record rather than the one just computed —
+        # otherwise `source add` and `source list` disagree about where the
+        # repo lives, and a passed --name looks applied when it was not.
         src = existing
+        stored_location = (
+            str(getattr(existing, "location", "") or "") or resolved_location
+        )
     else:
         src = get_pot_service(host).add_source(
             pot_id=pot_id,
@@ -199,11 +246,14 @@ def register_repo_source(
         "source_id": src.source_id,
         "kind": src.kind,
         "name": src.name,
-        "location": resolved_location,
+        "location": stored_location,
+        "resolved_location": resolved_location,
         "pot_id": pot_id,
         "repo_default_set": repo_default_set,
         "repo_key": repo_key,
         "registration_only": True,
+        "reused_existing": reused,
+        "requested_name_ignored": bool(reused and name and name != src.name),
     }
 
 
@@ -420,18 +470,45 @@ def pot_rename(ref: str, new_name: str) -> None:
 @pot_app.command("reset")
 def pot_reset(
     ref: str = typer.Argument(None),
+    pot: str = typer.Option(
+        None, "--pot", help="Pot id/name to reset (same as the positional ref)."
+    ),
     confirm: bool = typer.Option(False, "--confirm"),
 ) -> None:
+    """Clear a pot's graph state. Sources and the pot itself survive."""
     with contract():
+        if ref and pot and ref != pot:
+            fail(
+                code="validation_error",
+                message=(
+                    f"conflicting pot selection: positional {ref!r} vs --pot {pot!r}"
+                ),
+                next_action="pass the pot once, either positionally or via --pot",
+            )
         host = get_root_runtime()
-        pot_id = resolve_pot_id(host, ref)
-        pot = next(
-            item for item in get_pot_service(host).list_pots() if item.pot_id == pot_id
+        selected = ref or pot
+        pot_id, resolved_via = resolve_pot_scope(host, selected)
+        target = pot_scope_info(host, pot_id)
+        active = get_pot_service(host).active_pot()
+        active_id = getattr(active, "pot_id", None) if active is not None else None
+        repo = current_repo_identity_for_cli()
+        # The most destructive pot operation must state exactly which pot it
+        # found and how, and must not let the active-pot pointer imply a
+        # different target than the one about to be cleared.
+        scope_line = (
+            f"'{target['name']}' ({pot_id}) "
+            f"{pot_scope_resolution_human(resolved_via, repo=repo)}"
+        )
+        mismatch = (
+            f"\nThe active pot is a different pot: {active.name} ({active_id})."
+            if active_id and active_id != pot_id
+            else ""
         )
         confirmation = confirm_destructive_operation(
             confirmed_by_flag=confirm,
-            prompt=f"Reset all graph state for '{pot.name}' ({pot_id})?",
+            prompt=f"Reset all graph state for {scope_line}?{mismatch}",
             rerun_command=f"potpie pot reset {pot_id} --confirm",
+            target=f"{scope_line}{mismatch}".replace("\n", " "),
         )
         result = run_engine_operation(
             get_engine_client(pot_id).reset_context(
@@ -440,8 +517,15 @@ def pot_reset(
             )
         )
         emit(
-            {"id": result.context_id, "reset": result.reset},
-            human=f"reset graph state for '{pot.name}'",
+            {
+                "id": result.context_id,
+                "reset": result.reset,
+                "pot_id": pot_id,
+                "pot_name": target["name"],
+                "resolved_via": resolved_via,
+                "active_pot_id": active_id,
+            },
+            human=f"reset graph state for {scope_line}",
         )
 
 
@@ -530,13 +614,25 @@ def source_add(
         )
         resolved_location = payload.get("location", location)
         repo_default_set = bool(payload.get("repo_default_set"))
+        verb = (
+            "reused existing source"
+            if payload.get("reused_existing")
+            else ("registered source")
+        )
+        notes = ""
+        if payload.get("requested_name_ignored"):
+            notes += (
+                f"kept the existing name '{payload['name']}' "
+                f"(--name is only applied at first registration)\n"
+            )
         payload, human = enrich_with_pot_guidance(
             host,
             pot_id,
             dict(payload),
             human=(
-                f"registered source {payload['kind']}:{payload['name']} "
+                f"{verb} {payload['kind']}:{payload['name']} "
                 f"({payload['source_id']}) at {resolved_location} in pot {pot_id}\n"
+                + notes
                 + (f"set repo default -> {pot_id}\n" if repo_default_set else "")
                 + "no ingestion or scan started"
             ),

--- a/potpie/cli/commands/query.py
+++ b/potpie/cli/commands/query.py
@@ -12,7 +12,10 @@ import typer
 from potpie.cli.commands._common import (
     contract,
     emit,
+    fail,
     get_engine_client,
+    get_root_runtime,
+    resolve_pot_id,
     run_engine_operation,
 )
 from potpie.cli.telemetry.onboarding_events import (
@@ -24,6 +27,11 @@ from potpie.cli.telemetry.usage_events import (
 from potpie_context_engine.requests import (
     RecordRequest as EngineRecordRequest,
     ResolveRequest as EngineResolveRequest,
+)
+from potpie_context_engine.core.context_records import (
+    REQUIRED_RECORD_DETAILS,
+    record_detail_choices,
+    required_record_details,
 )
 from potpie_context_engine.requests import SearchRequest as EngineSearchRequest
 
@@ -49,7 +57,7 @@ def register(root: typer.Typer) -> None:
     ) -> None:
         """context_resolve — a bounded context wrap for a task."""
         with contract():
-            client = get_engine_client(pot)
+            client = get_engine_client(resolve_pot_id(get_root_runtime(), pot))
             env = run_engine_operation(
                 client.resolve(
                     EngineResolveRequest(
@@ -71,7 +79,7 @@ def register(root: typer.Typer) -> None:
     ) -> None:
         """context_search — narrow follow-up lookup."""
         with contract():
-            client = get_engine_client(pot)
+            client = get_engine_client(resolve_pot_id(get_root_runtime(), pot))
             env = run_engine_operation(
                 client.search(EngineSearchRequest(query=query, include=_split(include)))
             )
@@ -81,21 +89,38 @@ def register(root: typer.Typer) -> None:
     @root.command()
     def record(
         type: str = typer.Option(
-            ..., "--type", help="Record type (fix, decision, preference, …)."
+            ...,
+            "--type",
+            help=(
+                "Record type. Structured types and their required --detail keys: "
+                + _RECORD_TYPE_HELP
+            ),
         ),
         summary: str = typer.Option(..., "--summary"),
         scope: str = typer.Option(
             None, "--scope", help="key:value scope, e.g. service:inventory-svc"
         ),
+        detail: list[str] | None = typer.Option(
+            None,
+            "--detail",
+            help=(
+                "Repeatable key=value payload field, e.g. "
+                "--detail rationale='cheaper to operate'. Required for the "
+                "structured record types (see --type)."
+            ),
+        ),
         pot: str = typer.Option(None, "--pot"),
     ) -> None:
         """context_record — write a durable project learning."""
         with contract():
+            details = _parse_details(detail)
+            _require_record_details(type, details)
             receipt = run_engine_operation(
-                get_engine_client(pot).record(
+                get_engine_client(resolve_pot_id(get_root_runtime(), pot)).record(
                     EngineRecordRequest(
                         record_type=type,
                         summary=summary,
+                        details=details,
                         scope=_parse_scope(scope),
                     )
                 )
@@ -112,6 +137,59 @@ def register(root: typer.Typer) -> None:
                     "mutations_applied": receipt.mutations_applied,
                 },
                 human=f"{receipt.status}: {receipt.record_id} ({receipt.mutations_applied} mutations)",
+            )
+
+
+def _record_type_help() -> str:
+    """Advertise only what ``record`` can actually write, with its flags."""
+
+    structured = "; ".join(
+        f"{record_type} (needs "
+        + ", ".join(f"--detail {field}=…" for field in fields)
+        + ")"
+        for record_type, fields in sorted(REQUIRED_RECORD_DETAILS.items())
+    )
+    return f"free-form types (fix, investigation, workflow, …) need no --detail; {structured}"
+
+
+_RECORD_TYPE_HELP = _record_type_help()
+
+
+def _parse_details(pairs: list[str] | None) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for pair in pairs or ():
+        key, sep, value = str(pair).partition("=")
+        if not sep or not key.strip():
+            fail(
+                code="validation_error",
+                message=f"--detail expects key=value, got {pair!r}",
+                next_action="pass a field such as --detail rationale='<why>'",
+            )
+        out[key.strip()] = value.strip()
+    return out
+
+
+def _require_record_details(record_type: str, details: dict[str, str]) -> None:
+    """Fail with the flag to type, before the write reaches the engine."""
+
+    for field in required_record_details(record_type):
+        choices = record_detail_choices(record_type, field)
+        value = details.get(field)
+        if not value:
+            hint = f"one of {', '.join(choices)}" if choices else "<value>"
+            fail(
+                code="validation_error",
+                message=f"record type '{record_type}' requires a '{field}' detail",
+                next_action=f"add --detail {field}={hint}",
+            )
+        if choices and value not in choices:
+            fail(
+                code="validation_error",
+                message=(
+                    f"record type '{record_type}' detail '{field}' must be one of "
+                    f"{', '.join(choices)}; got {value!r}"
+                ),
+                next_action=f"add --detail {field}={choices[0]}",
             )
 
 
@@ -147,13 +225,55 @@ def _envelope_payload(env) -> dict[str, object]:
     }
 
 
+# Payload keys that can carry an item's human-readable line, most specific
+# first. Reader families disagree on which one they populate, so a renderer
+# that only knows two of them prints blank bullets for the rest.
+_ITEM_TEXT_KEYS: tuple[str, ...] = (
+    "fact",
+    "summary",
+    "description",
+    "label",
+    "section_title",
+    "snippet",
+    "title",
+    "name",
+    "text",
+)
+
+
+def _item_text(item) -> str:
+    payload = dict(item.payload)
+    for key in _ITEM_TEXT_KEYS:
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return " ".join(value.split())
+    # Nothing readable: fall back to an identifier so the bullet still points
+    # somewhere instead of rendering as an empty line.
+    for key in ("fetch", "source_ref", "claim_key", "subject_key"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return str(getattr(item, "candidate_key", "") or "(no summary in payload)")
+
+
 def _envelope_human(env) -> str:
     lines = [
         f"pot={env.pot_id} intent={env.intent} confidence={env.overall_confidence} items={len(env.items)}"
     ]
+    # Identical items are already merged upstream; anything that still renders
+    # the same text is a *different* record worded identically, so name what
+    # distinguishes it rather than printing the same line twice.
+    seen: dict[str, int] = {}
     for item in env.items[:10]:
-        fact = dict(item.payload).get("fact") or dict(item.payload).get("summary") or ""
-        lines.append(f"  • [{item.include}] {fact}")
+        text = _item_text(item)
+        seen[text] = seen.get(text, 0) + 1
+        suffix = ""
+        if seen[text] > 1:
+            subject = dict(item.payload).get("subject_key") or getattr(
+                item, "candidate_key", ""
+            )
+            suffix = f"  (distinct record: {subject})" if subject else ""
+        lines.append(f"  • [{item.include}] {text}{suffix}")
     for unsup in env.unsupported_includes:
         lines.append(f"  ! {unsup.name}: {unsup.reason}")
     return "\n".join(lines)

--- a/potpie/cli/commands/skills.py
+++ b/potpie/cli/commands/skills.py
@@ -95,7 +95,10 @@ def skills_install(
                 "metadata": dict(res.metadata),
             },
             human=_format_skill_operation(
-                verb="installed", agent=res.agent, changed=res.changed
+                verb="installed",
+                agent=res.agent,
+                changed=res.changed,
+                target_root=dict(res.metadata).get("target_root"),
             ),
         )
 
@@ -120,7 +123,10 @@ def skills_update(
                 "metadata": dict(res.metadata),
             },
             human=_format_skill_operation(
-                verb="updated", agent=res.agent, changed=res.changed
+                verb="updated",
+                agent=res.agent,
+                changed=res.changed,
+                target_root=dict(res.metadata).get("target_root"),
             ),
         )
 
@@ -166,6 +172,19 @@ def skills_status(
     with contract():
         effective_scope = _effective_scope(scope=scope, path=path)
         st = get_skill_service().status(agent=agent, path=path, scope=effective_scope)
+        unmanaged = list(getattr(st, "unmanaged", ()) or ())
+        human = (
+            f"agent={st.agent} installed={len(st.installed)} "
+            f"missing={[s.id for s in st.missing]} "
+            f"outdated={[s.id for s in st.outdated]}"
+        )
+        if unmanaged:
+            # These are loaded by the harness but not in this build's catalog,
+            # so this CLI cannot update or service them.
+            human += (
+                f"\n  unmanaged potpie skills this build does not ship: {unmanaged}"
+                "\n  remove them, or upgrade potpie to a build that ships them"
+            )
         emit(
             {
                 "agent": st.agent,
@@ -173,11 +192,9 @@ def skills_status(
                 "installed": [s.id for s in st.installed],
                 "missing": [s.id for s in st.missing],
                 "outdated": [s.id for s in st.outdated],
+                "unmanaged": unmanaged,
             },
-            human=(
-                f"agent={st.agent} installed={len(st.installed)} "
-                f"missing={[s.id for s in st.missing]} outdated={[s.id for s in st.outdated]}"
-            ),
+            human=human,
         )
 
 
@@ -188,12 +205,22 @@ def skills_add(source: str) -> None:
         emit({"detail": res.detail}, human=res.detail or "added")
 
 
-def _format_skill_operation(*, verb: str, agent: str, changed: tuple[str, ...]) -> str:
+def _format_skill_operation(
+    *,
+    verb: str,
+    agent: str,
+    changed: tuple[str, ...],
+    target_root: str | None = None,
+) -> str:
     if changed:
-        return f"{verb} Potpie skills for {agent}: {', '.join(changed)}"
-    if verb == "installed":
-        return f"Potpie skills for {agent} are already installed"
-    return f"Potpie skills for {agent} are already up to date"
+        line = f"{verb} Potpie skills for {agent}: {', '.join(changed)}"
+    elif verb == "installed":
+        line = f"Potpie skills for {agent} are already installed"
+    else:
+        line = f"Potpie skills for {agent} are already up to date"
+    # Skills land in the harness's own tree, not under CONTEXT_ENGINE_HOME.
+    # Name the directory so the write target is never a surprise.
+    return f"{line}\n  into: {target_root}" if target_root else line
 
 
 def _format_skill_remove(*, agent: str, removed: tuple[str, ...]) -> str:

--- a/potpie/cli/main.py
+++ b/potpie/cli/main.py
@@ -43,16 +43,19 @@ from potpie.cli.commands._common import (
 from potpie.cli.telemetry.context import bind_telemetry_context
 
 
-def _package_version() -> str:
+def _package_version(name: str = "potpie-context-engine") -> str:
     try:
-        return metadata.version("potpie-context-engine")
+        return metadata.version(name)
     except metadata.PackageNotFoundError:
-        return "0.1.0"
+        return "unknown"
 
 
 def _version_callback(value: bool) -> None:
     if not value:
         return
+    # The product's own version comes first: a user who installs `potpie`
+    # must be able to learn which potpie they have from `potpie --version`.
+    typer.echo(f"potpie {_package_version('potpie')}")
     typer.echo(f"potpie-context-engine {_package_version()}")
     typer.echo(f"python {platform.python_version()} ({sys.executable})")
     raise typer.Exit()

--- a/potpie/cli/read_presenter.py
+++ b/potpie/cli/read_presenter.py
@@ -357,8 +357,8 @@ def _timeline_event_bullet_lines(
 def _item_bullet_lines(
     item: Mapping[str, Any], ctx: ReadPresentationContext
 ) -> list[str]:
-    entity_type = item.get("entity_type") or "?"
     entity_key = _item_entity_key(item)
+    entity_type = _entity_label(item, entity_key)
     summary = _display_fact(item.get("summary") or entity_key or "", ctx)
     meta_parts: list[str] = []
     if item.get("score") is not None:
@@ -499,6 +499,33 @@ def _related_keys_from_relations(
             if len(keys) >= 10:
                 return keys
     return keys
+
+
+def _entity_label(item: Mapping[str, Any], entity_key: str) -> str:
+    """Best label for a row's ``[type]`` tag.
+
+    Rows whose reader does not set ``entity_type`` used to render a bare
+    ``[?]``. The key is namespaced (``decision:…``, ``service:local:…``), so
+    its prefix names the kind even when the type field is absent.
+    """
+    explicit = _str(item.get("entity_type"))
+    if explicit:
+        return explicit
+    labels = item.get("labels")
+    if isinstance(labels, (list, tuple)) and labels:
+        first = _str(labels[0])
+        if first:
+            return first
+    scheme, separator, rest = entity_key.partition("://")
+    if separator and scheme:
+        # `potpie://res/<doc>/<section>/<seq>` — the first path segment names
+        # the kind; the scheme is always "potpie" and says nothing.
+        segment = rest.split("/", 1)[0]
+        return segment or scheme
+    prefix, separator, _rest = entity_key.partition(":")
+    if separator and prefix:
+        return prefix
+    return "?"
 
 
 def _item_entity_key(item: Mapping[str, Any]) -> str:

--- a/potpie/cli/repo_location.py
+++ b/potpie/cli/repo_location.py
@@ -6,18 +6,35 @@ import subprocess
 from pathlib import Path
 
 
+class RepoLocationError(ValueError):
+    """Raised when a repo's durable identity cannot be determined."""
+
+
 def resolve_repo_location(location: str) -> str:
     """Resolve repo-source shorthand to a durable, matchable location.
 
     ``.`` / ``current`` and relative paths registered verbatim are hard to match
     back to a working tree. Prefer the current repo's normalized remote when
     available, otherwise store an absolute path.
+
+    Determinism matters here: the stored location *is* the repo's identity, and
+    silently substituting an absolute path when a ``git`` probe happened to be
+    slow made two identical invocations register two different identities. A
+    repo with no ``origin`` deterministically gets its absolute path; a probe
+    that *fails* raises instead of guessing.
     """
 
     raw = (location or "").strip()
     if raw.lower() in (".", "current"):
         cwd = Path.cwd().resolve()
-        remote = current_git_remote(cwd)
+        remote, failure = git_remote_or_reason(cwd)
+        if failure is not None:
+            raise RepoLocationError(
+                f"could not determine this repo's git remote ({failure}); "
+                "refusing to register it under a different identity — "
+                "pass the location explicitly, e.g. "
+                "'potpie source add repo <owner>/<repo>'"
+            )
         return remote or str(cwd)
     if raw.startswith((".", "~")):
         return str(Path(raw).expanduser().resolve(strict=False))
@@ -49,20 +66,49 @@ def current_repo_identity(cwd: Path) -> str | None:
         return str(cwd)
 
 
-def current_git_remote(cwd: Path) -> str | None:
+# `git remote get-url` exits 2 when the remote is not configured, and 128
+# when the directory is not a work tree. Both are definitive answers ("no
+# origin"), unlike a timeout or a missing git binary.
+_GIT_DEFINITIVE_NO_REMOTE_CODES = frozenset({2, 128})
+
+
+def git_remote_or_reason(cwd: Path) -> tuple[str | None, str | None]:
+    """Return ``(remote, failure_reason)`` for the current work tree.
+
+    ``(remote, None)`` when origin resolved, ``(None, None)`` when the repo
+    definitively has no origin, and ``(None, reason)`` when the probe itself
+    could not answer — the case callers must not paper over.
+    """
     try:
         proc = subprocess.run(
             ["git", "-C", str(cwd), "remote", "get-url", "origin"],
             check=False,
             capture_output=True,
             text=True,
-            timeout=2,
+            timeout=10,
         )
-    except Exception:
-        return None
+    except FileNotFoundError:
+        return None, "git is not installed"
+    except subprocess.TimeoutExpired:
+        return None, "git did not respond within 10s"
+    except OSError as exc:
+        return None, f"git could not be run: {exc}"
+    if proc.returncode in _GIT_DEFINITIVE_NO_REMOTE_CODES:
+        return None, None
     if proc.returncode != 0:
-        return None
-    return normalize_repo_ref(proc.stdout.strip())
+        detail = (proc.stderr or "").strip().splitlines()
+        return None, detail[0] if detail else f"git exited {proc.returncode}"
+    return normalize_repo_ref(proc.stdout.strip()), None
+
+
+def current_git_remote(cwd: Path) -> str | None:
+    """Lenient probe for identity *lookups*, where a miss is recoverable.
+
+    Registration uses :func:`git_remote_or_reason` instead, because there a
+    silent miss writes the wrong identity.
+    """
+    remote, _failure = git_remote_or_reason(cwd)
+    return remote
 
 
 def normalize_repo_ref(value: str) -> str | None:
@@ -91,8 +137,10 @@ def normalize_repo_ref(value: str) -> str | None:
 
 
 __all__ = [
+    "RepoLocationError",
     "current_git_remote",
     "current_repo_identity",
+    "git_remote_or_reason",
     "normalize_repo_ref",
     "repo_identity_key",
     "resolve_repo_location",

--- a/potpie/cli/repo_location.py
+++ b/potpie/cli/repo_location.py
@@ -66,10 +66,19 @@ def current_repo_identity(cwd: Path) -> str | None:
         return str(cwd)
 
 
-# `git remote get-url` exits 2 when the remote is not configured, and 128
-# when the directory is not a work tree. Both are definitive answers ("no
-# origin"), unlike a timeout or a missing git binary.
-_GIT_DEFINITIVE_NO_REMOTE_CODES = frozenset({2, 128})
+# `git remote get-url` exits 2 only when the remote is not configured — a
+# definitive "no origin". Exit 128 is overloaded: it covers "not a git
+# repository" (also definitive) *and* fatal repository/config errors, which
+# must not be papered over as "no origin" or registration silently stores a
+# path identity for a repo that does have a remote. So 128 is classified from
+# git's own message.
+_GIT_NO_REMOTE_CODE = 2
+_GIT_FATAL_CODE = 128
+_GIT_NOT_A_REPOSITORY = (
+    "not a git repository",
+    "not a work tree",
+    "this operation must be run in a work tree",
+)
 
 
 def git_remote_or_reason(cwd: Path) -> tuple[str | None, str | None]:
@@ -93,12 +102,21 @@ def git_remote_or_reason(cwd: Path) -> tuple[str | None, str | None]:
         return None, "git did not respond within 10s"
     except OSError as exc:
         return None, f"git could not be run: {exc}"
-    if proc.returncode in _GIT_DEFINITIVE_NO_REMOTE_CODES:
+    if proc.returncode == _GIT_NO_REMOTE_CODE:
         return None, None
     if proc.returncode != 0:
-        detail = (proc.stderr or "").strip().splitlines()
-        return None, detail[0] if detail else f"git exited {proc.returncode}"
+        first_line = next(iter((proc.stderr or "").strip().splitlines()), "")
+        if proc.returncode == _GIT_FATAL_CODE and _is_not_a_repository(first_line):
+            return None, None
+        return None, first_line or f"git exited {proc.returncode}"
     return normalize_repo_ref(proc.stdout.strip()), None
+
+
+def _is_not_a_repository(message: str) -> bool:
+    """True for git's "there is no work tree here", not for a fatal error."""
+
+    lowered = message.lower()
+    return any(marker in lowered for marker in _GIT_NOT_A_REPOSITORY)
 
 
 def current_git_remote(cwd: Path) -> str | None:

--- a/potpie/config/local_paths.py
+++ b/potpie/config/local_paths.py
@@ -12,4 +12,18 @@ def default_home() -> Path:
     return Path(raw).expanduser() if raw else Path.home() / ".potpie"
 
 
-__all__ = ["default_home"]
+def harness_home() -> Path:
+    """Return the home under which *harness* directories live.
+
+    Skills install into the agent's own tree (``~/.claude/skills`` and
+    friends), which is a different thing from Potpie's state home — so
+    ``CONTEXT_ENGINE_HOME`` deliberately does not move them, and a run under
+    an "isolated" ``CONTEXT_ENGINE_HOME`` still rewrote the operator's real
+    skill set. ``POTPIE_HARNESS_HOME`` is the knob that does relocate them, so
+    tests and trial installs can be contained without overriding ``HOME``.
+    """
+    raw = os.getenv("POTPIE_HARNESS_HOME")
+    return Path(raw).expanduser() if raw else Path.home()
+
+
+__all__ = ["default_home", "harness_home"]

--- a/potpie/context-engine/src/potpie_context_engine/application/services/envelope_builder.py
+++ b/potpie/context-engine/src/potpie_context_engine/application/services/envelope_builder.py
@@ -107,6 +107,11 @@ class EnvelopeBuilder:
             )
 
         items.sort(key=lambda i: i.score, reverse=True)
+        items, duplicates_dropped = _dedupe_items(items)
+
+        envelope_metadata = dict(metadata or {})
+        if duplicates_dropped:
+            envelope_metadata["duplicate_items_dropped"] = duplicates_dropped
 
         return AgentEnvelope(
             pot_id=pot_id,
@@ -116,8 +121,73 @@ class EnvelopeBuilder:
             unsupported_includes=tuple(unsupported_raw),
             overall_confidence=derive_overall_confidence(coverage=coverage),
             as_of=as_of,
-            metadata=dict(metadata or {}),
+            metadata=envelope_metadata,
         )
+
+
+# Payload keys carrying the item's visible text, in the order the surfaces
+# render them. Two items that show the reader the same sentence about the same
+# subject are one piece of evidence, however many claims produced it.
+_TEXT_KEYS: tuple[str, ...] = ("fact", "summary", "description", "text")
+_SUBJECT_KEYS: tuple[str, ...] = ("subject_key", "entity_key", "anchor_entity_key")
+
+
+def _dedupe_items(items: list[EvidenceItem]) -> tuple[list[EvidenceItem], int]:
+    """Drop cross-include repeats, keeping the highest-scoring occurrence.
+
+    Readers dedupe within their own family, but the same claim can surface
+    through several include families; concatenating them put four copies of one
+    sentence in the top four slots. ``items`` must already be score-sorted so
+    the survivor is the best-ranked copy.
+    """
+    seen: set[tuple[str, ...]] = set()
+    kept: list[EvidenceItem] = []
+    dropped = 0
+    for item in items:
+        identity = _dedupe_identity(item)
+        if identity is None:
+            kept.append(item)
+            continue
+        if identity in seen:
+            dropped += 1
+            continue
+        seen.add(identity)
+        kept.append(item)
+    return kept, dropped
+
+
+def _dedupe_identity(item: EvidenceItem) -> tuple[str, ...] | None:
+    """A stable identity for one piece of evidence, or ``None`` to never merge.
+
+    Endpoints and predicate are part of the identity, so two *different*
+    relationships that happen to be worded the same both survive; only rows a
+    reader cannot tell apart are folded together.
+    """
+    payload = item.payload
+    text = ""
+    for text_key in _TEXT_KEYS:
+        value = payload.get(text_key)
+        if isinstance(value, str) and value.strip():
+            text = " ".join(value.split()).casefold()
+            break
+    if text:
+        return (
+            "text",
+            _payload_str(payload, _SUBJECT_KEYS),
+            _payload_str(payload, ("object_key",)),
+            _payload_str(payload, ("predicate",)),
+            text,
+        )
+    key = str(item.candidate_key or "").strip()
+    return ("key", key) if key else None
+
+
+def _payload_str(payload: Mapping[str, object], keys: Sequence[str]) -> str:
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
 
 
 def envelope_to_dict(envelope: AgentEnvelope) -> dict[str, object]:

--- a/potpie/context-engine/src/potpie_context_engine/application/services/envelope_builder.py
+++ b/potpie/context-engine/src/potpie_context_engine/application/services/envelope_builder.py
@@ -170,15 +170,16 @@ def _dedupe_identity(item: EvidenceItem) -> tuple[str, ...] | None:
         if isinstance(value, str) and value.strip():
             text = " ".join(value.split()).casefold()
             break
-    if text:
-        return (
-            "text",
-            _payload_str(payload, _SUBJECT_KEYS),
-            _payload_str(payload, ("object_key",)),
-            _payload_str(payload, ("predicate",)),
-            text,
-        )
     key = str(item.candidate_key or "").strip()
+    if text:
+        subject = _payload_str(payload, _SUBJECT_KEYS)
+        obj = _payload_str(payload, ("object_key",))
+        predicate = _payload_str(payload, ("predicate",))
+        # With no endpoints at all there is nothing to tell two same-worded
+        # records apart, so fall back to the candidate key rather than
+        # merging records the payload gives us no reason to call identical.
+        discriminator = "" if (subject or obj or predicate) else key
+        return ("text", subject, obj, predicate, discriminator, text)
     return ("key", key) if key else None
 
 

--- a/potpie/context-engine/src/potpie_context_engine/application/services/graph_service.py
+++ b/potpie/context-engine/src/potpie_context_engine/application/services/graph_service.py
@@ -1025,12 +1025,44 @@ def _missing_required_read_scope(
     )
 
 
+# Scope keys that are set by their own flag rather than by ``--scope k:v``.
+_SCOPE_KEY_FLAGS: dict[str, str] = {
+    "query": "--query <text>",
+    "environment": "--environment <name>",
+    "source_ref": "--source-ref <ref>",
+    "repo": "--repo <owner/repo>",
+    # ``scope`` means "any scope entry at all", not a key literally named scope.
+    "scope": "--scope <key>:<value>",
+}
+
+
+def _scope_key_flag(key: str) -> str:
+    return _SCOPE_KEY_FLAGS.get(key, f"--scope {key}:<value>")
+
+
 def _missing_required_scope_message(contract: ViewContract) -> str:
+    """Name what to type, not just which wire keys are missing.
+
+    ``requires one of service, anchor_entity_key`` pointed at names that are
+    not flags anywhere on ``graph read``, leaving a reachable view unreachable
+    without guessing. The concrete form is appended for each key.
+    """
     requirements: list[str] = []
     if contract.required_scope:
-        requirements.append("all of " + ", ".join(contract.required_scope))
+        requirements.append(
+            "all of "
+            + ", ".join(contract.required_scope)
+            + " ("
+            + ", ".join(_scope_key_flag(key) for key in contract.required_scope)
+            + ")"
+        )
     if contract.required_any_scope:
-        requirements.append("one of " + ", ".join(contract.required_any_scope))
+        requirements.append(
+            "one of "
+            + ", ".join(contract.required_any_scope)
+            + " — pass "
+            + " or ".join(_scope_key_flag(key) for key in contract.required_any_scope)
+        )
     required = "; ".join(requirements) or "a required scope"
     return f"graph read view {contract.name!r} requires {required}"
 

--- a/potpie/context-engine/src/potpie_context_engine/core/context_records.py
+++ b/potpie/context-engine/src/potpie_context_engine/core/context_records.py
@@ -35,6 +35,39 @@ class ContextRecordValidationError(ValueError):
 
 
 VERIFICATION_OUTCOMES = frozenset({"worked", "didnt_work", "partial"})
+
+# Detail keys each structured record type *must* carry, keyed by record type.
+# The ``_build_*`` validators below are the enforcement; this table is the
+# machine-readable statement of the same contract, so callers (the CLI's
+# ``record --detail``) can ask what a type needs instead of discovering it by
+# submitting and failing. ``test_context_records`` keeps the two in lockstep.
+REQUIRED_RECORD_DETAILS: dict[str, tuple[str, ...]] = {
+    "bug_pattern": ("kind",),
+    "decision": ("rationale",),
+    "preference": ("policy_kind",),
+    "policy": ("policy_kind",),
+    "verification": ("target_ref", "outcome"),
+}
+
+# Detail keys constrained to a fixed vocabulary, so callers can say which
+# values are legal up front.
+RECORD_DETAIL_CHOICES: dict[tuple[str, str], tuple[str, ...]] = {
+    ("verification", "outcome"): tuple(sorted(VERIFICATION_OUTCOMES)),
+}
+
+
+def required_record_details(record_type: str) -> tuple[str, ...]:
+    """Detail keys ``record_type`` requires; empty for free-form types."""
+
+    return REQUIRED_RECORD_DETAILS.get((record_type or "").strip().lower(), ())
+
+
+def record_detail_choices(record_type: str, field: str) -> tuple[str, ...]:
+    """Allowed values for a constrained detail field, else empty."""
+
+    return RECORD_DETAIL_CHOICES.get(((record_type or "").strip().lower(), field), ())
+
+
 PREFERENCE_STRENGTHS = frozenset({"hard", "strong", "soft"})
 PREFERENCE_AUDIENCES = frozenset({"team", "service", "project", "global"})
 SCOPE_KINDS = frozenset(
@@ -391,6 +424,8 @@ _BUILDERS = {
 
 __all__ = [
     "BugPatternRecord",
+    "RECORD_DETAIL_CHOICES",
+    "REQUIRED_RECORD_DETAILS",
     "ContextRecordValidationError",
     "DecisionRecord",
     "FixRecord",
@@ -404,7 +439,9 @@ __all__ = [
     "VerificationRecord",
     "has_structured_schema",
     "has_structured_details",
+    "record_detail_choices",
     "record_to_dict",
+    "required_record_details",
     "structured_detail_keys",
     "validate_record_payload",
 ]

--- a/potpie/context-engine/src/potpie_context_engine/core/errors.py
+++ b/potpie/context-engine/src/potpie_context_engine/core/errors.py
@@ -1,5 +1,39 @@
 """Domain-level errors; translate to HTTP/CLI at adapter boundaries."""
 
+# Wire field -> the CLI flag that sets it. A required-field error naming only
+# the wire field ("claimed_by is required") points at nothing the user can
+# type, because the flag is `--by`. Boundaries that reject a missing field
+# render the hint through :func:`missing_field_message`.
+CLI_FLAG_FOR_FIELD: dict[str, str] = {
+    "action": "--action",
+    "artifact_id": "--artifact-id",
+    "artifact_type": "--artifact-type",
+    "claimed_by": "--by",
+    "closed_by": "--by",
+    "destination": "--destination",
+    "event_id": "--event-id",
+    "event_type": "--event-type",
+    "item_id": "the ITEM_ID argument",
+    "plan_id": "the PLAN_ID argument",
+    "query": "--query",
+    "record_type": "--type",
+    "rejection_reason": "--reason",
+    "report": "the REPORT argument",
+    "source": "--source",
+    "source_id": "--source-id",
+    "source_system": "--source-system",
+    "subgraph": "--subgraph",
+    "summary": "--summary",
+    "view": "--view",
+}
+
+
+def missing_field_message(field: str) -> str:
+    """``"<field> is required"``, naming the flag that supplies it."""
+
+    flag = CLI_FLAG_FOR_FIELD.get(field)
+    return f"{field} is required (pass {flag})" if flag else f"{field} is required"
+
 
 class ContextEngineError(Exception):
     """Base for all context-engine domain errors."""

--- a/potpie/context-engine/src/potpie_context_engine/core/ports/agent_context.py
+++ b/potpie/context-engine/src/potpie_context_engine/core/ports/agent_context.py
@@ -128,15 +128,30 @@ class StatusReport:
     """Outcome of ``context_status`` — composed across the three services."""
 
     pot_id: str
+    """The pot this report actually describes — the one every scoped command in
+    this working directory will touch. ``data_plane`` and ``pot_summary`` are
+    always this pot's."""
+
     profile: str  # local | managed
     daemon_up: bool
     active_pot: str | None
+    """Name of the globally *active* pot pointer, which is not necessarily
+    :attr:`pot_id` — a repo default can route this directory elsewhere."""
+
     backend_ready: bool
     data_plane: Mapping[str, Any] = field(default_factory=dict)
     pot_summary: Mapping[str, Any] = field(default_factory=dict)
     skills: SkillNudge | None = None
     recommended_next_action: str | None = None
     metadata: Mapping[str, Any] = field(default_factory=dict)
+    pot_name: str | None = None
+    """Display name of :attr:`pot_id`."""
+
+    resolved_via: str | None = None
+    """How :attr:`pot_id` was chosen: explicit | repo_default | linked_repo |
+    active_pot."""
+
+    active_pot_id: str | None = None
 
 
 class AgentContextPort(Protocol):

--- a/potpie/context-engine/src/potpie_context_engine/core/workbench_service.py
+++ b/potpie/context-engine/src/potpie_context_engine/core/workbench_service.py
@@ -20,7 +20,10 @@ from potpie_context_engine.core.semantic_mutation_lowering import lower_semantic
 from potpie_context_engine.core.semantic_mutation_validator import (
     validate_semantic_request,
 )
-from potpie_context_engine.core.errors import CapabilityNotImplemented
+from potpie_context_engine.core.errors import (
+    CapabilityNotImplemented,
+    missing_field_message,
+)
 from potpie_context_engine.core.graph_contract import (
     GRAPH_CONTRACT_VERSION as DATA_PLANE_CONTRACT_VERSION,
 )
@@ -307,8 +310,16 @@ class GraphWorkbenchService:
                 status="not_found",
                 risk=MutationRisk.low.value,
                 pot_id=pot_id,
-                detail=f"mutation plan {plan_id!r} was not found for this pot",
-                recommended_next_action="Run graph propose and commit the returned plan_id.",
+                detail=(
+                    f"mutation plan {plan_id!r} was not found in pot {pot_id}. "
+                    "Plans are pot-scoped, so a plan proposed against a "
+                    "different pot is invisible here."
+                ),
+                recommended_next_action=(
+                    f"re-run with '--pot {pot_id}' from the directory you "
+                    "proposed in, or run graph propose again and commit the "
+                    "plan_id it returns"
+                ),
             )
 
         if record.status == GraphMutationPlanStatus.committed.value:
@@ -3285,7 +3296,7 @@ def _clean_str(value: str | None) -> str | None:
 def _required_clean(value: str | None, field: str) -> str:
     clean = _clean_str(value)
     if not clean:
-        raise ValueError(f"{field} is required")
+        raise ValueError(missing_field_message(field))
     return clean
 
 
@@ -3329,8 +3340,11 @@ def _inbox_missing_result(
         ok=False,
         pot_id=pot_id,
         action=action,
-        detail=f"inbox item {item_id!r} was not found for this pot",
-        recommended_next_action="Run graph inbox list --json and use an item_id from the result.",
+        detail=f"inbox item {item_id!r} was not found in pot {pot_id}",
+        recommended_next_action=(
+            f"run 'graph inbox list --pot {pot_id} --json' and use an item_id "
+            "from the result"
+        ),
     )
 
 

--- a/potpie/context-engine/src/potpie_context_engine/core/workbench_service.py
+++ b/potpie/context-engine/src/potpie_context_engine/core/workbench_service.py
@@ -316,9 +316,9 @@ class GraphWorkbenchService:
                     "different pot is invisible here."
                 ),
                 recommended_next_action=(
-                    f"re-run with '--pot {pot_id}' from the directory you "
-                    "proposed in, or run graph propose again and commit the "
-                    "plan_id it returns"
+                    "re-run the commit with the pot you proposed in — "
+                    "'graph propose --json' reports it as pot_id — or run "
+                    "graph propose again here and commit the plan_id it returns"
                 ),
             )
 

--- a/potpie/context-engine/tests/unit/test_envelope.py
+++ b/potpie/context-engine/tests/unit/test_envelope.py
@@ -203,3 +203,156 @@ class TestAgentContractGenerator:
         emit(buf_a)
         emit(buf_b)
         assert buf_a.getvalue() == buf_b.getvalue()
+
+
+class TestDuplicateEvidenceIsMerged:
+    """Release finding m5: one fact occupied the top four ranked slots.
+
+    Readers dedupe inside their own family, but the builder concatenated
+    families without a cross-family pass, so the same evidence could repeat.
+    """
+
+    def _payload(self, *, subject: str, fact: str, obj: str = "service:api") -> dict:
+        return {
+            "subject_key": subject,
+            "object_key": obj,
+            "predicate": "DECIDED",
+            "fact": fact,
+        }
+
+    def test_the_same_evidence_from_two_families_collapses_to_one(self) -> None:
+        payload = self._payload(subject="decision:retry", fact="Retries cap at 3.")
+        envelope = EnvelopeBuilder().build(
+            pot_id="pot-1",
+            intent="review",
+            results=[
+                IncludeResult(
+                    include="decisions",
+                    response=_resp(
+                        family="decisions",
+                        items=[
+                            _ranked_item(key="claim:a", score=0.58, payload=payload)
+                        ],
+                        coverage_status="complete",
+                    ),
+                ),
+                IncludeResult(
+                    include="timeline",
+                    response=_resp(
+                        family="timeline",
+                        items=[
+                            _ranked_item(key="claim:b", score=0.51, payload=payload)
+                        ],
+                        coverage_status="complete",
+                    ),
+                ),
+            ],
+        )
+
+        assert len(envelope.items) == 1
+        # The best-ranked copy survives.
+        assert envelope.items[0].score == 0.58
+        assert envelope.metadata["duplicate_items_dropped"] == 1
+
+    def test_identical_wording_about_different_subjects_both_survive(self) -> None:
+        """Two records worded the same are still two records, not a repeat."""
+        envelope = EnvelopeBuilder().build(
+            pot_id="pot-1",
+            intent="review",
+            results=[
+                IncludeResult(
+                    include="decisions",
+                    response=_resp(
+                        family="decisions",
+                        items=[
+                            _ranked_item(
+                                key="claim:a",
+                                score=0.58,
+                                payload=self._payload(
+                                    subject="decision:one", fact="Same words."
+                                ),
+                            ),
+                            _ranked_item(
+                                key="claim:b",
+                                score=0.57,
+                                payload=self._payload(
+                                    subject="decision:two", fact="Same words."
+                                ),
+                            ),
+                        ],
+                        coverage_status="complete",
+                    ),
+                ),
+            ],
+        )
+
+        assert len(envelope.items) == 2
+        assert "duplicate_items_dropped" not in envelope.metadata
+
+    def test_repeats_merge_even_when_the_candidate_key_is_missing(self) -> None:
+        """The reported case: candidate_key was None, so nothing keyed on it."""
+        payload = self._payload(subject="activity:deploy", fact="Deployed api v9.")
+        envelope = EnvelopeBuilder().build(
+            pot_id="pot-1",
+            intent="operations",
+            results=[
+                IncludeResult(
+                    include="timeline",
+                    response=_resp(
+                        family="timeline",
+                        items=[
+                            _ranked_item(key="", score=0.582, payload=payload),
+                            _ranked_item(key="", score=0.581, payload=payload),
+                            _ranked_item(key="", score=0.576, payload=payload),
+                        ],
+                        coverage_status="complete",
+                    ),
+                ),
+            ],
+        )
+
+        assert len(envelope.items) == 1
+        assert envelope.metadata["duplicate_items_dropped"] == 2
+
+    def test_items_without_text_or_key_are_never_merged(self) -> None:
+        envelope = EnvelopeBuilder().build(
+            pot_id="pot-1",
+            intent="review",
+            results=[
+                IncludeResult(
+                    include="decisions",
+                    response=_resp(
+                        family="decisions",
+                        items=[
+                            _ranked_item(key="", score=0.4, payload={"a": 1}),
+                            _ranked_item(key="", score=0.3, payload={"a": 1}),
+                        ],
+                        coverage_status="complete",
+                    ),
+                ),
+            ],
+        )
+
+        assert len(envelope.items) == 2
+
+    def test_serialised_envelope_carries_the_merge_count(self) -> None:
+        payload = self._payload(subject="decision:x", fact="One fact.")
+        envelope = EnvelopeBuilder().build(
+            pot_id="pot-1",
+            intent="review",
+            results=[
+                IncludeResult(
+                    include="decisions",
+                    response=_resp(
+                        family="decisions",
+                        items=[
+                            _ranked_item(key="claim:a", score=0.6, payload=payload),
+                            _ranked_item(key="claim:a", score=0.5, payload=payload),
+                        ],
+                        coverage_status="complete",
+                    ),
+                ),
+            ],
+        )
+
+        assert envelope_to_dict(envelope)["metadata"] == {"duplicate_items_dropped": 1}

--- a/potpie/context-engine/tests/unit/test_envelope.py
+++ b/potpie/context-engine/tests/unit/test_envelope.py
@@ -356,3 +356,53 @@ class TestDuplicateEvidenceIsMerged:
         )
 
         assert envelope_to_dict(envelope)["metadata"] == {"duplicate_items_dropped": 1}
+
+    def test_text_only_records_with_distinct_keys_both_survive(self) -> None:
+        """No endpoints means nothing says these are the same record.
+
+        Merging on text alone would drop a genuinely distinct item whose only
+        discriminator is its candidate key.
+        """
+        payload = {"fact": "Same words, different records."}
+        envelope = EnvelopeBuilder().build(
+            pot_id="pot-1",
+            intent="review",
+            results=[
+                IncludeResult(
+                    include="decisions",
+                    response=_resp(
+                        family="decisions",
+                        items=[
+                            _ranked_item(key="claim:a", score=0.6, payload=payload),
+                            _ranked_item(key="claim:b", score=0.5, payload=payload),
+                        ],
+                        coverage_status="complete",
+                    ),
+                ),
+            ],
+        )
+
+        assert len(envelope.items) == 2
+
+    def test_text_only_records_without_keys_still_merge(self) -> None:
+        payload = {"fact": "Same words, no way to tell them apart."}
+        envelope = EnvelopeBuilder().build(
+            pot_id="pot-1",
+            intent="review",
+            results=[
+                IncludeResult(
+                    include="decisions",
+                    response=_resp(
+                        family="decisions",
+                        items=[
+                            _ranked_item(key="", score=0.6, payload=payload),
+                            _ranked_item(key="", score=0.5, payload=payload),
+                        ],
+                        coverage_status="complete",
+                    ),
+                ),
+            ],
+        )
+
+        assert len(envelope.items) == 1
+        assert envelope.metadata["duplicate_items_dropped"] == 1

--- a/potpie/context-engine/tests/unit/test_graph_workbench_inbox.py
+++ b/potpie/context-engine/tests/unit/test_graph_workbench_inbox.py
@@ -238,3 +238,34 @@ def test_local_json_inbox_store_preserves_cross_process_writes(tmp_path) -> None
     state = json.loads((tmp_path / "graph_inbox.json").read_text(encoding="utf-8"))
     assert "graph-inbox:first" in state["items"]["pot-a"]
     assert "graph-inbox:second" in state["items"]["pot-b"]
+
+
+def test_inbox_item_not_found_names_the_pot_it_searched(tmp_path) -> None:
+    """m4: inbox items are pot-scoped; the failure must say which pot."""
+    workbench, _backend = _service(tmp_path)
+
+    result = workbench.inbox_show(pot_id="pot-beta", item_id="graph-inbox:nope")
+
+    assert result.ok is False
+    assert "pot-beta" in result.detail
+    assert "--pot pot-beta" in result.recommended_next_action
+
+
+def test_inbox_actor_fields_are_rejected_with_the_flag_that_sets_them(
+    tmp_path,
+) -> None:
+    """m6: "claimed_by is required" named a wire field, not the `--by` flag."""
+    workbench, _backend = _service(tmp_path)
+    added = workbench.inbox_add(pot_id=POT, summary="Investigate prior bug")
+    assert added.item is not None
+
+    with pytest.raises(ValueError, match=r"claimed_by is required \(pass --by\)"):
+        workbench.inbox_claim(pot_id=POT, item_id=added.item.item_id, claimed_by="")
+
+    with pytest.raises(ValueError, match=r"closed_by is required \(pass --by\)"):
+        workbench.inbox_mark_applied(
+            pot_id=POT,
+            item_id=added.item.item_id,
+            closed_by=None,
+            linked_plan_id="mutation-plan:test",
+        )

--- a/potpie/context-engine/tests/unit/test_graph_workbench_plans.py
+++ b/potpie/context-engine/tests/unit/test_graph_workbench_plans.py
@@ -972,3 +972,29 @@ def _record_in_window(
             continue
         return True
     return False
+
+
+def test_plan_not_found_names_the_pot_it_searched() -> None:
+    """m4: plans are pot-scoped, but the failure never said which pot.
+
+    Proposing in one directory and committing in another resolves to a
+    different pot, and the old message ("… for this pot") gave the caller
+    nothing to compare against.
+    """
+    workbench, _backend, _store = _service()
+    proposal = workbench.propose(_link_payload(), pot_id="pot-alpha")
+
+    result = workbench.commit(proposal.plan_id, pot_id="pot-beta")
+
+    assert result.ok is False
+    assert result.status == "not_found"
+    assert "pot-beta" in result.detail
+    assert "pot-scoped" in result.detail
+    assert "--pot pot-beta" in result.recommended_next_action
+
+
+def test_a_plan_committed_in_its_own_pot_still_succeeds() -> None:
+    workbench, _backend, _store = _service()
+    proposal = workbench.propose(_link_payload(), pot_id="pot-alpha")
+
+    assert workbench.commit(proposal.plan_id, pot_id="pot-alpha").ok is True

--- a/potpie/context-engine/tests/unit/test_graph_workbench_plans.py
+++ b/potpie/context-engine/tests/unit/test_graph_workbench_plans.py
@@ -990,7 +990,10 @@ def test_plan_not_found_names_the_pot_it_searched() -> None:
     assert result.status == "not_found"
     assert "pot-beta" in result.detail
     assert "pot-scoped" in result.detail
-    assert "--pot pot-beta" in result.recommended_next_action
+    # The guidance must not point back at the pot that just failed: committing
+    # again with --pot pot-beta would repeat this same not_found.
+    assert "pot-beta" not in result.recommended_next_action
+    assert "the pot you proposed in" in result.recommended_next_action
 
 
 def test_a_plan_committed_in_its_own_pot_still_succeeds() -> None:

--- a/potpie/context-engine/tests/unit/test_release_findings_messages.py
+++ b/potpie/context-engine/tests/unit/test_release_findings_messages.py
@@ -1,0 +1,146 @@
+"""Engine-side regressions for the potpie 2.0.1 release-test findings.
+
+These all concern *what an error tells the caller*: which pot it searched,
+and which flag the caller must type. Each one was a case where the message
+named an internal field and pointed at nothing the user could act on.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from potpie_context_engine.application.services.graph_service import (
+    _missing_required_scope_message,
+)
+from potpie_context_engine.core.context_records import (
+    ContextRecordValidationError,
+    REQUIRED_RECORD_DETAILS,
+    record_detail_choices,
+    required_record_details,
+    validate_record_payload,
+)
+from potpie_context_engine.core.errors import (
+    CLI_FLAG_FOR_FIELD,
+    missing_field_message,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _ViewContract:
+    def __init__(self, name, required_scope=(), required_any_scope=()):
+        self.name = name
+        self.required_scope = required_scope
+        self.required_any_scope = required_any_scope
+
+
+class TestMissingScopeMessageNamesTheFlag:
+    """m6: neither `service` nor `anchor_entity_key` is a flag on graph read."""
+
+    def test_any_of_requirements_spell_out_the_scope_syntax(self) -> None:
+        message = _missing_required_scope_message(
+            _ViewContract(
+                "infra_topology.service_neighborhood",
+                required_any_scope=("service", "anchor_entity_key"),
+            )
+        )
+
+        assert "requires one of service, anchor_entity_key" in message
+        assert "--scope service:<value>" in message
+        assert "--scope anchor_entity_key:<value>" in message
+
+    def test_keys_with_their_own_flag_are_named_by_that_flag(self) -> None:
+        message = _missing_required_scope_message(
+            _ViewContract(
+                "knowledge.document_context",
+                required_any_scope=("query", "environment", "source_ref", "repo"),
+            )
+        )
+
+        assert "--query <text>" in message
+        assert "--environment <name>" in message
+        assert "--source-ref <ref>" in message
+        assert "--repo <owner/repo>" in message
+
+    def test_the_generic_scope_key_is_not_rendered_as_scope_scope(self) -> None:
+        message = _missing_required_scope_message(
+            _ViewContract("decisions.active_decisions", required_any_scope=("scope",))
+        )
+
+        assert "--scope <key>:<value>" in message
+        assert "--scope scope:" not in message
+
+    def test_all_of_requirements_are_spelled_out_too(self) -> None:
+        message = _missing_required_scope_message(
+            _ViewContract("x.y", required_scope=("service",))
+        )
+
+        assert "all of service" in message
+        assert "--scope service:<value>" in message
+
+
+class TestRequiredFieldMessagesNameTheFlag:
+    def test_inbox_actor_fields_point_at_by(self) -> None:
+        assert missing_field_message("claimed_by").endswith("(pass --by)")
+        assert missing_field_message("closed_by").endswith("(pass --by)")
+
+    def test_positional_arguments_are_described_as_arguments(self) -> None:
+        assert "the ITEM_ID argument" in missing_field_message("item_id")
+        assert "the PLAN_ID argument" in missing_field_message("plan_id")
+
+    def test_unmapped_fields_keep_the_plain_message(self) -> None:
+        assert missing_field_message("nonesuch") == "nonesuch is required"
+
+    def test_every_mapped_flag_is_a_flag_or_a_named_argument(self) -> None:
+        for field, flag in CLI_FLAG_FOR_FIELD.items():
+            assert flag.startswith("--") or "argument" in flag, field
+
+
+class TestRequiredRecordDetailsMatchTheValidators:
+    """M5: five record types were unreachable because no flag set their detail.
+
+    The published table must stay in lockstep with the validators, or the CLI
+    will advertise a detail the engine does not want (or miss one it does).
+    """
+
+    @pytest.mark.parametrize("record_type", sorted(REQUIRED_RECORD_DETAILS))
+    def test_omitting_a_required_detail_is_rejected(self, record_type: str) -> None:
+        fields = required_record_details(record_type)
+        assert fields
+        for omitted in fields:
+            details = {
+                field: _legal_value(record_type, field)
+                for field in fields
+                if field != omitted
+            }
+            with pytest.raises(ContextRecordValidationError):
+                validate_record_payload(
+                    record_type=record_type, summary="s", details=details
+                )
+
+    @pytest.mark.parametrize("record_type", sorted(REQUIRED_RECORD_DETAILS))
+    def test_supplying_every_required_detail_validates(self, record_type: str) -> None:
+        details = {
+            field: _legal_value(record_type, field)
+            for field in required_record_details(record_type)
+        }
+        assert validate_record_payload(
+            record_type=record_type, summary="s", details=details
+        )
+
+    def test_free_form_types_require_nothing(self) -> None:
+        assert required_record_details("fix") == ()
+        assert required_record_details("investigation") == ()
+
+    def test_constrained_details_publish_their_vocabulary(self) -> None:
+        assert record_detail_choices("verification", "outcome") == (
+            "didnt_work",
+            "partial",
+            "worked",
+        )
+        assert record_detail_choices("decision", "rationale") == ()
+
+
+def _legal_value(record_type: str, field: str) -> str:
+    choices = record_detail_choices(record_type, field)
+    return choices[0] if choices else "value"

--- a/potpie/daemon/discovery.py
+++ b/potpie/daemon/discovery.py
@@ -27,7 +27,52 @@ _CONSERVATIVE_UDS_PATH_LIMIT = 90
 
 
 class DaemonDiscoveryError(RuntimeError):
-    """A canonical discovery or credential record is missing or invalid."""
+    """A canonical discovery or credential record is missing or invalid.
+
+    ``code`` classifies *why* so callers can tell an absent record (first run)
+    from one this build cannot read (an upgrade left an older daemon's record
+    behind). The wedge in the 2.0.1 report came from collapsing both into one
+    opaque "unavailable", which routed users to a recovery that could not run.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = "daemon_discovery_unavailable",
+        recommended_next_action: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.recommended_next_action = recommended_next_action
+
+    @property
+    def message(self) -> str:
+        return str(self)
+
+    @property
+    def recoverable_by_replacement(self) -> bool:
+        """True when replacing the daemon process is the documented recovery."""
+
+        return self.code in _REPLACEABLE_DISCOVERY_CODES
+
+
+DISCOVERY_ABSENT = "daemon_discovery_absent"
+DISCOVERY_UNREADABLE = "daemon_discovery_unreadable"
+DISCOVERY_SCHEMA_UNSUPPORTED = "daemon_discovery_schema_unsupported"
+DISCOVERY_CREDENTIAL_UNAVAILABLE = "daemon_credential_unavailable"
+
+_REPLACEABLE_DISCOVERY_CODES = frozenset(
+    {
+        DISCOVERY_UNREADABLE,
+        DISCOVERY_SCHEMA_UNSUPPORTED,
+        DISCOVERY_CREDENTIAL_UNAVAILABLE,
+    }
+)
+
+# Keys written by pre-2.0.1 daemons. Recognising them lets the CLI say
+# "written by an older potpie" instead of "invalid".
+_LEGACY_DISCOVERY_KEYS = frozenset({"base_url", "token", "transport"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -168,16 +213,40 @@ def read_daemon_discovery(home: Path) -> DaemonDiscovery | None:
     _require_private_regular_file(path)
     try:
         document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DaemonDiscoveryError(
+            "the daemon runtime record could not be read",
+            code=DISCOVERY_UNREADABLE,
+            recommended_next_action="run 'potpie daemon restart'",
+        ) from exc
+    if _looks_like_legacy_document(document):
+        raise DaemonDiscoveryError(
+            "the daemon runtime record was written by an older potpie and this "
+            "build cannot authenticate that daemon",
+            code=DISCOVERY_SCHEMA_UNSUPPORTED,
+            recommended_next_action=(
+                "run 'potpie daemon restart' to replace the pre-upgrade daemon"
+            ),
+        )
+    try:
         return _decode_discovery(document, home=home)
-    except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
-        raise DaemonDiscoveryError("canonical daemon discovery is invalid") from exc
+    except (TypeError, ValueError) as exc:
+        raise DaemonDiscoveryError(
+            f"the daemon runtime record is not valid for this build: {exc}",
+            code=DISCOVERY_SCHEMA_UNSUPPORTED,
+            recommended_next_action="run 'potpie daemon restart'",
+        ) from exc
 
 
 def load_daemon_connection(home: Path) -> DaemonConnection:
     home = Path(home).resolve()
     discovery = read_daemon_discovery(home)
     if discovery is None:
-        raise DaemonDiscoveryError("daemon discovery is unavailable")
+        raise DaemonDiscoveryError(
+            "no daemon runtime record was found",
+            code=DISCOVERY_ABSENT,
+            recommended_next_action="run 'potpie daemon start'",
+        )
     token = read_daemon_credential(home)
     return DaemonConnection(discovery=discovery, bearer_token=token)
 
@@ -189,10 +258,28 @@ def read_daemon_credential(home: Path) -> str:
     try:
         token = path.read_text(encoding="utf-8").strip()
     except OSError as exc:
-        raise DaemonDiscoveryError("daemon credential is unavailable") from exc
+        raise DaemonDiscoveryError(
+            "the daemon credential could not be read",
+            code=DISCOVERY_CREDENTIAL_UNAVAILABLE,
+            recommended_next_action="run 'potpie daemon restart'",
+        ) from exc
     if len(token.encode()) < 32:
-        raise DaemonDiscoveryError("daemon credential is invalid")
+        raise DaemonDiscoveryError(
+            "the daemon credential is not valid for this build",
+            code=DISCOVERY_CREDENTIAL_UNAVAILABLE,
+            recommended_next_action="run 'potpie daemon restart'",
+        )
     return token
+
+
+def _looks_like_legacy_document(document: object) -> bool:
+    """Recognise a pre-2.0.1 discovery record by its distinctive flat shape."""
+
+    if not isinstance(document, Mapping):
+        return False
+    if "schema_version" in document:
+        return False
+    return bool(_LEGACY_DISCOVERY_KEYS & set(document))
 
 
 def remove_daemon_runtime_records(
@@ -401,8 +488,12 @@ def canonical_discovery(
 __all__ = [
     "AUTHENTICATION_SCHEME",
     "CREDENTIAL_FILENAME",
+    "DISCOVERY_ABSENT",
+    "DISCOVERY_CREDENTIAL_UNAVAILABLE",
     "DISCOVERY_FILENAME",
+    "DISCOVERY_SCHEMA_UNSUPPORTED",
     "DISCOVERY_SCHEMA_VERSION",
+    "DISCOVERY_UNREADABLE",
     "PID_FILENAME",
     "DaemonConnection",
     "DaemonDiscovery",

--- a/potpie/daemon/discovery.py
+++ b/potpie/daemon/discovery.py
@@ -210,7 +210,17 @@ def read_daemon_discovery(home: Path) -> DaemonDiscovery | None:
     path = discovery_path(home)
     if not path.exists():
         return None
-    _require_private_regular_file(path)
+    try:
+        _require_private_regular_file(path)
+    except DaemonDiscoveryError as exc:
+        # A record that vanished between exists() and stat(), or that is not
+        # an owner-only regular file, is still an unreadable record — it must
+        # carry the same classification as a corrupt one.
+        raise DaemonDiscoveryError(
+            str(exc),
+            code=DISCOVERY_UNREADABLE,
+            recommended_next_action="run 'potpie daemon restart'",
+        ) from exc
     try:
         document = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
@@ -254,7 +264,14 @@ def load_daemon_connection(home: Path) -> DaemonConnection:
 def read_daemon_credential(home: Path) -> str:
     home = Path(home).resolve()
     path = credential_path(home)
-    _require_private_regular_file(path)
+    try:
+        _require_private_regular_file(path)
+    except DaemonDiscoveryError as exc:
+        raise DaemonDiscoveryError(
+            str(exc),
+            code=DISCOVERY_CREDENTIAL_UNAVAILABLE,
+            recommended_next_action="run 'potpie daemon restart'",
+        ) from exc
     try:
         token = path.read_text(encoding="utf-8").strip()
     except OSError as exc:

--- a/potpie/daemon/http/ui/static.py
+++ b/potpie/daemon/http/ui/static.py
@@ -21,7 +21,11 @@ _PLACEHOLDER = """<!doctype html>
 margin:4rem auto;padding:0 1rem;color:#222}code{background:#f3f3f5;padding:.15em .4em;
 border-radius:4px}</style></head><body>
 <h1>Potpie Graph Explorer</h1>
-<p>The UI bundle has not been built yet. From the repo root, run:</p>
+<p>The UI bundle has not been built yet.</p>
+<p>Installed from PyPI? Reinstall to get the bundle:</p>
+<pre><code>uv tool install --force potpie
+potpie daemon restart</code></pre>
+<p>Working from a source checkout? Build it from the repo root:</p>
 <pre><code>make cli-install
 # or: make ui-build
 potpie daemon restart</code></pre>

--- a/potpie/daemon/lifecycle.py
+++ b/potpie/daemon/lifecycle.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import shlex
 import signal
 import socket
 import subprocess
@@ -64,10 +65,13 @@ class DaemonStopError(Exception):
         self.error = error
 
 
-# Command-line fragments that identify a process as one of our own daemons.
-# The recorded PID alone is not proof of identity (PIDs are reused), so a
-# forced takedown of an unauthenticatable daemon checks this first.
-_DAEMON_COMMAND_MARKERS = ("potpie.daemon", "potpie-daemon", "potpied")
+# How our daemon is actually launched: `<python> -m potpie.daemon` (see
+# ``_launch_spec``) or one of the console scripts. This gates a SIGTERM, and
+# the recorded PID alone is not proof of identity (PIDs are reused), so the
+# command line is matched as *tokens* — a substring test would also accept an
+# unrelated process such as `potpie.daemon_helper` or a grep for that string.
+_DAEMON_MODULE = "potpie.daemon"
+_DAEMON_EXECUTABLES = frozenset({"potpie-daemon", "potpied"})
 
 
 def _process_command_line(pid: int) -> str | None:
@@ -88,11 +92,28 @@ def _process_command_line(pid: int) -> str | None:
     return (proc.stdout or "").strip() or None
 
 
+def _is_daemon_command(command: str) -> bool:
+    """True only for the exact argv shapes this module launches."""
+
+    try:
+        argv = shlex.split(command)
+    except ValueError:
+        argv = command.split()
+    if not argv:
+        return False
+    if os.path.basename(argv[0]) in _DAEMON_EXECUTABLES:
+        return True
+    # `<python> [-X …] -m potpie.daemon [args]`: the module must be the token
+    # immediately after `-m`, not merely present somewhere in the line.
+    for index, token in enumerate(argv[:-1]):
+        if token == "-m":
+            return argv[index + 1] == _DAEMON_MODULE
+    return False
+
+
 def _looks_like_potpie_daemon(pid: int) -> bool:
     command = _process_command_line(pid)
-    if command is None:
-        return False
-    return any(marker in command for marker in _DAEMON_COMMAND_MARKERS)
+    return bool(command) and _is_daemon_command(command)
 
 
 def _terminate_pid(pid: int, *, grace_s: float = 10.0) -> str:
@@ -540,7 +561,12 @@ class Daemon:
                 )
             )
         mode = _terminate_pid(pid)
-        self._cleanup_runtime_records()
+        # Report success only if we actually owned the cleanup. ``expected_pid``
+        # is deliberately not passed: it is verified against the discovery
+        # record, which in this path is precisely the thing we cannot read.
+        if not self._cleanup_runtime_records():
+            self._controller = None
+            self._raise_cleanup_ownership_conflict(expected_pid=pid)
         self._controller = None
         return {
             "detail": {

--- a/potpie/daemon/lifecycle.py
+++ b/potpie/daemon/lifecycle.py
@@ -6,7 +6,9 @@ import asyncio
 import os
 import signal
 import socket
+import subprocess
 import sys
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -15,6 +17,7 @@ from uuid import uuid4
 from potpie.daemon.discovery import (
     DaemonDiscoveryError,
     canonical_discovery,
+    discovery_path,
     load_daemon_connection,
     read_daemon_pid,
     read_daemon_discovery,
@@ -41,9 +44,16 @@ from potpie_context_engine.core.lifecycle import DONE, SKIPPED, SetupPlan, StepR
 class DaemonStartError(Exception):
     """Raised when the canonical local daemon cannot become ready."""
 
-    def __init__(self, message: str, *, log_path: Path | None = None) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        log_path: Path | None = None,
+        recommended_next_action: str | None = None,
+    ) -> None:
         super().__init__(message)
         self.log_path = log_path
+        self.recommended_next_action = recommended_next_action
 
 
 class DaemonStopError(Exception):
@@ -52,6 +62,68 @@ class DaemonStopError(Exception):
     def __init__(self, error: ResourceLifecycleError) -> None:
         super().__init__(error.message)
         self.error = error
+
+
+# Command-line fragments that identify a process as one of our own daemons.
+# The recorded PID alone is not proof of identity (PIDs are reused), so a
+# forced takedown of an unauthenticatable daemon checks this first.
+_DAEMON_COMMAND_MARKERS = ("potpie.daemon", "potpie-daemon", "potpied")
+
+
+def _process_command_line(pid: int) -> str | None:
+    """Best-effort command line for ``pid``; ``None`` when it cannot be read."""
+
+    try:
+        proc = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "command="],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return (proc.stdout or "").strip() or None
+
+
+def _looks_like_potpie_daemon(pid: int) -> bool:
+    command = _process_command_line(pid)
+    if command is None:
+        return False
+    return any(marker in command for marker in _DAEMON_COMMAND_MARKERS)
+
+
+def _terminate_pid(pid: int, *, grace_s: float = 10.0) -> str:
+    """SIGTERM then SIGKILL the recorded process; return how it ended."""
+
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return "already_stopped"
+    except OSError as exc:
+        raise DaemonStopError(
+            ResourceLifecycleError(
+                code="daemon_signal_failed",
+                message=f"could not signal the recorded daemon process: {exc}",
+                details={"pid": pid},
+                recommended_next_action=f"stop it manually with 'kill {pid}'",
+                retry_posture="safe",
+            )
+        ) from exc
+    deadline = time.monotonic() + grace_s
+    while time.monotonic() < deadline:
+        if not _pid_alive(pid):
+            return "terminated"
+        time.sleep(0.05)
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return "terminated"
+    except OSError:
+        return "terminated"
+    return "killed"
 
 
 def _pid_alive(pid: int) -> bool:
@@ -158,11 +230,30 @@ class Daemon:
             else "detached daemon not running",
         }
         if not up or pid is None:
+            result["identity"] = "absent"
             return result
         connection = self._connection_for_pid(pid)
         if connection is None:
-            result["detail"] = "detached daemon running without canonical discovery"
+            reason = self._discovery_failure()
+            result["identity"] = "unauthenticated"
+            result["detail"] = (
+                "detached daemon running, but its runtime record cannot be "
+                f"authenticated by this build ({reason.message})"
+                if reason is not None
+                else (
+                    "detached daemon running, but its runtime record does not "
+                    "match the recorded process"
+                )
+            )
+            result["identity_reason"] = (
+                reason.code if reason is not None else "daemon_discovery_mismatch"
+            )
+            result["recovery"] = (
+                "run 'potpie daemon restart' to replace it "
+                f"(manual escape hatch: kill {pid})"
+            )
             return result
+        result["identity"] = "ok"
         discovery, observer = connection
         existing_controller = self._controller
         controller = self._controller_for_existing(pid, observer=observer)
@@ -230,6 +321,17 @@ class Daemon:
     def start(self, *, backend: str | None = None) -> dict[str, Any]:
         pid = self._recorded_pid()
         if pid is not None and _pid_alive(pid):
+            # "already running" is unhelpful when that daemon is the reason
+            # every command is failing; name the operation that replaces it.
+            if self._connection_for_pid(pid) is None:
+                raise DaemonStartError(
+                    f"daemon already running (pid={pid}), but its runtime record "
+                    "cannot be authenticated by this build",
+                    recommended_next_action=(
+                        "run 'potpie daemon restart' to replace it "
+                        f"(manual escape hatch: kill {pid})"
+                    ),
+                )
             raise DaemonStartError(f"daemon already running (pid={pid})")
         if not self._cleanup_runtime_records():
             raise DaemonStartError("another daemon boot owns the runtime scope")
@@ -269,7 +371,7 @@ class Daemon:
             "url": status.get("url", ""),
         }
 
-    def stop(self) -> dict[str, Any]:
+    def stop(self, *, force: bool = False) -> dict[str, Any]:
         controller = self._controller
         pid = controller.pid if controller is not None else self._recorded_pid()
         if pid is None:
@@ -286,21 +388,9 @@ class Daemon:
         if controller is None:
             connection = self._connection_for_pid(pid)
             if connection is None:
-                raise DaemonStopError(
-                    ResourceLifecycleError(
-                        code="daemon_attached_identity_unavailable",
-                        message=(
-                            "refusing to signal the recorded process because its "
-                            "daemon identity could not be authenticated"
-                        ),
-                        details={"pid": pid},
-                        recommended_next_action=(
-                            "inspect daemon status and runtime records before "
-                            "manual recovery"
-                        ),
-                        retry_posture="safe",
-                    )
-                )
+                if force:
+                    return self._force_stop(pid)
+                raise DaemonStopError(self._unauthenticated_identity_error(pid))
             discovery, observer = connection
             expected_instance_id = discovery.instance_id
             controller = self._controller_for_existing(pid, observer=observer)
@@ -324,12 +414,36 @@ class Daemon:
     def restart(self) -> dict[str, Any]:
         current_status = self.status()
         current_backend = current_status.get("backend")
-        if current_status.get("up") and not isinstance(current_backend, str):
-            raise RuntimeError(
-                "cannot determine running daemon backend; "
-                "refusing restart to avoid backend drift"
+        unauthenticated = current_status.get("identity") == "unauthenticated"
+        if (
+            current_status.get("up")
+            and not isinstance(current_backend, str)
+            and not unauthenticated
+        ):
+            raise DaemonStopError(
+                ResourceLifecycleError(
+                    code="daemon_backend_undetermined",
+                    message=(
+                        "cannot determine the running daemon's backend; refusing "
+                        "restart to avoid backend drift"
+                    ),
+                    details={"pid": current_status.get("pid")},
+                    recommended_next_action=(
+                        "check 'potpie daemon status', then stop it with "
+                        "'potpie daemon stop' and start it again"
+                    ),
+                    retry_posture="safe",
+                )
             )
-        self.stop()
+        # An unauthenticatable record (a pre-upgrade daemon, a truncated or
+        # legacy discovery file) has no readable backend and no typed shutdown
+        # path. Restart is exactly the operation that replaces that process, so
+        # take it down by signal rather than dead-ending the only recovery the
+        # CLI recommends.
+        if unauthenticated:
+            self.stop(force=True)
+        else:
+            self.stop()
         info = self.start(
             backend=current_backend if isinstance(current_backend, str) else None
         )
@@ -367,6 +481,76 @@ class Daemon:
         )
         self._controller = controller
         return controller
+
+    def _discovery_failure(self) -> DaemonDiscoveryError | None:
+        """Return why the runtime record is unusable, if that is the reason."""
+
+        try:
+            read_daemon_discovery(self.home)
+        except DaemonDiscoveryError as exc:
+            return exc
+        return None
+
+    def _unauthenticated_identity_error(self, pid: int) -> ResourceLifecycleError:
+        reason = self._discovery_failure()
+        detail = f" ({reason.message})" if reason is not None else ""
+        return ResourceLifecycleError(
+            code="daemon_attached_identity_unavailable",
+            message=(
+                "refusing to signal the recorded process because its daemon "
+                f"identity could not be authenticated{detail}"
+            ),
+            details={
+                "pid": pid,
+                "discovery_record": str(discovery_path(self.home)),
+                **({"reason": reason.code} if reason is not None else {}),
+            },
+            recommended_next_action=(
+                "run 'potpie daemon restart' to replace it, or "
+                f"'potpie daemon stop --force'; manual escape hatch: kill {pid}"
+            ),
+            retry_posture="safe",
+        )
+
+    def _force_stop(self, pid: int) -> dict[str, Any]:
+        """Replace a daemon whose runtime record cannot be authenticated.
+
+        The recorded PID alone is not proof of identity, so verify the process
+        still looks like one of our daemons before signalling it.
+        """
+
+        if not _looks_like_potpie_daemon(pid):
+            raise DaemonStopError(
+                ResourceLifecycleError(
+                    code="daemon_recorded_pid_not_a_daemon",
+                    message=(
+                        f"the recorded process (pid={pid}) is not a potpie daemon; "
+                        "refusing to signal it"
+                    ),
+                    details={
+                        "pid": pid,
+                        "discovery_record": str(discovery_path(self.home)),
+                        "command": _process_command_line(pid),
+                    },
+                    recommended_next_action=(
+                        "the runtime record is stale — remove "
+                        f"{self.home} runtime files or stop pid {pid} yourself"
+                    ),
+                    retry_posture="safe",
+                )
+            )
+        mode = _terminate_pid(pid)
+        self._cleanup_runtime_records()
+        self._controller = None
+        return {
+            "detail": {
+                "already_stopped": "daemon not running",
+                "terminated": "daemon stopped (forced: identity unauthenticated)",
+                "killed": "daemon killed (forced after timeout)",
+            }[mode],
+            "forced": True,
+            "pid": pid,
+        }
 
     def _connection_for_pid(self, pid: int):
         try:

--- a/potpie/pots/contracts.py
+++ b/potpie/pots/contracts.py
@@ -45,7 +45,13 @@ class SourceInfo:
 
 @dataclass(frozen=True, slots=True)
 class PotAggregateStatus:
-    """Control-plane half of ``context_status``."""
+    """Control-plane half of ``context_status``.
+
+    ``active_pot`` is the globally active pot pointer; ``target_pot`` is the pot
+    the rollup actually describes (``sources``/``backend_ready``). The two
+    differ whenever a repo default routes the caller elsewhere, so both are
+    reported rather than letting one label the other's numbers.
+    """
 
     active_pot: PotInfo | None
     pot_count: int = 0
@@ -53,6 +59,7 @@ class PotAggregateStatus:
     backend_ready: bool = False
     detail: str | None = None
     metadata: Mapping[str, Any] = field(default_factory=dict)
+    target_pot: PotInfo | None = None
 
 
 class PotManagementService(Protocol):

--- a/potpie/pots/local_service.py
+++ b/potpie/pots/local_service.py
@@ -108,12 +108,19 @@ class LocalPotManagementService:
         target_id = pot_id or (active.pot_id if active else None)
         sources = tuple(self.list_sources(pot_id=target_id)) if target_id else ()
         ready = bool(target_id) and self.backend.mutation.readiness(target_id).ready
+        target = None
+        if target_id:
+            target = next(
+                (pot for pot in self.list_pots() if pot.pot_id == target_id),
+                None,
+            )
         return PotAggregateStatus(
             active_pot=active,
             pot_count=len(self.store.list_pots()),
             sources=sources,
             backend_ready=ready,
             detail=None if target_id else "no active pot — run 'potpie setup'",
+            target_pot=target,
         )
 
 

--- a/potpie/runtime/composition.py
+++ b/potpie/runtime/composition.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -104,9 +105,15 @@ def _configured_backend_profile() -> str | None:
 
     try:
         with open(default_home() / "config.json", encoding="utf-8") as handle:
-            configured = json.load(handle).get("backend")
+            document = json.load(handle)
     except (OSError, ValueError):
         return None
+    # A hand-edited config can hold any JSON root; only an object has a
+    # backend, and anything else must fall through to the default rather
+    # than raising out of composition.
+    if not isinstance(document, Mapping):
+        return None
+    configured = document.get("backend")
     if not isinstance(configured, str):
         return None
     return configured.strip().lower() or None

--- a/potpie/runtime/composition.py
+++ b/potpie/runtime/composition.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 from dataclasses import dataclass
 from typing import Any
@@ -84,11 +85,31 @@ class LocalRuntimeComposition:
 
 
 def default_backend_profile() -> str:
+    """Env override, else the backend persisted at setup, else the OSS default.
+
+    Reading ``config.json`` matters: without it a plain ``potpie daemon start``
+    silently ran on ``falkordb_lite`` for a user whose setup had configured a
+    different backend, and their graph looked empty rather than unreachable.
+    """
     for env_name in ("CONTEXT_ENGINE_BACKEND", "GRAPH_DB_BACKEND"):
         profile = (os.getenv(env_name) or "").strip().lower()
         if profile:
             return profile
-    return "falkordb_lite"
+    return _configured_backend_profile() or "falkordb_lite"
+
+
+def _configured_backend_profile() -> str | None:
+    """Backend recorded in ``<home>/config.json`` by ``potpie setup``."""
+    from potpie.config.local_paths import default_home
+
+    try:
+        with open(default_home() / "config.json", encoding="utf-8") as handle:
+            configured = json.load(handle).get("backend")
+    except (OSError, ValueError):
+        return None
+    if not isinstance(configured, str):
+        return None
+    return configured.strip().lower() or None
 
 
 def default_host_mode() -> str:

--- a/potpie/runtime/local_engine.py
+++ b/potpie/runtime/local_engine.py
@@ -33,6 +33,7 @@ from potpie_context_engine.core.errors import (
     CapabilityNotImplemented,
     ContextEngineDisabled,
     PotNotFound,
+    missing_field_message,
 )
 from potpie_context_engine.core.ports.agent_context import (
     RecordRequest as AgentRecordRequest,
@@ -935,7 +936,7 @@ def build_local_resource_manager(services: Any) -> ContextResourceManager:
 
 def _required_value(value: str | None, field: str) -> str:
     if not isinstance(value, str) or not value.strip():
-        raise ValueError(f"{field} is required")
+        raise ValueError(missing_field_message(field))
     return value
 
 

--- a/potpie/skills/contracts.py
+++ b/potpie/skills/contracts.py
@@ -38,6 +38,11 @@ class SkillStatus:
     installed: tuple[SkillInfo, ...] = ()
     missing: tuple[SkillInfo, ...] = ()
     outdated: tuple[SkillInfo, ...] = ()
+    unmanaged: tuple[str, ...] = ()
+    """Potpie-named skill directories present in the harness that this build's
+    catalog does not contain — usually left behind by a newer or older potpie.
+    Reporting them keeps ``skills status`` from claiming a clean install while
+    the harness is loading skills this CLI cannot service."""
 
 
 @dataclass(frozen=True, slots=True)

--- a/potpie/skills/manager.py
+++ b/potpie/skills/manager.py
@@ -182,9 +182,10 @@ class DefaultSkillManager:
         self, *, agent: str, path: str | None = None, scope: str = "global"
     ) -> SkillStatus:
         catalog = catalog_by_id()
-        installed = self._target_for_scope(
-            agent=agent, scope=scope, path=path
-        ).installed()
+        target = self._target_for_scope(agent=agent, scope=scope, path=path)
+        installed = target.installed()
+        unmanaged_probe = getattr(target, "unmanaged", None)
+        unmanaged = tuple(unmanaged_probe()) if callable(unmanaged_probe) else ()
         installed_infos: list[SkillInfo] = []
         missing: list[SkillInfo] = []
         outdated: list[SkillInfo] = []
@@ -211,6 +212,7 @@ class DefaultSkillManager:
             installed=tuple(installed_infos),
             missing=tuple(missing),
             outdated=tuple(outdated),
+            unmanaged=unmanaged,
         )
 
     def nudge(self, *, agent: str) -> SkillNudge:

--- a/potpie/skills/targets.py
+++ b/potpie/skills/targets.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Mapping
 
-from potpie.config.local_paths import default_home
+from potpie.config.local_paths import default_home, harness_home
 from potpie.skills.catalog import (
     RECOMMENDED_SKILL_IDS,
 )
@@ -58,6 +58,9 @@ class FileBackedAgentTarget:
             if self._skill_file(sid).exists():
                 installed[sid] = manifest.get(sid, "unknown")
         return installed
+
+    def unmanaged(self) -> tuple[str, ...]:
+        return _unmanaged_skill_ids(self.skills_root)
 
     def install(self, *, skill_id: str, version: str, path: str | None = None) -> None:
         root = Path(path).expanduser() if path else self.skills_root
@@ -117,6 +120,10 @@ class ProjectAgentTarget:
                 installed[sid] = manifest.get(sid, "unknown")
         return installed
 
+    def unmanaged(self) -> tuple[str, ...]:
+        sample = project_skill_path(self.path, agent=self.agent, skill_id="__probe__")
+        return _unmanaged_skill_ids(sample.parent.parent)
+
     def install(self, *, skill_id: str, version: str, path: str | None = None) -> None:
         root = Path(path) if path else self.path
         install_agent_bundle(root, agent=self.agent, skill_ids=(skill_id,), force=True)
@@ -139,12 +146,35 @@ class ProjectAgentTarget:
         self._save(data)
 
 
+# Skill directories we own are named `potpie-*`; anything matching that shape
+# but absent from this build's catalog is an orphan the harness still loads.
+_POTPIE_SKILL_PREFIX = "potpie-"
+
+
+def _unmanaged_skill_ids(skills_root: Path | None) -> tuple[str, ...]:
+    if skills_root is None:
+        return ()
+    root = Path(skills_root).expanduser()
+    try:
+        entries = sorted(entry.name for entry in root.iterdir() if entry.is_dir())
+    except OSError:
+        return ()
+    known = set(RECOMMENDED_SKILL_IDS)
+    return tuple(
+        name
+        for name in entries
+        if name.startswith(_POTPIE_SKILL_PREFIX)
+        and name not in known
+        and (root / name / "SKILL.md").exists()
+    )
+
+
 class CursorAgentTarget(FileBackedAgentTarget):
     def __init__(self, *, home: Path | None = None) -> None:
         kwargs = {"home": home} if home is not None else {}
         super().__init__(
             agent="cursor",
-            skills_root=Path.home() / ".cursor" / "skills",
+            skills_root=harness_home() / ".cursor" / "skills",
             **kwargs,
         )
 
@@ -154,8 +184,8 @@ class ClaudeAgentTarget(FileBackedAgentTarget):
         kwargs = {"home": home} if home is not None else {}
         super().__init__(
             agent="claude",
-            skills_root=Path.home() / ".claude" / "skills",
-            instructions_root=Path.home() / ".claude",
+            skills_root=harness_home() / ".claude" / "skills",
+            instructions_root=harness_home() / ".claude",
             instructions_agent="claude",
             **kwargs,
         )
@@ -166,7 +196,7 @@ class OpenCodeAgentTarget(FileBackedAgentTarget):
         kwargs = {"home": home} if home is not None else {}
         super().__init__(
             agent="opencode",
-            skills_root=Path.home() / ".config" / "opencode" / "skills",
+            skills_root=harness_home() / ".config" / "opencode" / "skills",
             **kwargs,
         )
 
@@ -176,8 +206,8 @@ class CodexAgentTarget(FileBackedAgentTarget):
         kwargs = {"home": home} if home is not None else {}
         super().__init__(
             agent="codex",
-            skills_root=Path.home() / ".agents" / "skills",
-            instructions_root=Path.home() / ".codex",
+            skills_root=harness_home() / ".agents" / "skills",
+            instructions_root=harness_home() / ".codex",
             instructions_agent="codex",
             **kwargs,
         )

--- a/potpie/skills/targets.py
+++ b/potpie/skills/targets.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import shutil
 from dataclasses import dataclass, field
@@ -20,6 +21,17 @@ from potpie.skills.installer import (
 )
 
 
+# Where each harness installs skills when POTPIE_HARNESS_HOME is unset. Used
+# only to recognise the default root, so its manifest keeps its historical
+# filename and existing installs are not orphaned.
+_DEFAULT_SKILLS_SUBPATH: dict[str, tuple[str, ...]] = {
+    "claude": (".claude", "skills"),
+    "cursor": (".cursor", "skills"),
+    "opencode": (".config", "opencode", "skills"),
+    "codex": (".agents", "skills"),
+}
+
+
 @dataclass(slots=True)
 class FileBackedAgentTarget:
     """Install packaged Potpie skills into one harness-specific skills root."""
@@ -33,7 +45,27 @@ class FileBackedAgentTarget:
 
     @property
     def _path(self) -> Path:
-        return self.home / f"skills_{self.agent}_{self.scope}.json"
+        # The manifest records which version is installed *in this root*.
+        # Since POTPIE_HARNESS_HOME can point two roots at one state home, the
+        # root is part of the manifest's identity — otherwise installing into
+        # one root rewrites the versions reported for the other. The default
+        # root keeps the original filename so existing installs still resolve.
+        return self.home / f"skills_{self.agent}_{self.scope}{self._root_suffix()}.json"
+
+    def _root_suffix(self) -> str:
+        resolved = self.skills_root.expanduser()
+        if resolved == self._default_skills_root():
+            return ""
+        digest = hashlib.sha256(str(resolved).encode()).hexdigest()[:12]
+        return f"_{digest}"
+
+    def _default_skills_root(self) -> Path:
+        """Where this harness installs when no override is in play."""
+
+        relative = _DEFAULT_SKILLS_SUBPATH.get(self.agent)
+        if relative is None:
+            return self.skills_root.expanduser()
+        return Path.home().joinpath(*relative)
 
     def _load(self) -> dict[str, str]:
         try:

--- a/tests/unit/test_cli_bootstrap_status.py
+++ b/tests/unit/test_cli_bootstrap_status.py
@@ -129,7 +129,9 @@ def test_status_default_emits_host_report(monkeypatch: pytest.MonkeyPatch) -> No
 
     _common.set_runtime(mock_host)
     monkeypatch.setattr(
-        bootstrap, "resolve_pot_id", lambda _host, pot: pot or "foo-pot"
+        bootstrap,
+        "resolve_pot_scope",
+        lambda _host, pot: (pot or "foo-pot", "explicit" if pot else "active_pot"),
     )
 
     result = runner.invoke(cli_main.app, ["status"])
@@ -155,7 +157,9 @@ def test_status_host_flag_remains_compatible(monkeypatch: pytest.MonkeyPatch) ->
 
     _common.set_runtime(mock_host)
     monkeypatch.setattr(
-        bootstrap, "resolve_pot_id", lambda _host, pot: pot or "foo-pot"
+        bootstrap,
+        "resolve_pot_scope",
+        lambda _host, pot: (pot or "foo-pot", "explicit" if pot else "active_pot"),
     )
 
     result = runner.invoke(cli_main.app, ["status", "--host"])
@@ -189,8 +193,8 @@ def test_status_non_default_pot_triggers_host_path(
     _common.set_runtime(mock_host)
     monkeypatch.setattr(
         bootstrap,
-        "resolve_pot_id",
-        lambda _host, pot: pot or "custom-pot",
+        "resolve_pot_scope",
+        lambda _host, pot: (pot or "custom-pot", "explicit"),
     )
 
     result = runner.invoke(cli_main.app, ["status", "--pot", "custom-pot"])
@@ -212,7 +216,9 @@ def test_status_host_json_output(monkeypatch: pytest.MonkeyPatch) -> None:
     mock_host = MagicMock()
     _configure_status_host(mock_host, report)
     _common.set_runtime(mock_host)
-    monkeypatch.setattr(bootstrap, "resolve_pot_id", lambda _host, pot: "foo-pot")
+    monkeypatch.setattr(
+        bootstrap, "resolve_pot_scope", lambda _host, pot: ("foo-pot", "active_pot")
+    )
 
     result = runner.invoke(cli_main.app, ["--json", "status"])
 

--- a/tests/unit/test_cli_ergonomics.py
+++ b/tests/unit/test_cli_ergonomics.py
@@ -139,7 +139,9 @@ class _Graph:
 
 def test_source_add_repo_dot_resolves_before_storing(monkeypatch) -> None:
     monkeypatch.setattr(
-        repo_location, "current_git_remote", lambda cwd: "github.com/acme/shop"
+        repo_location,
+        "git_remote_or_reason",
+        lambda cwd: ("github.com/acme/shop", None),
     )
     pots_service = _Pots(
         [_Pot("p1", "shop", True)], {}, active=_Pot("p1", "shop", True)
@@ -158,7 +160,7 @@ def test_source_add_repo_dot_resolves_before_storing(monkeypatch) -> None:
 
 
 def test_source_add_repo_current_falls_back_to_cwd(monkeypatch, tmp_path) -> None:
-    monkeypatch.setattr(repo_location, "current_git_remote", lambda cwd: None)
+    monkeypatch.setattr(repo_location, "git_remote_or_reason", lambda cwd: (None, None))
     monkeypatch.chdir(tmp_path)
     pots_service = _Pots(
         [_Pot("p1", "shop", True)], {}, active=_Pot("p1", "shop", True)
@@ -185,7 +187,9 @@ def test_source_add_non_repo_kind_keeps_location_verbatim() -> None:
 
 def test_source_add_repo_no_default_skips_repo_default(monkeypatch) -> None:
     monkeypatch.setattr(
-        repo_location, "current_git_remote", lambda cwd: "github.com/acme/shop"
+        repo_location,
+        "git_remote_or_reason",
+        lambda cwd: ("github.com/acme/shop", None),
     )
     pots_service = _Pots(
         [_Pot("p1", "shop", True)], {}, active=_Pot("p1", "shop", True)

--- a/tests/unit/test_cli_install_status.py
+++ b/tests/unit/test_cli_install_status.py
@@ -211,7 +211,7 @@ def test_sibling_editable_dependency_does_not_mark_tool_editable(
     assert status["editable"] is False
     assert status["hint"] is not None
     assert "make cli-install" not in status["hint"]
-    assert "uv tool install potpie" in status["hint"]
+    assert "uv tool install --force potpie" in status["hint"]
 
 
 def test_published_uv_tool_hint_omits_make_cli_install(
@@ -243,18 +243,21 @@ def test_published_uv_tool_hint_omits_make_cli_install(
     assert status["install_method"] == "uv_tool"
     assert status["editable"] is False
     assert status["hint"] is not None
-    assert "uv tool install potpie" in status["hint"]
+    assert "uv tool install --force potpie" in status["hint"]
     assert "make cli-install" not in status["hint"]
+    # A published install must not be told to run repo-only `make` targets.
+    assert "make" not in " ".join(status["diagnostic_commands"])
     human = cis.cli_install_human(status)
     assert "via=uv_tool" in human
-    assert "published: uv tool install potpie" in human
-    assert "local reinstall: make cli-install" not in human
+    assert "uv tool install --force potpie" in human
+    assert "make cli-install" not in human
 
 
-def test_cli_install_human_when_missing_from_path() -> None:
+def test_cli_install_human_when_entry_point_unresolvable() -> None:
     human = cis.cli_install_human({"on_path": False})
-    assert "NOT on PATH" in human
-    assert "make cli-install" in human
+    assert "not resolvable" in human
+    # No `make` target: the wheel ships no Makefile.
+    assert "make" not in human
 
 
 def test_python_from_script_ignores_binary_executable(tmp_path) -> None:
@@ -304,9 +307,8 @@ def test_doctor_includes_cli_install(monkeypatch: pytest.MonkeyPatch) -> None:
     result = runner.invoke(cli_main.app, ["doctor"])
     assert result.exit_code == 0, result.stdout
     human = " ".join(result.stdout.split())
-    assert "cli: potpie-context-engine 0.1.0" in human
+    assert "potpie-context-engine 0.1.0" in human
     assert "via=uv_tool" in human
-    assert "make cli-status" in human
     assert "make cli-install" in human
 
 
@@ -314,6 +316,7 @@ def test_cli_install_human_uv_tool_includes_reinstall_hint() -> None:
     human = cis.cli_install_human(
         {
             "on_path": True,
+            "running_on_path": True,
             "package_name": "potpie-context-engine",
             "package_version": "0.1.0",
             "primary_path": "/Users/me/.local/bin/potpie",
@@ -323,7 +326,6 @@ def test_cli_install_human_uv_tool_includes_reinstall_hint() -> None:
         }
     )
     assert "via=uv_tool" in human
-    assert "make cli-status" in human
     assert "make cli-install" in human
 
 
@@ -338,4 +340,54 @@ def test_collect_cli_install_status_omits_hint_without_uv_tool(
 
     assert status["uv_tool_installed"] is False
     assert status["hint"] is None
-    assert "make cli-install" in status["diagnostic_commands"]
+    # Not an editable repo install, so no `make` targets are advertised.
+    assert "make cli-install" not in status["diagnostic_commands"]
+    assert "potpie doctor" in status["diagnostic_commands"]
+
+
+def test_running_cli_wins_over_a_different_potpie_first_on_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """doctor must describe the binary that is running, not $PATH's first hit."""
+    other = tmp_path / "other" / "potpie"
+    other.parent.mkdir(parents=True)
+    other.write_text("#!/bin/sh\nexec echo other\n", encoding="utf-8")
+    other.chmod(0o755)
+    running = tmp_path / "running" / "potpie"
+    running.parent.mkdir(parents=True)
+    running.write_text("#!/usr/bin/python3\n", encoding="utf-8")
+    running.chmod(0o755)
+
+    monkeypatch.setattr(cis.sys, "argv", [str(running), "doctor"])
+    monkeypatch.setattr(cis, "_potpie_paths_on_path", lambda: [str(other)])
+    monkeypatch.setattr(cis.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(cis, "_installed_package_version", lambda: "2.0.1")
+
+    status = cis.collect_cli_install_status()
+
+    assert status["primary_path"] == str(running)
+    assert status["running_path"] == str(running)
+    assert status["other_paths"] == [str(other)]
+    # The running process answers for its own interpreter.
+    assert status["python_version"] == status["runtime_python_version"]
+    assert status["running_on_path"] is False
+    assert "not the one on $PATH" in cis.cli_install_human(status)
+
+
+def test_shell_wrapper_shebang_is_not_reported_as_a_python_version(
+    tmp_path: Path,
+) -> None:
+    """A `#!/bin/sh` entry point must not yield bash's version as python."""
+    script = tmp_path / "potpie"
+    script.write_text("#!/bin/sh\nexec echo hi\n", encoding="utf-8")
+    script.chmod(0o755)
+
+    assert cis._python_from_script(str(script)) is None
+    assert cis._python_version("/bin/sh") is None
+
+
+def test_python_version_reads_env_shebangs(tmp_path: Path) -> None:
+    script = tmp_path / "potpie"
+    script.write_text("#!/usr/bin/env python3.12\n", encoding="utf-8")
+    interpreter = cis._python_from_script(str(script))
+    assert interpreter == "python3.12"

--- a/tests/unit/test_daemon_lifecycle_runtime.py
+++ b/tests/unit/test_daemon_lifecycle_runtime.py
@@ -69,15 +69,79 @@ def test_daemon_restart_refuses_when_running_backend_unknown(
     monkeypatch.setattr(
         daemon,
         "status",
-        lambda: {"up": True, "mode": "detached", "home": str(tmp_path)},
+        lambda: {
+            "up": True,
+            "mode": "detached",
+            "home": str(tmp_path),
+            "identity": "ok",
+        },
     )
     monkeypatch.setattr(daemon, "stop", lambda: calls.append("stop"))
     monkeypatch.setattr(daemon, "start", lambda **_kwargs: calls.append("start"))
 
-    with pytest.raises(RuntimeError, match="cannot determine running daemon backend"):
+    # A *typed* refusal, not a bare RuntimeError: the CLI renders this as a
+    # daemon failure with a next action instead of "Unexpected internal error".
+    with pytest.raises(DaemonStopError) as raised:
         daemon.restart()
 
+    assert "cannot determine the running daemon" in str(raised.value)
+    assert raised.value.error.code == "daemon_backend_undetermined"
+    assert raised.value.error.recommended_next_action
     assert calls == []
+
+
+def test_daemon_restart_replaces_a_daemon_it_cannot_authenticate(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """An upgrade leaves a running daemon whose record this build cannot read.
+
+    Restart is the recovery the CLI recommends, so it must take that process
+    down by signal rather than refusing for an unknown backend.
+    """
+    daemon = Daemon(home=tmp_path, in_process=False)
+    calls: list[tuple[str, object]] = []
+    monkeypatch.setattr(
+        daemon,
+        "status",
+        lambda: {
+            "up": True,
+            "mode": "detached",
+            "home": str(tmp_path),
+            "pid": 4242,
+            "identity": "unauthenticated",
+        },
+    )
+    monkeypatch.setattr(daemon, "stop", lambda **kwargs: calls.append(("stop", kwargs)))
+    monkeypatch.setattr(
+        daemon, "start", lambda **kwargs: calls.append(("start", kwargs)) or {}
+    )
+
+    daemon.restart()
+
+    assert calls[0] == ("stop", {"force": True})
+    assert calls[1][0] == "start"
+
+
+def test_force_stop_refuses_a_recorded_pid_that_is_not_a_daemon(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """PIDs are reused; a forced takedown must verify identity first."""
+    daemon = Daemon(home=tmp_path, in_process=False)
+    monkeypatch.setattr(
+        "potpie.daemon.lifecycle._process_command_line",
+        lambda _pid: "/usr/bin/vim notes.txt",
+    )
+    killed: list[int] = []
+    monkeypatch.setattr(
+        "potpie.daemon.lifecycle.os.kill",
+        lambda pid, _sig: killed.append(pid),
+    )
+
+    with pytest.raises(DaemonStopError) as raised:
+        daemon._force_stop(4242)
+
+    assert raised.value.error.code == "daemon_recorded_pid_not_a_daemon"
+    assert killed == []
 
 
 def test_stop_preserves_credential_while_replacement_boot_owns_runtime(

--- a/tests/unit/test_graph_cli_contract.py
+++ b/tests/unit/test_graph_cli_contract.py
@@ -1801,22 +1801,62 @@ def test_graph_read_include_guess_error_carries_did_you_mean() -> None:
     )
 
 
-def test_graph_read_rejects_fully_qualified_view_before_service_call() -> None:
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["read", "--view", "debugging.prior_occurrences"],
+        ["read", "debugging.prior_occurrences"],
+        # Redundant but unambiguous: the qualifier agrees with --subgraph.
+        ["read", "--subgraph", "debugging", "--view", "debugging.prior_occurrences"],
+    ],
+)
+def test_graph_read_accepts_the_qualified_view_name_catalog_prints(argv) -> None:
+    """`graph catalog` advertises `<subgraph>.<view>`; that string must work."""
+    _common.set_json(True)
+    graph_service = _Graph(read_result=_timeline_env())
+    _common.set_runtime(_Host(graph_service))
+
+    result = CliRunner().invoke(graph.graph_app, argv)
+
+    assert result.exit_code == 0, result.output
+    assert graph_service.read_called is True
+    assert graph_service.read_request.subgraph == "debugging"
+    assert graph_service.read_request.view == "prior_occurrences"
+
+
+def test_graph_read_rejects_a_qualifier_that_contradicts_subgraph() -> None:
     _common.set_json(True)
     graph_service = _Graph()
     _common.set_runtime(_Host(graph_service))
 
     result = CliRunner().invoke(
         graph.graph_app,
-        ["read", "--subgraph", "debugging", "--view", "debugging.prior_occurrences"],
+        ["read", "--subgraph", "knowledge", "--view", "debugging.prior_occurrences"],
     )
 
-    assert result.exit_code == 1
+    assert result.exit_code == _common.EXIT_VALIDATION
     assert graph_service.read_called is False
     emitted = json.loads(result.output)
     _assert_graph_envelope(emitted, "graph.read", ok=False)
     assert emitted["error"]["code"] == "validation_error"
-    assert "--subgraph <name> --view <view>" in emitted["error"]["message"]
+    assert "conflicts with" in emitted["error"]["message"]
+
+
+def test_graph_read_names_the_missing_subgraph_for_an_unqualified_view() -> None:
+    _common.set_json(True)
+    graph_service = _Graph()
+    _common.set_runtime(_Host(graph_service))
+
+    result = CliRunner().invoke(
+        graph.graph_app, ["read", "--view", "prior_occurrences"]
+    )
+
+    assert result.exit_code == _common.EXIT_VALIDATION
+    assert graph_service.read_called is False
+    emitted = json.loads(result.output)
+    message = emitted["error"]["message"]
+    assert "--subgraph is required for view 'prior_occurrences'" in message
+    assert "graph catalog" in message
 
 
 def _timeline_env() -> GraphReadResult:

--- a/tests/unit/test_pot_create_repo.py
+++ b/tests/unit/test_pot_create_repo.py
@@ -87,7 +87,9 @@ class _Host:
 
 def test_pot_create_repo_dot_uses_source_add_normalization(monkeypatch) -> None:
     monkeypatch.setattr(
-        repo_location, "current_git_remote", lambda cwd: "github.com/acme/shop"
+        repo_location,
+        "git_remote_or_reason",
+        lambda cwd: ("github.com/acme/shop", None),
     )
     fake_pots = _Pots()
     _common.set_runtime(_Host(pots=fake_pots))
@@ -120,7 +122,9 @@ def test_pot_create_repo_dot_uses_source_add_normalization(monkeypatch) -> None:
 
 def test_pot_create_repo_is_idempotent_when_pot_and_source_exist(monkeypatch) -> None:
     monkeypatch.setattr(
-        repo_location, "current_git_remote", lambda cwd: "github.com/acme/shop"
+        repo_location,
+        "git_remote_or_reason",
+        lambda cwd: ("github.com/acme/shop", None),
     )
     fake_pots = _Pots()
     _common.set_runtime(_Host(pots=fake_pots))
@@ -148,7 +152,9 @@ def test_pot_create_repo_is_idempotent_when_pot_and_source_exist(monkeypatch) ->
 
 def test_register_repo_source_skips_duplicate_matching_identity(monkeypatch) -> None:
     monkeypatch.setattr(
-        repo_location, "current_git_remote", lambda cwd: "github.com/acme/shop"
+        repo_location,
+        "git_remote_or_reason",
+        lambda cwd: ("github.com/acme/shop", None),
     )
     fake_pots = _Pots()
     host = _Host(pots=fake_pots)
@@ -167,7 +173,9 @@ def test_register_repo_source_skips_duplicate_matching_identity(monkeypatch) -> 
 
 def test_pot_create_repo_no_default_skips_repo_default(monkeypatch) -> None:
     monkeypatch.setattr(
-        repo_location, "current_git_remote", lambda cwd: "github.com/acme/shop"
+        repo_location,
+        "git_remote_or_reason",
+        lambda cwd: ("github.com/acme/shop", None),
     )
     fake_pots = _Pots()
     _common.set_runtime(_Host(pots=fake_pots))

--- a/tests/unit/test_release_findings_regressions.py
+++ b/tests/unit/test_release_findings_regressions.py
@@ -8,6 +8,7 @@ against each other.
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 import pytest
 from typer.testing import CliRunner
@@ -523,3 +524,145 @@ def test_entity_label_falls_back_to_the_key_namespace(item, key, expected) -> No
     from potpie.cli.read_presenter import _entity_label
 
     assert _entity_label(item, key) == expected
+
+
+# --- Review follow-ups: the safety edges around the fixes above -------------
+
+
+def test_pot_reset_accepts_an_id_and_a_name_for_the_same_pot(
+    repo_default_host: _Pots,
+) -> None:
+    """An id and its name select one pot; that is not a conflict."""
+    _common.set_json(True)
+
+    result = runner.invoke(pots.pot_app, ["reset", "alpha", "--pot", "pot-alpha"])
+
+    emitted = json.loads(result.output)
+    assert emitted["code"] == "destructive_confirmation_required"
+    assert "potpie pot reset pot-alpha --confirm" in emitted["recommended_next_action"]
+
+
+def test_git_probe_separates_a_fatal_error_from_a_missing_origin(
+    tmp_path: Path,
+) -> None:
+    """Exit 128 covers both "no work tree" and a fatal config error.
+
+    Only the former is a definitive "no origin"; treating the latter the same
+    way silently registers a path identity for a repo that has a remote.
+    """
+    broken = tmp_path / "broken"
+    broken.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=broken, check=True)
+    (broken / ".git" / "config").write_text(
+        "[core\n\tbroken = true\n", encoding="utf-8"
+    )
+
+    remote, failure = repo_location.git_remote_or_reason(broken)
+
+    assert remote is None
+    assert failure and "fatal" in failure
+
+    # A directory that is simply not a work tree stays a definitive answer.
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    assert repo_location.git_remote_or_reason(plain) == (None, None)
+
+
+@pytest.mark.parametrize(
+    ("command", "is_daemon"),
+    [
+        ("/usr/bin/python3.12 -m potpie.daemon", True),
+        ("/opt/python -X dev -m potpie.daemon --flag", True),
+        ("/Users/me/.local/bin/potpie-daemon", True),
+        ("/usr/bin/potpied", True),
+        # Near matches: a substring test would authorise a kill on all of these.
+        ("/usr/bin/python -m potpie.daemon_helper", False),
+        ("grep -rn potpie.daemon /src", False),
+        ("/usr/bin/vim potpie.daemon.py", False),
+        ('python -c "import potpie.daemon"', False),
+        ("", False),
+    ],
+)
+def test_forced_stop_only_recognises_the_real_daemon_argv(command, is_daemon) -> None:
+    from potpie.daemon.lifecycle import _is_daemon_command
+
+    assert _is_daemon_command(command) is is_daemon
+
+
+def test_force_stop_reports_a_conflict_rather_than_a_false_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cleanup that could not take ownership must not be reported as stopped."""
+    from potpie.daemon.lifecycle import DaemonStopError
+
+    daemon = Daemon(home=tmp_path, in_process=False)
+    monkeypatch.setattr(
+        "potpie.daemon.lifecycle._looks_like_potpie_daemon", lambda _pid: True
+    )
+    monkeypatch.setattr(
+        "potpie.daemon.lifecycle._terminate_pid", lambda _pid: "terminated"
+    )
+    monkeypatch.setattr(daemon, "_cleanup_runtime_records", lambda **_kwargs: False)
+
+    with pytest.raises(DaemonStopError) as raised:
+        daemon._force_stop(4242)
+
+    assert raised.value.error.code == "daemon_cleanup_ownership_conflict"
+
+
+def test_unreadable_runtime_files_carry_the_recovery_classification(
+    tmp_path: Path,
+) -> None:
+    """A world-readable record fails validation before the classified handlers."""
+    record = daemon_discovery.discovery_path(tmp_path)
+    record.write_text("{}", encoding="utf-8")
+    record.chmod(0o644)
+
+    with pytest.raises(daemon_discovery.DaemonDiscoveryError) as raised:
+        daemon_discovery.read_daemon_discovery(tmp_path)
+
+    assert raised.value.code == daemon_discovery.DISCOVERY_UNREADABLE
+    assert raised.value.recommended_next_action
+
+    credential = daemon_discovery.credential_path(tmp_path)
+    credential.write_text("x" * 40, encoding="utf-8")
+    credential.chmod(0o644)
+
+    with pytest.raises(daemon_discovery.DaemonDiscoveryError) as raised:
+        daemon_discovery.read_daemon_credential(tmp_path)
+
+    assert raised.value.code == daemon_discovery.DISCOVERY_CREDENTIAL_UNAVAILABLE
+    assert raised.value.recommended_next_action
+
+
+def test_a_non_object_config_root_falls_back_to_the_default_backend(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from potpie.runtime.composition import default_backend_profile
+
+    monkeypatch.delenv("CONTEXT_ENGINE_BACKEND", raising=False)
+    monkeypatch.delenv("GRAPH_DB_BACKEND", raising=False)
+    monkeypatch.setenv("CONTEXT_ENGINE_HOME", str(tmp_path))
+    (tmp_path / "config.json").write_text('["not", "an", "object"]', encoding="utf-8")
+
+    assert default_backend_profile() == "falkordb_lite"
+
+
+def test_each_harness_root_keeps_its_own_skill_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two harness roots sharing one state home must not share versions."""
+    from potpie.skills.targets import ClaudeAgentTarget
+
+    state_home = tmp_path / "state"
+    monkeypatch.setenv("POTPIE_HARNESS_HOME", str(tmp_path / "a"))
+    first = ClaudeAgentTarget(home=state_home)
+    monkeypatch.setenv("POTPIE_HARNESS_HOME", str(tmp_path / "b"))
+    second = ClaudeAgentTarget(home=state_home)
+
+    assert first._path != second._path
+
+    # The unrelocated root keeps its historical filename, so an existing
+    # install's manifest is not orphaned by this change.
+    monkeypatch.delenv("POTPIE_HARNESS_HOME")
+    assert ClaudeAgentTarget(home=state_home)._path.name == "skills_claude_global.json"

--- a/tests/unit/test_release_findings_regressions.py
+++ b/tests/unit/test_release_findings_regressions.py
@@ -1,0 +1,525 @@
+"""Regressions for the potpie 2.0.1 release-test findings.
+
+Each test names the finding it locks down. Grouped by the thing that was
+wrong rather than by module, so the report and the suite stay legible
+against each other.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import pytest
+from typer.testing import CliRunner
+
+from potpie.cli import main as cli_main
+from potpie.cli import repo_location
+from potpie.cli.commands import _common, pots, query
+from potpie.daemon import discovery as daemon_discovery
+from potpie.daemon.lifecycle import Daemon
+from potpie.pots.contracts import PotAggregateStatus, PotInfo
+
+pytestmark = pytest.mark.unit
+
+runner = CliRunner()
+
+
+# --- B1: a stale daemon across an upgrade must not wedge the CLI ------------
+
+
+def _write_private(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+    path.chmod(0o600)
+
+
+def test_legacy_discovery_record_is_named_as_such_not_merely_invalid(
+    tmp_path: Path,
+) -> None:
+    """A pre-upgrade record must be diagnosed, and marked recoverable."""
+    _write_private(
+        daemon_discovery.discovery_path(tmp_path),
+        json.dumps(
+            {
+                "transport": "http",
+                "base_url": "http://127.0.0.1:60096",
+                "token": "x" * 40,
+                "pid": 30984,
+            }
+        ),
+    )
+
+    with pytest.raises(daemon_discovery.DaemonDiscoveryError) as raised:
+        daemon_discovery.read_daemon_discovery(tmp_path)
+
+    error = raised.value
+    assert error.code == daemon_discovery.DISCOVERY_SCHEMA_UNSUPPORTED
+    assert "older potpie" in str(error)
+    assert error.recoverable_by_replacement is True
+    assert "daemon restart" in (error.recommended_next_action or "")
+
+
+def test_absent_discovery_record_points_at_start_not_restart(tmp_path: Path) -> None:
+    with pytest.raises(daemon_discovery.DaemonDiscoveryError) as raised:
+        daemon_discovery.load_daemon_connection(tmp_path)
+
+    assert raised.value.code == daemon_discovery.DISCOVERY_ABSENT
+    assert "daemon start" in (raised.value.recommended_next_action or "")
+    assert raised.value.recoverable_by_replacement is False
+
+
+def test_status_of_an_unauthenticatable_daemon_names_the_escape_hatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`daemon status` used to report a bare up=True, contradicting `status`."""
+    _write_private(daemon_discovery.pid_path(tmp_path), "4242\n")
+    _write_private(
+        daemon_discovery.discovery_path(tmp_path),
+        json.dumps({"base_url": "http://127.0.0.1:1", "token": "x" * 40}),
+    )
+    monkeypatch.setattr("potpie.daemon.lifecycle._pid_alive", lambda _pid: True)
+
+    status = Daemon(home=tmp_path, in_process=False).status()
+
+    assert status["up"] is True
+    assert status["identity"] == "unauthenticated"
+    assert status["identity_reason"] == daemon_discovery.DISCOVERY_SCHEMA_UNSUPPORTED
+    assert "kill 4242" in status["recovery"]
+    assert "daemon restart" in status["recovery"]
+
+
+def test_stop_refusal_offers_force_and_the_manual_kill(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_private(daemon_discovery.pid_path(tmp_path), "4242\n")
+    _write_private(
+        daemon_discovery.discovery_path(tmp_path),
+        json.dumps({"base_url": "http://127.0.0.1:1", "token": "x" * 40}),
+    )
+    monkeypatch.setattr("potpie.daemon.lifecycle._pid_alive", lambda _pid: True)
+
+    from potpie.daemon.lifecycle import DaemonStopError
+
+    with pytest.raises(DaemonStopError) as raised:
+        Daemon(home=tmp_path, in_process=False).stop()
+
+    next_action = raised.value.error.recommended_next_action or ""
+    assert "daemon stop --force" in next_action
+    assert "kill 4242" in next_action
+
+
+# --- B2 / M1: one pot resolution, reported honestly -------------------------
+
+
+class _Pot:
+    def __init__(self, pot_id: str, name: str, active: bool = False) -> None:
+        self.pot_id = pot_id
+        self.name = name
+        self.active = active
+        self.archived = False
+
+
+class _Pots:
+    """Active pot is `alpha`; this repo's default binding is `beta`."""
+
+    supports_repo_defaults = True
+
+    def __init__(self) -> None:
+        self.alpha = _Pot("pot-alpha", "alpha", active=True)
+        self.beta = _Pot("pot-beta", "beta")
+        self.reset_calls: list[str] = []
+
+    def list_pots(self):
+        return [self.alpha, self.beta]
+
+    def active_pot(self):
+        return self.alpha
+
+    def repo_default(self, *, repo: str):
+        return "pot-beta"
+
+    def list_sources(self, *, pot_id: str):
+        return []
+
+    def aggregate_status(self, *, pot_id: str | None = None):
+        target = next(
+            (pot for pot in self.list_pots() if pot.pot_id == pot_id), self.alpha
+        )
+        return PotAggregateStatus(
+            active_pot=PotInfo(pot_id="pot-alpha", name="alpha", active=True),
+            pot_count=2,
+            target_pot=PotInfo(pot_id=target.pot_id, name=target.name),
+        )
+
+
+class _Host:
+    def __init__(self, pots_service: _Pots) -> None:
+        self.pots = pots_service
+        self.profile = "local"
+
+
+@pytest.fixture
+def repo_default_host(monkeypatch: pytest.MonkeyPatch) -> _Pots:
+    pots_service = _Pots()
+    _common.set_runtime(_Host(pots_service))
+    monkeypatch.setattr(
+        _common, "_current_repo_identity", lambda: "github.com/acme/shop"
+    )
+    return pots_service
+
+
+def test_pot_reset_names_the_target_and_the_diverging_active_pot(
+    repo_default_host: _Pots,
+) -> None:
+    """The most destructive pot op must not target an unreported pot."""
+    _common.set_json(True)
+
+    result = runner.invoke(pots.pot_app, ["reset"])
+
+    emitted = json.loads(result.output)
+    assert emitted["code"] == "destructive_confirmation_required"
+    # The refusal names the repo-default target *and* says the active pot differs.
+    assert "pot-beta" in emitted["message"]
+    assert "alpha (pot-alpha)" in emitted["message"]
+    assert "potpie pot reset pot-beta --confirm" in emitted["recommended_next_action"]
+
+
+def test_pot_reset_accepts_pot_flag(repo_default_host: _Pots) -> None:
+    _common.set_json(True)
+
+    result = runner.invoke(pots.pot_app, ["reset", "--pot", "alpha"])
+
+    emitted = json.loads(result.output)
+    assert "potpie pot reset pot-alpha --confirm" in emitted["recommended_next_action"]
+
+
+def test_pot_reset_rejects_two_conflicting_pot_selections(
+    repo_default_host: _Pots,
+) -> None:
+    _common.set_json(True)
+
+    result = runner.invoke(pots.pot_app, ["reset", "beta", "--pot", "alpha"])
+
+    emitted = json.loads(result.output)
+    assert emitted["code"] == "validation_error"
+    assert "conflicting pot selection" in emitted["message"]
+
+
+def test_pot_list_marks_the_pot_commands_here_actually_use(
+    repo_default_host: _Pots,
+) -> None:
+    """`*` alone hid the active-vs-effective split behind every other command."""
+    _common.set_json(True)
+
+    result = runner.invoke(pots.pot_app, ["list"])
+
+    emitted = json.loads(result.output)
+    rows = {row["name"]: row for row in emitted["pots"]}
+    assert rows["alpha"]["active"] is True
+    assert rows["alpha"]["effective_for_current_repo"] is False
+    assert rows["beta"]["active"] is False
+    assert rows["beta"]["effective_for_current_repo"] is True
+
+
+def test_pot_info_accepts_pot_flag(repo_default_host: _Pots) -> None:
+    _common.set_json(True)
+
+    result = runner.invoke(pots.pot_app, ["info", "--pot", "alpha"])
+
+    emitted = json.loads(result.output)
+    assert emitted["pot"]["id"] == "pot-alpha"
+    assert emitted["pot"]["resolved_via"] == "explicit"
+    assert emitted["active_pot"]["id"] == "pot-alpha"
+
+
+# --- M4: an evidence item must never render as an empty bullet --------------
+
+
+class _Item:
+    def __init__(self, payload: dict, candidate_key: str = "") -> None:
+        self.payload = payload
+        self.candidate_key = candidate_key
+        self.include = "resources"
+        self.score = 0.5
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"fact": "a fact"}, "a fact"),
+        ({"summary": "a summary"}, "a summary"),
+        ({"description": "a description"}, "a description"),
+        # The shape that rendered as a blank bullet: no fact, no summary.
+        (
+            {"label": "Runbook §2", "section_title": "Rollback", "snippet": "…"},
+            "Runbook §2",
+        ),
+        ({"section_title": "Rollback"}, "Rollback"),
+        ({"fetch": "potpie resource get potpie://res/a/b/1"}, "potpie resource get"),
+    ],
+)
+def test_envelope_human_never_renders_an_empty_bullet(payload, expected) -> None:
+    assert expected in query._item_text(_Item(payload))
+
+
+def test_envelope_human_falls_back_to_the_candidate_key() -> None:
+    text = query._item_text(_Item({}, candidate_key="claim:xyz"))
+    assert text == "claim:xyz"
+
+
+# --- M5: every advertised record type must be writable ----------------------
+
+
+def test_record_detail_flag_reaches_the_structured_types() -> None:
+    from potpie_context_engine.core.context_records import REQUIRED_RECORD_DETAILS
+
+    # The five types the CLI could not reach before `--detail` existed.
+    assert set(REQUIRED_RECORD_DETAILS) == {
+        "bug_pattern",
+        "decision",
+        "preference",
+        "policy",
+        "verification",
+    }
+    for record_type, fields in REQUIRED_RECORD_DETAILS.items():
+        details = {field: "value" for field in fields}
+        # `outcome` is enum-constrained; use a legal member.
+        if "outcome" in details:
+            details["outcome"] = "worked"
+        query._require_record_details(record_type, details)
+
+
+def test_record_missing_detail_error_names_the_flag_to_type(capsys) -> None:
+    import typer
+
+    with pytest.raises(typer.Exit):
+        query._require_record_details("decision", {})
+
+    assert "--detail rationale" in capsys.readouterr().err
+
+
+def test_record_rejects_a_value_outside_a_constrained_detail(capsys) -> None:
+    import typer
+
+    with pytest.raises(typer.Exit):
+        query._require_record_details(
+            "verification", {"target_ref": "fix:a", "outcome": "nope"}
+        )
+
+    stderr = capsys.readouterr().err
+    assert "must be one of" in stderr
+    assert "worked" in stderr
+
+
+def test_record_type_help_lists_every_required_detail() -> None:
+    assert "--detail rationale" in query._RECORD_TYPE_HELP
+    assert "--detail policy_kind" in query._RECORD_TYPE_HELP
+    assert "--detail target_ref" in query._RECORD_TYPE_HELP
+
+
+def test_parse_details_rejects_a_bare_token(capsys) -> None:
+    import typer
+
+    with pytest.raises(typer.Exit):
+        query._parse_details(["rationale"])
+
+    assert "key=value" in capsys.readouterr().err
+
+
+def test_parse_details_builds_the_payload_the_engine_expects() -> None:
+    assert query._parse_details(["rationale=cheaper", "outcome=worked"]) == {
+        "rationale": "cheaper",
+        "outcome": "worked",
+    }
+
+
+# --- m1: --version must name the product --------------------------------
+
+
+def test_version_reports_potpies_own_version() -> None:
+    result = runner.invoke(cli_main.app, ["--version"])
+
+    assert result.exit_code == 0, result.stdout
+    lines = result.stdout.splitlines()
+    assert lines[0].startswith("potpie ")
+    assert lines[1].startswith("potpie-context-engine ")
+
+
+# --- m2: --verbose must actually produce a traceback ------------------------
+
+
+def test_verbose_discloses_the_traceback_and_plain_mode_does_not(capsys) -> None:
+    import typer
+
+    _common.set_json(True)
+    _common.set_verbose(False)
+    with pytest.raises(typer.Exit):
+        with _common.contract():
+            raise RuntimeError("boom in /Users/someone/private")
+    quiet = json.loads(capsys.readouterr().out)
+    assert quiet["message"] == "Unexpected internal error."
+    assert quiet["detail"] is None
+    assert "--verbose" in quiet["recommended_next_action"]
+
+    _common.set_verbose(True)
+    try:
+        with pytest.raises(typer.Exit):
+            with _common.contract():
+                raise RuntimeError("boom in /Users/someone/private")
+        captured = capsys.readouterr()
+    finally:
+        _common.set_verbose(False)
+    loud = json.loads(captured.out)
+    assert "RuntimeError" in loud["message"]
+    assert loud["detail"]["traceback"]
+    assert "Traceback" in captured.err
+
+
+# --- m3: shipped diagnostics must not name repo-only make targets -----------
+
+
+def test_shipped_diagnostics_omit_make_targets_for_published_installs() -> None:
+    from potpie.cli import cli_install_status as cis
+
+    assert not any("make" in command for command in cis._DIAGNOSTIC_COMMANDS)
+    assert "make" not in cis._PUBLISHED_HINT
+    status = {"primary_path": "/x/potpie", "running_on_path": True}
+    assert "make" not in cis.cli_install_human(status)
+
+
+# --- m6: required-field errors must name the flag the user types ------------
+
+
+def test_missing_field_errors_name_the_cli_flag() -> None:
+    from potpie_context_engine.core.errors import missing_field_message
+
+    assert missing_field_message("claimed_by") == "claimed_by is required (pass --by)"
+    assert missing_field_message("closed_by") == "closed_by is required (pass --by)"
+    # An unmapped field still produces the plain message.
+    assert missing_field_message("widget") == "widget is required"
+
+
+# --- m7: skill installs must be relocatable without overriding HOME ---------
+
+
+def test_harness_home_relocates_skill_targets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from potpie.skills.targets import ClaudeAgentTarget
+
+    monkeypatch.setenv("POTPIE_HARNESS_HOME", str(tmp_path))
+    target = ClaudeAgentTarget()
+    assert target.skills_root == tmp_path / ".claude" / "skills"
+
+    monkeypatch.delenv("POTPIE_HARNESS_HOME")
+    assert str(ClaudeAgentTarget().skills_root).startswith(str(Path.home()))
+
+
+def test_unmanaged_potpie_skills_are_reported(tmp_path: Path) -> None:
+    """`skills status` was blind to orphaned potpie-* directories."""
+    from potpie.skills.catalog import RECOMMENDED_SKILL_IDS
+    from potpie.skills.targets import _unmanaged_skill_ids
+
+    for name in (RECOMMENDED_SKILL_IDS[0], "potpie-resource-pdf", "other-tool"):
+        (tmp_path / name).mkdir()
+        (tmp_path / name / "SKILL.md").write_text("x", encoding="utf-8")
+
+    assert _unmanaged_skill_ids(tmp_path) == ("potpie-resource-pdf",)
+
+
+def test_unmanaged_skill_scan_tolerates_a_missing_root(tmp_path: Path) -> None:
+    from potpie.skills.targets import _unmanaged_skill_ids
+
+    assert _unmanaged_skill_ids(tmp_path / "nope") == ()
+
+
+# --- c3: repo registration must be deterministic ----------------------------
+
+
+def test_repo_location_refuses_to_guess_when_the_git_probe_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A slow git probe used to silently register an absolute path instead."""
+    monkeypatch.setattr(
+        repo_location,
+        "git_remote_or_reason",
+        lambda _cwd: (None, "git did not respond within 10s"),
+    )
+
+    with pytest.raises(repo_location.RepoLocationError) as raised:
+        repo_location.resolve_repo_location(".")
+
+    assert "git did not respond" in str(raised.value)
+
+
+def test_repo_location_uses_the_path_when_there_is_definitively_no_remote(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        repo_location, "git_remote_or_reason", lambda _cwd: (None, None)
+    )
+
+    assert repo_location.resolve_repo_location(".") == str(Path.cwd().resolve())
+
+
+def test_git_remote_probe_separates_no_remote_from_a_failed_probe(
+    tmp_path: Path,
+) -> None:
+    # Not a work tree at all: git exits 128, a definitive "no origin".
+    assert repo_location.git_remote_or_reason(tmp_path) == (None, None)
+
+
+# --- M7 (local analogue): the persisted backend must not be ignored ---------
+
+
+def test_default_backend_profile_honours_the_persisted_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from potpie.runtime.composition import default_backend_profile
+
+    monkeypatch.delenv("CONTEXT_ENGINE_BACKEND", raising=False)
+    monkeypatch.delenv("GRAPH_DB_BACKEND", raising=False)
+    monkeypatch.setenv("CONTEXT_ENGINE_HOME", str(tmp_path))
+    (tmp_path / "config.json").write_text(
+        json.dumps({"profile": "local", "backend": "neo4j"}), encoding="utf-8"
+    )
+
+    assert default_backend_profile() == "neo4j"
+
+    monkeypatch.setenv("CONTEXT_ENGINE_BACKEND", "falkordb_lite")
+    assert default_backend_profile() == "falkordb_lite"
+
+
+def test_default_backend_profile_falls_back_without_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from potpie.runtime.composition import default_backend_profile
+
+    monkeypatch.delenv("CONTEXT_ENGINE_BACKEND", raising=False)
+    monkeypatch.delenv("GRAPH_DB_BACKEND", raising=False)
+    monkeypatch.setenv("CONTEXT_ENGINE_HOME", str(tmp_path))
+
+    assert default_backend_profile() == "falkordb_lite"
+
+
+# --- c4: an entity row must not render as a bare [?] ------------------------
+
+
+@pytest.mark.parametrize(
+    ("item", "key", "expected"),
+    [
+        ({"entity_type": "Decision"}, "decision:x", "Decision"),
+        ({"labels": ["Feature"]}, "feature:x", "Feature"),
+        # No entity_type: the namespaced key names the kind.
+        ({}, "decision:retry-budget", "decision"),
+        ({}, "service:local:payments-api", "service"),
+        # A resource URI's first path segment, not its always-"potpie" scheme.
+        ({}, "potpie://res/runbook/rollback/1", "res"),
+        # Nothing to go on: the honest unknown marker survives.
+        ({}, "opaque", "?"),
+        ({}, "", "?"),
+    ],
+)
+def test_entity_label_falls_back_to_the_key_namespace(item, key, expected) -> None:
+    from potpie.cli.read_presenter import _entity_label
+
+    assert _entity_label(item, key) == expected

--- a/tests/unit/test_source_cli_contract.py
+++ b/tests/unit/test_source_cli_contract.py
@@ -100,10 +100,13 @@ def test_source_add_json_marks_registration_only() -> None:
         "kind": "repo",
         "name": "platform",
         "location": "owner/repo",
+        "resolved_location": "owner/repo",
         "pot_id": "pot-1",
         "registration_only": True,
         "repo_default_set": False,
         "repo_key": "owner/repo",
+        "reused_existing": False,
+        "requested_name_ignored": False,
     }
     assert fake_pots.repo_defaults == {}
 


### PR DESCRIPTION
Someone ran a full test sweep against potpie 2.0.1 after it went up on PyPI and
found 20 problems. This fixes all of them.

I reproduced every one first — against a throwaway daemon and throwaway pots, so
nothing touched a real setup — then fixed it, then checked it was actually gone.

---

## The two that stop people working

### Upgrading potpie while the daemon is running bricks the CLI

If you had a daemon running and then upgraded, the new potpie couldn't talk to
the old daemon. Fine so far — except it also couldn't stop it, restart it, or
replace it. Every suggestion it gave you led nowhere:

| you run | you get |
|---|---|
| `potpie status` | "discovery is unavailable — run `potpie daemon restart`" |
| `potpie daemon restart` | "Unexpected internal error." |
| `potpie daemon stop` | "refusing to signal the recorded process" |
| `potpie daemon start` | "daemon already running" |
| `potpie daemon status` | "up=True" — which contradicts `status` |

The only way out was to find the process ID yourself and `kill` it. Nothing in
the CLI told you that. This is what *every* existing user hit when they upgraded.

**Now:** potpie recognises the old daemon and says so in plain words — "the
runtime record was written by an older potpie". `daemon restart` genuinely
recovers: it shuts the old daemon down and starts a fresh one. `daemon status`
admits the daemon is there but unusable, and prints the `kill` command as a last
resort. `daemon stop` offers `--force`.

Before killing anything, potpie checks the process really is a potpie daemon
(process IDs get recycled, so a stale ID could point at something else entirely
— that's why the old code refused in the first place).

### `pot reset` wiped a different pot than everything else showed you

`pot reset` deletes a pot's graph data. It was picking a *different pot* than the
one `pot list` and `potpie status` displayed as current. So the most destructive
command in the tool was aimed at something you were never shown.

The cause turned out to be one bug behind several symptoms. Potpie can pick a pot
in two ways: the pot you last switched to ("active"), or a pot bound to the repo
you're standing in ("repo default"). Commands were working out the right answer,
using it for logging, and then **throwing it away** and letting a second, separate
piece of code work it out again. The two could disagree.

That's also why `potpie status` showed one pot's name next to another pot's
numbers:

| where you ran it | pot it named | claims it reported |
|---|---|---|
| inside the repo | `cli-wide-test` | 0 |
| outside any repo | `cli-wide-test` | 17 |
| `--pot cli-wide-test` | `default` | 19 |

**Now:** the pot is worked out once and used everywhere. `status` tells you which
pot it's talking about, how it picked it, and — if the "active" pot is a different
one — says so outright. `pot list` marks the pot your commands here will actually
use. `pot reset` takes `--pot`, names its target, and warns you if that isn't the
active pot.

---

## Things that were lying to you

**`potpie doctor` described the wrong potpie.** It scanned your `PATH` and
reported on whatever `potpie` it found first — which might not be the one you just
ran. It confidently reported another install's version. With `PATH` trimmed, the
running binary announced it wasn't installed at all. Now it asks itself, and lists
anything else it finds separately.

**`doctor` reported bash's version as your Python version.** uv's launcher script
starts with `#!/bin/sh`, so doctor ran `/bin/sh --version`, got "GNU bash, version
3.2.57", grabbed the first number it saw and printed `python=3.2.57`. It now checks
the thing is actually Python before asking.

**`potpie --version` never printed potpie's version.** It printed the engine's
version and your Python. If you installed 2.0.1 you couldn't find that out from
`--version`.

**`--verbose` promised tracebacks and never printed one.** Now it does. (The
normal message stays vague on purpose — error text can contain your file paths.)

**Diagnostics told you to run `make`.** No Makefile ships in the package, so that
advice only works if you happen to have the source checked out.

---

## Things you couldn't do

**A third of `record`'s types couldn't be written.** `potpie record` accepts 15
types, but 5 of them need an extra field and there was no flag to supply one. Its
own help text gave three examples — two of which were impossible to use:

```
$ potpie record --type decision --summary "..."
error: decision: 'rationale' must be a non-empty string      # no way to pass it
```

Added `--detail key=value`, so all 15 work. Which types need what is now published
by the engine and checked by a test, so the help and the validator can't drift
apart.

**Copy-pasting from `graph catalog` always failed.** The catalog lists views as
`debugging.prior_occurrences`, but every way of passing that back was rejected —
you had to know to split it into `--subgraph debugging --view prior_occurrences`.
Now the name it prints is the name it takes.

**A view was reachable but undiscoverable.** Asking for it said it "requires one
of service, anchor_entity_key" — neither of which is a flag. The answer was
`--scope service:<name>`, findable only by guessing. Errors now name the flag you
type: `--by`, `--scope service:<value>`, and so on.

**Search results printed as empty bullets.** Some results carry their text under a
different key than the printer knew about, so they rendered as `• [resources]` and
nothing else. Four of ten visible results were blank lines while the JSON was full.
Fixed, along with rows that showed up as `[?]`.

**The same fact appeared four times in a row.** Duplicates now collapse — but only
when they're genuinely the same record. Two different records that happen to be
worded identically both survive, and the second is labelled so you can see they're
distinct.

---

## Things that were quietly wrong

**Registering the same repo twice stored two different identities.** `source add
repo .` uses your git remote as the repo's identity, falling back to a filesystem
path if it can't get one. It treated *any* git failure as "no remote" — so a slow
or failing git call silently produced a different identity for the same repo.
Now a real failure says so and stops; only a genuine "this repo has no remote"
falls back to the path.

Re-registering also silently ignored a new `--name` and reported a location that
wasn't what got stored. It now says it reused the existing registration.

**Running under an isolated home still wrote to your real `~/.claude`.**
`CONTEXT_ENGINE_HOME` moves potpie's own state but never moved agent skills, so a
"safe" test run rewrote the tester's actual skill set. `POTPIE_HARNESS_HOME` now
does that, and installs print where the files went.

**`skills status` reported a clean bill of health while ignoring skills it can't
service.** Three `potpie-resource-*` skill folders were installed and being loaded
by the agent; this build doesn't ship them and can't update them, and status said
nothing. It now lists them.

**The backend you configured at setup was ignored.** `potpie setup` records your
choice in `config.json`, but starting the daemon never read it and always used the
default. If you'd configured something else, your graph looked empty.

---

## Three findings that don't apply here

Three items describe features that exist on an unmerged branch, not in 2.0.1 or on
`main` — the tester's machine had leftovers from it. There's nothing to fix in this
lineage: the `potpie resource` command and the links pointing at it, the managed
(remote) host config, and the `knowledge.document_passages` view.

Where those findings had a half that *does* apply here, that half is fixed above:
orphaned-skill reporting, the ignored backend setting, and the blank-row rendering.

---

## Review round

CodeRabbit raised 11 points; 9 were real and are fixed in the second commit. Most
were edge cases around the fixes above — the notable ones:

- `git remote get-url` exits 128 both for "not a repo" *and* for a broken config
  file. I was treating both as "no remote", which reintroduced the exact silent
  fallback I was fixing. Only a real "no repo here" counts now.
- The forced daemon kill matched its command line by substring, so a process
  called `potpie.daemon_helper` would have qualified. It now matches the exact
  command shapes the daemon is started with, and there are tests for the near
  misses.
- Skill version records were keyed only by agent, so two isolated harness homes
  overwrote each other's. Each home gets its own record now; the normal one keeps
  its current filename so existing installs aren't disturbed.

Two I didn't act on, with reasons: `fix` records were said to need a `fix_steps`
field — they don't, a bare `fix` record validates and writes (verified both in the
validator and end to end). And two tests were said to be calling a method without
parentheses — it's a property, and the tests pass.

---

## How this was checked

- 1477 CLI tests, 1184 engine tests — green. 90 of them are new and cover each
  finding.
- Every fix re-run by hand against a throwaway daemon: the upgrade wedge recovers,
  the three pot displays agree, all 15 record types write, every catalog view name
  pastes back in.
- Two `test_daemon_controller` and two `test_product_process_surfaces` tests fail
  in my local sandbox for reasons unrelated to this branch — my dev environment has
  one shared editable install pointing at a checkout that's currently on someone
  else's branch, so a spawned test daemon picks up mismatched halves. They pass on
  a clean checkout.
