### PR TITLE
fix(deps): remediate xmldom vulnerability (POT-2475)

### DIFF
--- a/tests/docs/package-lock.json
+++ b/tests/docs/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "potpie-docs-check",
       "dependencies": {
-        "@xmldom/xmldom": "^0.9.11",
+        "@xmldom/xmldom": "^0.9.12",
         "yaml": "^2.8.2"
       },
       "engines": {
@@ -14,9 +14,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.11.tgz",
-      "integrity": "sha512-tW8bcK3hsG0/uqSnNz6TK4BkcuZSezoU7DlnYssILmZDktPnSHHuDJJFM0AJv+13gz2r0iGdrj6qqKeUnxXEDg==",
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.12.tgz",
+      "integrity": "sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==",
       "license": "MIT",
       "engines": {
         "node": ">=14.6"

--- a/tests/docs/package.json
+++ b/tests/docs/package.json
@@ -11,7 +11,7 @@
     "node": ">=22"
   },
   "dependencies": {
-    "@xmldom/xmldom": "^0.9.11",
+    "@xmldom/xmldom": "^0.9.12",
     "yaml": "^2.8.2"
   }
 }


### PR DESCRIPTION
## Summary
- upgrade `@xmldom/xmldom` from vulnerable 0.9.11 to patched 0.9.12
- refresh the docs-check npm lockfile with the verified 0.9.12 integrity hash

Fixes POT-2475 (CVE-2026-83610).

## Verification
- `npm ci --ignore-scripts --no-audit`
- `npm test` — 91 passing
- `npm run check` is blocked because this checkout has no `tests/docs/docs/config.json`; the existing test suite passes.
